### PR TITLE
feat(sync): adaptive backoff for pivot block selection + state download errors

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
@@ -9,12 +9,14 @@ import org.apache.pekko.actor.Scheduler
 import org.apache.pekko.util.ByteString
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import com.chipprbots.ethereum.blockchain.sync.Blacklist
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.InvalidPivotBlockElectionResponse
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.PivotBlockElectionTimeout
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
+import com.chipprbots.ethereum.blockchain.sync.RetryState
+import com.chipprbots.ethereum.blockchain.sync.RetryStrategy
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg.PeerWithInfo
 import com.chipprbots.ethereum.domain.BlockHeader
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
@@ -56,6 +58,13 @@ class PivotBlockSelector(
   // This is separate from pivotBlockRetryCount which resets after each scheduleRetry call.
   // Configurable via sync.pivot-block-max-total-selection-attempts.
   private val maxTotalSelectionAttempts = syncConfig.pivotBlockMaxTotalSelectionAttempts
+
+  // Exponential backoff across full pivot selection cycles.
+  // Besu: PivotBlockRetriever — SUSPICIOUS_NUMBER_OF_RETRIES = 5 (warn every 5th retry).
+  // Initial delay = startRetryInterval so first retry is unchanged vs. the fixed interval.
+  private var pivotRetryState: RetryState = RetryState(
+    strategy = RetryStrategy(initialDelay = syncConfig.startRetryInterval, maxDelay = 60.seconds, jitterFactor = 0.0)
+  )
 
   override def receive: Receive = idle
 
@@ -122,12 +131,12 @@ class PivotBlockSelector(
       startPivotBlockSelection(electionDetails)
     } else {
       log.debug(
-        "Cannot pick pivot block. Current best block number [{}]. Retrying in [{}]",
+        "Cannot pick pivot block. Current best block number [{}]. Scheduling retry with backoff (attempt {})",
         pivotBlockNumber,
-        startRetryInterval
+        pivotRetryState.attempt + 1
       )
       // Restart the whole process.
-      scheduleRetry(startRetryInterval)
+      scheduleRetry()
     }
   }
 
@@ -172,8 +181,8 @@ class PivotBlockSelector(
           blacklist.add(peerId, blacklistDuration, PivotBlockElectionTimeout)
         }
         peerEventBus ! Unsubscribe()
-        log.warning("Pivot block header receive timeout. Retrying in {}", startRetryInterval)
-        scheduleRetry(startRetryInterval)
+        log.warning("Pivot block header receive timeout. Scheduling retry with backoff (attempt {})", pivotRetryState.attempt + 1)
+        scheduleRetry()
     }
 
   private def votingProcess(
@@ -210,8 +219,8 @@ class PivotBlockSelector(
         )
       } else { // No more peers. Restart the whole process
         peerEventBus ! Unsubscribe()
-        log.warning("Not enough votes for pivot block. Retrying in {}", startRetryInterval)
-        scheduleRetry(startRetryInterval)
+        log.warning("Not enough votes for pivot block. Scheduling retry with backoff (attempt {})", pivotRetryState.attempt + 1)
+        scheduleRetry()
       }
       // Continue voting
     } else {
@@ -230,13 +239,23 @@ class PivotBlockSelector(
   private def isPossibleToReachConsensus(peersLeft: Int, bestHeaderVotes: Int): Boolean =
     peersLeft + bestHeaderVotes >= minPeersToChoosePivotBlock
 
-  private def scheduleRetry(interval: FiniteDuration): Unit = {
+  private def scheduleRetry(): Unit = {
     pivotBlockRetryCount = 0
-    scheduler.scheduleOnce(interval, self, SelectPivotBlock)
+    val delay = pivotRetryState.nextDelay
+    pivotRetryState = pivotRetryState.recordAttempt
+    if (pivotRetryState.attempt % PivotBlockSelector.SuspiciousRetryThreshold == 0) {
+      log.warning(
+        "{} pivot block selection retries have failed to obtain a valid pivot block",
+        pivotRetryState.attempt
+      )
+    }
+    log.debug("Scheduling pivot block selection retry in {}", delay)
+    scheduler.scheduleOnce(delay, self, SelectPivotBlock)
     context.become(idle)
   }
 
   private def sendResponseAndCleanup(pivotBlockHeader: BlockHeader): Unit = {
+    pivotRetryState = pivotRetryState.reset
     log.info("Found pivot block: {} hash: {}", pivotBlockHeader.number, pivotBlockHeader.hashAsHexString)
     fastSync ! Result(pivotBlockHeader)
     peerEventBus ! Unsubscribe()
@@ -285,6 +304,10 @@ class PivotBlockSelector(
 }
 
 object PivotBlockSelector {
+  // Besu: PivotBlockRetriever.SUSPICIOUS_NUMBER_OF_RETRIES = 5
+  // Warn every 5th consecutive pivot selection retry cycle.
+  val SuspiciousRetryThreshold: Int = 5
+
   def props(
       networkPeerManager: ActorRef,
       peerEventBus: ActorRef,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
@@ -18,6 +18,8 @@ import com.chipprbots.ethereum.blockchain.sync.Blacklist
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.InvalidStateResponse
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
+import com.chipprbots.ethereum.blockchain.sync.RetryState
+import com.chipprbots.ethereum.blockchain.sync.RetryStrategy
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg.PeerWithInfo
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.ResponseReceived
@@ -65,6 +67,17 @@ class SyncStateSchedulerActor(
     */
   private var consecutiveUselessResponses: Int = 0
   private val UselessResponseThreshold: Int = 20
+
+  // Exponential backoff for InvalidStateResponse errors.
+  // Besu: PipelineChainDownloader.PAUSE_AFTER_ERROR_DURATION = 2s.
+  // Prevents spinning on bad state responses; resets to PauseAfterErrorDuration on any success.
+  private var uselessResponseRetryState: RetryState = RetryState(
+    strategy = RetryStrategy(
+      initialDelay = SyncStateSchedulerActor.PauseAfterErrorDuration,
+      maxDelay = 30.seconds,
+      jitterFactor = 0.1
+    )
+  )
 
   /** Check if a capability supports GetNodeData message. GetNodeData is available in ETH63-67 but removed in ETH68 per
     * EIP-4938. SNAP protocol uses different messages (GetAccountRange, etc.) and doesn't support GetNodeData.
@@ -243,6 +256,7 @@ class SyncStateSchedulerActor(
     timers.startTimerAtFixedRate(PrintInfoKey, PrintInfo, 30.seconds)
     currentStateRoot = root
     consecutiveUselessResponses = 0
+    uselessResponseRetryState = uselessResponseRetryState.reset
     log.info("Starting state sync to root {} on block {}", ByteStringUtils.hash2string(root), bn)
     // TODO handle case when we already have root i.e state is synced up to this point
     val initState = sync.initState(root).getOrElse {
@@ -418,6 +432,7 @@ class SyncStateSchedulerActor(
 
       case ProcessingResult(Right(ProcessingSuccess(newState, newDownloaderState, newStats))) =>
         consecutiveUselessResponses = 0 // Reset on successful processing
+        uselessResponseRetryState = uselessResponseRetryState.reset
         log.debug(
           "Finished processing mpt node batch. Got {} missing nodes. Missing queue has {} elements",
           newState.numberOfPendingRequests,
@@ -456,6 +471,7 @@ class SyncStateSchedulerActor(
                     consecutiveUselessResponses
                   )
                   consecutiveUselessResponses = 0
+                  uselessResponseRetryState = uselessResponseRetryState.reset
                   handleRestart(
                     currentState.currentSchedulerState,
                     currentState.currentStats,
@@ -463,8 +479,12 @@ class SyncStateSchedulerActor(
                     context.parent
                   )
                 } else {
+                  // Besu: PipelineChainDownloader pauses PAUSE_AFTER_ERROR_DURATION (2s) after failures.
+                  // Use exponential backoff so repeated bad-root responses back off gradually.
+                  val delay = uselessResponseRetryState.nextDelay
+                  uselessResponseRetryState = uselessResponseRetryState.recordAttempt
                   context.become(syncing(currentState.withNewDownloaderState(newDownloaderState)))
-                  self ! Sync
+                  timers.startSingleTimer(SyncKey, Sync, delay)
                 }
               case _ =>
                 context.become(syncing(currentState.withNewDownloaderState(newDownloaderState)))
@@ -488,6 +508,10 @@ class SyncStateSchedulerActor(
 object SyncStateSchedulerActor {
   case object SyncKey
   case object Sync
+
+  // Besu: PipelineChainDownloader.PAUSE_AFTER_ERROR_DURATION = 2s.
+  // Base delay for exponential backoff on InvalidStateResponse errors.
+  val PauseAfterErrorDuration: FiniteDuration = 2.seconds
 
   private def reportStats(
       to: ActorRef,


### PR DESCRIPTION
## Summary

Replaces two fixed-interval retry loops with exponential backoff, aligning with
Besu's `PivotBlockRetriever` and `PipelineChainDownloader`.

### PivotBlockSelector — adaptive pivot selection retry

| Before | After |
|--------|-------|
| Always retried at fixed `startRetryInterval` | Exponential backoff starting at `startRetryInterval`, capping at 60s |
| No warning on repeated failures | Warns every 5th retry cycle (Besu: `SUSPICIOUS_NUMBER_OF_RETRIES = 5`) |

- `SuspiciousRetryThreshold = 5` added to companion object (matches Besu constant)
- `pivotRetryState` resets on successful pivot find — no penalty for normal operation
- First retry delay unchanged (`startRetryInterval`), so existing tests pass without modification
- Uses existing `RetryStrategy` / `RetryState` (no new file needed)

### SyncStateSchedulerActor — backoff on state node errors

| Before | After |
|--------|-------|
| Immediately re-queued `self ! Sync` on `InvalidStateResponse` | `timers.startSingleTimer` with 2s initial delay, growing to 30s cap |
| No pause between useless-data retries | `PauseAfterErrorDuration = 2.seconds` (Besu: `PipelineChainDownloader.PAUSE_AFTER_ERROR_DURATION`) |

- `uselessResponseRetryState` resets on `ProcessingResult(Right(...))` success and on new sync target
- Non-`InvalidStateResponse` error paths (`RequestFailed`, etc.) unchanged
- `PauseAfterErrorDuration` companion object constant for documentation

### Besu references

- `ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockRetriever.java` — `SUSPICIOUS_NUMBER_OF_RETRIES = 5`, `DEFAULT_MAX_PIVOT_BLOCK_RESETS = 250`
- `ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java` — `PAUSE_AFTER_ERROR_DURATION = Duration.ofSeconds(2)`

### Wire protocol compatibility

No changes. Both modifications are internal client-side timing policy, invisible to peers. GetBlockHeaders / GetNodeData / GetTrieNodes message formats are unchanged.

## Test plan

- [x] `sbt testOnly *PivotBlockSelectorSpec` — 12/12 pass
- [x] `sbt testOnly *SyncStateSchedulerSpec` — 9/9 pass
- [x] `sbt compile` — clean (pre-existing warnings only)
- [ ] Fast sync on Mordor to verify pivot election under low-peer conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)