### PR TITLE
Fix snap sync finalization deadlocks and remove stale TODO

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
@@ -242,7 +242,9 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
       return Left(s"Expected ${RequestType.GetByteCodes} but got response for ${pending.requestType}")
     }
 
-    // TODO: Validate bytecode hashes match requested hashes
+    // Bytecode hash validation is performed by ByteCodeCoordinator.validateReturnedCodes()
+    // which keccak256-hashes each returned code and verifies it matches the requested hashes
+    // in subsequence order. No need to duplicate that check here.
     Right(response)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -67,6 +67,7 @@ class SNAPSyncController(
   private var trieNodeHealingCoordinator: Option[ActorRef] = None
   private var chainDownloader: Option[ActorRef] = None
   private var chainDownloadComplete: Boolean = false
+  private var chainDownloadTimeoutTask: Option[Cancellable] = None
 
   // Monotonic counter appended to coordinator actor names so restarts don't collide
   // with still-stopping actors from the previous cycle.
@@ -2189,8 +2190,14 @@ class SNAPSyncController(
         }
 
       case _ =>
-        log.error("Missing state root or pivot block for validation")
-        log.error("Sync cannot complete - missing state root or pivot block")
+        log.error("Missing state root or pivot block for validation — cannot validate state")
+        log.error(s"stateRoot=${stateRoot.map(_.toHex.take(16))}, pivotBlock=$pivotBlock")
+        // Don't leave the controller stuck in StateValidation phase.
+        // Mark SNAP done and hand off to regular sync, which will fetch any
+        // missing state on-demand during block execution.
+        log.warning("Proceeding to regular sync without state validation")
+        appStateStorage.snapSyncDone().commit()
+        context.parent ! Done
     }
   }
 
@@ -2622,6 +2629,13 @@ class SNAPSyncController(
           ))
           currentPhase = ChainDownloadCompletion
           progressMonitor.startPhase(ChainDownloadCompletion)
+          // Safety timeout: if the chain downloader never sends Done (crash, lost message),
+          // finalize anyway after 2 hours rather than hanging indefinitely.
+          chainDownloadTimeoutTask = Some(
+            scheduler.scheduleOnce(2.hours) {
+              self ! ChainDownloadTimeout
+            }(ec)
+          )
           context.become(waitingForChainDownload)
           return
         }
@@ -2632,6 +2646,8 @@ class SNAPSyncController(
 
   /** Final SNAP sync completion — called when both state sync and chain download are done. */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
+    chainDownloadTimeoutTask.foreach(_.cancel())
+    chainDownloadTimeoutTask = None
     appStateStorage.snapSyncDone().commit()
 
     // Look up the pivot header so we can store a complete "best block" anchor.
@@ -2691,6 +2707,16 @@ class SNAPSyncController(
   def waitingForChainDownload: Receive = handlePeerListMessagesWithRateTracking.orElse {
     case ChainDownloader.Done =>
       log.info("Parallel chain download complete. Finalizing SNAP sync.")
+      chainDownloadTimeoutTask.foreach(_.cancel())
+      chainDownloadTimeoutTask = None
+      chainDownloadComplete = true
+      pivotBlock.foreach(finalizeSnapSync)
+
+    case ChainDownloadTimeout =>
+      log.warning(
+        "Chain download did not complete within timeout. " +
+          "Finalizing SNAP sync anyway — regular sync will handle remaining chain data."
+      )
       chainDownloadComplete = true
       pivotBlock.foreach(finalizeSnapSync)
 
@@ -2830,6 +2856,7 @@ object SNAPSyncController {
   case object StateHealingComplete
   case object HealingAllPeersStateless
   case object StateValidationComplete
+  case object ChainDownloadTimeout
   case object GetProgress
 
   /** Signal from coordinators that the current pivot/stateRoot is likely not serveable by peers.


### PR DESCRIPTION
Three issues that could prevent SNAP sync from completing:

1. CRITICAL: validateState() deadlocks when stateRoot/pivotBlock is None.
   The catch-all case logged errors but never sent StateValidationComplete
   or Done, leaving the controller stuck in StateValidation phase forever.
   Fix: proceed to regular sync (mark snapSyncDone, send Done to parent).

2. MODERATE: waitingForChainDownload has no timeout. If ChainDownloader
   crashes or Done message is lost, the controller hangs indefinitely.
   Fix: 2-hour safety timeout that finalizes sync regardless.

3. LOW: Remove stale TODO in SNAPRequestTracker.validateByteCodes().
   Bytecode hash validation is already performed by
   ByteCodeCoordinator.validateReturnedCodes() which keccak256-hashes
   each returned code and verifies it matches requested hashes in order.

https://claude.ai/code/session_01BNHtvqupfxeLLugFU7S7SN