### PR TITLE
feat(vm): ExecutionTracer interface + StructLog/Call/Prestate/VmTracer implementations

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
@@ -1,0 +1,177 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.utils.Hex
+
+/** Native callTracer matching go-ethereum's eth/tracers/native/call.go.
+  *
+  * Produces a nested call tree for debug_traceTransaction/debug_traceCall:
+  * {{{
+  * {
+  *   "type": "CALL",
+  *   "from": "0x...",
+  *   "to": "0x...",
+  *   "gas": 123456,
+  *   "gasUsed": 45678,
+  *   "value": "0x0",
+  *   "input": "0x...",
+  *   "output": "0x...",
+  *   "error": "execution reverted",
+  *   "revertReason": "ERC20: ...",
+  *   "calls": [ ... ]
+  * }
+  * }}}
+  *
+  * Besu reference: FlatTraceGenerator produces OpenEthereum flat trace format (different schema).
+  * This tracer matches go-ethereum's callTracer nested call tree format, which is the standard
+  * for debug_traceTransaction with {tracer: "callTracer"}.
+  *
+  * @param onlyTopCall when true, only capture the top-level call (skip sub-calls)
+  */
+class CallTracer(onlyTopCall: Boolean = false) extends ExecutionTracer {
+
+  private case class CallFrame(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString,
+      var gasUsed: BigInt = 0,
+      var output: ByteString = ByteString.empty,
+      var error: Option[String] = None,
+      var revertReason: Option[String] = None,
+      calls: mutable.ArrayBuffer[CallFrame] = mutable.ArrayBuffer.empty
+  )
+
+  private val callStack             = mutable.Stack[CallFrame]()
+  private var rootFrame: Option[CallFrame] = None
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    val opCode = if (to.isDefined) "CALL" else "CREATE"
+    val frame = CallFrame(
+      opCode = opCode,
+      from = from,
+      to = to.getOrElse(Address(0)),
+      gas = gas,
+      value = value,
+      input = input
+    )
+    callStack.push(frame)
+    rootFrame = Some(frame)
+  }
+
+  override def onTxEnd(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (callStack.nonEmpty) {
+      val frame = callStack.pop()
+      frame.gasUsed = gasUsed
+      frame.output = output
+      frame.error = error
+      if (error.exists(_.contains("execution reverted")) && output.length >= 4) {
+        frame.revertReason = parseRevertReason(output)
+      }
+    }
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    if (onlyTopCall) return
+
+    val frame = CallFrame(
+      opCode = opCode,
+      from = from,
+      to = to,
+      gas = gas,
+      value = value,
+      input = input
+    )
+    callStack.push(frame)
+  }
+
+  override def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (onlyTopCall) return
+    if (callStack.size <= 1) return // don't pop the root frame
+
+    val frame = callStack.pop()
+    frame.gasUsed = gasUsed
+    frame.output = output
+    frame.error = error
+    if (error.exists(_.contains("execution reverted")) && output.length >= 4) {
+      frame.revertReason = parseRevertReason(output)
+    }
+
+    if (callStack.nonEmpty) {
+      callStack.top.calls += frame
+    }
+  }
+
+  override def getResult: JValue = rootFrame match {
+    case Some(frame) => encodeFrame(frame)
+    case None        => JNull
+  }
+
+  private def encodeFrame(frame: CallFrame): JValue = {
+    var obj: JObject = ("type" -> frame.opCode) ~
+      ("from" -> encodeAddress(frame.from)) ~
+      ("to" -> encodeAddress(frame.to)) ~
+      ("gas" -> JInt(frame.gas.bigInteger)) ~
+      ("gasUsed" -> JInt(frame.gasUsed.bigInteger))
+
+    if (frame.opCode == "CALL" || frame.opCode == "CREATE" || frame.opCode == "CREATE2") {
+      obj = obj ~ ("value" -> encodeHex(frame.value))
+    }
+
+    obj = obj ~
+      ("input" -> encodeHexBytes(frame.input)) ~
+      ("output" -> encodeHexBytes(frame.output))
+
+    frame.error.foreach(e => obj = obj ~ ("error" -> JString(e)))
+    frame.revertReason.foreach(r => obj = obj ~ ("revertReason" -> JString(r)))
+
+    if (frame.calls.nonEmpty) {
+      obj = obj ~ ("calls" -> JArray(frame.calls.toList.map(encodeFrame)))
+    }
+
+    obj
+  }
+
+  private def encodeAddress(addr: Address): JString =
+    JString("0x" + Hex.toHexString(addr.bytes.toArray))
+
+  private def encodeHex(value: BigInt): JString =
+    JString("0x" + value.toString(16))
+
+  private def encodeHexBytes(bs: ByteString): JString =
+    if (bs.isEmpty) JString("0x")
+    else JString("0x" + Hex.toHexString(bs.toArray))
+
+  /** Parse Solidity revert reason from ABI-encoded error data.
+    * Format: 0x08c379a0 + offset + length + utf8 string
+    */
+  private def parseRevertReason(data: ByteString): Option[String] = {
+    if (data.length < 68) return None
+    val selector = data.take(4)
+    if (selector != ByteString(0x08, 0xc3, 0x79, 0xa0)) return None
+    try {
+      val offset = BigInt(1, data.slice(4, 36).toArray).toInt
+      val length = BigInt(1, data.slice(36 + offset, 68 + offset).toArray).toInt
+      if (data.length < 68 + offset + length) return None
+      Some(new String(data.slice(68 + offset, 68 + offset + length).toArray, "UTF-8"))
+    } catch {
+      case _: Exception => None
+    }
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
@@ -127,8 +127,8 @@ class CallTracer(onlyTopCall: Boolean = false) extends ExecutionTracer {
     var obj: JObject = ("type" -> frame.opCode) ~
       ("from" -> encodeAddress(frame.from)) ~
       ("to" -> encodeAddress(frame.to)) ~
-      ("gas" -> JInt(frame.gas.bigInteger)) ~
-      ("gasUsed" -> JInt(frame.gasUsed.bigInteger))
+      ("gas" -> JString("0x" + frame.gas.toString(16))) ~
+      ("gasUsed" -> JString("0x" + frame.gasUsed.toString(16)))
 
     if (frame.opCode == "CALL" || frame.opCode == "CREATE" || frame.opCode == "CREATE2") {
       obj = obj ~ ("value" -> encodeHex(frame.value))

--- a/src/main/scala/com/chipprbots/ethereum/vm/ExecutionTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/ExecutionTracer.scala
@@ -1,0 +1,78 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.domain.Address
+
+/** Pluggable execution tracer interface — Fukuii's equivalent of Besu's OperationTracer.
+  *
+  * Besu reference: evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
+  *
+  * Mapping to Besu hooks:
+  *   - onStep       → tracePostExecution (after each opcode; prevState gives pre-execution view)
+  *   - onTxStart    → traceStartTransaction
+  *   - onTxEnd      → traceEndTransaction
+  *   - onCallEnter  → traceContextEnter (entering a sub-call frame)
+  *   - onCallExit   → traceContextExit  (exiting a sub-call frame)
+  *
+  * Divergence from Besu: Besu separates tracePreExecution/tracePostExecution; Fukuii uses a
+  * single post-execution hook with both prevState and nextState available. Semantically
+  * equivalent — prevState provides the pre-execution view.
+  *
+  * Implementations:
+  *   - StructLogTracer: opcode-by-opcode trace (go-ethereum structLog format)
+  *   - CallTracer: nested call tree (go-ethereum native callTracer)
+  *   - PrestateTracer: pre-transaction state snapshot (go-ethereum native prestateTracer)
+  *   - VmTracer: Parity/OpenEthereum vmTrace format
+  *
+  * All methods have default no-op implementations so each tracer only overrides what it needs.
+  */
+trait ExecutionTracer {
+
+  /** Called after each opcode execution in the VM exec loop.
+    * Corresponds to Besu's tracePostExecution. prevState gives the pre-execution view.
+    */
+  def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = ()
+
+  /** Called once for the top-level transaction before execution begins.
+    * Corresponds to Besu's traceStartTransaction.
+    */
+  def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = ()
+
+  /** Called once when the top-level transaction returns.
+    * Corresponds to Besu's traceEndTransaction.
+    */
+  def onTxEnd(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = ()
+
+  /** Called when entering an internal CALL/CALLCODE/DELEGATECALL/STATICCALL/CREATE/CREATE2.
+    * Only fires for internal sub-calls (callDepth > 0), not the top-level transaction.
+    * Corresponds to Besu's traceContextEnter.
+    *
+    * @param opCode the opcode name: "CALL", "STATICCALL", "DELEGATECALL", "CALLCODE", "CREATE", "CREATE2"
+    * @param from   calling address
+    * @param to     called address (for CREATE/CREATE2, the newly computed address)
+    * @param gas    gas allocated to the sub-call
+    * @param value  ETH value transferred
+    * @param input  call data or init code
+    */
+  def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = ()
+
+  /** Called when an internal CALL/CREATE returns.
+    * Corresponds to Besu's traceContextExit.
+    */
+  def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = ()
+
+  /** Returns the tracer-specific result as a JSON value for the RPC response. */
+  def getResult: org.json4s.JValue
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/PrestateTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/PrestateTracer.scala
@@ -1,0 +1,214 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+import com.chipprbots.ethereum.utils.Hex
+
+/** Native prestateTracer matching go-ethereum's eth/tracers/native/prestate.go.
+  *
+  * Besu reference: StateTraceGenerator generates state diffs; this tracer also supports
+  * go-ethereum's pre-state snapshot mode.
+  *
+  * Default mode — returns pre-transaction state for all touched accounts:
+  * {{{
+  * { "0xaddr": { "balance": "0x...", "nonce": 1, "code": "0x...", "storage": {"0xkey": "0xval"} } }
+  * }}}
+  *
+  * diffMode — returns pre and post state (post only includes changed fields):
+  * {{{
+  * { "pre": { "0xaddr": { ... } }, "post": { "0xaddr": { ... } } }
+  * }}}
+  *
+  * @param preWorld  world state snapshot before transaction execution
+  * @param diffMode  when true, return {pre, post} diff instead of just prestate
+  */
+class PrestateTracer[W <: WorldStateProxy[W, S], S <: Storage[S]](
+    val preWorld: W,
+    diffMode: Boolean = false
+) extends ExecutionTracer {
+
+  private val touchedAddresses   = mutable.LinkedHashSet[Address]()
+  private val touchedStorageKeys = mutable.HashMap[Address, mutable.LinkedHashSet[UInt256]]()
+  private var postWorld: Option[W] = None
+
+  def setPostWorld(world: W): Unit = {
+    postWorld = Some(world)
+  }
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    touchedAddresses += from
+    to.foreach(addr => touchedAddresses += addr)
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    touchedAddresses += from
+    touchedAddresses += to
+  }
+
+  override def onStep[W2 <: WorldStateProxy[W2, S2], S2 <: Storage[S2]](
+      opCode: OpCode,
+      prevState: ProgramState[W2, S2],
+      nextState: ProgramState[W2, S2]
+  ): Unit = {
+    val opName = opCode.toString
+    if (opName == "SLOAD" || opName == "SSTORE") {
+      val stack = prevState.stack
+      if (stack.size >= 1) {
+        val addr = prevState.env.ownerAddr
+        val key  = stack.toSeq.head
+        touchedAddresses += addr
+        touchedStorageKeys.getOrElseUpdate(addr, mutable.LinkedHashSet.empty) += key
+      }
+    }
+    opName match {
+      case "BALANCE" | "EXTCODESIZE" | "EXTCODECOPY" | "EXTCODEHASH" =>
+        val stack = prevState.stack
+        if (stack.size >= 1) {
+          val addrUint = stack.toSeq.head
+          touchedAddresses += Address(addrUint)
+        }
+      case "SELFDESTRUCT" =>
+        val stack = prevState.stack
+        if (stack.size >= 1) {
+          val beneficiary = stack.toSeq.head
+          touchedAddresses += Address(beneficiary)
+          touchedAddresses += prevState.env.ownerAddr
+        }
+      case _ => ()
+    }
+  }
+
+  override def getResult: JValue = {
+    if (diffMode) {
+      postWorld match {
+        case Some(pw) => encodeDiff(pw)
+        case None     => encodePrestate()
+      }
+    } else {
+      encodePrestate()
+    }
+  }
+
+  private def encodePrestate(): JValue = {
+    val fields = touchedAddresses.toList.flatMap { addr =>
+      preWorld.getAccount(addr).map { account =>
+        val addrHex = "0x" + Hex.toHexString(addr.bytes.toArray)
+        addrHex -> encodeAccountState(addr, account, preWorld)
+      }
+    }
+    JObject(fields.map { case (k, v) => JField(k, v) })
+  }
+
+  private def encodeDiff(pw: W): JValue = {
+    val preFields  = mutable.ListBuffer[JField]()
+    val postFields = mutable.ListBuffer[JField]()
+
+    touchedAddresses.foreach { addr =>
+      val addrHex     = "0x" + Hex.toHexString(addr.bytes.toArray)
+      val preAccount  = preWorld.getAccount(addr)
+      val postAccount = pw.getAccount(addr)
+
+      preAccount.foreach { acc =>
+        preFields += JField(addrHex, encodeAccountState(addr, acc, preWorld))
+      }
+
+      postAccount.foreach { postAcc =>
+        val preAcc = preAccount.getOrElse(com.chipprbots.ethereum.domain.Account.empty(0))
+        val diff   = encodeAccountDiff(addr, preAcc, postAcc, pw)
+        if (diff != JNothing) {
+          postFields += JField(addrHex, diff)
+        }
+      }
+
+      if (preAccount.isEmpty && postAccount.isDefined) {
+        postFields += JField(addrHex, encodeAccountState(addr, postAccount.get, pw))
+      }
+    }
+
+    ("pre" -> JObject(preFields.toList)) ~ ("post" -> JObject(postFields.toList))
+  }
+
+  private def encodeAccountState(addr: Address, account: com.chipprbots.ethereum.domain.Account, world: W): JValue = {
+    var obj: JObject = ("balance" -> JString("0x" + account.balance.toBigInt.toString(16))) ~
+      ("nonce" -> JInt(account.nonce.bigInteger))
+
+    val code = world.getCode(addr)
+    if (code.nonEmpty) {
+      obj = obj ~ ("code" -> JString("0x" + Hex.toHexString(code.toArray)))
+    }
+
+    val storageKeys = touchedStorageKeys.getOrElse(addr, Set.empty)
+    if (storageKeys.nonEmpty) {
+      val storage = world.getStorage(addr)
+      val storageFields = storageKeys.toList.flatMap { key =>
+        val value = storage.load(key.toBigInt)
+        if (value != BigInt(0)) {
+          val keyHex = "0x" + key.toBigInt.toString(16).reverse.padTo(64, '0').reverse
+          val valHex = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(JField(keyHex, JString(valHex)))
+        } else None
+      }
+      if (storageFields.nonEmpty) {
+        obj = obj ~ ("storage" -> JObject(storageFields))
+      }
+    }
+
+    obj
+  }
+
+  private def encodeAccountDiff(
+      addr: Address,
+      preAcc: com.chipprbots.ethereum.domain.Account,
+      postAcc: com.chipprbots.ethereum.domain.Account,
+      pw: W
+  ): JValue = {
+    var fields = List.empty[JField]
+
+    if (preAcc.balance != postAcc.balance) {
+      fields :+= JField("balance", JString("0x" + postAcc.balance.toBigInt.toString(16)))
+    }
+    if (preAcc.nonce != postAcc.nonce) {
+      fields :+= JField("nonce", JInt(postAcc.nonce.bigInteger))
+    }
+
+    val preCode  = preWorld.getCode(addr)
+    val postCode = pw.getCode(addr)
+    if (preCode != postCode && postCode.nonEmpty) {
+      fields :+= JField("code", JString("0x" + Hex.toHexString(postCode.toArray)))
+    }
+
+    val storageKeys = touchedStorageKeys.getOrElse(addr, Set.empty)
+    if (storageKeys.nonEmpty) {
+      val preStorage  = preWorld.getStorage(addr)
+      val postStorage = pw.getStorage(addr)
+      val storageFields = storageKeys.toList.flatMap { key =>
+        val preVal  = preStorage.load(key.toBigInt)
+        val postVal = postStorage.load(key.toBigInt)
+        if (preVal != postVal) {
+          val keyHex = "0x" + key.toBigInt.toString(16).reverse.padTo(64, '0').reverse
+          val valHex = "0x" + postVal.toString(16).reverse.padTo(64, '0').reverse
+          Some(JField(keyHex, JString(valHex)))
+        } else None
+      }
+      if (storageFields.nonEmpty) {
+        fields :+= JField("storage", JObject(storageFields))
+      }
+    }
+
+    if (fields.isEmpty) JNothing else JObject(fields)
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/StructLogTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/StructLogTracer.scala
@@ -1,0 +1,112 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.UInt256
+
+/** A single step in EVM execution, matching go-ethereum's structLog format. */
+case class StructLog(
+    pc: Int,
+    op: String,
+    gas: BigInt,
+    gasCost: BigInt,
+    depth: Int,
+    stack: Seq[BigInt],
+    memory: Option[Seq[String]],
+    storage: Option[Map[String, String]],
+    error: Option[String]
+)
+
+/** Collects opcode-by-opcode execution trace in go-ethereum structLog format.
+  *
+  * Besu reference: evm/src/main/java/org/hyperledger/besu/evm/tracing/StreamingOperationTracer.java
+  *
+  * Besu streams structLog to a PrintStream; Fukuii collects to a buffer for in-memory access.
+  * Output format is equivalent: per-opcode pc, op, gas, gasCost, depth, stack, memory, storage.
+  *
+  * @param enableMemory  include memory snapshot per step (expensive)
+  * @param enableStorage include storage diff per step (expensive)
+  * @param limit         maximum number of steps to capture (0 = unlimited)
+  */
+class StructLogTracer(
+    enableMemory: Boolean = false,
+    enableStorage: Boolean = false,
+    limit: Int = 0
+) extends ExecutionTracer {
+  private val steps       = scala.collection.mutable.ArrayBuffer[StructLog]()
+  private var _gas: BigInt             = 0
+  private var _failed: Boolean         = false
+  private var _returnValue: ByteString = ByteString.empty
+
+  override def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = {
+    if (limit > 0 && steps.size >= limit) return
+
+    val gasCost = prevState.gas - nextState.gas
+
+    val memorySnapshot = if (enableMemory) {
+      val mem = prevState.memory
+      if (mem.size > 0) {
+        val words = (0 until mem.size by 32).map { offset =>
+          val word = mem.load(UInt256(offset), UInt256(32))._1
+          word.toArray.map("%02x".format(_)).mkString
+        }
+        Some(words.toSeq)
+      } else Some(Seq.empty)
+    } else None
+
+    val storageSnapshot = if (enableStorage) {
+      opCode match {
+        case SLOAD if prevState.stack.size >= 1 =>
+          val slot  = prevState.stack.toSeq.head.toBigInt
+          val value = nextState.stack.toSeq.head.toBigInt
+          val k = "0x" + slot.toString(16).reverse.padTo(64, '0').reverse
+          val v = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(Map(k -> v))
+        case SSTORE if prevState.stack.size >= 2 =>
+          val slot  = prevState.stack.toSeq(0).toBigInt
+          val value = prevState.stack.toSeq(1).toBigInt
+          val k = "0x" + slot.toString(16).reverse.padTo(64, '0').reverse
+          val v = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(Map(k -> v))
+        case _ => None
+      }
+    } else None
+
+    val error = nextState.error.map(_.toString)
+
+    steps += StructLog(
+      pc      = prevState.pc,
+      op      = opCode.toString,
+      gas     = prevState.gas,
+      gasCost = gasCost,
+      depth   = prevState.env.callDepth + 1, // go-ethereum uses 1-based depth
+      stack   = prevState.stack.toSeq.map(_.toBigInt),
+      memory  = memorySnapshot,
+      storage = storageSnapshot,
+      error   = error
+    )
+  }
+
+  def setResult(gas: BigInt, returnValue: ByteString, failed: Boolean): Unit = {
+    _gas = gas
+    _returnValue = returnValue
+    _failed = failed
+  }
+
+  def getSteps: Seq[StructLog]  = steps.toSeq
+  def gas: BigInt               = _gas
+  def failed: Boolean           = _failed
+  def returnValue: ByteString   = _returnValue
+
+  /** Not used for StructLogTracer — response is built by DebugTracingJsonMethodsImplicits using
+    * getSteps/gas/failed/returnValue. Exists to satisfy the ExecutionTracer trait.
+    */
+  override def getResult: JValue = JNothing
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
@@ -17,7 +17,9 @@ import com.chipprbots.ethereum.rlp.UInt256RLPImplicits._
 import com.chipprbots.ethereum.utils.DebugTrace
 import com.chipprbots.ethereum.utils.Logger
 
-class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
+class VM[W <: WorldStateProxy[W, S], S <: Storage[S]](
+    val tracer: Option[ExecutionTracer] = None
+) extends Logger {
 
   type PC = ProgramContext[W, S]
   type PR = ProgramResult[W, S]
@@ -201,6 +203,7 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
             error = newState.error.map(_.toString)
           )
         }
+        tracer.foreach(_.onStep(opCode, state, newState))
         import newState._
         log.trace(
           s"$opCode | pc: $pc | depth: ${env.callDepth} | gasUsed: ${state.gas - gas} | gas: $gas | stack: $stack"

--- a/src/main/scala/com/chipprbots/ethereum/vm/VmTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/VmTracer.scala
@@ -1,0 +1,173 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+import com.chipprbots.ethereum.utils.Hex
+
+/** Parity-format vmTrace tracer for trace_replayBlockTransactions / trace_replayTransaction.
+  *
+  * Besu reference: ethereum/api/.../results/tracing/vm/VmTraceGenerator.java
+  *
+  * Produces the vmTrace field matching OpenEthereum / Besu format:
+  * {{{
+  * {
+  *   "code": "0x...",
+  *   "ops": [
+  *     {
+  *       "cost": 3,
+  *       "ex": {
+  *         "mem": {"data": "0x...", "off": 32},
+  *         "push": ["0x1"],
+  *         "store": {"key": "0x0", "val": "0x1"},
+  *         "used": 21000
+  *       },
+  *       "pc": 0,
+  *       "sub": null
+  *     }
+  *   ]
+  * }
+  * }}}
+  *
+  * Frame stack mirrors the call depth. onCallEnter pushes a new frame; onCallExit encodes it
+  * and attaches it as the `sub` field on the triggering CALL/CREATE op in the parent frame.
+  *
+  * Divergence from Besu: VmTraceGenerator post-processes TraceFrames; this tracer streams
+  * during execution. Semantically equivalent for standard use cases.
+  */
+class VmTracer extends ExecutionTracer {
+
+  private case class VmFrame(
+      var code: ByteString = ByteString.empty,
+      ops: mutable.ArrayBuffer[VmOp] = mutable.ArrayBuffer.empty
+  )
+
+  private case class VmOp(
+      pc: Int,
+      cost: BigInt,
+      exUsed: BigInt,
+      exPush: Seq[BigInt],
+      exMem: Option[(BigInt, ByteString)],  // (offset, data written)
+      exStore: Option[(BigInt, BigInt)],     // (key, value written)
+      var sub: Option[JValue] = None
+  )
+
+  private val frameStack              = mutable.Stack[VmFrame]()
+  private var rootFrame: Option[VmFrame] = None
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    val frame = VmFrame()
+    frameStack.push(frame)
+    rootFrame = Some(frame)
+  }
+
+  override def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = {
+    if (frameStack.isEmpty) return
+    val frame = frameStack.top
+
+    if (frame.code.isEmpty) {
+      frame.code = prevState.env.program.code
+    }
+
+    val cost   = prevState.gas - nextState.gas
+    val exUsed = nextState.gas
+
+    val exPush: Seq[BigInt] =
+      if (opCode.alpha > 0)
+        nextState.stack.toSeq.take(opCode.alpha).map(_.toBigInt)
+      else
+        Seq.empty
+
+    val exMem: Option[(BigInt, ByteString)] = opCode match {
+      case MSTORE if prevState.stack.size >= 2 =>
+        val offset = prevState.stack.toSeq.head
+        val data   = nextState.memory.load(offset, UInt256(32))._1
+        Some((offset.toBigInt, data))
+      case MSTORE8 if prevState.stack.size >= 2 =>
+        val offset = prevState.stack.toSeq.head
+        val data   = nextState.memory.load(offset, UInt256(1))._1
+        Some((offset.toBigInt, data))
+      case _ =>
+        None
+    }
+
+    val exStore: Option[(BigInt, BigInt)] = opCode match {
+      case SSTORE if prevState.stack.size >= 2 =>
+        val key = prevState.stack.toSeq(0).toBigInt
+        val v   = prevState.stack.toSeq(1).toBigInt
+        Some((key, v))
+      case _ =>
+        None
+    }
+
+    frame.ops += VmOp(
+      pc      = prevState.pc,
+      cost    = cost,
+      exUsed  = exUsed,
+      exPush  = exPush,
+      exMem   = exMem,
+      exStore = exStore
+    )
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    val frame = VmFrame()
+    frameStack.push(frame)
+  }
+
+  override def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (frameStack.size <= 1) return
+    val frame   = frameStack.pop()
+    val encoded = encodeFrame(frame)
+    if (frameStack.nonEmpty && frameStack.top.ops.nonEmpty) {
+      frameStack.top.ops.last.sub = Some(encoded)
+    }
+  }
+
+  override def getResult: JValue = rootFrame match {
+    case Some(frame) => encodeFrame(frame)
+    case None        => JNull
+  }
+
+  private def encodeFrame(frame: VmFrame): JValue =
+    ("code" -> encodeHexBytes(frame.code)) ~
+      ("ops" -> JArray(frame.ops.toList.map(encodeOp)))
+
+  private def encodeOp(op: VmOp): JValue = {
+    val ex: JValue =
+      ("mem" -> op.exMem.map { case (off, data) =>
+        ("data" -> encodeHexBytes(data)) ~ ("off" -> JInt(off.bigInteger))
+      }.getOrElse(JNull: JValue)) ~
+        ("push" -> JArray(op.exPush.map(v => JString("0x" + v.toString(16))).toList)) ~
+        ("store" -> op.exStore.map { case (k, v) =>
+          ("key" -> JString("0x" + k.toString(16))) ~ ("val" -> JString("0x" + v.toString(16)))
+        }.getOrElse(JNull: JValue)) ~
+        ("used" -> JInt(op.exUsed.bigInteger))
+
+    ("cost" -> JInt(op.cost.bigInteger)) ~
+      ("ex" -> ex) ~
+      ("pc" -> JInt(op.pc)) ~
+      ("sub" -> op.sub.getOrElse(JNull: JValue))
+  }
+
+  private def encodeHexBytes(bs: ByteString): JString =
+    if (bs.isEmpty) JString("0x")
+    else JString("0x" + Hex.toHexString(bs.toArray))
+}

--- a/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
@@ -27,8 +27,8 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       (result \ "type") shouldBe JString("CALL")
       (result \ "from") shouldBe a[JString]
       (result \ "to") shouldBe a[JString]
-      (result \ "gas") shouldBe JInt(21000)
-      (result \ "gasUsed") shouldBe JInt(21000)
+      (result \ "gas") shouldBe JString("0x5208")
+      (result \ "gasUsed") shouldBe JString("0x5208")
       (result \ "input") shouldBe a[JString]
       (result \ "output") shouldBe a[JString]
     }
@@ -58,7 +58,7 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       val callArray = calls.asInstanceOf[JArray].arr
       callArray should have size 1
       (callArray.head \ "type") shouldBe JString("STATICCALL")
-      (callArray.head \ "gasUsed") shouldBe JInt(10000)
+      (callArray.head \ "gasUsed") shouldBe JString("0x2710")
     }
 
     "should skip sub-calls when onlyTopCall is true" in {
@@ -84,15 +84,15 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       (result \ "error") shouldBe JString("out of gas")
     }
 
-    "should encode gas as decimal integer, not hex" in {
+    "should encode gas and gasUsed as hex strings matching core-geth callFrameMarshaling" in {
       val tracer = new CallTracer()
 
       tracer.onTxStart(from, Some(to), gas = 1000000, value = 0, input = input)
       tracer.onTxEnd(gasUsed = 500000, output = output, error = None)
 
       val result = tracer.getResult
-      (result \ "gas") shouldBe JInt(1000000)
-      (result \ "gasUsed") shouldBe JInt(500000)
+      (result \ "gas") shouldBe JString("0xf4240")
+      (result \ "gasUsed") shouldBe JString("0x7a120")
     }
 
     "should omit value for STATICCALL and DELEGATECALL" in {

--- a/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
@@ -1,0 +1,116 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.domain.Address
+
+class CallTracerSpec extends AnyFreeSpec with Matchers {
+
+  private val from   = Address(0x1234)
+  private val to     = Address(0x5678)
+  private val input  = ByteString(0x12, 0x34)
+  private val output = ByteString(0xab, 0xcd)
+
+  "CallTracer" - {
+    "should produce a root CALL frame for a simple transaction" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 21000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "type") shouldBe JString("CALL")
+      (result \ "from") shouldBe a[JString]
+      (result \ "to") shouldBe a[JString]
+      (result \ "gas") shouldBe JInt(21000)
+      (result \ "gasUsed") shouldBe JInt(21000)
+      (result \ "input") shouldBe a[JString]
+      (result \ "output") shouldBe a[JString]
+    }
+
+    "should produce a CREATE frame when to is None" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, to = None, gas = 100000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 50000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "type") shouldBe JString("CREATE")
+    }
+
+    "should build a nested call tree" in {
+      val tracer = new CallTracer()
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val result    = tracer.getResult
+      val calls     = result \ "calls"
+      calls shouldBe a[JArray]
+      val callArray = calls.asInstanceOf[JArray].arr
+      callArray should have size 1
+      (callArray.head \ "type") shouldBe JString("STATICCALL")
+      (callArray.head \ "gasUsed") shouldBe JInt(10000)
+    }
+
+    "should skip sub-calls when onlyTopCall is true" in {
+      val tracer = new CallTracer(onlyTopCall = true)
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "calls") shouldBe JNothing
+    }
+
+    "should include error on failure" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 100000, output = ByteString.empty, error = Some("out of gas"))
+
+      val result = tracer.getResult
+      (result \ "error") shouldBe JString("out of gas")
+    }
+
+    "should encode gas as decimal integer, not hex" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 1000000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 500000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "gas") shouldBe JInt(1000000)
+      (result \ "gasUsed") shouldBe JInt(500000)
+    }
+
+    "should omit value for STATICCALL and DELEGATECALL" in {
+      val tracer = new CallTracer()
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val calls = (tracer.getResult \ "calls").asInstanceOf[JArray].arr
+      (calls.head \ "value") shouldBe JNothing
+    }
+
+    "should return JNull when no transaction was traced" in {
+      val tracer = new CallTracer()
+      tracer.getResult shouldBe JNull
+    }
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/vm/PrestateTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/PrestateTracerSpec.scala
@@ -1,0 +1,123 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.domain.Account
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+
+class PrestateTracerSpec extends AnyFreeSpec with Matchers {
+
+  private val from = Address(0x1234)
+  private val to   = Address(0x5678)
+
+  private def worldWith(entries: (Address, Account)*): MockWorldState =
+    MockWorldState(accounts = entries.toMap)
+
+  "PrestateTracer" - {
+    "default mode should return touched account states" in {
+      val account = Account(nonce = 1, balance = UInt256(1000))
+      val world   = worldWith(from -> account)
+      val tracer  = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      result shouldBe a[JObject]
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 1
+    }
+
+    "default mode should include balance and nonce" in {
+      val account = Account(nonce = 5, balance = UInt256(9999))
+      val world   = worldWith(from -> account)
+      val tracer  = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result      = tracer.getResult
+      val obj         = result.asInstanceOf[JObject]
+      val accountJson = obj.obj.head._2
+      (accountJson \ "nonce") shouldBe JInt(5)
+      (accountJson \ "balance") shouldBe a[JString]
+    }
+
+    "diffMode should return pre and post objects" in {
+      val preAccount  = Account(nonce = 1, balance = UInt256(1000))
+      val postAccount = Account(nonce = 2, balance = UInt256(500))
+      val preWorld    = worldWith(from -> preAccount)
+      val postWorld   = worldWith(from -> postAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result = tracer.getResult
+      (result \ "pre") shouldBe a[JObject]
+      (result \ "post") shouldBe a[JObject]
+    }
+
+    "diffMode post should only include changed fields" in {
+      val preAccount  = Account(nonce = 1, balance = UInt256(1000))
+      val postAccount = Account(nonce = 1, balance = UInt256(500))
+      val preWorld    = worldWith(from -> preAccount)
+      val postWorld   = worldWith(from -> postAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result      = tracer.getResult
+      val postObj     = result \ "post"
+      val fromHex     = "0x" + com.chipprbots.ethereum.utils.Hex.toHexString(from.bytes.toArray)
+      val accountPost = postObj \ fromHex
+      (accountPost \ "balance") shouldBe a[JString]
+      (accountPost \ "nonce") shouldBe JNothing
+    }
+
+    "should track addresses from onCallEnter" in {
+      val inner   = Address(0xabcd)
+      val account = Account(nonce = 0, balance = UInt256(100))
+      val world   = worldWith(from -> account, to -> account, inner -> account)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](world)
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = ByteString.empty)
+      tracer.onCallEnter("CALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 3
+    }
+
+    "should omit accounts that don't exist in world" in {
+      val world  = worldWith(from -> Account(nonce = 0, balance = UInt256(100)))
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 1
+    }
+
+    "diffMode should show newly created accounts in post" in {
+      val preWorld   = worldWith(from -> Account(nonce = 1, balance = UInt256(1000)))
+      val newAccount = Account(nonce = 0, balance = UInt256(500))
+      val postWorld  = worldWith(from -> Account(nonce = 2, balance = UInt256(500)), to -> newAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result  = tracer.getResult
+      val postObj = result \ "post"
+      val toHex   = "0x" + com.chipprbots.ethereum.utils.Hex.toHexString(to.bytes.toArray)
+      (postObj \ toHex) should not be JNothing
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ExecutionTracer` interface + four tracer implementations for VM-level tracing.

**Interface:**
- `ExecutionTracer` — `onStep(opCode, stateBefore, stateAfter)` hook; injected into `VM` as optional constructor parameter

**Implementations:**
- `StructLogTracer` — per-opcode structured log (pc, op, gas, gasCost, stack, memory)
- `CallTracer` — call tree (call/create/selfdestruct frames, input/output, gas)
- `PrestateTracer` — pre/post state diffs for accounts touched during execution
- `VmTracer` — raw EVM step recording

**Rebase resolution (vs. PR #1026):**
PR #1026 (`b8ab0da63`) independently added `state.env.tracer` hookup in `VM.exec()` for the StructLog path. Our `tracer.foreach(_.onStep(...))` call coexists: `state.env.tracer` fires the environment-bound tracer (StructLog via `debug_traceTransaction`), while `VM.tracer` fires the constructor-injected `ExecutionTracer`. Both call sites retained; one conflict in `VM.scala` resolved by dropping the duplicate `val newState` declaration.

## Test plan

- [x] `sbt compile` — clean
- [x] `sbt testOnly *CallTracerSpec* *PrestateTracerSpec*` — all tests pass

---

> **Rebase note (2026-04-17):** rebased onto `develop` after PR #1026 merged. One conflict
> in `VM.scala` resolved (duplicate `val newState` declaration). Both tracer hookups retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)