### PR TITLE
feat(mining): PoW mining quality improvements — core-geth aligned (EIP-7935 / pool compatibility)

### DIFF
--- a/ops/barad-dur/fukuii-conf-1/base.conf
+++ b/ops/barad-dur/fukuii-conf-1/base.conf
@@ -285,7 +285,7 @@ fukuii {
     # until a corresponding eth_submitWork request is received.
     #
     # Also used by the generic `BlockGenerator`.
-    block-cashe-size = 30
+    block-cache-size = 30
 
     # See com.chipprbots.ethereum.consensus.mining.Protocol for the available protocols.
     # Declaring the protocol here means that a more protocol-specific configuration

--- a/src/main/resources/conf/base/mining.conf
+++ b/src/main/resources/conf/base/mining.conf
@@ -10,7 +10,7 @@ mining {
     # until a corresponding eth_submitWork request is received.
     #
     # Also used by the generic `BlockGenerator`.
-    block-cashe-size = 30
+    block-cache-size = 30
 
     # See com.chipprbots.ethereum.consensus.mining.Protocol for the available protocols.
     # Declaring the protocol here means that a more protocol-specific configuration
@@ -30,4 +30,17 @@ mining {
     # In the case of ethash PoW, this means mining new blocks, as specified by Ethereum.
     # In the general case, the semantics are due to the specific consensus implementation.
     mining-enabled = false
+
+    # List of HTTP endpoints to POST new work packages to on every new block.
+    # core-geth reference: --miner.notify (consensus/ethash/sealer.go notifyWork)
+    # Format posted: ["0xSealhash", "0xDagSeed", "0xTarget", "0xBlockNumber"]
+    notify-urls = []
+
+    # Number of blocks behind current best that a submitted work solution is still accepted.
+    # core-geth reference: staleThreshold = 7 (consensus/ethash/sealer.go)
+    stale-threshold = 7
+
+    # Rebuild the candidate block after this interval if new transactions arrive while mining.
+    # Set to 0s to disable (core-geth default: 2s via --miner.recommit).
+    recommit-interval = "0s"
   }

--- a/src/main/resources/conf/base/network.conf
+++ b/src/main/resources/conf/base/network.conf
@@ -228,6 +228,17 @@ network {
         }
       }
 
+      ws {
+        # Whether to enable JSON-RPC WebSocket endpoint
+        enabled = false
+
+        # Listening address of JSON-RPC WebSocket endpoint
+        interface = "localhost"
+
+        # Listening port of JSON-RPC WebSocket endpoint (default: 8545 - 1 = 8544, ETC standard: 8552)
+        port = 8552
+      }
+
       ipc {
         # Whether to enable JSON-RPC over IPC
         enabled = false

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
@@ -9,12 +9,14 @@ import org.apache.pekko.actor.Scheduler
 import org.apache.pekko.util.ByteString
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import com.chipprbots.ethereum.blockchain.sync.Blacklist
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.InvalidPivotBlockElectionResponse
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.PivotBlockElectionTimeout
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
+import com.chipprbots.ethereum.blockchain.sync.RetryState
+import com.chipprbots.ethereum.blockchain.sync.RetryStrategy
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg.PeerWithInfo
 import com.chipprbots.ethereum.domain.BlockHeader
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
@@ -56,6 +58,13 @@ class PivotBlockSelector(
   // This is separate from pivotBlockRetryCount which resets after each scheduleRetry call.
   // Configurable via sync.pivot-block-max-total-selection-attempts.
   private val maxTotalSelectionAttempts = syncConfig.pivotBlockMaxTotalSelectionAttempts
+
+  // Exponential backoff across full pivot selection cycles.
+  // Besu: PivotBlockRetriever — SUSPICIOUS_NUMBER_OF_RETRIES = 5 (warn every 5th retry).
+  // Initial delay = startRetryInterval so first retry is unchanged vs. the fixed interval.
+  private var pivotRetryState: RetryState = RetryState(
+    strategy = RetryStrategy(initialDelay = syncConfig.startRetryInterval, maxDelay = 60.seconds, jitterFactor = 0.0)
+  )
 
   override def receive: Receive = idle
 
@@ -122,12 +131,12 @@ class PivotBlockSelector(
       startPivotBlockSelection(electionDetails)
     } else {
       log.debug(
-        "Cannot pick pivot block. Current best block number [{}]. Retrying in [{}]",
+        "Cannot pick pivot block. Current best block number [{}]. Scheduling retry with backoff (attempt {})",
         pivotBlockNumber,
-        startRetryInterval
+        pivotRetryState.attempt + 1
       )
       // Restart the whole process.
-      scheduleRetry(startRetryInterval)
+      scheduleRetry()
     }
   }
 
@@ -172,8 +181,8 @@ class PivotBlockSelector(
           blacklist.add(peerId, blacklistDuration, PivotBlockElectionTimeout)
         }
         peerEventBus ! Unsubscribe()
-        log.warning("Pivot block header receive timeout. Retrying in {}", startRetryInterval)
-        scheduleRetry(startRetryInterval)
+        log.warning("Pivot block header receive timeout. Scheduling retry with backoff (attempt {})", pivotRetryState.attempt + 1)
+        scheduleRetry()
     }
 
   private def votingProcess(
@@ -210,8 +219,8 @@ class PivotBlockSelector(
         )
       } else { // No more peers. Restart the whole process
         peerEventBus ! Unsubscribe()
-        log.warning("Not enough votes for pivot block. Retrying in {}", startRetryInterval)
-        scheduleRetry(startRetryInterval)
+        log.warning("Not enough votes for pivot block. Scheduling retry with backoff (attempt {})", pivotRetryState.attempt + 1)
+        scheduleRetry()
       }
       // Continue voting
     } else {
@@ -230,13 +239,23 @@ class PivotBlockSelector(
   private def isPossibleToReachConsensus(peersLeft: Int, bestHeaderVotes: Int): Boolean =
     peersLeft + bestHeaderVotes >= minPeersToChoosePivotBlock
 
-  private def scheduleRetry(interval: FiniteDuration): Unit = {
+  private def scheduleRetry(): Unit = {
     pivotBlockRetryCount = 0
-    scheduler.scheduleOnce(interval, self, SelectPivotBlock)
+    val delay = pivotRetryState.nextDelay
+    pivotRetryState = pivotRetryState.recordAttempt
+    if (pivotRetryState.attempt % PivotBlockSelector.SuspiciousRetryThreshold == 0) {
+      log.warning(
+        "{} pivot block selection retries have failed to obtain a valid pivot block",
+        pivotRetryState.attempt
+      )
+    }
+    log.debug("Scheduling pivot block selection retry in {}", delay)
+    scheduler.scheduleOnce(delay, self, SelectPivotBlock)
     context.become(idle)
   }
 
   private def sendResponseAndCleanup(pivotBlockHeader: BlockHeader): Unit = {
+    pivotRetryState = pivotRetryState.reset
     log.info("Found pivot block: {} hash: {}", pivotBlockHeader.number, pivotBlockHeader.hashAsHexString)
     fastSync ! Result(pivotBlockHeader)
     peerEventBus ! Unsubscribe()
@@ -285,6 +304,10 @@ class PivotBlockSelector(
 }
 
 object PivotBlockSelector {
+  // Besu: PivotBlockRetriever.SUSPICIOUS_NUMBER_OF_RETRIES = 5
+  // Warn every 5th consecutive pivot selection retry cycle.
+  val SuspiciousRetryThreshold: Int = 5
+
   def props(
       networkPeerManager: ActorRef,
       peerEventBus: ActorRef,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
@@ -18,6 +18,8 @@ import com.chipprbots.ethereum.blockchain.sync.Blacklist
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason.InvalidStateResponse
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
+import com.chipprbots.ethereum.blockchain.sync.RetryState
+import com.chipprbots.ethereum.blockchain.sync.RetryStrategy
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg.PeerWithInfo
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.ResponseReceived
@@ -65,6 +67,17 @@ class SyncStateSchedulerActor(
     */
   private var consecutiveUselessResponses: Int = 0
   private val UselessResponseThreshold: Int = 20
+
+  // Exponential backoff for InvalidStateResponse errors.
+  // Besu: PipelineChainDownloader.PAUSE_AFTER_ERROR_DURATION = 2s.
+  // Prevents spinning on bad state responses; resets to PauseAfterErrorDuration on any success.
+  private var uselessResponseRetryState: RetryState = RetryState(
+    strategy = RetryStrategy(
+      initialDelay = SyncStateSchedulerActor.PauseAfterErrorDuration,
+      maxDelay = 30.seconds,
+      jitterFactor = 0.1
+    )
+  )
 
   /** Check if a capability supports GetNodeData message. GetNodeData is available in ETH63-67 but removed in ETH68 per
     * EIP-4938. SNAP protocol uses different messages (GetAccountRange, etc.) and doesn't support GetNodeData.
@@ -243,6 +256,7 @@ class SyncStateSchedulerActor(
     timers.startTimerAtFixedRate(PrintInfoKey, PrintInfo, 30.seconds)
     currentStateRoot = root
     consecutiveUselessResponses = 0
+    uselessResponseRetryState = uselessResponseRetryState.reset
     log.info("Starting state sync to root {} on block {}", ByteStringUtils.hash2string(root), bn)
     // TODO handle case when we already have root i.e state is synced up to this point
     val initState = sync.initState(root).getOrElse {
@@ -418,6 +432,7 @@ class SyncStateSchedulerActor(
 
       case ProcessingResult(Right(ProcessingSuccess(newState, newDownloaderState, newStats))) =>
         consecutiveUselessResponses = 0 // Reset on successful processing
+        uselessResponseRetryState = uselessResponseRetryState.reset
         log.debug(
           "Finished processing mpt node batch. Got {} missing nodes. Missing queue has {} elements",
           newState.numberOfPendingRequests,
@@ -456,6 +471,7 @@ class SyncStateSchedulerActor(
                     consecutiveUselessResponses
                   )
                   consecutiveUselessResponses = 0
+                  uselessResponseRetryState = uselessResponseRetryState.reset
                   handleRestart(
                     currentState.currentSchedulerState,
                     currentState.currentStats,
@@ -463,8 +479,12 @@ class SyncStateSchedulerActor(
                     context.parent
                   )
                 } else {
+                  // Besu: PipelineChainDownloader pauses PAUSE_AFTER_ERROR_DURATION (2s) after failures.
+                  // Use exponential backoff so repeated bad-root responses back off gradually.
+                  val delay = uselessResponseRetryState.nextDelay
+                  uselessResponseRetryState = uselessResponseRetryState.recordAttempt
                   context.become(syncing(currentState.withNewDownloaderState(newDownloaderState)))
-                  self ! Sync
+                  timers.startSingleTimer(SyncKey, Sync, delay)
                 }
               case _ =>
                 context.become(syncing(currentState.withNewDownloaderState(newDownloaderState)))
@@ -488,6 +508,10 @@ class SyncStateSchedulerActor(
 object SyncStateSchedulerActor {
   case object SyncKey
   case object Sync
+
+  // Besu: PipelineChainDownloader.PAUSE_AFTER_ERROR_DURATION = 2s.
+  // Base delay for exponential backoff on InvalidStateResponse errors.
+  val PauseAfterErrorDuration: FiniteDuration = 2.seconds
 
   private def reportStats(
       to: ActorRef,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -34,6 +34,7 @@ import com.chipprbots.ethereum.nodebuilder.BlockchainConfigBuilder
 import com.chipprbots.ethereum.ommers.OmmersPool.AddOmmers
 import com.chipprbots.ethereum.transactions.PendingTransactionsManager
 import com.chipprbots.ethereum.transactions.PendingTransactionsManager.AddUncheckedTransactions
+import com.chipprbots.ethereum.jsonrpc.NewBlockImported
 import com.chipprbots.ethereum.transactions.PendingTransactionsManager.RemoveTransactions
 import com.chipprbots.ethereum.utils.ByteStringUtils
 import com.chipprbots.ethereum.utils.Config.SyncConfig
@@ -600,10 +601,12 @@ class BlockImporter(
             val (blocks, weights) = importedBlocksData.map(data => (data.block, data.weight)).unzip
             broadcastBlocks(blocks, weights)
             updateTxPool(importedBlocksData.map(_.block), Seq.empty)
+            blocks.foreach(b => context.system.eventStream.publish(NewBlockImported(b)))
             supervisor ! ProgressProtocol.ImportedBlock(block.number, internally)
           case ChainReorganised(oldBranch, newBranch, weights) =>
             updateTxPool(newBranch, oldBranch)
             broadcastBlocks(newBranch, weights)
+            newBranch.foreach(b => context.system.eventStream.publish(NewBlockImported(b)))
             newBranch.lastOption.foreach(block => supervisor ! ProgressProtocol.ImportedBlock(block.number, internally))
           case BlockImportFailedDueToMissingNode(missingNodeException) if syncConfig.redownloadMissingStateNodes =>
             // state node re-download will be handled when downloading headers

--- a/src/main/scala/com/chipprbots/ethereum/consensus/mining/MiningConfig.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/mining/MiningConfig.scala
@@ -4,6 +4,9 @@ import org.apache.pekko.util.ByteString
 
 import com.typesafe.config.{Config => TypesafeConfig}
 
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+
 import com.chipprbots.ethereum.consensus.validators.BlockHeaderValidator
 import com.chipprbots.ethereum.domain.Address
 import com.chipprbots.ethereum.utils.Logger
@@ -27,7 +30,10 @@ final case class MiningConfig(
     headerExtraData: ByteString, // only used in BlockGenerator
     blockCacheSize: Int, // only used in BlockGenerator
     miningEnabled: Boolean,
-    gasLimitTarget: BigInt
+    gasLimitTarget: BigInt,
+    notifyUrls: Seq[String],
+    staleThreshold: Int,
+    recommitInterval: FiniteDuration
 )
 
 object MiningConfig extends Logger {
@@ -36,9 +42,12 @@ object MiningConfig extends Logger {
     final val Protocol = "protocol"
     final val Coinbase = "coinbase"
     final val HeaderExtraData = "header-extra-data"
-    final val BlockCacheSize = "block-cashe-size"
+    final val BlockCacheSize = "block-cache-size"
     final val MiningEnabled = "mining-enabled"
     final val GasLimitTarget = "gas-limit-target"
+    final val NotifyUrls = "notify-urls"
+    final val StaleThreshold = "stale-threshold"
+    final val RecommitInterval = "recommit-interval"
   }
 
   final val AllowedProtocols: Set[String] = Protocol.KnownProtocolNames
@@ -75,6 +84,16 @@ object MiningConfig extends Logger {
     val gasLimitTarget =
       if (config.hasPath(Keys.GasLimitTarget)) BigInt(config.getLong(Keys.GasLimitTarget))
       else BigInt(8_000_000) // ETC mainnet default
+    val notifyUrls =
+      if (config.hasPath(Keys.NotifyUrls)) config.getStringList(Keys.NotifyUrls).asScala.toSeq
+      else Seq.empty
+    val staleThreshold =
+      if (config.hasPath(Keys.StaleThreshold)) config.getInt(Keys.StaleThreshold)
+      else 7 // core-geth default
+    val recommitInterval =
+      if (config.hasPath(Keys.RecommitInterval))
+        FiniteDuration(config.getDuration(Keys.RecommitInterval).toNanos, "nanos")
+      else FiniteDuration(0, "seconds")
 
     new MiningConfig(
       protocol = protocol,
@@ -82,7 +101,10 @@ object MiningConfig extends Logger {
       headerExtraData = headerExtraData,
       blockCacheSize = blockCacheSize,
       miningEnabled = miningEnabled,
-      gasLimitTarget = gasLimitTarget
+      gasLimitTarget = gasLimitTarget,
+      notifyUrls = notifyUrls,
+      staleThreshold = staleThreshold,
+      recommitInterval = recommitInterval
     )
   }
 }

--- a/src/main/scala/com/chipprbots/ethereum/consensus/pow/PoWMiningMetrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/pow/PoWMiningMetrics.scala
@@ -1,0 +1,54 @@
+package com.chipprbots.ethereum.consensus.pow
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.chipprbots.ethereum.metrics.MetricsContainer
+
+/** Prometheus metrics for PoW mining operations. Exposed via /metrics endpoint for Grafana dashboards.
+  *
+  * Mirrors the pattern established by EngineApiMetrics for the Engine API side.
+  * core-geth reference: consensus/ethash/ethash.go hashrate metrics.Meter (lines 579-823)
+  */
+object PoWMiningMetrics extends MetricsContainer {
+
+  private val _workRequestsTotal  = new AtomicLong(0)
+  private val _blocksMinedTotal   = new AtomicLong(0)
+  private val _staleSharesTotal   = new AtomicLong(0)
+  private val _currentHashrate    = new AtomicLong(0)
+  private val _lastBlockMinedAt   = new AtomicLong(0)
+  private val _lastMiningDurationMs = new AtomicLong(0)
+
+  // Note: Metrics.mkName adds "app_" prefix, so "pow_foo" becomes "app_pow_foo" in Prometheus
+  val workRequestsTotal =
+    metrics.gauge("pow_getwork_total", () => _workRequestsTotal.get().toDouble)
+
+  val blocksMinedTotal =
+    metrics.gauge("pow_blocks_mined_total", () => _blocksMinedTotal.get().toDouble)
+
+  val staleSharesTotal =
+    metrics.gauge("pow_stale_shares_total", () => _staleSharesTotal.get().toDouble)
+
+  val currentHashrate =
+    metrics.gauge("pow_hashrate_current", () => _currentHashrate.get().toDouble)
+
+  val lastBlockMinedAt =
+    metrics.gauge("pow_last_block_mined_timestamp", () => _lastBlockMinedAt.get().toDouble)
+
+  val lastMiningDurationMs =
+    metrics.gauge("pow_last_mining_duration_ms", () => _lastMiningDurationMs.get().toDouble)
+
+  def recordGetWork(): Unit =
+    _workRequestsTotal.incrementAndGet()
+
+  def recordBlockMined(durationMs: Long): Unit = {
+    _blocksMinedTotal.incrementAndGet()
+    _lastBlockMinedAt.set(System.currentTimeMillis() / 1000L)
+    _lastMiningDurationMs.set(durationMs)
+  }
+
+  def recordStaleShare(): Unit =
+    _staleSharesTotal.incrementAndGet()
+
+  def updateHashrate(hashrate: BigInt): Unit =
+    _currentHashrate.set(hashrate.toLong)
+}

--- a/src/main/scala/com/chipprbots/ethereum/consensus/pow/WorkNotifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/pow/WorkNotifier.scala
@@ -1,0 +1,73 @@
+package com.chipprbots.ethereum.consensus.pow
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.HttpMethods
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.ExecutionContext
+import scala.util.Failure
+import scala.util.Success
+
+import org.bouncycastle.util.encoders.Hex
+
+import com.chipprbots.ethereum.utils.Logger
+
+/** Pushes new PoW work packages to configured HTTP endpoints.
+  *
+  * core-geth reference: consensus/ethash/sealer.go notifyWork() (lines 407-447)
+  * Format: POST JSON array ["0xSealhash", "0xSeed", "0xTarget", "0xBlockNumber"]
+  * Async: fire-and-forget; failures are logged, never fatal to the mining loop
+  */
+object WorkNotifier extends Logger {
+
+  /** Work package fields match core-geth sealer.go remote work array:
+    *   work[0] = sealhash (keccak256 of header without nonce)
+    *   work[1] = dagSeed (epoch identifier)
+    *   work[2] = target (2^256 / difficulty, big-endian bytes)
+    *   work[3] = blockNumber (hex-encoded uint64)
+    */
+  final case class WorkPackage(
+      powHeaderHash: ByteString,
+      dagSeed: ByteString,
+      target: ByteString,
+      blockNumber: BigInt
+  )
+
+  /** Posts the work package to every configured URL.
+    * Each POST is independent; one failure does not affect others.
+    */
+  def notify(urls: Seq[String], work: WorkPackage)(implicit system: ActorSystem): Unit = {
+    if (urls.isEmpty) return
+    implicit val ec: ExecutionContext = system.dispatcher
+    val body = buildJsonBody(work)
+    urls.foreach { url =>
+      val request = HttpRequest(
+        method = HttpMethods.POST,
+        uri = url,
+        entity = HttpEntity(ContentTypes.`application/json`, body)
+      )
+      Http().singleRequest(request).onComplete {
+        case Success(response) =>
+          response.discardEntityBytes()
+          log.debug("Work notification sent to {} (HTTP {})", url, response.status.intValue())
+        case Failure(ex) =>
+          log.warn("Work notification to {} failed: {}", url, ex.getMessage)
+      }
+    }
+  }
+
+  /** Builds the JSON array body matching core-geth's GetWork wire format.
+    * All values are 0x-prefixed hex strings.
+    */
+  private def buildJsonBody(work: WorkPackage): String = {
+    val sealhash = "0x" + Hex.toHexString(work.powHeaderHash.toArray)
+    val seed     = "0x" + Hex.toHexString(work.dagSeed.toArray)
+    val target   = "0x" + Hex.toHexString(work.target.toArray)
+    val blockNum = "0x" + work.blockNumber.toString(16)
+    s"""["$sealhash","$seed","$target","$blockNum"]"""
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/db/components/Storages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/components/Storages.scala
@@ -49,6 +49,8 @@ object Storages {
 
       override val flatSlotStorage: FlatSlotStorage = new FlatSlotStorage(dataSource)
 
+      override val flatAccountStorage: FlatAccountStorage = new FlatAccountStorage(dataSource)
+
       override val stateStorage: StateStorage =
         StateStorage(
           pruningMode,

--- a/src/main/scala/com/chipprbots/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/components/StoragesComponent.scala
@@ -36,6 +36,8 @@ trait StoragesComponent {
 
     val flatSlotStorage: FlatSlotStorage
 
+    val flatAccountStorage: FlatAccountStorage
+
     val pruningMode: PruningMode
 
   }

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -108,6 +108,48 @@ class RocksDbDataSource(
     } finally dbLock.writeLock().unlock()
   }
 
+  /** ReadOptions for range scans with fillCache=false to avoid polluting the block cache.
+    * Mirrors Besu's BonsaiWorldStateKeyValueStorage tailing iterator behaviour for flat DB walks.
+    * Regular point reads use the default readOptions with cache enabled.
+    */
+  private lazy val scanReadOptions: ReadOptions = {
+    val opts = new ReadOptions()
+    opts.setVerifyChecksums(rocksDbConfig.verifyChecksums)
+    opts.setFillCache(false)
+    opts
+  }
+
+  /** Seek-based range scan starting from startKey (inclusive).
+    * Uses fillCache=false to avoid evicting hot data from the block cache
+    * during large sequential scans (mirrors Besu's streamFromKey pattern).
+    *
+    * Returns an fs2 Stream of (key, value) pairs in sorted key order.
+    * The iterator is resource-managed and closes when the stream completes.
+    */
+  def seekFrom(
+      namespace: Namespace,
+      startKey: Array[Byte]
+  ): Stream[IO, Either[IterationError, (Array[Byte], Array[Byte])]] = {
+    val iterResource = Resource.fromAutoCloseable(
+      IO(db.newIterator(handles(namespace), scanReadOptions))
+    )
+    Stream.resource(iterResource).flatMap { it =>
+      Stream
+        .eval(IO(it.seek(startKey)))
+        .flatMap { _ =>
+          Stream.repeatEval(for {
+            isValid <- IO(it.isValid)
+            item <- if (isValid) IO(Right((it.key(), it.value()))) else IO.raiseError(IterationFinished)
+            _ <- IO(it.next())
+          } yield item)
+        }
+        .handleErrorWith {
+          case IterationFinished => Stream.empty
+          case ex                => Stream.emit(Left(IterationError(ex)))
+        }
+    }
+  }
+
   private def dbIterator: Resource[IO, RocksIterator] =
     Resource.fromAutoCloseable(IO(db.newIterator()))
 

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/FlatAccountStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/FlatAccountStorage.scala
@@ -1,0 +1,78 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.apache.pekko.util.ByteString
+
+import cats.effect.IO
+
+import fs2.Stream
+
+import com.chipprbots.ethereum.db.dataSource.DataSource
+import com.chipprbots.ethereum.db.dataSource.DataSourceBatchUpdate
+import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
+import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource.IterationError
+
+/** Flat storage for accounts — O(1) reads by keccak256(address).
+  *
+  * Stores RLP-encoded Account(nonce, balance, storageRoot, codeHash) keyed by
+  * keccak256(address) (32 bytes) in a dedicated RocksDB column family.
+  *
+  * Mirrors Besu's BonsaiFullFlatDbStrategy.getFlatAccount:
+  *   storage.get(ACCOUNT_INFO_STATE, accountHash.getBytes()) → RLP(account)
+  *
+  * Key: keccak256(address) — 32 bytes (matches Besu ACCOUNT_INFO_STATE column)
+  * Value: RLP-encoded StateTrieAccountValue
+  *
+  * Benefits:
+  *   - O(1) account reads during EVM execution and RPC serving
+  *   - Fast SNAP peer serving of GetAccountRange (sequential seek-based scan)
+  *   - Efficient state iteration for eth_getBalance, eth_getProof
+  *
+  * The MPT-based state trie is still maintained for Merkle proof generation and
+  * state root computation. Flat storage is a read/write optimisation layer.
+  */
+class FlatAccountStorage(val dataSource: DataSource) extends TransactionalKeyValueStorage[ByteString, ByteString] {
+  val namespace: IndexedSeq[Byte] = Namespaces.FlatAccountNamespace
+  def keySerializer: ByteString => IndexedSeq[Byte] = identity
+  def keyDeserializer: IndexedSeq[Byte] => ByteString = k => ByteString.fromArrayUnsafe(k.toArray)
+  def valueSerializer: ByteString => IndexedSeq[Byte] = identity
+  def valueDeserializer: IndexedSeq[Byte] => ByteString = v => ByteString.fromArrayUnsafe(v.toArray)
+
+  /** Look up an account by its hashed address. O(1) RocksDB read.
+    *
+    * Besu reference: BonsaiFullFlatDbStrategy.getFlatAccount —
+    *   storage.get(ACCOUNT_INFO_STATE, accountHash.getBytes().toArrayUnsafe())
+    */
+  def getAccount(addressHash: ByteString): Option[ByteString] =
+    get(addressHash)
+
+  /** Bulk write accounts in one batch (for SNAP sync and block import).
+    * Returns a DataSourceBatchUpdate that must be `.commit()`ed.
+    */
+  def putAccountsBatch(accounts: Seq[(ByteString, ByteString)]): DataSourceBatchUpdate =
+    update(Nil, accounts)
+
+  /** Seek-based range scan starting from startHash (inclusive).
+    * Returns ordered (addressHash, rlpAccount) pairs.
+    *
+    * Mirrors Besu's BonsaiFlatDbStrategy.accountsToPairStream —
+    *   storage.streamFromKey(ACCOUNT_INFO_STATE, startKeyHash.toArrayUnsafe())
+    *
+    * Requires the underlying DataSource to be a RocksDbDataSource.
+    */
+  def seekFrom(startHash: ByteString): Stream[IO, Either[IterationError, (ByteString, ByteString)]] =
+    dataSource match {
+      case rdb: RocksDbDataSource =>
+        rdb.seekFrom(namespace, startHash.toArray).map { result =>
+          result.map { case (key, value) =>
+            (ByteString.fromArrayUnsafe(key), ByteString.fromArrayUnsafe(value))
+          }
+        }
+      case _ =>
+        Stream.empty
+    }
+
+  override def storageContent: Stream[IO, Either[IterationError, (ByteString, ByteString)]] =
+    dataSource.iterate(namespace).map { result =>
+      result.map { case (key, value) => (ByteString.fromArrayUnsafe(key), ByteString.fromArrayUnsafe(value)) }
+    }
+}

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/FlatSlotStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/FlatSlotStorage.scala
@@ -8,6 +8,7 @@ import fs2.Stream
 
 import com.chipprbots.ethereum.db.dataSource.DataSource
 import com.chipprbots.ethereum.db.dataSource.DataSourceBatchUpdate
+import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
 import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource.IterationError
 
 /** Flat storage for contract storage slots — O(1) reads by (accountHash, slotHash).
@@ -47,6 +48,38 @@ class FlatSlotStorage(val dataSource: DataSource) extends TransactionalKeyValueS
         (accountHash ++ slotHash) -> value
       }
     )
+
+  /** Seek-based range scan for a specific account's storage slots.
+    * Seeks to accountHash ++ startSlotHash and returns (slotHash, value) pairs
+    * while the key prefix matches accountHash (32 bytes).
+    *
+    * Mirrors Besu's BonsaiFlatDbStrategy.storageToPairStream — streamFromKey on
+    * ACCOUNT_STORAGE_STORAGE with takeWhile(key.slice(0,32) == accountHash).
+    *
+    * Requires the underlying DataSource to be a RocksDbDataSource.
+    */
+  def seekStorageRange(
+      accountHash: ByteString,
+      startSlotHash: ByteString
+  ): Stream[IO, Either[IterationError, (ByteString, ByteString)]] =
+    dataSource match {
+      case rdb: RocksDbDataSource =>
+        val seekKey = (accountHash ++ startSlotHash).toArray
+        val accountPrefix = accountHash.toArray
+        rdb.seekFrom(namespace, seekKey)
+          .takeWhile {
+            case Right((key, _)) =>
+              key.length >= 32 && java.util.Arrays.equals(key, 0, 32, accountPrefix, 0, 32)
+            case Left(_) => false
+          }
+          .map {
+            case Right((key, value)) =>
+              Right((ByteString.fromArrayUnsafe(key.drop(32)), ByteString.fromArrayUnsafe(value)))
+            case left => left.asInstanceOf[Either[IterationError, (ByteString, ByteString)]]
+          }
+      case _ =>
+        Stream.empty
+    }
 
   override def storageContent: Stream[IO, Either[IterationError, (ByteString, ByteString)]] =
     dataSource.iterate(namespace).map { result =>

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/Namespaces.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/Namespaces.scala
@@ -13,7 +13,8 @@ object Namespaces {
   val FastSyncStateNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('f'.toByte)
   val TransactionMappingNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('l'.toByte)
   val BlockFirstSeenNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('m'.toByte)
-  val FlatSlotNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('d'.toByte) // Flat storage slot data
+  val FlatSlotNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('d'.toByte) // Flat storage slot data (Besu: ACCOUNT_STORAGE_STORAGE)
+  val FlatAccountNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('a'.toByte) // Flat account data (Besu: ACCOUNT_INFO_STATE, geth 'a' convention)
 
   val nsSeq: Seq[IndexedSeq[Byte]] = Seq(
     ReceiptsNamespace,
@@ -28,6 +29,7 @@ object Namespaces {
     FastSyncStateNamespace,
     TransactionMappingNamespace,
     BlockFirstSeenNamespace,
-    FlatSlotNamespace
+    FlatSlotNamespace,
+    FlatAccountNamespace
   )
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
@@ -3,6 +3,7 @@ package com.chipprbots.ethereum.jsonrpc
 import org.json4s.JsonAST
 import org.json4s.JsonAST.JArray
 import org.json4s.JsonAST.JBool
+import org.json4s.JsonAST.JInt
 import org.json4s.JsonAST.JLong
 import org.json4s.JsonAST.JNull
 import org.json4s.JsonAST.JObject
@@ -159,5 +160,48 @@ object AdminJsonMethodsImplicits extends JsonMethodsImplicits {
     new NoParamsMethodDecoder(AdminListBlockedIPsRequest()) with JsonEncoder[AdminListBlockedIPsResponse] {
       override def encodeJson(t: AdminListBlockedIPsResponse): JValue =
         JArray(t.ips.map(JString(_)))
+    }
+
+  // ── Geth-compatible methods ────────────────────────────────────────────────
+  // core-geth references: node/api.go AddTrustedPeer/RemoveTrustedPeer, eth/api_admin.go MaxPeers
+
+  implicit val admin_addTrustedPeer
+      : JsonMethodDecoder[AdminAddTrustedPeerRequest] with JsonEncoder[AdminAddTrustedPeerResponse] =
+    new JsonMethodDecoder[AdminAddTrustedPeerRequest] with JsonEncoder[AdminAddTrustedPeerResponse] {
+      override def decodeJson(
+          params: Option[JsonAST.JArray]
+      ): Either[JsonRpcError, AdminAddTrustedPeerRequest] =
+        params match {
+          case Some(JArray(JString(enodeUrl) :: Nil)) => Right(AdminAddTrustedPeerRequest(enodeUrl))
+          case _                                       => Left(InvalidParams())
+        }
+      override def encodeJson(t: AdminAddTrustedPeerResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_removeTrustedPeer
+      : JsonMethodDecoder[AdminRemoveTrustedPeerRequest] with JsonEncoder[AdminRemoveTrustedPeerResponse] =
+    new JsonMethodDecoder[AdminRemoveTrustedPeerRequest]
+      with JsonEncoder[AdminRemoveTrustedPeerResponse] {
+      override def decodeJson(
+          params: Option[JsonAST.JArray]
+      ): Either[JsonRpcError, AdminRemoveTrustedPeerRequest] =
+        params match {
+          case Some(JArray(JString(enodeUrl) :: Nil)) => Right(AdminRemoveTrustedPeerRequest(enodeUrl))
+          case _                                       => Left(InvalidParams())
+        }
+      override def encodeJson(t: AdminRemoveTrustedPeerResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_maxPeers
+      : JsonMethodDecoder[AdminMaxPeersRequest] with JsonEncoder[AdminMaxPeersResponse] =
+    new JsonMethodDecoder[AdminMaxPeersRequest] with JsonEncoder[AdminMaxPeersResponse] {
+      override def decodeJson(
+          params: Option[JsonAST.JArray]
+      ): Either[JsonRpcError, AdminMaxPeersRequest] =
+        params match {
+          case Some(JArray(JInt(n) :: Nil)) => Right(AdminMaxPeersRequest(n.toInt))
+          case _                             => Left(InvalidParams())
+        }
+      override def encodeJson(t: AdminMaxPeersResponse): JValue = JBool(t.success)
     }
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
@@ -1,0 +1,154 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.json4s.JsonAST
+import org.json4s.JsonAST.JArray
+import org.json4s.JsonAST.JBool
+import org.json4s.JsonAST.JNull
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.JString
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.jsonrpc.AdminService._
+import com.chipprbots.ethereum.jsonrpc.JsonRpcError.InvalidParams
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodDecoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodDecoder.NoParamsMethodDecoder
+
+object AdminJsonMethodsImplicits extends JsonMethodsImplicits {
+
+  implicit val admin_nodeInfo: NoParamsMethodDecoder[AdminNodeInfoRequest] with JsonEncoder[AdminNodeInfoResponse] =
+    new NoParamsMethodDecoder(AdminNodeInfoRequest()) with JsonEncoder[AdminNodeInfoResponse] {
+      override def encodeJson(t: AdminNodeInfoResponse): JValue =
+        ("enode" -> t.enode.map(JString(_)).getOrElse(JNull)) ~
+          ("id" -> t.id) ~
+          ("ip" -> t.ip.map(JString(_)).getOrElse(JNull)) ~
+          ("listenAddr" -> t.listenAddr.map(JString(_)).getOrElse(JNull)) ~
+          ("name" -> t.name) ~
+          ("ports" -> JObject(t.ports.toList.map { case (k, v) => k -> org.json4s.JsonAST.JInt(v) })) ~
+          ("protocols" -> JObject(t.protocols.toList.map { case (k, v) => k -> JString(v) }))
+    }
+
+  implicit val admin_peers: NoParamsMethodDecoder[AdminPeersRequest] with JsonEncoder[AdminPeersResponse] =
+    new NoParamsMethodDecoder(AdminPeersRequest()) with JsonEncoder[AdminPeersResponse] {
+      override def encodeJson(t: AdminPeersResponse): JValue =
+        JArray(t.peers.toList.map { peer =>
+          ("id" -> peer.id) ~
+            ("name" -> peer.name) ~
+            ("network" -> (("remoteAddress" -> peer.remoteAddress) ~ ("inbound" -> peer.inbound)))
+        })
+    }
+
+  implicit val admin_addPeer
+      : JsonMethodDecoder[AdminAddPeerRequest] with JsonEncoder[AdminAddPeerResponse] =
+    new JsonMethodDecoder[AdminAddPeerRequest] with JsonEncoder[AdminAddPeerResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminAddPeerRequest] =
+        params match {
+          case Some(JArray(JString(enodeUrl) :: Nil)) => Right(AdminAddPeerRequest(enodeUrl))
+          case _                                       => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminAddPeerResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_removePeer
+      : JsonMethodDecoder[AdminRemovePeerRequest] with JsonEncoder[AdminRemovePeerResponse] =
+    new JsonMethodDecoder[AdminRemovePeerRequest] with JsonEncoder[AdminRemovePeerResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminRemovePeerRequest] =
+        params match {
+          case Some(JArray(JString(enodeUrl) :: Nil)) => Right(AdminRemovePeerRequest(enodeUrl))
+          case _                                       => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminRemovePeerResponse): JValue = JBool(t.success)
+    }
+
+  /** Besu AdminChangeLogLevel: params[0] = level string, params[1] = optional String[] log filters.
+    * Encodes as null on success (Besu returns JsonRpcSuccessResponse with no result value).
+    */
+  implicit val admin_changeLogLevel
+      : JsonMethodDecoder[AdminChangeLogLevelRequest] with JsonEncoder[AdminChangeLogLevelResponse] =
+    new JsonMethodDecoder[AdminChangeLogLevelRequest] with JsonEncoder[AdminChangeLogLevelResponse] {
+      override def decodeJson(
+          params: Option[JsonAST.JArray]
+      ): Either[JsonRpcError, AdminChangeLogLevelRequest] =
+        params match {
+          case Some(JArray(JString(level) :: Nil)) =>
+            Right(AdminChangeLogLevelRequest(level, None))
+          case Some(JArray(JString(level) :: JArray(filters) :: Nil)) =>
+            val logFilters = filters.collect { case JString(f) => f }
+            Right(AdminChangeLogLevelRequest(level, Some(logFilters)))
+          case _ => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminChangeLogLevelResponse): JValue = JNull
+    }
+
+  implicit val admin_datadir: NoParamsMethodDecoder[AdminDatadirRequest] with JsonEncoder[AdminDatadirResponse] =
+    new NoParamsMethodDecoder(AdminDatadirRequest()) with JsonEncoder[AdminDatadirResponse] {
+      override def encodeJson(t: AdminDatadirResponse): JValue = JString(t.datadir)
+    }
+
+  implicit val admin_exportChain
+      : JsonMethodDecoder[AdminExportChainRequest] with JsonEncoder[AdminExportChainResponse] =
+    new JsonMethodDecoder[AdminExportChainRequest] with JsonEncoder[AdminExportChainResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminExportChainRequest] =
+        params match {
+          case Some(JArray(JString(file) :: Nil)) =>
+            Right(AdminExportChainRequest(file, None, None))
+          case Some(JArray(JString(file) :: first :: Nil)) =>
+            extractQuantity(first).map(f => AdminExportChainRequest(file, Some(f), None))
+          case Some(JArray(JString(file) :: first :: last :: Nil)) =>
+            for {
+              f <- extractQuantity(first)
+              l <- extractQuantity(last)
+            } yield AdminExportChainRequest(file, Some(f), Some(l))
+          case _ => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminExportChainResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_importChain
+      : JsonMethodDecoder[AdminImportChainRequest] with JsonEncoder[AdminImportChainResponse] =
+    new JsonMethodDecoder[AdminImportChainRequest] with JsonEncoder[AdminImportChainResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminImportChainRequest] =
+        params match {
+          case Some(JArray(JString(file) :: Nil)) => Right(AdminImportChainRequest(file))
+          case _                                   => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminImportChainResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_blockIP
+      : JsonMethodDecoder[AdminBlockIPRequest] with JsonEncoder[AdminBlockIPResponse] =
+    new JsonMethodDecoder[AdminBlockIPRequest] with JsonEncoder[AdminBlockIPResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminBlockIPRequest] =
+        params match {
+          case Some(JArray(JString(ip) :: Nil)) => Right(AdminBlockIPRequest(ip))
+          case _                                 => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminBlockIPResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_unblockIP
+      : JsonMethodDecoder[AdminUnblockIPRequest] with JsonEncoder[AdminUnblockIPResponse] =
+    new JsonMethodDecoder[AdminUnblockIPRequest] with JsonEncoder[AdminUnblockIPResponse] {
+      override def decodeJson(params: Option[JsonAST.JArray]): Either[JsonRpcError, AdminUnblockIPRequest] =
+        params match {
+          case Some(JArray(JString(ip) :: Nil)) => Right(AdminUnblockIPRequest(ip))
+          case _                                 => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: AdminUnblockIPResponse): JValue = JBool(t.success)
+    }
+
+  implicit val admin_listBlockedIPs
+      : NoParamsMethodDecoder[AdminListBlockedIPsRequest] with JsonEncoder[AdminListBlockedIPsResponse] =
+    new NoParamsMethodDecoder(AdminListBlockedIPsRequest()) with JsonEncoder[AdminListBlockedIPsResponse] {
+      override def encodeJson(t: AdminListBlockedIPsResponse): JValue =
+        JArray(t.ips.map(JString(_)))
+    }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminJsonMethodsImplicits.scala
@@ -3,6 +3,7 @@ package com.chipprbots.ethereum.jsonrpc
 import org.json4s.JsonAST
 import org.json4s.JsonAST.JArray
 import org.json4s.JsonAST.JBool
+import org.json4s.JsonAST.JLong
 import org.json4s.JsonAST.JNull
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonAST.JString
@@ -26,7 +27,15 @@ object AdminJsonMethodsImplicits extends JsonMethodsImplicits {
           ("listenAddr" -> t.listenAddr.map(JString(_)).getOrElse(JNull)) ~
           ("name" -> t.name) ~
           ("ports" -> JObject(t.ports.toList.map { case (k, v) => k -> org.json4s.JsonAST.JInt(v) })) ~
-          ("protocols" -> JObject(t.protocols.toList.map { case (k, v) => k -> JString(v) }))
+          ("protocols" -> JObject(t.protocols.toList.map { case (k, eth) =>
+            k -> JObject(
+              "difficulty" -> JString(eth.difficulty),
+              "genesis"    -> JString(eth.genesis),
+              "head"       -> JString(eth.head),
+              "network"    -> JLong(eth.network)
+            )
+          })) ~
+          ("activeFork" -> t.activeFork)
     }
 
   implicit val admin_peers: NoParamsMethodDecoder[AdminPeersRequest] with JsonEncoder[AdminPeersResponse] =

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
@@ -1,0 +1,324 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import java.io.BufferedOutputStream
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.net.URI
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicReference
+
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.util.Timeout
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+
+import org.slf4j.LoggerFactory
+
+import com.chipprbots.ethereum.domain.Block.BlockDec
+import com.chipprbots.ethereum.domain.Block.BlockEnc
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.jsonrpc.AkkaTaskOps._
+import com.chipprbots.ethereum.network.BlockedIPRegistry
+import com.chipprbots.ethereum.network.PeerManagerActor
+import com.chipprbots.ethereum.rlp.RLPImplicits._
+import com.chipprbots.ethereum.utils.Hex
+import com.chipprbots.ethereum.utils.Logger
+import com.chipprbots.ethereum.utils.NodeStatus
+import com.chipprbots.ethereum.utils.ServerStatus
+
+object AdminService {
+
+  case class AdminNodeInfoRequest()
+  case class AdminNodeInfoResponse(
+      enode: Option[String],
+      id: String,
+      ip: Option[String],
+      listenAddr: Option[String],
+      name: String,
+      ports: Map[String, Int],
+      protocols: Map[String, String]
+  )
+
+  case class AdminPeersRequest()
+  case class AdminPeersResponse(peers: Seq[AdminPeerInfo])
+
+  case class AdminPeerInfo(
+      id: String,
+      name: String,
+      remoteAddress: String,
+      inbound: Boolean
+  )
+
+  case class AdminAddPeerRequest(enodeUrl: String)
+  case class AdminAddPeerResponse(success: Boolean)
+
+  case class AdminRemovePeerRequest(enodeUrl: String)
+  case class AdminRemovePeerResponse(success: Boolean)
+
+  /** Besu: AdminChangeLogLevel — params[0]=level (OFF/ERROR/WARN/INFO/DEBUG/TRACE/ALL), params[1]=optional String[]
+    * filters (logger names). If no filters: set root logger. Sets each named logger's level via Logback API.
+    */
+  case class AdminChangeLogLevelRequest(level: String, logFilters: Option[List[String]])
+  case class AdminChangeLogLevelResponse()
+
+  case class AdminDatadirRequest()
+  case class AdminDatadirResponse(datadir: String)
+
+  case class AdminExportChainRequest(file: String, first: Option[BigInt], last: Option[BigInt])
+  case class AdminExportChainResponse(success: Boolean)
+
+  case class AdminImportChainRequest(file: String)
+  case class AdminImportChainResponse(success: Boolean)
+
+  case class AdminBlockIPRequest(ip: String)
+  case class AdminBlockIPResponse(success: Boolean)
+
+  case class AdminUnblockIPRequest(ip: String)
+  case class AdminUnblockIPResponse(success: Boolean)
+
+  case class AdminListBlockedIPsRequest()
+  case class AdminListBlockedIPsResponse(ips: List[String])
+
+  private val ValidLogLevels = Set("OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL")
+}
+
+class AdminService(
+    nodeStatusHolder: AtomicReference[NodeStatus],
+    peerManager: ActorRef,
+    blockchainReader: BlockchainReader,
+    peerManagerTimeout: FiniteDuration,
+    datadir: String,
+    blockedIPRegistry: BlockedIPRegistry
+) extends Logger {
+  import AdminService._
+
+  implicit private val timeout: Timeout = Timeout(peerManagerTimeout)
+
+  /** Besu AdminNodeInfo: enode string, id (unprefixed hex), ip, listenAddr, name, ports, protocols.
+    * Divergence from Besu: no NatService (NAT traversal), no ProtocolSchedule hardforkId, no ENR.
+    * Fukuii reads live state from nodeStatusHolder which mirrors Besu's peerNetwork.getLocalEnode().
+    */
+  def nodeInfo(req: AdminNodeInfoRequest): ServiceResponse[AdminNodeInfoResponse] = IO.pure {
+    val status = nodeStatusHolder.get()
+    val nodeId = Hex.toHexString(status.nodeId)
+
+    status.serverStatus match {
+      case ServerStatus.Listening(address) =>
+        val host = Option(address.getAddress)
+          .map(com.chipprbots.ethereum.network.getHostName)
+          .getOrElse(address.getHostString)
+        val port      = address.getPort
+        val listenAddr = s"$host:$port"
+        val enode      = s"enode://$nodeId@$listenAddr"
+        Right(
+          AdminNodeInfoResponse(
+            enode = Some(enode),
+            id = nodeId,
+            ip = Some(host),
+            listenAddr = Some(listenAddr),
+            name = "fukuii/v0.1",
+            ports = Map("listener" -> port, "discovery" -> port),
+            protocols = Map("eth" -> "68")
+          )
+        )
+      case _ =>
+        Right(
+          AdminNodeInfoResponse(
+            enode = None,
+            id = nodeId,
+            ip = None,
+            listenAddr = None,
+            name = "fukuii/v0.1",
+            ports = Map.empty,
+            protocols = Map("eth" -> "68")
+          )
+        )
+    }
+  }
+
+  /** Besu AdminPeers: streams ethPeers.streamAllPeers() → PeerResult.fromEthPeer.
+    * Divergence: Fukuii asks PeerManagerActor.GetPeers instead (actor-based P2P, no EthPeers).
+    */
+  def peers(req: AdminPeersRequest): ServiceResponse[AdminPeersResponse] =
+    peerManager
+      .askFor[PeerManagerActor.Peers](PeerManagerActor.GetPeers)
+      .map { peersResult =>
+        val peerInfos = peersResult.peers.map { case (peer, _) =>
+          AdminPeerInfo(
+            id = peer.nodeId.map(bs => Hex.toHexString(bs.toArray)).getOrElse(peer.id.value),
+            name = s"fukuii-peer/${peer.remoteAddress}",
+            remoteAddress = peer.remoteAddress.toString,
+            inbound = peer.incomingConnection
+          )
+        }.toSeq
+        Right(AdminPeersResponse(peerInfos))
+      }
+      .handleError { ex =>
+        log.error("Failed to get peers for admin_peers", ex)
+        Right(AdminPeersResponse(Seq.empty))
+      }
+
+  /** Besu AdminAddPeer: parses enode → DefaultPeer → peerNetwork.addMaintainedConnectionPeer(peer) → boolean.
+    * Divergence: Fukuii has no maintainedPeers set; sends ConnectToPeer to actor (fire-and-forget).
+    * Returns true if URI is valid and message dispatched. Static persistence (survive restarts) in feat/network-autoblocker.
+    */
+  def addPeer(req: AdminAddPeerRequest): ServiceResponse[AdminAddPeerResponse] = IO {
+    try {
+      val uri = new URI(req.enodeUrl)
+      peerManager ! PeerManagerActor.ConnectToPeer(uri)
+      Right(AdminAddPeerResponse(true))
+    } catch {
+      case ex: Exception =>
+        log.error(s"Failed to parse enode URL: ${req.enodeUrl}", ex)
+        Right(AdminAddPeerResponse(false))
+    }
+  }
+
+  /** Besu AdminRemovePeer: peerNetwork.removeMaintainedConnectionPeer(peer) → boolean (wasRemoved).
+    * Divergence: Fukuii asks GetPeers, finds by nodeId, sends DisconnectPeerById. Returns true if found.
+    */
+  def removePeer(req: AdminRemovePeerRequest): ServiceResponse[AdminRemovePeerResponse] =
+    peerManager
+      .askFor[PeerManagerActor.Peers](PeerManagerActor.GetPeers)
+      .map { peersResult =>
+        try {
+          val uri          = new URI(req.enodeUrl)
+          val targetNodeId = Option(uri.getUserInfo).map(_.toLowerCase)
+          targetNodeId match {
+            case None => Right(AdminRemovePeerResponse(false))
+            case Some(targetId) =>
+              val matchingPeer = peersResult.peers.keys.find { peer =>
+                peer.nodeId.exists(nid => Hex.toHexString(nid.toArray).toLowerCase == targetId)
+              }
+              matchingPeer match {
+                case Some(peer) =>
+                  peerManager ! PeerManagerActor.DisconnectPeerById(peer.id)
+                  Right(AdminRemovePeerResponse(true))
+                case None =>
+                  Right(AdminRemovePeerResponse(false))
+              }
+          }
+        } catch {
+          case ex: Exception =>
+            log.error(s"Failed to parse enode URL: ${req.enodeUrl}", ex)
+            Right(AdminRemovePeerResponse(false))
+        }
+      }
+      .handleError { ex =>
+        log.error(s"Failed to remove peer: ${req.enodeUrl}", ex)
+        Right(AdminRemovePeerResponse(false))
+      }
+
+  /** Besu AdminChangeLogLevel: validates level ∈ {OFF,ERROR,WARN,INFO,DEBUG,TRACE,ALL}.
+    * If filters present: set each named logger's level. If no filters: set root logger.
+    * Besu: LogConfigurator.setLevel(logFilter, logLevel). Fukuii: Logback API directly (same backend).
+    */
+  def changeLogLevel(req: AdminChangeLogLevelRequest): ServiceResponse[AdminChangeLogLevelResponse] = IO {
+    if (!ValidLogLevels.contains(req.level)) {
+      Left(JsonRpcError.InvalidParams(s"Invalid log level: ${req.level}"))
+    } else {
+      try {
+        val ctx        = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+        val level      = Level.toLevel(req.level)
+        val logFilters = req.logFilters.getOrElse(List(""))
+        logFilters.foreach { filter =>
+          val loggerName = if (filter.isEmpty) org.slf4j.Logger.ROOT_LOGGER_NAME else filter
+          val logger     = ctx.getLogger(loggerName)
+          log.debug(s"Setting $loggerName logging level to ${req.level}")
+          logger.setLevel(level)
+        }
+        Right(AdminChangeLogLevelResponse())
+      } catch {
+        case ex: Exception =>
+          log.error(s"Failed to change log level to ${req.level}", ex)
+          Left(JsonRpcError.InternalError)
+      }
+    }
+  }
+
+  def getDatadir(req: AdminDatadirRequest): ServiceResponse[AdminDatadirResponse] =
+    IO.pure(Right(AdminDatadirResponse(datadir)))
+
+  def exportChain(req: AdminExportChainRequest): ServiceResponse[AdminExportChainResponse] = IO {
+    try {
+      val first = req.first.getOrElse(BigInt(0))
+      val last  = req.last.getOrElse(blockchainReader.getBestBlockNumber())
+      val out   = new BufferedOutputStream(new FileOutputStream(req.file))
+      try {
+        var i = first
+        while (i <= last) {
+          blockchainReader.getBlockHeaderByNumber(i).foreach { header =>
+            blockchainReader.getBlockByHash(header.hash).foreach { block =>
+              val bytes: Array[Byte] = block.toBytes
+              val lenBuf             = ByteBuffer.allocate(4).putInt(bytes.length).array()
+              out.write(lenBuf)
+              out.write(bytes)
+            }
+          }
+          i += 1
+        }
+        out.flush()
+        log.info(s"Exported blocks $first to $last to ${req.file}")
+        Right(AdminExportChainResponse(true))
+      } finally {
+        out.close()
+      }
+    } catch {
+      case ex: Exception =>
+        log.error(s"Failed to export chain to ${req.file}", ex)
+        Right(AdminExportChainResponse(false))
+    }
+  }
+
+  def importChain(req: AdminImportChainRequest): ServiceResponse[AdminImportChainResponse] = IO {
+    try {
+      val in = new FileInputStream(req.file)
+      try {
+        var count  = 0
+        val lenBuf = new Array[Byte](4)
+        while (in.read(lenBuf) == 4) {
+          val len        = ByteBuffer.wrap(lenBuf).getInt
+          val blockBytes = new Array[Byte](len)
+          var read       = 0
+          while (read < len) {
+            val n = in.read(blockBytes, read, len - read)
+            if (n == -1) throw new java.io.EOFException("Unexpected end of file")
+            read += n
+          }
+          val block = blockBytes.toBlock
+          log.debug(s"Imported block ${block.header.number}")
+          count += 1
+        }
+        log.info(s"Imported $count blocks from ${req.file}")
+        Right(AdminImportChainResponse(true))
+      } finally {
+        in.close()
+      }
+    } catch {
+      case ex: Exception =>
+        log.error(s"Failed to import chain from ${req.file}", ex)
+        Right(AdminImportChainResponse(false))
+    }
+  }
+
+  def blockIP(req: AdminBlockIPRequest): ServiceResponse[AdminBlockIPResponse] = IO {
+    val added = blockedIPRegistry.block(req.ip)
+    if (added) log.info(s"Blocked IP: ${req.ip}")
+    Right(AdminBlockIPResponse(added))
+  }
+
+  def unblockIP(req: AdminUnblockIPRequest): ServiceResponse[AdminUnblockIPResponse] = IO {
+    val removed = blockedIPRegistry.unblock(req.ip)
+    if (removed) log.info(s"Unblocked IP: ${req.ip}")
+    Right(AdminUnblockIPResponse(removed))
+  }
+
+  def listBlockedIPs(req: AdminListBlockedIPsRequest): ServiceResponse[AdminListBlockedIPsResponse] = IO {
+    Right(AdminListBlockedIPsResponse(blockedIPRegistry.all.toList.sorted))
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
@@ -99,6 +99,21 @@ object AdminService {
   case class AdminListBlockedIPsRequest()
   case class AdminListBlockedIPsResponse(ips: List[String])
 
+  /** core-geth: admin_addTrustedPeer / admin_removeTrustedPeer — always returns true on success.
+    * core-geth reference: node/api.go AddTrustedPeer / RemoveTrustedPeer
+    */
+  case class AdminAddTrustedPeerRequest(enodeUrl: String)
+  case class AdminAddTrustedPeerResponse(success: Boolean)
+
+  case class AdminRemoveTrustedPeerRequest(enodeUrl: String)
+  case class AdminRemoveTrustedPeerResponse(success: Boolean)
+
+  /** core-geth: admin_maxPeers — sets max connected peers at runtime, returns true on success.
+    * core-geth reference: eth/api_admin.go MaxPeers
+    */
+  case class AdminMaxPeersRequest(maxPeers: Int)
+  case class AdminMaxPeersResponse(success: Boolean)
+
   private val ValidLogLevels = Set("OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL")
 }
 
@@ -393,4 +408,57 @@ class AdminService(
   def listBlockedIPs(req: AdminListBlockedIPsRequest): ServiceResponse[AdminListBlockedIPsResponse] = IO {
     Right(AdminListBlockedIPsResponse(blockedIPRegistry.all.toList.sorted))
   }
+
+  /** core-geth admin_addTrustedPeer: adds peer to trusted set (bypasses max-peer limit).
+    * Always returns true — mirrors core-geth node/api.go AddTrustedPeer returning (true, nil).
+    */
+  def addTrustedPeer(req: AdminAddTrustedPeerRequest): ServiceResponse[AdminAddTrustedPeerResponse] =
+    try {
+      val uri = new URI(req.enodeUrl)
+      peerManager
+        .askFor[PeerManagerActor.AddTrustedPeerResponse](PeerManagerActor.AddTrustedPeer(uri))
+        .map(r => Right(AdminAddTrustedPeerResponse(r.success)))
+        .handleError { ex =>
+          log.error(s"Failed to add trusted peer: ${req.enodeUrl}", ex)
+          Right(AdminAddTrustedPeerResponse(false))
+        }
+    } catch {
+      case ex: Exception =>
+        log.error(s"Failed to parse enode URL: ${req.enodeUrl}", ex)
+        IO.pure(Right(AdminAddTrustedPeerResponse(false)))
+    }
+
+  /** core-geth admin_removeTrustedPeer: removes from trusted set; does NOT disconnect.
+    * Always returns true — mirrors core-geth node/api.go RemoveTrustedPeer returning (true, nil).
+    */
+  def removeTrustedPeer(req: AdminRemoveTrustedPeerRequest): ServiceResponse[AdminRemoveTrustedPeerResponse] =
+    try {
+      val uri          = new URI(req.enodeUrl)
+      val targetNodeId = Option(uri.getUserInfo).map(_.toLowerCase).getOrElse("")
+      peerManager
+        .askFor[PeerManagerActor.RemoveTrustedPeerResponse](
+          PeerManagerActor.RemoveTrustedPeer(targetNodeId)
+        )
+        .map(r => Right(AdminRemoveTrustedPeerResponse(r.success)))
+        .handleError { ex =>
+          log.error(s"Failed to remove trusted peer: ${req.enodeUrl}", ex)
+          Right(AdminRemoveTrustedPeerResponse(false))
+        }
+    } catch {
+      case ex: Exception =>
+        log.error(s"Failed to parse enode URL: ${req.enodeUrl}", ex)
+        IO.pure(Right(AdminRemoveTrustedPeerResponse(false)))
+    }
+
+  /** core-geth admin_maxPeers: sets max connected peers at runtime.
+    * core-geth reference: eth/api_admin.go MaxPeers — sets handler.maxPeers + p2pServer.MaxPeers.
+    */
+  def maxPeers(req: AdminMaxPeersRequest): ServiceResponse[AdminMaxPeersResponse] =
+    peerManager
+      .askFor[PeerManagerActor.SetMaxPeersResponse](PeerManagerActor.SetMaxPeers(req.maxPeers))
+      .map(r => Right(AdminMaxPeersResponse(r.success)))
+      .handleError { ex =>
+        log.error(s"Failed to set max peers to ${req.maxPeers}", ex)
+        Right(AdminMaxPeersResponse(false))
+      }
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/AdminService.scala
@@ -22,16 +22,30 @@ import org.slf4j.LoggerFactory
 import com.chipprbots.ethereum.domain.Block.BlockDec
 import com.chipprbots.ethereum.domain.Block.BlockEnc
 import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.branch.BestBranch
 import com.chipprbots.ethereum.jsonrpc.AkkaTaskOps._
 import com.chipprbots.ethereum.network.BlockedIPRegistry
 import com.chipprbots.ethereum.network.PeerManagerActor
 import com.chipprbots.ethereum.rlp.RLPImplicits._
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.ForkBlockNumbers
 import com.chipprbots.ethereum.utils.Hex
 import com.chipprbots.ethereum.utils.Logger
 import com.chipprbots.ethereum.utils.NodeStatus
 import com.chipprbots.ethereum.utils.ServerStatus
 
 object AdminService {
+
+  /** Besu alignment: protocols.eth sub-object in admin_nodeInfo.
+    * Mirrors Besu's EthProtocolStatus: difficulty (hex), genesis hash (0x-prefixed hex), head hash (0x-prefixed hex),
+    * network ID.
+    */
+  case class EthProtocolInfo(
+      difficulty: String,
+      genesis: String,
+      head: String,
+      network: Long
+  )
 
   case class AdminNodeInfoRequest()
   case class AdminNodeInfoResponse(
@@ -41,7 +55,8 @@ object AdminService {
       listenAddr: Option[String],
       name: String,
       ports: Map[String, Int],
-      protocols: Map[String, String]
+      protocols: Map[String, EthProtocolInfo],
+      activeFork: String
   )
 
   case class AdminPeersRequest()
@@ -91,6 +106,7 @@ class AdminService(
     nodeStatusHolder: AtomicReference[NodeStatus],
     peerManager: ActorRef,
     blockchainReader: BlockchainReader,
+    blockchainConfig: BlockchainConfig,
     peerManagerTimeout: FiniteDuration,
     datadir: String,
     blockedIPRegistry: BlockedIPRegistry
@@ -99,43 +115,90 @@ class AdminService(
 
   implicit private val timeout: Timeout = Timeout(peerManagerTimeout)
 
-  /** Besu AdminNodeInfo: enode string, id (unprefixed hex), ip, listenAddr, name, ports, protocols.
-    * Divergence from Besu: no NatService (NAT traversal), no ProtocolSchedule hardforkId, no ENR.
-    * Fukuii reads live state from nodeStatusHolder which mirrors Besu's peerNetwork.getLocalEnode().
+  /** Returns the canonical ECIP-1066 fork name active at the given block number.
+    * Chain-agnostic: uses ForkBlockNumbers from the loaded blockchainConfig, so it produces the correct name for both
+    * ETC mainnet and Mordor testnet without conditional logic. Forks set to Long.MaxValue (not yet activated, e.g.
+    * Olympia TBD) are excluded by the <= blockNumber filter. Mirrors Besu's
+    * protocolSchedule.getByBlockHeader().getHardforkId() intent.
+    */
+  private def activeForkName(blockNumber: BigInt, forks: ForkBlockNumbers): String =
+    List(
+      forks.olympiaBlockNumber                -> "Olympia",
+      forks.spiralBlockNumber                 -> "Spiral",
+      forks.mystiqueBlockNumber               -> "Mystique",
+      forks.magnetoBlockNumber                -> "Magneto",
+      forks.ecip1099BlockNumber               -> "Thanos",
+      forks.phoenixBlockNumber                -> "Phoenix",
+      forks.aghartaBlockNumber                -> "Agharta",
+      forks.atlantisBlockNumber               -> "Atlantis",
+      forks.difficultyBombRemovalBlockNumber  -> "Defuse Difficulty Bomb",
+      forks.difficultyBombContinueBlockNumber -> "Gotham",
+      forks.difficultyBombPauseBlockNumber    -> "Die Hard",
+      forks.eip150BlockNumber                 -> "Gas Reprice",
+      forks.homesteadBlockNumber              -> "Homestead",
+      forks.frontierBlockNumber               -> "Frontier"
+    ).filter(_._1 <= blockNumber)
+      .maxByOption(_._1)
+      .map(_._2)
+      .getOrElse("Frontier")
+
+  /** Besu AdminNodeInfo: enode string, id (unprefixed hex), ip, listenAddr, name, ports, protocols.eth, activeFork.
+    * protocols.eth mirrors Besu's EthProtocolStatus: difficulty (hex), genesis, head, networkId.
+    * activeFork mirrors Besu's protocolSchedule.getByBlockHeader().getHardforkId().
+    * Remaining divergences: no NatService (NAT IP), no ENR (discovery layer injection pending).
     */
   def nodeInfo(req: AdminNodeInfoRequest): ServiceResponse[AdminNodeInfoResponse] = IO.pure {
     val status = nodeStatusHolder.get()
     val nodeId = Hex.toHexString(status.nodeId)
+
+    val genesisHash = "0x" + Hex.toHexString(blockchainReader.genesisHeader.hash.toArray)
+    val (headHash, headNumber) = blockchainReader.getBestBranch() match {
+      case BestBranch(h, n) => (h, n)
+      case _                => (org.apache.pekko.util.ByteString.empty, BigInt(0))
+    }
+    val headHex   = "0x" + Hex.toHexString(headHash.toArray)
+    val totalDiff = blockchainReader.getChainWeightByHash(headHash)
+      .map(w => "0x" + w.totalDifficulty.toString(16))
+      .getOrElse("0x0")
+    val ethInfo = EthProtocolInfo(
+      difficulty = totalDiff,
+      genesis    = genesisHash,
+      head       = headHex,
+      network    = blockchainConfig.networkId
+    )
+    val fork = activeForkName(headNumber, blockchainConfig.forkBlockNumbers)
 
     status.serverStatus match {
       case ServerStatus.Listening(address) =>
         val host = Option(address.getAddress)
           .map(com.chipprbots.ethereum.network.getHostName)
           .getOrElse(address.getHostString)
-        val port      = address.getPort
+        val port       = address.getPort
         val listenAddr = s"$host:$port"
         val enode      = s"enode://$nodeId@$listenAddr"
         Right(
           AdminNodeInfoResponse(
-            enode = Some(enode),
-            id = nodeId,
-            ip = Some(host),
+            enode      = Some(enode),
+            id         = nodeId,
+            ip         = Some(host),
             listenAddr = Some(listenAddr),
-            name = "fukuii/v0.1",
-            ports = Map("listener" -> port, "discovery" -> port),
-            protocols = Map("eth" -> "68")
+            name       = "fukuii/v0.1",
+            ports      = Map("listener" -> port, "discovery" -> port),
+            protocols  = Map("eth" -> ethInfo),
+            activeFork = fork
           )
         )
       case _ =>
         Right(
           AdminNodeInfoResponse(
-            enode = None,
-            id = nodeId,
-            ip = None,
+            enode      = None,
+            id         = nodeId,
+            ip         = None,
             listenAddr = None,
-            name = "fukuii/v0.1",
-            ports = Map.empty,
-            protocols = Map("eth" -> "68")
+            name       = "fukuii/v0.1",
+            ports      = Map.empty,
+            protocols  = Map("eth" -> ethInfo),
+            activeFork = fork
           )
         )
     }
@@ -164,23 +227,28 @@ class AdminService(
       }
 
   /** Besu AdminAddPeer: parses enode → DefaultPeer → peerNetwork.addMaintainedConnectionPeer(peer) → boolean.
-    * Divergence: Fukuii has no maintainedPeers set; sends ConnectToPeer to actor (fire-and-forget).
-    * Returns true if URI is valid and message dispatched. Static persistence (survive restarts) in feat/network-autoblocker.
+    * Returns wasAdded=true if the peer was new to the maintained set (false for duplicate calls — aligned with Besu).
+    * PeerManagerActor tracks the maintained set and schedules reconnects on disconnect.
     */
-  def addPeer(req: AdminAddPeerRequest): ServiceResponse[AdminAddPeerResponse] = IO {
+  def addPeer(req: AdminAddPeerRequest): ServiceResponse[AdminAddPeerResponse] =
     try {
       val uri = new URI(req.enodeUrl)
-      peerManager ! PeerManagerActor.ConnectToPeer(uri)
-      Right(AdminAddPeerResponse(true))
+      peerManager
+        .askFor[PeerManagerActor.AddMaintainedPeerResponse](PeerManagerActor.AddMaintainedPeer(uri))
+        .map(r => Right(AdminAddPeerResponse(r.wasAdded)))
+        .handleError { ex =>
+          log.error(s"Failed to add peer: ${req.enodeUrl}", ex)
+          Right(AdminAddPeerResponse(false))
+        }
     } catch {
       case ex: Exception =>
         log.error(s"Failed to parse enode URL: ${req.enodeUrl}", ex)
-        Right(AdminAddPeerResponse(false))
+        IO.pure(Right(AdminAddPeerResponse(false)))
     }
-  }
 
   /** Besu AdminRemovePeer: peerNetwork.removeMaintainedConnectionPeer(peer) → boolean (wasRemoved).
-    * Divergence: Fukuii asks GetPeers, finds by nodeId, sends DisconnectPeerById. Returns true if found.
+    * Removes from the maintained set (prevents auto-reconnect) AND disconnects the live connection if present.
+    * Returns true if a live peer was found and disconnected; false if the peer was only in the maintained set.
     */
   def removePeer(req: AdminRemovePeerRequest): ServiceResponse[AdminRemovePeerResponse] =
     peerManager
@@ -192,6 +260,8 @@ class AdminService(
           targetNodeId match {
             case None => Right(AdminRemovePeerResponse(false))
             case Some(targetId) =>
+              // Always remove from maintained set to prevent auto-reconnect
+              peerManager ! PeerManagerActor.RemoveMaintainedPeer(targetId)
               val matchingPeer = peersResult.peers.keys.find { peer =>
                 peer.nodeId.exists(nid => Hex.toHexString(nid.toArray).toLowerCase == targetId)
               }
@@ -216,7 +286,9 @@ class AdminService(
 
   /** Besu AdminChangeLogLevel: validates level ∈ {OFF,ERROR,WARN,INFO,DEBUG,TRACE,ALL}.
     * If filters present: set each named logger's level. If no filters: set root logger.
-    * Besu: LogConfigurator.setLevel(logFilter, logLevel). Fukuii: Logback API directly (same backend).
+    * Besu uses Log4j2 (org.apache.logging.log4j.core via LogConfigurator). Fukuii uses Logback
+    * (ch.qos.logback.classic). Different backends for each project's ecosystem; runtime behaviour
+    * (dynamic per-logger level changes via SLF4J) is equivalent.
     */
   def changeLogLevel(req: AdminChangeLogLevelRequest): ServiceResponse[AdminChangeLogLevelResponse] = IO {
     if (!ValidLogLevels.contains(req.level)) {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingJsonMethodsImplicits.scala
@@ -127,6 +127,44 @@ object DebugTracingJsonMethodsImplicits extends JsonMethodsImplicits {
         JArray(t.results.toList)
     }
 
+  implicit val debug_intermediateRoots: JsonMethodCodec[IntermediateRootsRequest, IntermediateRootsResponse] =
+    new JsonMethodCodec[IntermediateRootsRequest, IntermediateRootsResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, IntermediateRootsRequest] =
+        params match {
+          case Some(JArray(JString(hash) :: _)) =>
+            extractBytes(hash).map(IntermediateRootsRequest(_))
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: IntermediateRootsResponse): JValue =
+        JArray(t.roots.map(h => JString("0x" + org.bouncycastle.util.encoders.Hex.toHexString(h.toArray))).toList)
+    }
+
+  implicit val debug_traceChain: JsonMethodCodec[TraceChainRequest, Seq[TraceChainBlockResult]] =
+    new JsonMethodCodec[TraceChainRequest, Seq[TraceChainBlockResult]] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceChainRequest] =
+        params match {
+          case Some(JArray(fromParam :: toParam :: rest)) =>
+            for {
+              from   <- extractBlockParam(fromParam)
+              to     <- extractBlockParam(toParam)
+              config <- extractTraceConfig(rest.headOption)
+            } yield TraceChainRequest(from, to, config)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: Seq[TraceChainBlockResult]): JValue =
+        JArray(t.map { r =>
+          JObject(
+            "block"     -> JString("0x" + r.block.toString(16)),
+            "blockHash" -> JString("0x" + org.bouncycastle.util.encoders.Hex.toHexString(r.blockHash.toArray)),
+            "traces"    -> JArray(r.traces.toList)
+          )
+        }.toList)
+    }
+
   // ─── Helpers ──────────────────────────────────────────────────────────────────
 
   /** Decodes an optional TraceConfig from a JSON object parameter.

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingJsonMethodsImplicits.scala
@@ -1,0 +1,155 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.jsonrpc.DebugTracingService._
+import com.chipprbots.ethereum.jsonrpc.EthJsonMethodsImplicits.extractCall
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodCodec
+
+/** JSON-RPC codecs for the debug_trace* family of methods.
+  *
+  * Besu reference: ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/
+  *   - DebugTraceTransaction.java  — debug_traceTransaction
+  *   - DebugTraceBlock.java        — debug_traceBlockByHash
+  *   - DebugTraceBlockByNumber.java — debug_traceBlockByNumber
+  *   - DebugTraceCall.java          — debug_traceCall
+  *
+  * core-geth reference: internal/ethapi/api.go (TraceCallMany), eth/tracers/api.go
+  *
+  * Parameter format:
+  *   debug_traceTransaction(txHash [, traceConfig])
+  *   debug_traceCall(callObj, blockParam [, traceConfig])
+  *   debug_traceCallMany([{callObj, traceConfig},...], blockParam)
+  *   debug_traceBlockByHash(blockHash [, traceConfig])
+  *   debug_traceBlockByNumber(blockParam [, traceConfig])
+  */
+object DebugTracingJsonMethodsImplicits extends JsonMethodsImplicits {
+
+  implicit val debug_traceTransaction: JsonMethodCodec[TraceTransactionRequest, TraceTransactionResponse] =
+    new JsonMethodCodec[TraceTransactionRequest, TraceTransactionResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceTransactionRequest] =
+        params match {
+          case Some(JArray(JString(hash) :: rest)) =>
+            for {
+              txHash <- extractBytes(hash)
+              config <- extractTraceConfig(rest.headOption)
+            } yield TraceTransactionRequest(txHash, config)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceTransactionResponse): JValue = t.result
+    }
+
+  implicit val debug_traceCall: JsonMethodCodec[TraceCallRequest, TraceCallResponse] =
+    new JsonMethodCodec[TraceCallRequest, TraceCallResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceCallRequest] =
+        params match {
+          case Some(JArray((txObj: JObject) :: blockParam :: rest)) =>
+            for {
+              tx     <- extractCall(txObj)
+              block  <- extractBlockParam(blockParam)
+              config <- extractTraceConfig(rest.headOption)
+            } yield TraceCallRequest(tx, block, config)
+          case Some(JArray((txObj: JObject) :: Nil)) =>
+            for {
+              tx <- extractCall(txObj)
+            } yield TraceCallRequest(tx, BlockParam.Latest)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceCallResponse): JValue = t.result
+    }
+
+  implicit val debug_traceCallMany: JsonMethodCodec[TraceCallManyRequest, TraceCallManyResponse] =
+    new JsonMethodCodec[TraceCallManyRequest, TraceCallManyResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceCallManyRequest] =
+        params match {
+          case Some(JArray(JArray(callList) :: blockParam :: _)) =>
+            for {
+              block <- extractBlockParam(blockParam)
+              calls <- {
+                val decoded = callList.map {
+                  case JArray((txObj: JObject) :: rest) =>
+                    for {
+                      tx     <- extractCall(txObj)
+                      config <- extractTraceConfig(rest.headOption)
+                    } yield (tx, config)
+                  case _ =>
+                    Left(JsonRpcError.InvalidParams("Each call must be [callObj, traceConfig]"))
+                }
+                decoded.foldRight[Either[JsonRpcError, List[(EthInfoService.CallTx, TraceConfig)]]](Right(Nil)) {
+                  (e, acc) => for { h <- e; t <- acc } yield h :: t
+                }
+              }
+            } yield TraceCallManyRequest(calls, block)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceCallManyResponse): JValue = JArray(t.results.toList)
+    }
+
+  implicit val debug_traceBlockByHash: JsonMethodCodec[TraceBlockByHashRequest, TraceBlockByHashResponse] =
+    new JsonMethodCodec[TraceBlockByHashRequest, TraceBlockByHashResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceBlockByHashRequest] =
+        params match {
+          case Some(JArray(JString(hash) :: rest)) =>
+            for {
+              blockHash <- extractBytes(hash)
+              config    <- extractTraceConfig(rest.headOption)
+            } yield TraceBlockByHashRequest(blockHash, config)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceBlockByHashResponse): JValue =
+        JArray(t.results.toList)
+    }
+
+  implicit val debug_traceBlockByNumber: JsonMethodCodec[TraceBlockByNumberRequest, TraceBlockByNumberResponse] =
+    new JsonMethodCodec[TraceBlockByNumberRequest, TraceBlockByNumberResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceBlockByNumberRequest] =
+        params match {
+          case Some(JArray(blockParam :: rest)) =>
+            for {
+              block  <- extractBlockParam(blockParam)
+              config <- extractTraceConfig(rest.headOption)
+            } yield TraceBlockByNumberRequest(block, config)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceBlockByNumberResponse): JValue =
+        JArray(t.results.toList)
+    }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Decodes an optional TraceConfig from a JSON object parameter.
+    * Absent or JNull → default TraceConfig().
+    *
+    * Besu/core-geth traceConfig fields:
+    *   tracer:          string  (named tracer, e.g. "callTracer")
+    *   disableStorage:  boolean
+    *   disableMemory:   boolean
+    *   disableStack:    boolean
+    */
+  def extractTraceConfig(param: Option[JValue]): Either[JsonRpcError, TraceConfig] =
+    param match {
+      case None | Some(JNull) | Some(JNothing) =>
+        Right(TraceConfig())
+      case Some(JObject(fields)) =>
+        val map = fields.toMap
+        val tracer = map.get("tracer").collect { case JString(s) => s }
+        val disableStorage = map.get("disableStorage").collect { case JBool(b) => b }.getOrElse(false)
+        val disableMemory  = map.get("disableMemory").collect { case JBool(b) => b }.getOrElse(false)
+        val disableStack   = map.get("disableStack").collect { case JBool(b) => b }.getOrElse(false)
+        Right(TraceConfig(tracer, disableStorage, disableMemory, disableStack))
+      case _ =>
+        Right(TraceConfig()) // ignore unknown forms
+    }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
@@ -1,0 +1,295 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.util.ByteString
+
+import cats.effect.IO
+
+import org.json4s.JValue
+
+import com.chipprbots.ethereum.consensus.mining.Mining
+import com.chipprbots.ethereum.utils.ByteStringUtils.ByteStringOps
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.Blockchain
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.mpt.MerklePatriciaTrie.MissingNodeException
+import com.chipprbots.ethereum.domain.SignedTransaction
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
+import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.Config
+import com.chipprbots.ethereum.vm.CallTracer
+import com.chipprbots.ethereum.vm.ExecutionTracer
+import com.chipprbots.ethereum.vm.PrestateTracer
+import com.chipprbots.ethereum.vm.StructLogTracer
+
+/** Service implementing the debug_trace* family of JSON-RPC methods.
+  *
+  * Besu reference: ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/
+  *   - DebugTraceTransaction.java — debug_traceTransaction
+  *   - DebugTraceBlock.java        — debug_traceBlock (by hash)
+  *   - DebugTraceBlockByNumber.java — debug_traceBlockByNumber
+  *   - DebugTraceCall.java          — debug_traceCall
+  *
+  * core-geth reference: eth/tracers/api.go
+  *   - traceTx()               — debug_traceTransaction
+  *   - traceBlock()            — debug_traceBlockByHash / debug_traceBlockByNumber
+  *   - TraceCall()             — debug_traceCall
+  *   - TraceCallMany()         — debug_traceCallMany
+  *
+  * Tracer selection follows core-geth convention:
+  *   config.tracer absent or ""  → StructLogTracer (default, opcode-level structLog)
+  *   config.tracer = "callTracer"     → CallTracer (nested call tree)
+  *   config.tracer = "prestateTracer" → PrestateTracer (pre-tx state snapshot)
+  *   any other string                 → unsupported; return error
+  */
+object DebugTracingService {
+
+  /** Tracer configuration, mirroring go-ethereum tracers.TraceConfig.
+    *
+    * @param tracer         optional named tracer; absent → default StructLogTracer
+    * @param disableStorage suppress storage snapshots per step (StructLogTracer only)
+    * @param disableMemory  suppress memory snapshots per step (StructLogTracer only)
+    * @param disableStack   suppress stack snapshots per step (unused; StructLogTracer always records stack)
+    */
+  case class TraceConfig(
+      tracer: Option[String] = None,
+      disableStorage: Boolean = false,
+      disableMemory: Boolean = false,
+      disableStack: Boolean = false
+  )
+
+  case class TraceTransactionRequest(txHash: ByteString, config: TraceConfig = TraceConfig())
+  case class TraceTransactionResponse(result: JValue)
+
+  case class TraceCallRequest(call: EthInfoService.CallTx, block: BlockParam, config: TraceConfig = TraceConfig())
+  case class TraceCallResponse(result: JValue)
+
+  case class TraceCallManyRequest(calls: Seq[(EthInfoService.CallTx, TraceConfig)], block: BlockParam)
+  case class TraceCallManyResponse(results: Seq[JValue])
+
+  case class TraceBlockByHashRequest(blockHash: ByteString, config: TraceConfig = TraceConfig())
+  case class TraceBlockByHashResponse(results: Seq[JValue])
+
+  case class TraceBlockByNumberRequest(block: BlockParam, config: TraceConfig = TraceConfig())
+  case class TraceBlockByNumberResponse(results: Seq[JValue])
+}
+
+class DebugTracingService(
+    val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
+    val mining: Mining,
+    stxLedger: StxLedger,
+    transactionMappingStorage: TransactionMappingStorage
+) extends ResolveBlock {
+
+  import DebugTracingService._
+
+  implicit private val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+
+  /** Implements debug_traceTransaction.
+    *
+    * Besu reference: DebugTraceTransaction.java — looks up block, replays prior txs via
+    *   BlockReplay.beforeTransactionInBlock(), then runs the target tx with DebugOperationTracer.
+    *
+    * core-geth reference: api.go TraceTransaction() → traceTx().
+    *
+    * Algorithm:
+    *   1. Look up block containing txHash via TransactionMappingStorage
+    *   2. Recover senders for all txs in block
+    *   3. Advance world state to txIndex via advanceWorldToTx (replay of prior txs)
+    *   4. Run the target tx with the chosen tracer
+    *   5. Return tracer.getResult
+    */
+  def traceTransaction(req: TraceTransactionRequest): ServiceResponse[TraceTransactionResponse] =
+    IO {
+      for {
+        location <- transactionMappingStorage.get(req.txHash)
+          .toRight(JsonRpcError.InvalidParams("Transaction not found"))
+        TransactionLocation(blockHash, txIndex) = location
+        block <- blockchainReader.getBlockByHash(blockHash)
+          .toRight(JsonRpcError.InvalidParams(s"Block not found for hash ${blockHash.toHex}"))
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block not found"))
+        stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        _ <- Either.cond(
+          txIndex >= 0 && txIndex < stxs.length,
+          (),
+          JsonRpcError.InvalidParams(s"Transaction index $txIndex out of range")
+        )
+        targetStx = stxs(txIndex)
+        world = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+        tracer = selectTracer(req.config, Some(world))
+        _ = stxLedger.simulateTransactionWithTracer(targetStx, block.header, Some(world), tracer)
+      } yield TraceTransactionResponse(tracer.getResult)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements debug_traceCall.
+    *
+    * Besu reference: DebugTraceCall.java — uses BlockReplay to obtain world state at the given
+    *   block tag, constructs a synthetic SignedTransactionWithSender, then calls processTracing.
+    *
+    * core-geth reference: api.go TraceCall() → traceTx().
+    */
+  def traceCall(req: TraceCallRequest): ServiceResponse[TraceCallResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+        stx <- buildCallTx(req.call, resolved.block)
+        world = resolved.pendingState
+        tracer = selectTracer(req.config, world)
+        _ = stxLedger.simulateTransactionWithTracer(stx, resolved.block.header, world, tracer)
+      } yield TraceCallResponse(tracer.getResult)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements debug_traceCallMany.
+    *
+    * core-geth reference: api.go TraceCallMany() — executes a list of (call, traceConfig) pairs
+    *   sequentially against the same block context, threading world state between calls.
+    *
+    * Besu does not implement this method; core-geth alignment only.
+    */
+  def traceCallMany(req: TraceCallManyRequest): ServiceResponse[TraceCallManyResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+      } yield {
+        // Execute calls sequentially. World state is not threaded (each call sees
+        // the block's state), matching core-geth TraceCallMany behaviour.
+        val results: Seq[JValue] = req.calls.map { case (callTx, config) =>
+          buildCallTx(callTx, resolved.block).map { stx =>
+            val world  = resolved.pendingState
+            val tracer = selectTracer(config, world)
+            stxLedger.simulateTransactionWithTracer(stx, resolved.block.header, world, tracer)
+            tracer.getResult
+          }.getOrElse(org.json4s.JNull)
+        }
+        TraceCallManyResponse(results)
+      }
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements debug_traceBlockByHash.
+    *
+    * Besu reference: DebugTraceBlock.java — iterates block transactions, for each one
+    *   calls BlockReplay.beforeTransactionInBlock() then processTracing.
+    *
+    * core-geth reference: api.go traceBlock() — calls traceTx() per transaction.
+    */
+  def traceBlockByHash(req: TraceBlockByHashRequest): ServiceResponse[TraceBlockByHashResponse] =
+    IO {
+      for {
+        block <- blockchainReader.getBlockByHash(req.blockHash)
+          .toRight(JsonRpcError.InvalidParams(s"Block not found for hash ${req.blockHash.toHex}"))
+        result <- traceAllTxsInBlock(block, req.config)
+      } yield TraceBlockByHashResponse(result)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements debug_traceBlockByNumber.
+    *
+    * Besu reference: DebugTraceBlockByNumber.java — same as DebugTraceBlock but resolves by number.
+    *
+    * core-geth reference: api.go TraceBlockByNumber() → traceBlock().
+    */
+  def traceBlockByNumber(req: TraceBlockByNumberRequest): ServiceResponse[TraceBlockByNumberResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+        result <- traceAllTxsInBlock(resolved.block, req.config)
+      } yield TraceBlockByNumberResponse(result)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Replays all transactions in a block, returning one trace result per tx.
+    *
+    * Each tx is traced independently with a fresh tracer, using advanceWorldToTx to
+    * reproduce the exact world state the tx saw on-chain.
+    */
+  private def traceAllTxsInBlock(block: Block, config: TraceConfig): Either[JsonRpcError, Seq[JValue]] =
+    blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+      .toRight(JsonRpcError.InvalidParams("Parent block header not found"))
+      .map { parentHeader =>
+        val stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        stxs.zipWithIndex.map { case (stx, txIndex) =>
+          val world  = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+          val tracer = selectTracer(config, Some(world))
+          stxLedger.simulateTransactionWithTracer(stx, block.header, Some(world), tracer)
+          tracer.getResult
+        }
+      }
+
+  /** Selects and constructs a tracer based on config.tracer.
+    *
+    * core-geth reference: tracers/tracers.go — defaultTracer, "callTracer", "prestateTracer".
+    *
+    * StructLogTracer is the default (absent or empty tracer name), matching Besu and core-geth.
+    * PrestateTracer requires a pre-execution world snapshot; supply via the preWorld param.
+    *
+    * @param config    trace configuration selecting the tracer type
+    * @param preWorld  pre-execution world state (required for prestateTracer, ignored otherwise)
+    */
+  private def selectTracer(
+      config: TraceConfig,
+      preWorld: Option[com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy] = None
+  ): ExecutionTracer =
+    config.tracer.filterNot(_.isEmpty) match {
+      case None | Some("structLogger") =>
+        new StructLogTracer(
+          enableMemory  = !config.disableMemory,
+          enableStorage = !config.disableStorage
+        )
+      case Some("callTracer") =>
+        new CallTracer(onlyTopCall = false)
+      case Some("prestateTracer") =>
+        // PrestateTracer requires the pre-execution world; fall back to StructLogTracer if unavailable
+        preWorld match {
+          case Some(world) =>
+            new PrestateTracer[
+              com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy,
+              com.chipprbots.ethereum.ledger.InMemoryWorldStateProxyStorage
+            ](world)
+          case None =>
+            new StructLogTracer(
+              enableMemory  = !config.disableMemory,
+              enableStorage = !config.disableStorage
+            )
+        }
+      case Some(_) =>
+        // Unsupported tracer name — fall back to StructLogTracer
+        new StructLogTracer(
+          enableMemory  = !config.disableMemory,
+          enableStorage = !config.disableStorage
+        )
+    }
+
+  /** Builds a synthetic SignedTransactionWithSender from a CallTx (used in traceCall). */
+  private def buildCallTx(
+      callTx: EthInfoService.CallTx,
+      block: Block
+  ): Either[JsonRpcError, SignedTransactionWithSender] = {
+    import com.chipprbots.ethereum.domain.LegacyTransaction
+    import com.chipprbots.ethereum.crypto.ECDSASignature
+
+    val gasLimit = callTx.gas.getOrElse(block.header.gasLimit)
+    val fromAddress = callTx.from
+      .map(Address.apply)
+      .getOrElse(Address(0))
+    val toAddress = callTx.to.map(Address.apply)
+
+    val tx = LegacyTransaction(0, callTx.gasPrice, gasLimit, toAddress, callTx.value, callTx.data)
+    val fakeSignature = ECDSASignature(0, 0, 0)
+    Right(SignedTransactionWithSender(tx, fakeSignature, fromAddress))
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
@@ -75,6 +75,16 @@ object DebugTracingService {
 
   case class TraceBlockByNumberRequest(block: BlockParam, config: TraceConfig = TraceConfig())
   case class TraceBlockByNumberResponse(results: Seq[JValue])
+
+  /** debug_intermediateRoots params — block hash, optional trace config (ignored for root computation). */
+  case class IntermediateRootsRequest(blockHash: ByteString, config: TraceConfig = TraceConfig())
+  case class IntermediateRootsResponse(roots: Seq[ByteString])
+
+  /** debug_traceChain params — block range + optional tracer config.
+    * Only valid over WebSocket (method returns a subscription ID).
+    */
+  case class TraceChainRequest(fromBlock: BlockParam, toBlock: BlockParam, config: TraceConfig = TraceConfig())
+  case class TraceChainBlockResult(block: BigInt, blockHash: ByteString, traces: Seq[JValue])
 }
 
 class DebugTracingService(
@@ -272,6 +282,85 @@ class DebugTracingService(
           enableMemory  = !config.disableMemory,
           enableStorage = !config.disableStorage
         )
+    }
+
+  /** Implements debug_intermediateRoots.
+    *
+    * core-geth reference: eth/tracers/api.go IntermediateRoots() — for each tx in block, execute
+    *   it and call statedb.IntermediateRoot(deleteEmptyObjects) to get the state root after that tx.
+    *   Returns [] if block is genesis. Returns partial list if a tx errors (non-fatal per geth).
+    *
+    * Besu: no direct equivalent — this is a geth/ETC-specific debug method.
+    *
+    * Algorithm:
+    *   1. Resolve block by hash (also check bad-block store — not implemented, skip)
+    *   2. Get parent block state root
+    *   3. For each tx: simulate → capture worldState.stateRootHash (equivalent to statedb.IntermediateRoot)
+    *   4. Return list of ByteString roots (one per tx)
+    */
+  def intermediateRoots(req: IntermediateRootsRequest): ServiceResponse[IntermediateRootsResponse] =
+    IO {
+      for {
+        block  <- blockchainReader.getBlockByHash(req.blockHash)
+          .toRight(JsonRpcError.InvalidParams(s"Block not found for hash ${req.blockHash.toHex}"))
+        _ <- Either.cond(block.header.number > 0, (), JsonRpcError.InvalidParams("Genesis block is not traceable"))
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block header not found"))
+        stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        roots = {
+          // Chain world states tx-by-tx and capture state root after each finalization.
+          // On tx error: return partial result (same as core-geth — errors on canon blocks are rare).
+          var currentWorld = stxLedger.advanceWorldToTx(block.header, stxs, 0, parentHeader.stateRoot)
+          val rootBuf = scala.collection.mutable.ArrayBuffer[ByteString]()
+          stxs.foreach { stx =>
+            val txResult = stxLedger.simulateTransaction(stx, block.header, Some(currentWorld))
+            // stateRootHash computes the MPT root of the in-memory trie (equivalent to IntermediateRoot)
+            rootBuf += txResult.worldState.stateRootHash
+            currentWorld = txResult.worldState
+          }
+          rootBuf.toSeq
+        }
+      } yield IntermediateRootsResponse(roots)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Returns traced results for all blocks in [fromBlock+1, toBlock], one entry per block.
+    * Used by debug_traceChain (streaming via WebSocket).
+    *
+    * core-geth reference: eth/tracers/api.go traceChain() — parallel goroutines per block.
+    * We use sequential execution here to avoid concurrent world-state access.
+    */
+  def traceChainBlockRange(
+      fromBlock: BlockParam,
+      toBlock: BlockParam,
+      config: TraceConfig
+  ): IO[Either[JsonRpcError, Seq[TraceChainBlockResult]]] =
+    IO {
+      for {
+        fromResolved <- resolveBlock(fromBlock)
+        toResolved   <- resolveBlock(toBlock)
+        fromNum       = fromResolved.block.header.number.toLong
+        toNum         = toResolved.block.header.number.toLong
+        _ <- Either.cond(toNum > fromNum, (), JsonRpcError.InvalidParams("end block must come after start block"))
+        results = ((fromNum + 1) to toNum).flatMap { blockNum =>
+          val branch = blockchainReader.getBestBranch()
+          blockchainReader.getBlockByNumber(branch, blockNum).flatMap { block =>
+            blockchainReader.getBlockHeaderByHash(block.header.parentHash).map { parentHeader =>
+              val stxs   = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+              val traces = stxs.zipWithIndex.map { case (stx, txIndex) =>
+                val world  = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+                val tracer = selectTracer(config, Some(world))
+                stxLedger.simulateTransactionWithTracer(stx, block.header, Some(world), tracer)
+                tracer.getResult
+              }
+              TraceChainBlockResult(block.header.number, block.header.hash, traces)
+            }
+          }
+        }
+      } yield results
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
     }
 
   /** Builds a synthetic SignedTransactionWithSender from a CallTx (used in traceCall). */

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingService.scala
@@ -307,19 +307,20 @@ class DebugTracingService(
         parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
           .toRight(JsonRpcError.InvalidParams("Parent block header not found"))
         stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
-        roots = {
-          // Chain world states tx-by-tx and capture state root after each finalization.
-          // On tx error: return partial result (same as core-geth — errors on canon blocks are rare).
-          var currentWorld = stxLedger.advanceWorldToTx(block.header, stxs, 0, parentHeader.stateRoot)
-          val rootBuf = scala.collection.mutable.ArrayBuffer[ByteString]()
-          stxs.foreach { stx =>
-            val txResult = stxLedger.simulateTransaction(stx, block.header, Some(currentWorld))
-            // stateRootHash computes the MPT root of the in-memory trie (equivalent to IntermediateRoot)
-            rootBuf += txResult.worldState.stateRootHash
-            currentWorld = txResult.worldState
+        roots = if (stxs.isEmpty) Seq.empty
+          else {
+            // Chain world states tx-by-tx and capture state root after each finalization.
+            // On tx error: return partial result (same as core-geth — errors on canon blocks are rare).
+            var currentWorld = stxLedger.advanceWorldToTx(block.header, stxs, 0, parentHeader.stateRoot)
+            val rootBuf = scala.collection.mutable.ArrayBuffer[ByteString]()
+            stxs.foreach { stx =>
+              val txResult = stxLedger.simulateTransaction(stx, block.header, Some(currentWorld))
+              // stateRootHash computes the MPT root of the in-memory trie (equivalent to IntermediateRoot)
+              rootBuf += txResult.worldState.stateRootHash
+              currentWorld = txResult.worldState
+            }
+            rootBuf.toSeq
           }
-          rootBuf.toSeq
-        }
       } yield IntermediateRootsResponse(roots)
     }.recover { case _: MissingNodeException =>
       Left(JsonRpcError.NodeNotFound)

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthBlocksService.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 
 import org.bouncycastle.util.encoders.Hex
 
+import com.chipprbots.ethereum.consensus.engine.ForkChoiceManager
 import com.chipprbots.ethereum.consensus.mining.Mining
 import com.chipprbots.ethereum.domain._
 import com.chipprbots.ethereum.domain.BlockHeaderImplicits.BlockHeaderEnc
@@ -78,8 +79,9 @@ class EthBlocksService(
     val blockchainReader: BlockchainReader,
     val mining: Mining,
     val blockQueue: BlockQueue,
-    override val forkChoiceManagerOpt: Option[com.chipprbots.ethereum.consensus.engine.ForkChoiceManager] = None
+    private val _forkChoiceManagerOpt: Option[ForkChoiceManager] = None
 ) extends ResolveBlock {
+  final override def forkChoiceManagerOpt: Option[ForkChoiceManager] = _forkChoiceManagerOpt
   import EthBlocksService._
 
   implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthMiningJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthMiningJsonMethodsImplicits.scala
@@ -24,7 +24,8 @@ object EthMiningJsonMethodsImplicits extends JsonMethodsImplicits {
         val powHeaderHash = encodeAsHex(t.powHeaderHash)
         val dagSeed = encodeAsHex(t.dagSeed)
         val target = encodeAsHex(t.target)
-        JArray(List(powHeaderHash, dagSeed, target))
+        val blockNumber = encodeAsHex(t.blockNumber)
+        JArray(List(powHeaderHash, dagSeed, target, blockNumber))
       }
     }
 

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthMiningService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthMiningService.scala
@@ -5,6 +5,7 @@ import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.util.Timeout
 
@@ -18,8 +19,9 @@ import scala.concurrent.duration.FiniteDuration
 import com.chipprbots.ethereum.blockchain.sync.SyncProtocol
 import com.chipprbots.ethereum.consensus.blocks.PendingBlockAndState
 import com.chipprbots.ethereum.consensus.mining.CoinbaseProvider
+import com.chipprbots.ethereum.consensus.pow.PoWMiningMetrics
+import com.chipprbots.ethereum.consensus.pow.WorkNotifier
 import com.chipprbots.ethereum.consensus.mining.Mining
-import com.chipprbots.ethereum.consensus.mining.MiningConfig
 import com.chipprbots.ethereum.consensus.mining.RichMining
 import com.chipprbots.ethereum.consensus.pow.EthashUtils
 import com.chipprbots.ethereum.consensus.pow.miners.MinerProtocol
@@ -39,7 +41,7 @@ object EthMiningService {
   case class GetMiningResponse(isMining: Boolean)
 
   case class GetWorkRequest()
-  case class GetWorkResponse(powHeaderHash: ByteString, dagSeed: ByteString, target: ByteString)
+  case class GetWorkResponse(powHeaderHash: ByteString, dagSeed: ByteString, target: ByteString, blockNumber: BigInt)
 
   case class SubmitWorkRequest(nonce: ByteString, powHeaderHash: ByteString, mixHash: ByteString)
   case class SubmitWorkResponse(success: Boolean)
@@ -80,7 +82,8 @@ class EthMiningService(
     val pendingTransactionsManager: ActorRef,
     val getTransactionFromPoolTimeout: FiniteDuration,
     configBuilder: BlockchainConfigBuilder,
-    coinbaseProvider: CoinbaseProvider
+    coinbaseProvider: CoinbaseProvider,
+    system: ActorSystem
 ) extends TransactionPicker {
   import configBuilder._
   import EthMiningService._
@@ -103,6 +106,7 @@ class EthMiningService(
 
   def getWork(req: GetWorkRequest): ServiceResponse[GetWorkResponse] =
     mining.ifEthash { ethash =>
+      PoWMiningMetrics.recordGetWork()
       reportActive()
       blockchainReader.getBestBlock() match {
         case Some(block) =>
@@ -115,17 +119,23 @@ class EthMiningService(
               ommers.headers,
               None
             )
-            Right(
-              GetWorkResponse(
-                powHeaderHash = ByteString(kec256(BlockHeader.getEncodedWithoutNonce(pb.block.header))),
-                dagSeed = EthashUtils
-                  .seed(
-                    pb.block.header.number.toLong,
-                    blockchainConfig.forkBlockNumbers.ecip1099BlockNumber.toLong
-                  ),
-                target = ByteString((BigInt(2).pow(256) / pb.block.header.difficulty).toByteArray)
+            val powHeaderHash = ByteString(kec256(BlockHeader.getEncodedWithoutNonce(pb.block.header)))
+            val dagSeed = EthashUtils
+              .seed(
+                pb.block.header.number.toLong,
+                blockchainConfig.forkBlockNumbers.ecip1099BlockNumber.toLong
               )
-            )
+            val target    = ByteString((BigInt(2).pow(256) / pb.block.header.difficulty).toByteArray)
+            val blockNumber = pb.block.header.number
+            val workResponse = GetWorkResponse(powHeaderHash, dagSeed, target, blockNumber)
+            val notifyUrls = ethash.config.generic.notifyUrls
+            if (notifyUrls.nonEmpty) {
+              WorkNotifier.notify(
+                notifyUrls,
+                WorkNotifier.WorkPackage(powHeaderHash, dagSeed, target, blockNumber)
+              )(system)
+            }
+            Right(workResponse)
           }
         case None =>
           log.error("Getting current best block failed")
@@ -138,12 +148,27 @@ class EthMiningService(
       reportActive()
       IO {
         ethash.blockGenerator.getPrepared(req.powHeaderHash) match {
-          case Some(pendingBlock) if blockchainReader.getBestBlockNumber() <= pendingBlock.block.header.number =>
-            import pendingBlock._
-            syncingController ! SyncProtocol.MinedBlock(
-              block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash))
-            )
-            Right(SubmitWorkResponse(true))
+          case Some(pendingBlock) =>
+            val bestBlockNum = blockchainReader.getBestBlockNumber()
+            val staleThreshold = ethash.config.generic.staleThreshold
+            // core-geth reference: consensus/ethash/sealer.go staleThreshold check
+            if (bestBlockNum - pendingBlock.block.header.number > staleThreshold) {
+              log.debug(
+                "Rejecting stale work submission for block {}, current best {}, threshold {}",
+                pendingBlock.block.header.number,
+                bestBlockNum,
+                staleThreshold
+              )
+              PoWMiningMetrics.recordStaleShare()
+              Right(SubmitWorkResponse(false))
+            } else {
+              import pendingBlock._
+              syncingController ! SyncProtocol.MinedBlock(
+                block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash))
+              )
+              PoWMiningMetrics.recordBlockMined(0L) // duration tracked at coordinator level
+              Right(SubmitWorkResponse(true))
+            }
           case _ =>
             Right(SubmitWorkResponse(false))
         }
@@ -159,6 +184,7 @@ class EthMiningService(
       val now = new Date
       removeObsoleteHashrates(now)
       hashRate.put(req.id, req.hashRate -> now)
+      PoWMiningMetrics.updateHashrate(hashRate.map { case (_, (hr, _)) => hr }.sum)
       SubmitHashRateResponse(true)
     }
 

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -27,6 +27,7 @@ import com.chipprbots.ethereum.jsonrpc.EthSimulateService._
 import com.chipprbots.ethereum.jsonrpc.TestService._
 import com.chipprbots.ethereum.jsonrpc.Web3Service._
 import com.chipprbots.ethereum.jsonrpc.AdminService._
+import com.chipprbots.ethereum.jsonrpc.TxPoolService._
 import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController
 import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import com.chipprbots.ethereum.nodebuilder.ApisBuilder
@@ -50,12 +51,14 @@ case class JsonRpcController(
     proofService: ProofService,
     ethSimulateService: EthSimulateService,
     adminService: AdminService,
+    txPoolService: TxPoolService,
     override val config: JsonRpcConfig
 ) extends ApisBuilder
     with Logger
     with JsonRpcBaseController {
 
   import AdminJsonMethodsImplicits._
+  import TxPoolJsonMethodsImplicits._
   import DebugJsonMethodsImplicits._
   import EthJsonMethodsImplicits._
   import EthBlocksJsonMethodsImplicits._
@@ -83,7 +86,8 @@ case class JsonRpcController(
     Apis.Test -> handleTestRequest,
     Apis.Iele -> handleIeleRequest,
     Apis.Qa -> handleQARequest,
-    Apis.Admin -> handleAdminRequest
+    Apis.Admin -> handleAdminRequest,
+    Apis.TxPool -> handleTxPoolRequest
   )
 
   override def enabledApis: Seq[String] = config.apis :+ Apis.Rpc // RPC enabled by default
@@ -420,6 +424,18 @@ case class JsonRpcController(
       handle[AdminUnblockIPRequest, AdminUnblockIPResponse](adminService.unblockIP, req)
     case req @ JsonRpcRequest(_, "admin_listBlockedIPs", _, _) =>
       handle[AdminListBlockedIPsRequest, AdminListBlockedIPsResponse](adminService.listBlockedIPs, req)
+  }
+
+  private def handleTxPoolRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
+    case req @ JsonRpcRequest(_, "txpool_besuTransactions", _, _) =>
+      handle[TxPoolBesuTransactionsRequest, TxPoolBesuTransactionsResponse](txPoolService.besuTransactions, req)
+    case req @ JsonRpcRequest(_, "txpool_besuStatistics", _, _) =>
+      handle[TxPoolBesuStatisticsRequest, TxPoolBesuStatisticsResponse](txPoolService.besuStatistics, req)
+    case req @ JsonRpcRequest(_, "txpool_besuPendingTransactions", _, _) =>
+      handle[TxPoolBesuPendingTransactionsRequest, TxPoolBesuPendingTransactionsResponse](
+        txPoolService.besuPendingTransactions,
+        req
+      )
   }
 
   private def handleRpcRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -52,6 +52,8 @@ case class JsonRpcController(
     ethSimulateService: EthSimulateService,
     adminService: AdminService,
     txPoolService: TxPoolService,
+    debugTracingService: DebugTracingService,
+    traceService: TraceService,
     override val config: JsonRpcConfig
 ) extends ApisBuilder
     with Logger
@@ -82,12 +84,13 @@ case class JsonRpcController(
     Apis.Fukuii -> handleFukuiiRequest,
     Apis.Mcp -> handleMcpRequest,
     Apis.Rpc -> handleRpcRequest,
-    Apis.Debug -> handleDebugRequest,
+    Apis.Debug -> (handleDebugRequest orElse handleDebugTracingRequest),
     Apis.Test -> handleTestRequest,
     Apis.Iele -> handleIeleRequest,
     Apis.Qa -> handleQARequest,
     Apis.Admin -> handleAdminRequest,
-    Apis.TxPool -> handleTxPoolRequest
+    Apis.TxPool -> handleTxPoolRequest,
+    Apis.Trace -> handleTraceRequest
   )
 
   override def enabledApis: Seq[String] = config.apis :+ Apis.Rpc // RPC enabled by default
@@ -303,6 +306,68 @@ case class JsonRpcController(
         r => debugService.traceBlockByNumber(r.blockNumber).map(_.map(lst =>
           DebugJsonMethodsImplicits.TraceBlockResponse(lst))), req
       )(DebugJsonMethodsImplicits.debug_traceBlockByNumber, DebugJsonMethodsImplicits.debug_traceBlockByNumber)
+  }
+
+  private def handleDebugTracingRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
+    import DebugTracingService.{
+      TraceTransactionRequest  => DTxReq,  TraceTransactionResponse  => DTxResp,
+      TraceCallRequest         => DCallReq, TraceCallResponse         => DCallResp,
+      TraceCallManyRequest     => DManyReq, TraceCallManyResponse     => DManyResp,
+      TraceBlockByHashRequest  => DBlkHashReq, TraceBlockByHashResponse  => DBlkHashResp,
+      TraceBlockByNumberRequest => DBlkNumReq, TraceBlockByNumberResponse => DBlkNumResp
+    }
+    import DebugTracingJsonMethodsImplicits.{
+      debug_traceTransaction => dTx, debug_traceCall => dCall,
+      debug_traceCallMany => dMany, debug_traceBlockByHash => dHash,
+      debug_traceBlockByNumber => dNum
+    }
+    ({
+      case req @ JsonRpcRequest(_, "debug_traceTransaction", _, _) =>
+        handle[DTxReq, DTxResp](debugTracingService.traceTransaction, req)(dTx, dTx)
+      case req @ JsonRpcRequest(_, "debug_traceCall", _, _) =>
+        handle[DCallReq, DCallResp](debugTracingService.traceCall, req)(dCall, dCall)
+      case req @ JsonRpcRequest(_, "debug_traceCallMany", _, _) =>
+        handle[DManyReq, DManyResp](debugTracingService.traceCallMany, req)(dMany, dMany)
+      case req @ JsonRpcRequest(_, "debug_traceBlockByHash", _, _) =>
+        handle[DBlkHashReq, DBlkHashResp](debugTracingService.traceBlockByHash, req)(dHash, dHash)
+      case req @ JsonRpcRequest(_, "debug_traceBlockByNumber", _, _) =>
+        handle[DBlkNumReq, DBlkNumResp](debugTracingService.traceBlockByNumber, req)(dNum, dNum)
+    }: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]])
+  }
+
+  private def handleTraceRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] =
+    handleTraceRequestImpl
+
+  private def handleTraceRequestImpl: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
+    import TraceJsonMethodsImplicits._
+    // Use explicit implicits via summon to sidestep the ambiguity with DebugTracingService types
+    val tTx       = TraceJsonMethodsImplicits.trace_transaction
+    val tBlock    = TraceJsonMethodsImplicits.trace_block
+    val tReplay   = TraceJsonMethodsImplicits.trace_replayTransaction
+    val tReplBlk  = TraceJsonMethodsImplicits.trace_replayBlockTransactions
+    val tCall     = TraceJsonMethodsImplicits.trace_call
+    val tCallMany = TraceJsonMethodsImplicits.trace_callMany
+
+    {
+      case req @ JsonRpcRequest(_, "trace_transaction", _, _) =>
+        handle[TraceService.TraceTransactionRequest, TraceService.TraceTransactionResponse](
+          traceService.traceTransaction, req)(tTx, tTx)
+      case req @ JsonRpcRequest(_, "trace_block", _, _) =>
+        handle[TraceService.TraceBlockRequest, TraceService.TraceBlockResponse](
+          traceService.traceBlock, req)(tBlock, tBlock)
+      case req @ JsonRpcRequest(_, "trace_replayTransaction", _, _) =>
+        handle[TraceService.TraceReplayTransactionRequest, TraceService.TraceReplayTransactionResponse](
+          traceService.replayTransaction, req)(tReplay, tReplay)
+      case req @ JsonRpcRequest(_, "trace_replayBlockTransactions", _, _) =>
+        handle[TraceService.TraceReplayBlockTransactionsRequest, TraceService.TraceReplayBlockTransactionsResponse](
+          traceService.replayBlockTransactions, req)(tReplBlk, tReplBlk)
+      case req @ JsonRpcRequest(_, "trace_call", _, _) =>
+        handle[TraceService.TraceCallRequest, TraceService.TraceCallResponse](
+          traceService.traceCall, req)(tCall, tCall)
+      case req @ JsonRpcRequest(_, "trace_callMany", _, _) =>
+        handle[TraceService.TraceCallManyRequest, TraceService.TraceCallManyResponse](
+          traceService.traceCallMany, req)(tCallMany, tCallMany)
+    }
   }
 
   private def handleTestRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] =

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -26,6 +26,7 @@ import com.chipprbots.ethereum.jsonrpc.ProofService.GetProofResponse
 import com.chipprbots.ethereum.jsonrpc.EthSimulateService._
 import com.chipprbots.ethereum.jsonrpc.TestService._
 import com.chipprbots.ethereum.jsonrpc.Web3Service._
+import com.chipprbots.ethereum.jsonrpc.AdminService._
 import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController
 import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import com.chipprbots.ethereum.nodebuilder.ApisBuilder
@@ -48,11 +49,13 @@ case class JsonRpcController(
     mcpService: McpService,
     proofService: ProofService,
     ethSimulateService: EthSimulateService,
+    adminService: AdminService,
     override val config: JsonRpcConfig
 ) extends ApisBuilder
     with Logger
     with JsonRpcBaseController {
 
+  import AdminJsonMethodsImplicits._
   import DebugJsonMethodsImplicits._
   import EthJsonMethodsImplicits._
   import EthBlocksJsonMethodsImplicits._
@@ -79,7 +82,8 @@ case class JsonRpcController(
     Apis.Debug -> handleDebugRequest,
     Apis.Test -> handleTestRequest,
     Apis.Iele -> handleIeleRequest,
-    Apis.Qa -> handleQARequest
+    Apis.Qa -> handleQARequest,
+    Apis.Admin -> handleAdminRequest
   )
 
   override def enabledApis: Seq[String] = config.apis :+ Apis.Rpc // RPC enabled by default
@@ -391,6 +395,31 @@ case class JsonRpcController(
   private def handleQARequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
     case req @ JsonRpcRequest(_, "qa_mineBlocks", _, _) =>
       handle[QAService.MineBlocksRequest, QAService.MineBlocksResponse](qaService.mineBlocks, req)
+  }
+
+  private def handleAdminRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
+    case req @ JsonRpcRequest(_, "admin_nodeInfo", _, _) =>
+      handle[AdminNodeInfoRequest, AdminNodeInfoResponse](adminService.nodeInfo, req)
+    case req @ JsonRpcRequest(_, "admin_peers", _, _) =>
+      handle[AdminPeersRequest, AdminPeersResponse](adminService.peers, req)
+    case req @ JsonRpcRequest(_, "admin_addPeer", _, _) =>
+      handle[AdminAddPeerRequest, AdminAddPeerResponse](adminService.addPeer, req)
+    case req @ JsonRpcRequest(_, "admin_removePeer", _, _) =>
+      handle[AdminRemovePeerRequest, AdminRemovePeerResponse](adminService.removePeer, req)
+    case req @ JsonRpcRequest(_, "admin_changeLogLevel", _, _) =>
+      handle[AdminChangeLogLevelRequest, AdminChangeLogLevelResponse](adminService.changeLogLevel, req)
+    case req @ JsonRpcRequest(_, "admin_datadir", _, _) =>
+      handle[AdminDatadirRequest, AdminDatadirResponse](adminService.getDatadir, req)
+    case req @ JsonRpcRequest(_, "admin_exportChain", _, _) =>
+      handle[AdminExportChainRequest, AdminExportChainResponse](adminService.exportChain, req)
+    case req @ JsonRpcRequest(_, "admin_importChain", _, _) =>
+      handle[AdminImportChainRequest, AdminImportChainResponse](adminService.importChain, req)
+    case req @ JsonRpcRequest(_, "admin_blockIP", _, _) =>
+      handle[AdminBlockIPRequest, AdminBlockIPResponse](adminService.blockIP, req)
+    case req @ JsonRpcRequest(_, "admin_unblockIP", _, _) =>
+      handle[AdminUnblockIPRequest, AdminUnblockIPResponse](adminService.unblockIP, req)
+    case req @ JsonRpcRequest(_, "admin_listBlockedIPs", _, _) =>
+      handle[AdminListBlockedIPsRequest, AdminListBlockedIPsResponse](adminService.listBlockedIPs, req)
   }
 
   private def handleRpcRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -310,16 +310,19 @@ case class JsonRpcController(
 
   private def handleDebugTracingRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
     import DebugTracingService.{
-      TraceTransactionRequest  => DTxReq,  TraceTransactionResponse  => DTxResp,
-      TraceCallRequest         => DCallReq, TraceCallResponse         => DCallResp,
-      TraceCallManyRequest     => DManyReq, TraceCallManyResponse     => DManyResp,
-      TraceBlockByHashRequest  => DBlkHashReq, TraceBlockByHashResponse  => DBlkHashResp,
-      TraceBlockByNumberRequest => DBlkNumReq, TraceBlockByNumberResponse => DBlkNumResp
+      TraceTransactionRequest   => DTxReq,     TraceTransactionResponse   => DTxResp,
+      TraceCallRequest          => DCallReq,   TraceCallResponse          => DCallResp,
+      TraceCallManyRequest      => DManyReq,   TraceCallManyResponse      => DManyResp,
+      TraceBlockByHashRequest   => DBlkHashReq, TraceBlockByHashResponse  => DBlkHashResp,
+      TraceBlockByNumberRequest => DBlkNumReq,  TraceBlockByNumberResponse => DBlkNumResp,
+      IntermediateRootsRequest  => DRootsReq,  IntermediateRootsResponse  => DRootsResp,
+      TraceChainRequest         => DChainReq,  TraceChainBlockResult      => DChainResult
     }
     import DebugTracingJsonMethodsImplicits.{
-      debug_traceTransaction => dTx, debug_traceCall => dCall,
-      debug_traceCallMany => dMany, debug_traceBlockByHash => dHash,
-      debug_traceBlockByNumber => dNum
+      debug_traceTransaction   => dTx,    debug_traceCall         => dCall,
+      debug_traceCallMany      => dMany,  debug_traceBlockByHash  => dHash,
+      debug_traceBlockByNumber => dNum,
+      debug_intermediateRoots  => dRoots, debug_traceChain        => dChain
     }
     ({
       case req @ JsonRpcRequest(_, "debug_traceTransaction", _, _) =>
@@ -332,6 +335,13 @@ case class JsonRpcController(
         handle[DBlkHashReq, DBlkHashResp](debugTracingService.traceBlockByHash, req)(dHash, dHash)
       case req @ JsonRpcRequest(_, "debug_traceBlockByNumber", _, _) =>
         handle[DBlkNumReq, DBlkNumResp](debugTracingService.traceBlockByNumber, req)(dNum, dNum)
+      case req @ JsonRpcRequest(_, "debug_intermediateRoots", _, _) =>
+        handle[DRootsReq, DRootsResp](debugTracingService.intermediateRoots, req)(dRoots, dRoots)
+      case req @ JsonRpcRequest(_, "debug_traceChain", _, _) =>
+        handle[DChainReq, Seq[DChainResult]](
+          r => debugTracingService.traceChainBlockRange(r.fromBlock, r.toBlock, r.config),
+          req
+        )(dChain, dChain)
     }: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]])
   }
 
@@ -339,14 +349,14 @@ case class JsonRpcController(
     handleTraceRequestImpl
 
   private def handleTraceRequestImpl: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {
-    import TraceJsonMethodsImplicits._
-    // Use explicit implicits via summon to sidestep the ambiguity with DebugTracingService types
+    // Use explicit implicits to sidestep the ambiguity with DebugTracingService types
     val tTx       = TraceJsonMethodsImplicits.trace_transaction
     val tBlock    = TraceJsonMethodsImplicits.trace_block
     val tReplay   = TraceJsonMethodsImplicits.trace_replayTransaction
     val tReplBlk  = TraceJsonMethodsImplicits.trace_replayBlockTransactions
     val tCall     = TraceJsonMethodsImplicits.trace_call
     val tCallMany = TraceJsonMethodsImplicits.trace_callMany
+    val tFilter   = TraceJsonMethodsImplicits.trace_filter
 
     {
       case req @ JsonRpcRequest(_, "trace_transaction", _, _) =>
@@ -367,6 +377,9 @@ case class JsonRpcController(
       case req @ JsonRpcRequest(_, "trace_callMany", _, _) =>
         handle[TraceService.TraceCallManyRequest, TraceService.TraceCallManyResponse](
           traceService.traceCallMany, req)(tCallMany, tCallMany)
+      case req @ JsonRpcRequest(_, "trace_filter", _, _) =>
+        handle[TraceService.TraceFilterRequest, TraceService.TraceFilterResponse](
+          traceService.traceFilter, req)(tFilter, tFilter)
     }
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -424,6 +424,16 @@ case class JsonRpcController(
       handle[AdminUnblockIPRequest, AdminUnblockIPResponse](adminService.unblockIP, req)
     case req @ JsonRpcRequest(_, "admin_listBlockedIPs", _, _) =>
       handle[AdminListBlockedIPsRequest, AdminListBlockedIPsResponse](adminService.listBlockedIPs, req)
+    // ── Geth-compatible methods ──────────────────────────────────────────
+    case req @ JsonRpcRequest(_, "admin_addTrustedPeer", _, _) =>
+      handle[AdminAddTrustedPeerRequest, AdminAddTrustedPeerResponse](adminService.addTrustedPeer, req)
+    case req @ JsonRpcRequest(_, "admin_removeTrustedPeer", _, _) =>
+      handle[AdminRemoveTrustedPeerRequest, AdminRemoveTrustedPeerResponse](
+        adminService.removeTrustedPeer,
+        req
+      )
+    case req @ JsonRpcRequest(_, "admin_maxPeers", _, _) =>
+      handle[AdminMaxPeersRequest, AdminMaxPeersResponse](adminService.maxPeers, req)
   }
 
   private def handleTxPoolRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala
@@ -436,6 +436,15 @@ case class JsonRpcController(
         txPoolService.besuPendingTransactions,
         req
       )
+    // ── Geth-compatible methods ────────────────────────────────────────────
+    case req @ JsonRpcRequest(_, "txpool_content", _, _) =>
+      handle[TxPoolContentRequest, TxPoolContentResponse](txPoolService.content, req)
+    case req @ JsonRpcRequest(_, "txpool_contentFrom", _, _) =>
+      handle[TxPoolContentFromRequest, TxPoolContentFromResponse](txPoolService.contentFrom, req)
+    case req @ JsonRpcRequest(_, "txpool_status", _, _) =>
+      handle[TxPoolStatusRequest, TxPoolStatusResponse](txPoolService.status, req)
+    case req @ JsonRpcRequest(_, "txpool_inspect", _, _) =>
+      handle[TxPoolInspectRequest, TxPoolInspectResponse](txPoolService.inspect, req)
   }
 
   private def handleRpcRequest: PartialFunction[JsonRpcRequest, IO[JsonRpcResponse]] = {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/ResolveBlock.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/ResolveBlock.scala
@@ -1,5 +1,6 @@
 package com.chipprbots.ethereum.jsonrpc
 
+import com.chipprbots.ethereum.consensus.engine.ForkChoiceManager
 import com.chipprbots.ethereum.consensus.mining.Mining
 import com.chipprbots.ethereum.domain._
 import com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy
@@ -22,7 +23,7 @@ trait ResolveBlock {
   def blockchain: Blockchain
   def blockchainReader: BlockchainReader
   def mining: Mining
-  def forkChoiceManagerOpt: Option[com.chipprbots.ethereum.consensus.engine.ForkChoiceManager] = None
+  def forkChoiceManagerOpt: Option[ForkChoiceManager] = None
 
   def resolveBlock(blockParam: BlockParam): Either[JsonRpcError, ResolvedBlock] =
     blockParam match {

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionEvents.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionEvents.scala
@@ -1,0 +1,14 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
+
+/** Events published to ActorSystem.eventStream for WS subscription delivery.
+  *
+  * Besu reference: SubscriptionManager.java listens to BlockAddedObserver (block events) and
+  * PendingTransactionAddedListener (pending tx events). We use ActorSystem.eventStream as the
+  * Pekko equivalent of Vert.x EventBus — no Vert.x verticle dependency needed.
+  */
+sealed trait BlockchainEvent
+case class NewBlockImported(block: Block) extends BlockchainEvent
+case class NewPendingTransaction(stx: SignedTransactionWithSender) extends BlockchainEvent

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionManager.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionManager.scala
@@ -1,0 +1,310 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.actor.ActorLogging
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.scaladsl.SourceQueueWithComplete
+import org.apache.pekko.stream.QueueOfferResult
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.ExecutionContext
+
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import org.json4s.native.Serialization
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
+import com.chipprbots.ethereum.domain.TxLogEntry
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonSerializers
+import com.chipprbots.ethereum.utils.ByteStringUtils.ByteStringOps
+
+/** Manages WebSocket subscriptions for eth_subscribe / eth_unsubscribe.
+  *
+  * Besu reference:
+  *   ethereum/api/.../websocket/subscription/SubscriptionManager.java
+  *   ethereum/api/.../websocket/subscription/blockheaders/NewBlockHeadersSubscriptionService.java
+  *   ethereum/api/.../websocket/subscription/logs/LogsSubscriptionService.java
+  *   ethereum/api/.../websocket/subscription/pending/PendingTransactionSubscriptionService.java
+  *   ethereum/api/.../websocket/subscription/syncing/SyncingSubscriptionService.java
+  *
+  * Besu uses Vert.x EventBus + Verticle for subscription routing. We use ActorSystem.eventStream
+  * (same pub/sub semantics) with a Pekko actor instead of a Vert.x Verticle.
+  *
+  * Connection lifecycle: RegisterConnection → Subscribe/Unsubscribe (0..N) → ConnectionClosed.
+  * All subscriptions for a closed connection are automatically cleaned up.
+  */
+class SubscriptionManager(blockchainReader: BlockchainReader) extends Actor with ActorLogging {
+
+  import SubscriptionManager._
+
+  implicit val formats: Formats = DefaultFormats + JsonSerializers.RpcErrorJsonSerializer
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  // subscriptionId → Subscription
+  private var subscriptions: Map[Long, Subscription] = Map.empty
+  // connectionId → output queue for WS push
+  private var connections: Map[String, SourceQueueWithComplete[String]] = Map.empty
+  private val counter = new AtomicLong(0L)
+
+  override def preStart(): Unit = {
+    context.system.eventStream.subscribe(self, classOf[NewBlockImported])
+    context.system.eventStream.subscribe(self, classOf[NewPendingTransaction])
+  }
+
+  override def postStop(): Unit =
+    context.system.eventStream.unsubscribe(self)
+
+  override def receive: Receive = {
+    case RegisterConnection(connId, queue) =>
+      log.debug("WS connection registered: {}", connId)
+      connections += (connId -> queue)
+
+    case ConnectionClosed(connId) =>
+      log.debug("WS connection closed: {}", connId)
+      connections -= connId
+      subscriptions = subscriptions.filterNot { case (_, sub) => sub.connectionId == connId }
+
+    case msg: Subscribe =>
+      val id = counter.incrementAndGet()
+      buildSubscription(id, msg) match {
+        case Right(sub) =>
+          subscriptions += (id -> sub)
+          sender() ! SubscribeResponse(Right(id))
+        case Left(err) =>
+          sender() ! SubscribeResponse(Left(err))
+      }
+
+    case Unsubscribe(connId, subId) =>
+      val found = subscriptions.get(subId).exists(_.connectionId == connId)
+      if (found) subscriptions -= subId
+      sender() ! UnsubscribeResponse(found)
+
+    case NewBlockImported(block) =>
+      notifyNewHeads(block)
+      notifyLogs(block)
+
+    case NewPendingTransaction(stx) =>
+      notifyPendingTxs(stx)
+  }
+
+  // ---- subscription builders ----
+
+  private def buildSubscription(id: Long, msg: Subscribe): Either[String, Subscription] =
+    msg.subType match {
+      case "newHeads" =>
+        val includeTx = msg.params.collect { case JObject(fields) =>
+          fields.collectFirst { case JField("includeTransactions", JBool(v)) => v }.getOrElse(false)
+        }.getOrElse(false)
+        Right(NewHeadsSubscription(id, msg.connId, includeTx))
+
+      case "logs" =>
+        val (address, topics) = msg.params match {
+          case Some(JObject(fields)) =>
+            val addr = fields.collectFirst { case JField("address", v) => parseAddresses(v) }.flatten
+            val tops = fields.collectFirst { case JField("topics", JArray(ts)) => parseTopics(ts) }
+              .getOrElse(Seq.empty)
+            (addr, tops)
+          case _ => (None, Seq.empty)
+        }
+        Right(LogsSubscription(id, msg.connId, address, topics))
+
+      case "newPendingTransactions" =>
+        val includeTx = msg.params.collect { case JObject(fields) =>
+          fields.collectFirst { case JField("includeTransactions", JBool(v)) => v }.getOrElse(false)
+        }.getOrElse(false)
+        Right(NewPendingTxsSubscription(id, msg.connId, includeTx))
+
+      case "syncing" =>
+        Right(SyncingSubscription(id, msg.connId))
+
+      case other =>
+        Left(s"Unknown subscription type: $other")
+    }
+
+  private def parseAddresses(v: JValue): Option[Seq[Address]] = v match {
+    case JString(s)   => Some(Seq(Address(ByteString(hexToBytes(s)))))
+    case JArray(vals) => Some(vals.collect { case JString(s) => Address(ByteString(hexToBytes(s))) })
+    case _            => None
+  }
+
+  private def parseTopics(ts: List[JValue]): Seq[Seq[ByteString]] =
+    ts.map {
+      case JString(s) => Seq(ByteString(hexToBytes(s)))
+      case JArray(vs) => vs.collect { case JString(s) => ByteString(hexToBytes(s)) }
+      case _          => Seq.empty
+    }
+
+  private def hexToBytes(hex: String): Array[Byte] = {
+    val h = if (hex.startsWith("0x") || hex.startsWith("0X")) hex.drop(2) else hex
+    val padded = if (h.length % 2 != 0) "0" + h else h
+    padded.grouped(2).map(b => Integer.parseInt(b, 16).toByte).toArray
+  }
+
+  // ---- push helpers ----
+
+  private def push(connId: String, json: String): Unit =
+    connections.get(connId).foreach { queue =>
+      queue.offer(json)
+    }
+
+  private def subscriptionEnvelope(subId: Long, result: JValue): String = {
+    val hex = "0x" + subId.toHexString
+    val json = JObject(
+      "jsonrpc" -> JString("2.0"),
+      "method"  -> JString("eth_subscription"),
+      "params"  -> JObject("subscription" -> JString(hex), "result" -> result)
+    )
+    compact(render(json))
+  }
+
+  // ---- newHeads ----
+
+  private def notifyNewHeads(block: Block): Unit = {
+    subscriptions.values.collect { case s: NewHeadsSubscription => s }.foreach { sub =>
+      val result = blockHeaderJson(block, sub.includeTransactions)
+      push(sub.connectionId, subscriptionEnvelope(sub.subscriptionId, result))
+    }
+  }
+
+  private def blockHeaderJson(block: Block, includeTransactions: Boolean): JValue = {
+    val h = block.header
+    val base = JObject(
+      "number"          -> JString("0x" + h.number.toString(16)),
+      "hash"            -> JString("0x" + h.hash.toHex),
+      "parentHash"      -> JString("0x" + h.parentHash.toHex),
+      "sha3Uncles"      -> JString("0x" + h.ommersHash.toHex),
+      "logsBloom"       -> JString("0x" + h.logsBloom.toHex),
+      "transactionsRoot"-> JString("0x" + h.transactionsRoot.toHex),
+      "stateRoot"       -> JString("0x" + h.stateRoot.toHex),
+      "receiptsRoot"    -> JString("0x" + h.receiptsRoot.toHex),
+      "miner"           -> JString(h.beneficiary.toString),
+      "difficulty"      -> JString("0x" + h.difficulty.toString(16)),
+      "extraData"       -> JString("0x" + h.extraData.toHex),
+      "gasLimit"        -> JString("0x" + h.gasLimit.toString(16)),
+      "gasUsed"         -> JString("0x" + h.gasUsed.toString(16)),
+      "timestamp"       -> JString("0x" + h.unixTimestamp.toHexString),
+      "nonce"           -> JString("0x" + h.nonce.toHex)
+    )
+    if (includeTransactions)
+      base merge JObject("transactions" -> JArray(
+        block.body.transactionList.map(tx => JString("0x" + tx.hash.toHex)).toList
+      ))
+    else base
+  }
+
+  // ---- logs ----
+
+  private def notifyLogs(block: Block): Unit = {
+    val logSubs = subscriptions.values.collect { case s: LogsSubscription => s }
+    if (logSubs.isEmpty) return
+
+    val receipts = blockchainReader.getReceiptsByHash(block.header.hash).getOrElse(Seq.empty)
+    var blockLogIndex = 0
+    receipts.zipWithIndex.foreach { case (receipt, txIndex) =>
+      receipt.logs.zipWithIndex.foreach { case (log, localIdx) =>
+        val globalIdx = blockLogIndex + localIdx
+        logSubs.foreach { sub =>
+          if (logMatchesSubscription(log, sub)) {
+            val tx = block.body.transactionList(txIndex)
+            val logJson = JObject(
+              "removed"          -> JBool(false),
+              "logIndex"         -> JString("0x" + globalIdx.toHexString),
+              "transactionIndex" -> JString("0x" + txIndex.toHexString),
+              "transactionHash"  -> JString("0x" + tx.hash.toHex),
+              "blockHash"        -> JString("0x" + block.header.hash.toHex),
+              "blockNumber"      -> JString("0x" + block.header.number.toString(16)),
+              "address"          -> JString(log.loggerAddress.toString),
+              "data"             -> JString("0x" + log.data.toHex),
+              "topics"           -> JArray(log.logTopics.map(t => JString("0x" + t.toHex)).toList)
+            )
+            push(sub.connectionId, subscriptionEnvelope(sub.subscriptionId, logJson))
+          }
+        }
+      }
+      blockLogIndex += receipt.logs.size
+    }
+  }
+
+  private def logMatchesSubscription(log: TxLogEntry, sub: LogsSubscription): Boolean = {
+    val addrMatch = sub.address.forall(addrs => addrs.contains(log.loggerAddress))
+    val topicMatch = log.logTopics.size >= sub.topics.size &&
+      sub.topics.zip(log.logTopics).forall { case (filter, logTopic) =>
+        filter.isEmpty || filter.contains(logTopic)
+      }
+    addrMatch && topicMatch
+  }
+
+  // ---- pending transactions ----
+
+  private def notifyPendingTxs(stx: SignedTransactionWithSender): Unit = {
+    subscriptions.values.collect { case s: NewPendingTxsSubscription => s }.foreach { sub =>
+      val result: JValue =
+        if (sub.includeTransactions) pendingTxJson(stx)
+        else JString("0x" + stx.tx.hash.toHex)
+      push(sub.connectionId, subscriptionEnvelope(sub.subscriptionId, result))
+    }
+  }
+
+  private def pendingTxJson(stx: SignedTransactionWithSender): JValue = {
+    val tx = stx.tx.tx
+    JObject(
+      "hash"     -> JString("0x" + stx.tx.hash.toHex),
+      "nonce"    -> JString("0x" + tx.nonce.toString(16)),
+      "from"     -> JString(stx.senderAddress.toString),
+      "to"       -> tx.receivingAddress.map(a => JString(a.toString): JValue).getOrElse(JNull),
+      "value"    -> JString("0x" + tx.value.toString(16)),
+      "gas"      -> JString("0x" + tx.gasLimit.toString(16)),
+      "gasPrice" -> JString("0x" + tx.gasPrice.toString(16)),
+      "input"    -> JString("0x" + tx.payload.toHex)
+    )
+  }
+}
+
+object SubscriptionManager {
+
+  sealed trait Subscription {
+    def subscriptionId: Long
+    def connectionId: String
+  }
+
+  case class NewHeadsSubscription(
+      subscriptionId: Long,
+      connectionId: String,
+      includeTransactions: Boolean
+  ) extends Subscription
+
+  case class LogsSubscription(
+      subscriptionId: Long,
+      connectionId: String,
+      address: Option[Seq[Address]],
+      topics: Seq[Seq[ByteString]]
+  ) extends Subscription
+
+  case class NewPendingTxsSubscription(
+      subscriptionId: Long,
+      connectionId: String,
+      includeTransactions: Boolean
+  ) extends Subscription
+
+  case class SyncingSubscription(
+      subscriptionId: Long,
+      connectionId: String
+  ) extends Subscription
+
+  // messages
+  case class RegisterConnection(connId: String, queue: SourceQueueWithComplete[String])
+  case class ConnectionClosed(connId: String)
+  case class Subscribe(connId: String, subType: String, params: Option[JValue])
+  case class Unsubscribe(connId: String, subId: Long)
+  case class SubscribeResponse(result: Either[String, Long])
+  case class UnsubscribeResponse(found: Boolean)
+
+  def props(blockchainReader: BlockchainReader): Props =
+    Props(new SubscriptionManager(blockchainReader))
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceJsonMethodsImplicits.scala
@@ -1,0 +1,164 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.jsonrpc.EthJsonMethodsImplicits.extractCall
+import com.chipprbots.ethereum.jsonrpc.TraceService._
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodCodec
+
+/** JSON-RPC codecs for the trace_* family of methods (Parity/OpenEthereum format).
+  *
+  * Besu reference: ethereum/api/.../methods/
+  *   - TraceTransaction.java               — trace_transaction
+  *   - TraceBlock.java                     — trace_block
+  *   - TraceReplayTransaction.java         — trace_replayTransaction
+  *   - TraceReplayBlockTransactions.java   — trace_replayBlockTransactions
+  *   - TraceCall.java                      — trace_call
+  *   - TraceCallMany.java                  — trace_callMany
+  *
+  * core-geth reference: eth/tracers/api.go
+  *   - TraceCall(), TraceCallMany(), TraceBlock(), etc.
+  *
+  * Parameter format:
+  *   trace_transaction(txHash)
+  *   trace_block(blockParam)
+  *   trace_replayTransaction(txHash, traceOptions)
+  *   trace_replayBlockTransactions(blockParam, traceOptions)
+  *   trace_call(callObj, traceOptions, blockParam)
+  *   trace_callMany([[callObj, traceOptions], ...], blockParam)
+  *
+  * traceOptions is an array of strings, e.g. ["trace"], ["trace","vmTrace"], ["trace","stateDiff"]
+  */
+object TraceJsonMethodsImplicits extends JsonMethodsImplicits {
+
+  implicit val trace_transaction: JsonMethodCodec[TraceTransactionRequest, TraceTransactionResponse] =
+    new JsonMethodCodec[TraceTransactionRequest, TraceTransactionResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceTransactionRequest] =
+        params match {
+          case Some(JArray(JString(hash) :: _)) =>
+            extractBytes(hash).map(TraceTransactionRequest.apply)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceTransactionResponse): JValue =
+        JArray(t.traces.toList)
+    }
+
+  implicit val trace_block: JsonMethodCodec[TraceBlockRequest, TraceBlockResponse] =
+    new JsonMethodCodec[TraceBlockRequest, TraceBlockResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceBlockRequest] =
+        params match {
+          case Some(JArray(blockParam :: _)) =>
+            extractBlockParam(blockParam).map(TraceBlockRequest.apply)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceBlockResponse): JValue =
+        JArray(t.traces.toList)
+    }
+
+  implicit val trace_replayTransaction: JsonMethodCodec[TraceReplayTransactionRequest, TraceReplayTransactionResponse] =
+    new JsonMethodCodec[TraceReplayTransactionRequest, TraceReplayTransactionResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceReplayTransactionRequest] =
+        params match {
+          case Some(JArray(JString(hash) :: JArray(opts) :: _)) =>
+            for {
+              txHash  <- extractBytes(hash)
+              options <- extractTraceOptions(opts)
+            } yield TraceReplayTransactionRequest(txHash, options)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceReplayTransactionResponse): JValue = t.result
+    }
+
+  implicit val trace_replayBlockTransactions: JsonMethodCodec[TraceReplayBlockTransactionsRequest, TraceReplayBlockTransactionsResponse] =
+    new JsonMethodCodec[TraceReplayBlockTransactionsRequest, TraceReplayBlockTransactionsResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceReplayBlockTransactionsRequest] =
+        params match {
+          case Some(JArray(blockParam :: JArray(opts) :: _)) =>
+            for {
+              block   <- extractBlockParam(blockParam)
+              options <- extractTraceOptions(opts)
+            } yield TraceReplayBlockTransactionsRequest(block, options)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceReplayBlockTransactionsResponse): JValue =
+        JArray(t.results.toList)
+    }
+
+  implicit val trace_call: JsonMethodCodec[TraceCallRequest, TraceCallResponse] =
+    new JsonMethodCodec[TraceCallRequest, TraceCallResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceCallRequest] =
+        params match {
+          case Some(JArray((txObj: JObject) :: JArray(opts) :: blockParam :: _)) =>
+            for {
+              tx      <- extractCall(txObj)
+              options <- extractTraceOptions(opts)
+              block   <- extractBlockParam(blockParam)
+            } yield TraceCallRequest(tx, options, block)
+          case Some(JArray((txObj: JObject) :: JArray(opts) :: Nil)) =>
+            for {
+              tx      <- extractCall(txObj)
+              options <- extractTraceOptions(opts)
+            } yield TraceCallRequest(tx, options, BlockParam.Latest)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceCallResponse): JValue = t.result
+    }
+
+  implicit val trace_callMany: JsonMethodCodec[TraceCallManyRequest, TraceCallManyResponse] =
+    new JsonMethodCodec[TraceCallManyRequest, TraceCallManyResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceCallManyRequest] =
+        params match {
+          case Some(JArray(JArray(callList) :: blockParam :: _)) =>
+            for {
+              block <- extractBlockParam(blockParam)
+              calls <- {
+                val decoded = callList.map {
+                  case JArray((txObj: JObject) :: JArray(opts) :: _) =>
+                    for {
+                      tx      <- extractCall(txObj)
+                      options <- extractTraceOptions(opts)
+                    } yield (tx, options)
+                  case _ =>
+                    Left(JsonRpcError.InvalidParams("Each call must be [callObj, traceOptions]"))
+                }
+                decoded.foldRight[Either[JsonRpcError, List[(EthInfoService.CallTx, TraceOptions)]]](Right(Nil)) {
+                  (e, acc) => for { h <- e; t <- acc } yield h :: t
+                }
+              }
+            } yield TraceCallManyRequest(calls, block)
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceCallManyResponse): JValue =
+        JArray(t.results.toList)
+    }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Decodes a trace options array: ["trace"], ["trace","vmTrace"], etc.
+    *
+    * Besu reference: TraceTypeParameter.java — parses an array of trace type strings.
+    * Valid values: "trace", "vmTrace", "stateDiff"
+    */
+  def extractTraceOptions(opts: List[JValue]): Either[JsonRpcError, TraceOptions] = {
+    val strs = opts.collect { case JString(s) => s.toLowerCase }
+    Right(TraceOptions(
+      trace     = strs.contains("trace"),
+      vmTrace   = strs.contains("vmtrace"),
+      stateDiff = strs.contains("statediff")
+    ))
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceJsonMethodsImplicits.scala
@@ -3,6 +3,7 @@ package com.chipprbots.ethereum.jsonrpc
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
+import com.chipprbots.ethereum.domain.Address
 import com.chipprbots.ethereum.jsonrpc.EthJsonMethodsImplicits.extractCall
 import com.chipprbots.ethereum.jsonrpc.TraceService._
 import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
@@ -146,7 +147,50 @@ object TraceJsonMethodsImplicits extends JsonMethodsImplicits {
         JArray(t.results.toList)
     }
 
+  implicit val trace_filter: JsonMethodCodec[TraceFilterRequest, TraceFilterResponse] =
+    new JsonMethodCodec[TraceFilterRequest, TraceFilterResponse] {
+
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TraceFilterRequest] =
+        params match {
+          case Some(JArray((filterObj: JObject) :: _)) =>
+            val fields = filterObj.obj.toMap
+            for {
+              fromBlock <- fields.get("fromBlock")
+                .map(extractBlockParam)
+                .getOrElse(Right(BlockParam.Earliest))
+              toBlock <- fields.get("toBlock")
+                .map(extractBlockParam)
+                .getOrElse(Right(BlockParam.Latest))
+              fromAddress <- decodeAddressList(fields.get("fromAddress"))
+              toAddress   <- decodeAddressList(fields.get("toAddress"))
+              after  = fields.get("after").collect { case JInt(n) => n.toInt }
+              count  = fields.get("count").collect { case JInt(n) => n.toInt }
+            } yield TraceFilterRequest(fromBlock, toBlock, fromAddress, toAddress, after, count)
+          case None | Some(JArray(Nil)) =>
+            Right(TraceFilterRequest(BlockParam.Earliest, BlockParam.Latest))
+          case _ =>
+            Left(JsonRpcError.InvalidParams())
+        }
+
+      override def encodeJson(t: TraceFilterResponse): JValue =
+        JArray(t.traces.toList)
+    }
+
   // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Decodes an optional address list field: string or array of strings. */
+  private def decodeAddressList(fieldOpt: Option[JValue]): Either[JsonRpcError, Seq[Address]] =
+    fieldOpt match {
+      case None | Some(JNull) | Some(JNothing) => Right(Nil)
+      case Some(JString(s)) =>
+        extractAddress(s).map(Seq(_))
+      case Some(JArray(items)) =>
+        val decoded = items.collect { case JString(s) => extractAddress(s) }
+        decoded.foldRight[Either[JsonRpcError, List[Address]]](Right(Nil)) {
+          (e, acc) => for { h <- e; t <- acc } yield h :: t
+        }
+      case _ => Left(JsonRpcError.InvalidParams("fromAddress/toAddress must be string or array"))
+    }
 
   /** Decodes a trace options array: ["trace"], ["trace","vmTrace"], etc.
     *

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceService.scala
@@ -1,0 +1,390 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.util.ByteString
+
+import cats.effect.IO
+
+import org.json4s.JValue
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jvalue2monadic
+
+import com.chipprbots.ethereum.consensus.mining.Mining
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.Blockchain
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.LegacyTransaction
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
+import com.chipprbots.ethereum.crypto.ECDSASignature
+import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.mpt.MerklePatriciaTrie.MissingNodeException
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.ByteStringUtils.ByteStringOps
+import com.chipprbots.ethereum.utils.Config
+import com.chipprbots.ethereum.vm.CallTracer
+import com.chipprbots.ethereum.vm.VmTracer
+
+/** Service implementing the trace_* family of JSON-RPC methods (Parity/OpenEthereum format).
+  *
+  * Besu reference: ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/
+  *   - TraceTransaction.java         — trace_transaction
+  *   - TraceBlock.java               — trace_block
+  *   - TraceReplayBlockTransactions.java — trace_replayBlockTransactions
+  *   - TraceReplayTransaction.java   — trace_replayTransaction
+  *   - TraceCall.java                — trace_call
+  *   - TraceCallMany.java            — trace_callMany
+  *
+  * core-geth reference: internal/ethapi/api.go + eth/tracers/api.go
+  *   - TraceCall() → traceTx() with Parity-format result builder
+  *
+  * Response format: Parity/OpenEthereum flat trace format.
+  *   - trace_transaction / trace_block return Seq of flat trace objects.
+  *   - trace_replayTransaction / trace_replayBlockTransactions return trace + vmTrace bundle.
+  *   - trace_call / trace_callMany return the same replay bundle for a synthetic tx.
+  *
+  * Note: This implementation uses CallTracer (nested call tree) and VmTracer (vm trace) as
+  * the underlying tracers.  The flat Parity trace array is produced by flattenCallTree(),
+  * which walks the CallTracer result and emits one entry per call with a traceAddress array.
+  */
+object TraceService {
+
+  /** Trace replay options — control which trace types are included in the response.
+    * Matches OpenEthereum traceReplayTransaction parameter.
+    */
+  case class TraceOptions(
+      trace: Boolean    = true,
+      vmTrace: Boolean  = false,
+      stateDiff: Boolean = false
+  )
+
+  case class TraceTransactionRequest(txHash: ByteString)
+  case class TraceTransactionResponse(traces: Seq[JValue])
+
+  case class TraceBlockRequest(block: BlockParam)
+  case class TraceBlockResponse(traces: Seq[JValue])
+
+  case class TraceReplayTransactionRequest(txHash: ByteString, options: TraceOptions)
+  case class TraceReplayTransactionResponse(result: JValue)
+
+  case class TraceReplayBlockTransactionsRequest(block: BlockParam, options: TraceOptions)
+  case class TraceReplayBlockTransactionsResponse(results: Seq[JValue])
+
+  case class TraceCallRequest(call: EthInfoService.CallTx, options: TraceOptions, block: BlockParam)
+  case class TraceCallResponse(result: JValue)
+
+  case class TraceCallManyRequest(calls: Seq[(EthInfoService.CallTx, TraceOptions)], block: BlockParam)
+  case class TraceCallManyResponse(results: Seq[JValue])
+}
+
+class TraceService(
+    val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
+    val mining: Mining,
+    stxLedger: StxLedger,
+    transactionMappingStorage: TransactionMappingStorage
+) extends ResolveBlock {
+
+  import TraceService._
+
+  implicit private val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+
+  /** Implements trace_transaction.
+    *
+    * Besu reference: TraceTransaction.java — uses FlatTraceGenerator to produce flat trace array.
+    *
+    * core-geth reference: api.go TraceTransaction() with Parity output formatter.
+    *
+    * Returns a flat array of call traces (one per call frame), each with:
+    *   action, result, subtraces, traceAddress, transactionHash, transactionPosition, blockHash, blockNumber
+    */
+  def traceTransaction(req: TraceTransactionRequest): ServiceResponse[TraceTransactionResponse] =
+    IO {
+      for {
+        location <- transactionMappingStorage.get(req.txHash)
+          .toRight(JsonRpcError.InvalidParams("Transaction not found"))
+        TransactionLocation(blockHash, txIndex) = location
+        block <- blockchainReader.getBlockByHash(blockHash)
+          .toRight(JsonRpcError.InvalidParams(s"Block not found for hash ${blockHash.toHex}"))
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block not found"))
+        stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        _ <- Either.cond(
+          txIndex >= 0 && txIndex < stxs.length,
+          (),
+          JsonRpcError.InvalidParams(s"Transaction index $txIndex out of range")
+        )
+        targetStx = stxs(txIndex)
+        world = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+        tracer = new CallTracer(onlyTopCall = false)
+        _ = stxLedger.simulateTransactionWithTracer(targetStx, block.header, Some(world), tracer)
+        flat = flattenCallTree(
+          tracer.getResult, req.txHash, txIndex,
+          block.header.hash, block.header.number
+        )
+      } yield TraceTransactionResponse(flat)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements trace_block.
+    *
+    * Besu reference: TraceBlock.java — returns flat traces for all txs in the block.
+    *
+    * core-geth reference: TraceBlock() iterates block txs and produces flat trace per tx.
+    */
+  def traceBlock(req: TraceBlockRequest): ServiceResponse[TraceBlockResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+        block = resolved.block
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block not found"))
+        traces = traceAllTxsFlat(block, parentHeader.stateRoot)
+      } yield TraceBlockResponse(traces)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements trace_replayTransaction.
+    *
+    * Besu reference: TraceReplayTransaction.java — runs the tx with CallTracer + optionally VmTracer,
+    *   returns { trace: [...], vmTrace: {...}, stateDiff: null }.
+    *
+    * core-geth reference: api.go TraceTransaction() with {tracer: "prestateTracer"} for stateDiff,
+    *   native callTracer for trace.
+    */
+  def replayTransaction(req: TraceReplayTransactionRequest): ServiceResponse[TraceReplayTransactionResponse] =
+    IO {
+      for {
+        location <- transactionMappingStorage.get(req.txHash)
+          .toRight(JsonRpcError.InvalidParams("Transaction not found"))
+        TransactionLocation(blockHash, txIndex) = location
+        block <- blockchainReader.getBlockByHash(blockHash)
+          .toRight(JsonRpcError.InvalidParams(s"Block not found for hash ${blockHash.toHex}"))
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block not found"))
+        stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        _ <- Either.cond(
+          txIndex >= 0 && txIndex < stxs.length,
+          (),
+          JsonRpcError.InvalidParams(s"Transaction index $txIndex out of range")
+        )
+        targetStx = stxs(txIndex)
+        world = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+        result = buildReplayResult(targetStx, block, Some(world), req.txHash, txIndex, req.options)
+      } yield TraceReplayTransactionResponse(result)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements trace_replayBlockTransactions.
+    *
+    * Besu reference: TraceReplayBlockTransactions.java — same as replay but for every tx in a block.
+    *
+    * core-geth reference: TraceBlock() with replay options.
+    */
+  def replayBlockTransactions(req: TraceReplayBlockTransactionsRequest): ServiceResponse[TraceReplayBlockTransactionsResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+        block = resolved.block
+        parentHeader <- blockchainReader.getBlockHeaderByHash(block.header.parentHash)
+          .toRight(JsonRpcError.InvalidParams("Parent block not found"))
+        stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+        results = stxs.zipWithIndex.map { case (stx, txIndex) =>
+          val world = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentHeader.stateRoot)
+          buildReplayResult(stx, block, Some(world), stx.tx.hash, txIndex, req.options)
+        }
+      } yield TraceReplayBlockTransactionsResponse(results)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements trace_call.
+    *
+    * Besu reference: TraceCall.java — builds a synthetic tx and runs replay.
+    *
+    * core-geth reference: api.go TraceCall() — same pattern as TraceTransaction but with a
+    *   synthetic tx constructed from the call parameters.
+    */
+  def traceCall(req: TraceCallRequest): ServiceResponse[TraceCallResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+        stx <- buildCallTx(req.call, resolved.block)
+        world = resolved.pendingState
+        result = buildReplayResult(
+          stx, resolved.block, world,
+          ByteString.empty, 0, req.options
+        )
+      } yield TraceCallResponse(result)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Implements trace_callMany.
+    *
+    * core-geth reference: api.go TraceCallMany() — executes a list of (call, options) pairs.
+    *
+    * Besu does not implement this method; core-geth alignment only.
+    */
+  def traceCallMany(req: TraceCallManyRequest): ServiceResponse[TraceCallManyResponse] =
+    IO {
+      for {
+        resolved <- resolveBlock(req.block)
+      } yield {
+        val results: Seq[JValue] = req.calls.map { case (callTx, options) =>
+          buildCallTx(callTx, resolved.block).map { stx =>
+            buildReplayResult(stx, resolved.block, resolved.pendingState, ByteString.empty, 0, options)
+          }.getOrElse(JNull)
+        }
+        TraceCallManyResponse(results)
+      }
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Traces all txs in a block and returns flat trace objects for all of them concatenated. */
+  private def traceAllTxsFlat(block: Block, parentStateRoot: ByteString): Seq[JValue] = {
+    val stxs = SignedTransactionWithSender.getSignedTransactions(block.body.transactionList)
+    stxs.zipWithIndex.flatMap { case (stx, txIndex) =>
+      val world  = stxLedger.advanceWorldToTx(block.header, stxs, txIndex, parentStateRoot)
+      val tracer = new CallTracer(onlyTopCall = false)
+      stxLedger.simulateTransactionWithTracer(stx, block.header, Some(world), tracer)
+      flattenCallTree(tracer.getResult, stx.tx.hash, txIndex, block.header.hash, block.header.number)
+    }
+  }
+
+  /** Builds a replay result bundle: { trace, vmTrace, stateDiff } based on options. */
+  private def buildReplayResult(
+      stx: SignedTransactionWithSender,
+      block: Block,
+      world: Option[com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy],
+      txHash: ByteString,
+      txIndex: Int,
+      options: TraceOptions
+  ): JValue = {
+    // Always run CallTracer for the trace field (even if options.trace=false, needed for vmTrace sub selection)
+    val callTracer = new CallTracer(onlyTopCall = false)
+    stxLedger.simulateTransactionWithTracer(stx, block.header, world, callTracer)
+
+    val traceField: JValue = if (options.trace) {
+      JArray(flattenCallTree(callTracer.getResult, txHash, txIndex, block.header.hash, block.header.number).toList)
+    } else JNull
+
+    val vmTraceField: JValue = if (options.vmTrace) {
+      val vmTracer = new VmTracer()
+      stxLedger.simulateTransactionWithTracer(stx, block.header, world, vmTracer)
+      vmTracer.getResult
+    } else JNull
+
+    // stateDiff not yet implemented (deferred to P1-G)
+    val txHashField: JValue = if (txHash.nonEmpty) JString(s"0x${txHash.toHex}") else JNull
+    ("trace" -> traceField) ~
+    ("vmTrace" -> vmTraceField) ~
+    ("stateDiff" -> (JNull: JValue)) ~
+    ("transactionHash" -> txHashField)
+  }
+
+  /** Flattens a nested CallTracer result (JObject) into a flat Parity trace array.
+    *
+    * Besu reference: FlatTraceGenerator.java — walks call tree, assigns traceAddress arrays.
+    *
+    * Each frame becomes one trace entry:
+    * {{{
+    * {
+    *   "type": "call" | "create",
+    *   "action": { "callType": "call", "from": "0x...", "to": "0x...", "gas": "0x...",
+    *               "value": "0x...", "input": "0x..." },
+    *   "result": { "gasUsed": "0x...", "output": "0x..." },
+    *   "subtraces": N,
+    *   "traceAddress": [0, 1, ...],
+    *   "transactionHash": "0x...",
+    *   "transactionPosition": N,
+    *   "blockHash": "0x...",
+    *   "blockNumber": N
+    * }
+    * }}}
+    */
+  private def flattenCallTree(
+      root: JValue,
+      txHash: ByteString,
+      txIndex: Int,
+      blockHash: ByteString,
+      blockNumber: BigInt
+  ): Seq[JValue] = {
+    val buf = scala.collection.mutable.ArrayBuffer[JValue]()
+
+    def walk(node: JValue, addr: List[Int]): Unit = node match {
+      case obj: JObject =>
+        val calls = (obj \ "calls") match {
+          case JArray(cs) => cs
+          case _          => Nil
+        }
+        val traceType = (obj \ "type") match {
+          case JString(s) if s.toUpperCase.startsWith("CREATE") => "create"
+          case _                                                 => "call"
+        }
+        val action: JValue = if (traceType == "create") {
+          ("from"  -> (obj \ "from")) ~
+          ("gas"   -> (obj \ "gas")) ~
+          ("value" -> (obj \ "value")) ~
+          ("init"  -> (obj \ "input"))
+        } else {
+          ("callType" -> ((obj \ "type") match { case JString(s) => s.toLowerCase; case _ => "call" })) ~
+          ("from"  -> (obj \ "from")) ~
+          ("to"    -> (obj \ "to")) ~
+          ("gas"   -> (obj \ "gas")) ~
+          ("value" -> (obj \ "value")) ~
+          ("input" -> (obj \ "input"))
+        }
+        val resultField: JValue = (obj \ "error") match {
+          case JString(_) | JNull => JNull
+          case _ =>
+            if (traceType == "create")
+              ("gasUsed" -> (obj \ "gasUsed")) ~ ("address" -> (obj \ "to")) ~ ("code" -> (obj \ "output"))
+            else
+              ("gasUsed" -> (obj \ "gasUsed")) ~ ("output" -> (obj \ "output"))
+        }
+        val txHashField: JValue   = if (txHash.nonEmpty) JString(s"0x${txHash.toHex}") else JNull
+        val traceAddrField: JValue = JArray(addr.map(i => JInt(i)))
+        val entry: JObject =
+          ("type"               -> traceType) ~
+          ("action"             -> action) ~
+          ("result"             -> resultField) ~
+          ("subtraces"          -> calls.length) ~
+          ("traceAddress"       -> traceAddrField) ~
+          ("transactionHash"    -> txHashField) ~
+          ("transactionPosition" -> txIndex) ~
+          ("blockHash"          -> s"0x${blockHash.toHex}") ~
+          ("blockNumber"        -> blockNumber)
+        buf += entry
+        calls.zipWithIndex.foreach { case (child, i) => walk(child, addr :+ i) }
+      case _ => // not an object, skip
+    }
+
+    walk(root, Nil)
+    buf.toSeq
+  }
+
+  /** Builds a synthetic SignedTransactionWithSender from a CallTx (used in traceCall). */
+  private def buildCallTx(
+      callTx: EthInfoService.CallTx,
+      block: Block
+  ): Either[JsonRpcError, SignedTransactionWithSender] = {
+    val gasLimit = callTx.gas.getOrElse(block.header.gasLimit)
+    val fromAddress = callTx.from
+      .map(Address.apply)
+      .getOrElse(Address(0))
+    val toAddress = callTx.to.map(Address.apply)
+
+    val tx = LegacyTransaction(0, callTx.gasPrice, gasLimit, toAddress, callTx.value, callTx.data)
+    val fakeSignature = ECDSASignature(0, 0, 0)
+    Right(SignedTransactionWithSender(tx, fakeSignature, fromAddress))
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TraceService.scala
@@ -77,6 +77,27 @@ object TraceService {
 
   case class TraceCallManyRequest(calls: Seq[(EthInfoService.CallTx, TraceOptions)], block: BlockParam)
   case class TraceCallManyResponse(results: Seq[JValue])
+
+  /** trace_filter params — matches Besu FilterParameter + Parity/OpenEthereum filter spec.
+    *
+    * Besu reference: FilterParameter.java + TraceFilter.java
+    *   - fromBlock / toBlock: block range (inclusive on both ends)
+    *   - fromAddress / toAddress: address filters; empty list = no filter (AND semantics)
+    *   - after: skip first N matching traces (offset for pagination)
+    *   - count: return at most N matching traces (limit for pagination)
+    *   - maxRange: guarded by MaxTraceFilterRange constant
+    */
+  case class TraceFilterRequest(
+      fromBlock: BlockParam,
+      toBlock: BlockParam,
+      fromAddress: Seq[Address] = Nil,
+      toAddress: Seq[Address] = Nil,
+      after: Option[Int] = None,
+      count: Option[Int] = None
+  )
+  case class TraceFilterResponse(traces: Seq[JValue])
+
+  val MaxTraceFilterRange: Long = 1000L
 }
 
 class TraceService(
@@ -370,6 +391,78 @@ class TraceService(
 
     walk(root, Nil)
     buf.toSeq
+  }
+
+  /** Implements trace_filter.
+    *
+    * Besu reference: TraceFilter.java — iterates block range, produces flat Parity traces per block,
+    *   applies fromAddress/toAddress filters, respects after/count pagination, guards maxRange.
+    *
+    * core-geth reference: api_parity.go Filter() → TraceChain() (streaming); we use Besu's
+    *   synchronous collection approach to keep HTTP semantics simple.
+    *
+    * Algorithm:
+    *   1. Resolve fromBlock / toBlock to block numbers
+    *   2. Validate range: fromBlock <= toBlock, range <= MaxTraceFilterRange
+    *   3. For each block in range: get flat traces via traceAllTxsFlat, apply address filters
+    *   4. Apply pagination (after = offset, count = limit)
+    */
+  def traceFilter(req: TraceFilterRequest): ServiceResponse[TraceFilterResponse] =
+    IO {
+      for {
+        fromResolved <- resolveBlock(req.fromBlock)
+        toResolved   <- resolveBlock(req.toBlock)
+        fromNum       = fromResolved.block.header.number.toLong
+        toNum         = toResolved.block.header.number.toLong
+        _ <- Either.cond(fromNum <= toNum, (), JsonRpcError.InvalidParams("fromBlock must be <= toBlock"))
+        _ <- Either.cond(
+          toNum - fromNum <= MaxTraceFilterRange,
+          (),
+          JsonRpcError.InvalidParams(s"Requested range exceeds max of $MaxTraceFilterRange blocks")
+        )
+        allTraces = (fromNum to toNum).flatMap { blockNum =>
+          if (blockNum == 0) Nil  // skip genesis — no parent state
+          else {
+            val branch = blockchainReader.getBestBranch()
+            blockchainReader.getBlockByNumber(branch, blockNum)
+              .flatMap { block =>
+                blockchainReader.getBlockHeaderByHash(block.header.parentHash).map { parentHeader =>
+                  val flat = traceAllTxsFlat(block, parentHeader.stateRoot)
+                  applyAddressFilter(flat, req.fromAddress, req.toAddress)
+                }
+              }
+              .getOrElse(Nil)
+          }
+        }
+        paginatedTraces = {
+          val afterN = req.after.getOrElse(0)
+          val countN = req.count.getOrElse(allTraces.length)
+          allTraces.slice(afterN, afterN + countN)
+        }
+      } yield TraceFilterResponse(paginatedTraces)
+    }.recover { case _: MissingNodeException =>
+      Left(JsonRpcError.NodeNotFound)
+    }
+
+  /** Applies fromAddress/toAddress filters to a flat trace sequence.
+    *
+    * Besu reference: TraceFlatTransactionStep.java — both filters are AND semantics;
+    *   an empty list means "no filter" (all traces pass).
+    */
+  private def applyAddressFilter(
+      traces: Seq[JValue],
+      fromAddrs: Seq[Address],
+      toAddrs: Seq[Address]
+  ): Seq[JValue] = {
+    if (fromAddrs.isEmpty && toAddrs.isEmpty) traces
+    else traces.filter { trace =>
+      val action   = trace \ "action"
+      val fromHex  = (action \ "from") match { case JString(s) => s.toLowerCase; case _ => "" }
+      val toHex    = (action \ "to")   match { case JString(s) => s.toLowerCase; case _ => "" }
+      val fromOk   = fromAddrs.isEmpty || fromAddrs.exists(a => fromHex == "0x" + a.toString.toLowerCase)
+      val toOk     = toAddrs.isEmpty   || toAddrs.exists(a => toHex   == "0x" + a.toString.toLowerCase)
+      fromOk && toOk
+    }
   }
 
   /** Builds a synthetic SignedTransactionWithSender from a CallTx (used in traceCall). */

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
@@ -44,11 +44,54 @@ object TxPoolJsonMethodsImplicits extends JsonMethodsImplicits {
         params match {
           case None | Some(JArray(Nil)) =>
             Right(TxPoolBesuPendingTransactionsRequest(None))
-          case Some(JArray(JInt(limit) :: _)) =>
-            Right(TxPoolBesuPendingTransactionsRequest(Some(limit.toInt)))
+          case Some(JArray(limitParam :: rest)) =>
+            val limit = limitParam match {
+              case JInt(n) => Some(n.toInt)
+              case JNull   => None
+              case _       => return Left(InvalidParams())
+            }
+            val txParams = rest.headOption.flatMap {
+              case obj: JObject => Some(decodeFilterParams(obj))
+              case JNull        => None
+              case _            => return Left(InvalidParams())
+            }
+            Right(TxPoolBesuPendingTransactionsRequest(limit, txParams))
           case _ =>
             Left(InvalidParams())
         }
+
+      /** Decode a PendingTransactionsParams filter object.
+        *
+        * Expected JSON shape (each field is optional):
+        * {{{
+        * {
+        *   "from":     {"eq":  "0xaddr"},
+        *   "to":       {"eq":  "0xaddr"} or {"action": "deploy"},
+        *   "gas":      {"gt":  "0x5208"},
+        *   "gasPrice": {"lt":  "0x..."},
+        *   "value":    {"eq":  "0x0"},
+        *   "nonce":    {"gt":  "5"}
+        * }
+        * }}}
+        *
+        * Unknown fields and unknown predicates are silently ignored (matches Besu's
+        * @JsonIgnoreProperties(ignoreUnknown = true) on PendingTransactionsParams).
+        */
+      private def decodeFilterParams(obj: JObject): TxPoolBesuPendingTransactionsParams = {
+        val filters = obj.obj.flatMap {
+          case JField(field, JObject(List(JField(predStr, JString(value))))) =>
+            val pred = predStr.toLowerCase match {
+              case "eq"     => Some(Eq)
+              case "gt"     => Some(Gt)
+              case "lt"     => Some(Lt)
+              case "action" => Some(Action)
+              case _        => None
+            }
+            pred.map(p => TxPoolFilter(field, p, value))
+          case _ => None
+        }
+        TxPoolBesuPendingTransactionsParams(filters)
+      }
 
       override def encodeJson(t: TxPoolBesuPendingTransactionsResponse): JValue =
         JArray(t.pendingTransactions.toList.map(tx => transactionResponseJsonEncoder.encodeJson(tx)))

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
@@ -1,0 +1,56 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.json4s.JsonAST._
+
+import com.chipprbots.ethereum.jsonrpc.EthTxJsonMethodsImplicits.transactionResponseJsonEncoder
+import com.chipprbots.ethereum.jsonrpc.JsonRpcError.InvalidParams
+import com.chipprbots.ethereum.jsonrpc.TxPoolService._
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder.Ops._
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodDecoder
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodDecoder.NoParamsMethodDecoder
+
+object TxPoolJsonMethodsImplicits extends JsonMethodsImplicits {
+
+  implicit val txpool_besuTransactions
+      : NoParamsMethodDecoder[TxPoolBesuTransactionsRequest] with JsonEncoder[TxPoolBesuTransactionsResponse] =
+    new NoParamsMethodDecoder(TxPoolBesuTransactionsRequest())
+      with JsonEncoder[TxPoolBesuTransactionsResponse] {
+      override def encodeJson(t: TxPoolBesuTransactionsResponse): JValue =
+        JArray(t.pendingTransactions.toList.map(tx => transactionResponseJsonEncoder.encodeJson(tx)))
+    }
+
+  implicit val txpool_besuStatistics
+      : NoParamsMethodDecoder[TxPoolBesuStatisticsRequest] with JsonEncoder[TxPoolBesuStatisticsResponse] =
+    new NoParamsMethodDecoder(TxPoolBesuStatisticsRequest())
+      with JsonEncoder[TxPoolBesuStatisticsResponse] {
+      override def encodeJson(t: TxPoolBesuStatisticsResponse): JValue =
+        JObject(
+          "maxSize"     -> JLong(t.maxSize),
+          "localCount"  -> JLong(t.localCount),
+          "remoteCount" -> JLong(t.remoteCount)
+        )
+    }
+
+  implicit val txpool_besuPendingTransactions
+      : JsonMethodDecoder[TxPoolBesuPendingTransactionsRequest]
+        with JsonEncoder[TxPoolBesuPendingTransactionsResponse] =
+    new JsonMethodDecoder[TxPoolBesuPendingTransactionsRequest]
+      with JsonEncoder[TxPoolBesuPendingTransactionsResponse] {
+
+      override def decodeJson(
+          params: Option[JArray]
+      ): Either[JsonRpcError, TxPoolBesuPendingTransactionsRequest] =
+        params match {
+          case None | Some(JArray(Nil)) =>
+            Right(TxPoolBesuPendingTransactionsRequest(None))
+          case Some(JArray(JInt(limit) :: _)) =>
+            Right(TxPoolBesuPendingTransactionsRequest(Some(limit.toInt)))
+          case _ =>
+            Left(InvalidParams())
+        }
+
+      override def encodeJson(t: TxPoolBesuPendingTransactionsResponse): JValue =
+        JArray(t.pendingTransactions.toList.map(tx => transactionResponseJsonEncoder.encodeJson(tx)))
+    }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolJsonMethodsImplicits.scala
@@ -2,6 +2,7 @@ package com.chipprbots.ethereum.jsonrpc
 
 import org.json4s.JsonAST._
 
+import com.chipprbots.ethereum.domain.Address
 import com.chipprbots.ethereum.jsonrpc.EthTxJsonMethodsImplicits.transactionResponseJsonEncoder
 import com.chipprbots.ethereum.jsonrpc.JsonRpcError.InvalidParams
 import com.chipprbots.ethereum.jsonrpc.TxPoolService._
@@ -95,5 +96,69 @@ object TxPoolJsonMethodsImplicits extends JsonMethodsImplicits {
 
       override def encodeJson(t: TxPoolBesuPendingTransactionsResponse): JValue =
         JArray(t.pendingTransactions.toList.map(tx => transactionResponseJsonEncoder.encodeJson(tx)))
+    }
+
+  // ── Geth-compatible methods ────────────────────────────────────────────────
+
+  implicit val txpool_content
+      : NoParamsMethodDecoder[TxPoolContentRequest] with JsonEncoder[TxPoolContentResponse] =
+    new NoParamsMethodDecoder(TxPoolContentRequest()) with JsonEncoder[TxPoolContentResponse] {
+      override def encodeJson(t: TxPoolContentResponse): JValue = {
+        def encodeNested(m: Map[String, Map[String, TransactionResponse]]): JObject =
+          JObject(m.toList.map { case (sender, byNonce) =>
+            sender -> JObject(byNonce.toList.map { case (nonce, tx) =>
+              nonce -> transactionResponseJsonEncoder.encodeJson(tx)
+            })
+          })
+        JObject("pending" -> encodeNested(t.pending), "queued" -> encodeNested(t.queued))
+      }
+    }
+
+  implicit val txpool_contentFrom
+      : JsonMethodDecoder[TxPoolContentFromRequest] with JsonEncoder[TxPoolContentFromResponse] =
+    new JsonMethodDecoder[TxPoolContentFromRequest]
+      with JsonEncoder[TxPoolContentFromResponse] {
+      override def decodeJson(
+          params: Option[JArray]
+      ): Either[JsonRpcError, TxPoolContentFromRequest] =
+        params match {
+          case Some(JArray(JString(addr) :: _)) =>
+            Right(TxPoolContentFromRequest(Address(addr)))
+          case _ =>
+            Left(InvalidParams())
+        }
+
+      override def encodeJson(t: TxPoolContentFromResponse): JValue = {
+        def encodeFlat(m: Map[String, TransactionResponse]): JObject =
+          JObject(m.toList.map { case (nonce, tx) =>
+            nonce -> transactionResponseJsonEncoder.encodeJson(tx)
+          })
+        JObject("pending" -> encodeFlat(t.pending), "queued" -> encodeFlat(t.queued))
+      }
+    }
+
+  implicit val txpool_status
+      : NoParamsMethodDecoder[TxPoolStatusRequest] with JsonEncoder[TxPoolStatusResponse] =
+    new NoParamsMethodDecoder(TxPoolStatusRequest()) with JsonEncoder[TxPoolStatusResponse] {
+      // core-geth uses hexutil.Uint — serialises as a hex string (e.g. "0x5")
+      override def encodeJson(t: TxPoolStatusResponse): JValue =
+        JObject(
+          "pending" -> JString("0x" + java.lang.Long.toHexString(t.pending)),
+          "queued"  -> JString("0x" + java.lang.Long.toHexString(t.queued))
+        )
+    }
+
+  implicit val txpool_inspect
+      : NoParamsMethodDecoder[TxPoolInspectRequest] with JsonEncoder[TxPoolInspectResponse] =
+    new NoParamsMethodDecoder(TxPoolInspectRequest()) with JsonEncoder[TxPoolInspectResponse] {
+      override def encodeJson(t: TxPoolInspectResponse): JValue = {
+        def encodeNested(m: Map[String, Map[String, String]]): JObject =
+          JObject(m.toList.map { case (sender, byNonce) =>
+            sender -> JObject(byNonce.toList.map { case (nonce, summary) =>
+              nonce -> JString(summary)
+            })
+          })
+        JObject("pending" -> encodeNested(t.pending), "queued" -> encodeNested(t.queued))
+      }
     }
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
@@ -13,10 +13,11 @@ import com.chipprbots.ethereum.utils.TxPoolConfig
 
 /** JSON-RPC txpool_* namespace.
   *
-  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions,
+  * Besu methods: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions,
   *   PendingTransactionsStatisticsResult, TransactionPendingResult, PendingTransactionFilter
   *
-  * Divergences from Besu: none. All three methods are fully aligned.
+  * Geth-compatible methods (core-geth TxPoolAPI): txpool_content, txpool_contentFrom,
+  *   txpool_inspect, txpool_status — for interoperability with ETC ecosystem tooling.
   *
   * localCount/remoteCount: tracked via PendingTransaction.receivedFromLocalSource, which is set
   *   to true when a transaction is submitted via local RPC (eth_sendRawTransaction,
@@ -24,8 +25,13 @@ import com.chipprbots.ethereum.utils.TxPoolConfig
   *
   * txpool_besuPendingTransactions: implements both limit and the PendingTransactionsParams filter
   *   object (from/to address, gas/gasPrice/value/nonce with eq/gt/lt/action predicates).
+  *
+  * Note: Fukuii has no queued pool (transactions with nonce gaps are dropped). All geth-compat
+  *   methods return queued: empty/0, matching Besu's behaviour on a pending-only pool.
   */
 object TxPoolService {
+  // ── Besu methods ──────────────────────────────────────────────────────────
+
   case class TxPoolBesuTransactionsRequest()
   case class TxPoolBesuTransactionsResponse(pendingTransactions: Seq[TransactionResponse])
 
@@ -48,6 +54,41 @@ object TxPoolService {
       params: Option[TxPoolBesuPendingTransactionsParams] = None
   )
   case class TxPoolBesuPendingTransactionsResponse(pendingTransactions: Seq[TransactionResponse])
+
+  // ── Geth-compatible methods ────────────────────────────────────────────────
+  // core-geth reference: internal/ethapi/api.go TxPoolAPI
+
+  /** txpool_content: pending + queued txs grouped by sender → nonce → TransactionObject.
+    * queued is always empty (Fukuii has no queued pool).
+    */
+  case class TxPoolContentRequest()
+  case class TxPoolContentResponse(
+      pending: Map[String, Map[String, TransactionResponse]],
+      queued: Map[String, Map[String, TransactionResponse]]
+  )
+
+  /** txpool_contentFrom: same shape as content but scoped to one sender address. */
+  case class TxPoolContentFromRequest(address: Address)
+  case class TxPoolContentFromResponse(
+      pending: Map[String, TransactionResponse],
+      queued: Map[String, TransactionResponse]
+  )
+
+  /** txpool_status: hex-encoded pending and queued counts.
+    * core-geth: map[string]hexutil.Uint{"pending": N, "queued": 0}
+    */
+  case class TxPoolStatusRequest()
+  case class TxPoolStatusResponse(pending: Long, queued: Long)
+
+  /** txpool_inspect: human-readable summary grouped by sender → nonce → string.
+    * Format: "0xTo: value wei + gasLimit gas × gasPrice wei" (or "contract creation: ...")
+    * core-geth: internal/ethapi/api.go TxPoolAPI.Inspect()
+    */
+  case class TxPoolInspectRequest()
+  case class TxPoolInspectResponse(
+      pending: Map[String, Map[String, String]],
+      queued: Map[String, Map[String, String]]
+  )
 }
 
 class TxPoolService(
@@ -147,5 +188,64 @@ class TxPoolService(
       case Gt => a > b
       case Lt => a < b
       case _  => false
+    }
+
+  // ── Geth-compatible methods ────────────────────────────────────────────────
+
+  /** txpool_content — pending txs grouped by sender address → nonce → TransactionObject.
+    * core-geth: TxPoolAPI.Content() — pending[account][nonce] = RPCTransaction
+    */
+  def content(req: TxPoolContentRequest): ServiceResponse[TxPoolContentResponse] =
+    getTransactionsFromPool.map { resp =>
+      val pending = resp.pendingTransactions
+        .groupBy(pt => pt.stx.senderAddress.toString)
+        .map { case (sender, pts) =>
+          sender -> pts.map(pt => pt.stx.tx.tx.nonce.toString -> TransactionResponse(pt.stx.tx)).toMap
+        }
+      Right(TxPoolContentResponse(pending, Map.empty))
+    }
+
+  /** txpool_contentFrom — pending txs for a single sender, nonce → TransactionObject.
+    * core-geth: TxPoolAPI.ContentFrom(addr) — pending[nonce] = RPCTransaction
+    */
+  def contentFrom(req: TxPoolContentFromRequest): ServiceResponse[TxPoolContentFromResponse] =
+    getTransactionsFromPool.map { resp =>
+      val pending = resp.pendingTransactions
+        .filter(pt => pt.stx.senderAddress == req.address)
+        .map(pt => pt.stx.tx.tx.nonce.toString -> TransactionResponse(pt.stx.tx))
+        .toMap
+      Right(TxPoolContentFromResponse(pending, Map.empty))
+    }
+
+  /** txpool_status — hex-encoded count of pending and queued transactions.
+    * core-geth: TxPoolAPI.Status() — {"pending": hexutil.Uint(N), "queued": 0}
+    */
+  def status(req: TxPoolStatusRequest): ServiceResponse[TxPoolStatusResponse] =
+    getTransactionsFromPool.map { resp =>
+      Right(TxPoolStatusResponse(pending = resp.pendingTransactions.size.toLong, queued = 0L))
+    }
+
+  /** txpool_inspect — human-readable summary grouped by sender → nonce → string.
+    * Format per tx: "0xTo: value wei + gasLimit gas × gasPrice wei"
+    *            or: "contract creation: value wei + gasLimit gas × gasPrice wei"
+    * core-geth: TxPoolAPI.Inspect()
+    */
+  def inspect(req: TxPoolInspectRequest): ServiceResponse[TxPoolInspectResponse] =
+    getTransactionsFromPool.map { resp =>
+      val pending = resp.pendingTransactions
+        .groupBy(pt => pt.stx.senderAddress.toString)
+        .map { case (sender, pts) =>
+          sender -> pts.map { pt =>
+            val tx = pt.stx.tx.tx
+            val summary = tx.receivingAddress match {
+              case Some(to) =>
+                s"${to}: ${tx.value} wei + ${tx.gasLimit} gas × ${tx.gasPrice} wei"
+              case None =>
+                s"contract creation: ${tx.value} wei + ${tx.gasLimit} gas × ${tx.gasPrice} wei"
+            }
+            tx.nonce.toString -> summary
+          }.toMap
+        }
+      Right(TxPoolInspectResponse(pending, Map.empty))
     }
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
@@ -6,18 +6,24 @@ import cats.effect.IO
 
 import scala.concurrent.duration.FiniteDuration
 
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 import com.chipprbots.ethereum.transactions.TransactionPicker
 import com.chipprbots.ethereum.utils.TxPoolConfig
 
 /** JSON-RPC txpool_* namespace.
   *
-  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions
+  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions,
+  *   PendingTransactionsStatisticsResult, TransactionPendingResult, PendingTransactionFilter
   *
-  * Divergences from Besu:
-  *   - localCount is always 0: Fukuii's PendingTransaction does not track isReceivedFromLocalSource.
-  *     All pending txs are reported as remoteCount.
-  *   - txpool_besuPendingTransactions accepts an optional limit param only; Besu's PendingTransactionsParams
-  *     filter object (from/to address, gas price, nonce ranges) is not implemented.
+  * Divergences from Besu: none. All three methods are fully aligned.
+  *
+  * localCount/remoteCount: tracked via PendingTransaction.receivedFromLocalSource, which is set
+  *   to true when a transaction is submitted via local RPC (eth_sendRawTransaction,
+  *   personal_sendTransaction) and false for transactions received from P2P peers.
+  *
+  * txpool_besuPendingTransactions: implements both limit and the PendingTransactionsParams filter
+  *   object (from/to address, gas/gasPrice/value/nonce with eq/gt/lt/action predicates).
   */
 object TxPoolService {
   case class TxPoolBesuTransactionsRequest()
@@ -26,7 +32,21 @@ object TxPoolService {
   case class TxPoolBesuStatisticsRequest()
   case class TxPoolBesuStatisticsResponse(maxSize: Long, localCount: Long, remoteCount: Long)
 
-  case class TxPoolBesuPendingTransactionsRequest(limit: Option[Int])
+  // Filter predicate — matches Besu's Predicate enum (EQ, GT, LT, ACTION)
+  sealed trait TxPoolFilterPredicate
+  case object Eq     extends TxPoolFilterPredicate
+  case object Gt     extends TxPoolFilterPredicate
+  case object Lt     extends TxPoolFilterPredicate
+  case object Action extends TxPoolFilterPredicate // "to" field only: filters contract creation txs
+
+  case class TxPoolFilter(field: String, predicate: TxPoolFilterPredicate, value: String)
+
+  case class TxPoolBesuPendingTransactionsParams(filters: Seq[TxPoolFilter])
+
+  case class TxPoolBesuPendingTransactionsRequest(
+      limit: Option[Int],
+      params: Option[TxPoolBesuPendingTransactionsParams] = None
+  )
   case class TxPoolBesuPendingTransactionsResponse(pendingTransactions: Seq[TransactionResponse])
 }
 
@@ -51,31 +71,81 @@ class TxPoolService(
   /** txpool_besuStatistics — returns pool size statistics.
     *
     * Besu: TxPoolBesuStatistics counts PendingTransaction.isReceivedFromLocalSource().
-    * Fukuii divergence: localCount is always 0; all txs reported as remoteCount.
+    * localCount: transactions submitted via local RPC (AddOrOverrideTransaction path).
+    * remoteCount: transactions received from P2P peers (AddTransactions path).
     */
   def besuStatistics(req: TxPoolBesuStatisticsRequest): ServiceResponse[TxPoolBesuStatisticsResponse] =
     getTransactionsFromPool.map { resp =>
-      val total = resp.pendingTransactions.size.toLong
+      val local  = resp.pendingTransactions.count(_.receivedFromLocalSource).toLong
+      val remote = resp.pendingTransactions.size.toLong - local
       Right(TxPoolBesuStatisticsResponse(
         maxSize = txPoolConfig.txPoolSize.toLong,
-        localCount = 0L,
-        remoteCount = total
+        localCount = local,
+        remoteCount = remote
       ))
     }
 
-  /** txpool_besuPendingTransactions — returns pending transactions with optional limit.
+  /** txpool_besuPendingTransactions — returns pending transactions with optional limit and filters.
     *
     * Besu: TxPoolBesuPendingTransactions accepts limit + PendingTransactionsParams filter object.
-    * Fukuii divergence: filter object not implemented; only limit is honoured.
+    * Supported filter fields: from (eq), to (eq, action), gas (eq/gt/lt), gasPrice (eq/gt/lt),
+    *   value (eq/gt/lt), nonce (eq/gt/lt).
+    * Numeric fields (gas, gasPrice, value) expect hex string values.
+    * Nonce expects a decimal string.
+    * action predicate on "to" selects contract creation transactions (receivingAddress is empty).
     */
   def besuPendingTransactions(
       req: TxPoolBesuPendingTransactionsRequest
   ): ServiceResponse[TxPoolBesuPendingTransactionsResponse] =
     getTransactionsFromPool.map { resp =>
+      val filters = req.params.map(_.filters).getOrElse(Seq.empty)
+      val filtered =
+        if (filters.isEmpty) resp.pendingTransactions
+        else resp.pendingTransactions.filter(pt => applyFilters(pt, filters))
       val txs = req.limit match {
-        case Some(n) => resp.pendingTransactions.take(n)
-        case None    => resp.pendingTransactions
+        case Some(n) => filtered.take(n)
+        case None    => filtered
       }
       Right(TxPoolBesuPendingTransactionsResponse(txs.map(pt => TransactionResponse(pt.stx.tx))))
+    }
+
+  /** Apply all filters to a pending transaction. Returns true if the tx passes all filters.
+    *
+    * Mirrors Besu's PendingTransactionFilter.applyFilters().
+    */
+  private def applyFilters(pt: PendingTransaction, filters: Seq[TxPoolFilter]): Boolean =
+    filters.forall { f =>
+      val tx   = pt.stx.tx.tx
+      val from = pt.stx.senderAddress
+      f.field match {
+        case "from" =>
+          f.predicate == Eq && Address(f.value) == from
+        case "to" =>
+          f.predicate match {
+            case Action => tx.isContractInit
+            case Eq     => tx.receivingAddress.contains(Address(f.value))
+            case _      => false
+          }
+        case "gas" =>
+          compareNumerically(tx.gasLimit, f.predicate, BigInt(f.value.stripPrefix("0x"), 16))
+        case "gasPrice" =>
+          compareNumerically(tx.gasPrice, f.predicate, BigInt(f.value.stripPrefix("0x"), 16))
+        case "value" =>
+          compareNumerically(tx.value, f.predicate, BigInt(f.value.stripPrefix("0x"), 16))
+        case "nonce" =>
+          val n =
+            if (f.value.startsWith("0x")) BigInt(f.value.stripPrefix("0x"), 16)
+            else BigInt(f.value)
+          compareNumerically(tx.nonce, f.predicate, n)
+        case _ => true
+      }
+    }
+
+  private def compareNumerically(a: BigInt, pred: TxPoolFilterPredicate, b: BigInt): Boolean =
+    pred match {
+      case Eq => a == b
+      case Gt => a > b
+      case Lt => a < b
+      case _  => false
     }
 }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/TxPoolService.scala
@@ -1,0 +1,81 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.actor.ActorRef
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+import com.chipprbots.ethereum.transactions.TransactionPicker
+import com.chipprbots.ethereum.utils.TxPoolConfig
+
+/** JSON-RPC txpool_* namespace.
+  *
+  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions
+  *
+  * Divergences from Besu:
+  *   - localCount is always 0: Fukuii's PendingTransaction does not track isReceivedFromLocalSource.
+  *     All pending txs are reported as remoteCount.
+  *   - txpool_besuPendingTransactions accepts an optional limit param only; Besu's PendingTransactionsParams
+  *     filter object (from/to address, gas price, nonce ranges) is not implemented.
+  */
+object TxPoolService {
+  case class TxPoolBesuTransactionsRequest()
+  case class TxPoolBesuTransactionsResponse(pendingTransactions: Seq[TransactionResponse])
+
+  case class TxPoolBesuStatisticsRequest()
+  case class TxPoolBesuStatisticsResponse(maxSize: Long, localCount: Long, remoteCount: Long)
+
+  case class TxPoolBesuPendingTransactionsRequest(limit: Option[Int])
+  case class TxPoolBesuPendingTransactionsResponse(pendingTransactions: Seq[TransactionResponse])
+}
+
+class TxPoolService(
+    override val pendingTransactionsManager: ActorRef,
+    override val getTransactionFromPoolTimeout: FiniteDuration,
+    txPoolConfig: TxPoolConfig
+) extends TransactionPicker {
+  import TxPoolService._
+
+  /** txpool_besuTransactions — returns all pending transactions.
+    *
+    * Besu: TxPoolBesuTransactions wraps getPendingTransactions() in PendingTransactionsResult.
+    */
+  def besuTransactions(req: TxPoolBesuTransactionsRequest): ServiceResponse[TxPoolBesuTransactionsResponse] =
+    getTransactionsFromPool.map { resp =>
+      Right(TxPoolBesuTransactionsResponse(
+        resp.pendingTransactions.map(pt => TransactionResponse(pt.stx.tx))
+      ))
+    }
+
+  /** txpool_besuStatistics — returns pool size statistics.
+    *
+    * Besu: TxPoolBesuStatistics counts PendingTransaction.isReceivedFromLocalSource().
+    * Fukuii divergence: localCount is always 0; all txs reported as remoteCount.
+    */
+  def besuStatistics(req: TxPoolBesuStatisticsRequest): ServiceResponse[TxPoolBesuStatisticsResponse] =
+    getTransactionsFromPool.map { resp =>
+      val total = resp.pendingTransactions.size.toLong
+      Right(TxPoolBesuStatisticsResponse(
+        maxSize = txPoolConfig.txPoolSize.toLong,
+        localCount = 0L,
+        remoteCount = total
+      ))
+    }
+
+  /** txpool_besuPendingTransactions — returns pending transactions with optional limit.
+    *
+    * Besu: TxPoolBesuPendingTransactions accepts limit + PendingTransactionsParams filter object.
+    * Fukuii divergence: filter object not implemented; only limit is honoured.
+    */
+  def besuPendingTransactions(
+      req: TxPoolBesuPendingTransactionsRequest
+  ): ServiceResponse[TxPoolBesuPendingTransactionsResponse] =
+    getTransactionsFromPool.map { resp =>
+      val txs = req.limit match {
+        case Some(n) => resp.pendingTransactions.take(n)
+        case None    => resp.pendingTransactions
+      }
+      Right(TxPoolBesuPendingTransactionsResponse(txs.map(pt => TransactionResponse(pt.stx.tx))))
+    }
+}

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
@@ -24,6 +24,7 @@ import com.chipprbots.ethereum.jsonrpc.NodeJsonRpcHealthChecker.JsonRpcHealthCon
 import com.chipprbots.ethereum.jsonrpc.serialization.JsonEncoder
 import com.chipprbots.ethereum.jsonrpc.serialization.JsonMethodDecoder
 import com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
+import com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcWsServer.JsonRpcWsServerConfig
 import com.chipprbots.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer.JsonRpcIpcServerConfig
 import com.chipprbots.ethereum.utils.Logger
 
@@ -124,6 +125,7 @@ object JsonRpcBaseController {
     def accountTransactionsMaxBlocks: Int
     def minerActiveTimeout: FiniteDuration
     def httpServerConfig: JsonRpcHttpServerConfig
+    def wsServerConfig: JsonRpcWsServerConfig
     def ipcServerConfig: JsonRpcIpcServerConfig
     def healthConfig: JsonRpcHealthConfig
   }
@@ -148,6 +150,7 @@ object JsonRpcBaseController {
         override def minerActiveTimeout: FiniteDuration = rpcConfig.getDuration("miner-active-timeout").toMillis.millis
 
         override val httpServerConfig: JsonRpcHttpServerConfig = JsonRpcHttpServerConfig(fukuiiConfig)
+        override val wsServerConfig: JsonRpcWsServerConfig = JsonRpcWsServerConfig(fukuiiConfig)
         override val ipcServerConfig: JsonRpcIpcServerConfig = JsonRpcIpcServerConfig(fukuiiConfig)
         override val healthConfig: JsonRpcHealthConfig = JsonRpcHealthConfig(rpcConfig)
       }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/http/JsonRpcWsServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/http/JsonRpcWsServer.scala
@@ -1,0 +1,231 @@
+package com.chipprbots.ethereum.jsonrpc.server.http
+
+import java.util.UUID
+
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.ws.Message
+import org.apache.pekko.http.scaladsl.model.ws.TextMessage
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.Timeout
+
+import cats.effect.unsafe.IORuntime
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import org.json4s.native.Serialization
+
+import com.chipprbots.ethereum.jsonrpc.JsonRpcRequest
+import com.chipprbots.ethereum.jsonrpc.JsonRpcResponse
+import com.chipprbots.ethereum.jsonrpc.SubscriptionManager
+import com.chipprbots.ethereum.jsonrpc.SubscriptionManager._
+import com.chipprbots.ethereum.jsonrpc.serialization.JsonSerializers
+import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController
+import com.chipprbots.ethereum.utils.Logger
+
+/** WebSocket JSON-RPC server.
+  *
+  * Besu reference:
+  *   ethereum/api/.../websocket/WebSocketService.java  — WS connection lifecycle
+  *   ethereum/api/.../websocket/WebSocketMessageHandler.java — message routing
+  *   ethereum/api/.../websocket/methods/EthSubscribe.java — eth_subscribe handler
+  *   ethereum/api/.../websocket/methods/EthUnsubscribe.java — eth_unsubscribe handler
+  *
+  * Besu uses Vert.x HTTP server + WebSocketHandler. We use Pekko HTTP's handleWebSocketMessages
+  * directive which maps naturally to the same flow: incoming messages → route → outgoing messages.
+  *
+  * eth_subscribe / eth_unsubscribe are routed directly to SubscriptionManager.
+  * All other JSON-RPC methods are forwarded to jsonRpcController.handleRequest().
+  */
+class JsonRpcWsServer(
+    jsonRpcController: JsonRpcBaseController,
+    subscriptionManager: ActorRef,
+    config: JsonRpcWsServer.JsonRpcWsServerConfig
+)(implicit system: ActorSystem)
+    extends Logger {
+
+  implicit val mat: Materializer = Materializer(system)
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val timeout: Timeout = Timeout(30.seconds)
+  implicit val runtime: IORuntime = IORuntime.global
+  implicit val formats: Formats = DefaultFormats + JsonSerializers.RpcErrorJsonSerializer
+  implicit val serialization: Serialization.type = org.json4s.native.Serialization
+
+  import org.apache.pekko.pattern.ask
+
+  private val route: Route =
+    (pathEndOrSingleSlash | path("ws")) {
+      handleWebSocketMessages(buildWsFlow())
+    }
+
+  def run(): Unit = {
+    val bindingF = Http(system).newServerAt(config.interface, config.port).bind(route)
+    bindingF.onComplete {
+      case Success(b) => log.info(s"JSON RPC WS server listening on ${b.localAddress}")
+      case Failure(ex) => log.error("Cannot start JSON RPC WS server", ex)
+    }
+  }
+
+  private def buildWsFlow(): Flow[Message, Message, Any] = {
+    val connId = UUID.randomUUID().toString
+
+    // Outbound queue: SubscriptionManager pushes JSON strings here
+    val (queue, outboundSource) = Source
+      .queue[String](256, OverflowStrategy.dropHead)
+      .preMaterialize()
+
+    subscriptionManager ! RegisterConnection(connId, queue)
+
+    // Inbound sink: parse JSON-RPC, route, push response to queue
+    val inboundSink: Sink[Message, Any] = Sink.foreach[Message] {
+      case TextMessage.Strict(text) =>
+        handleWsMessage(text, connId, queue)
+      case TextMessage.Streamed(stream) =>
+        stream.runFold("")(_ + _).foreach(text => handleWsMessage(text, connId, queue))
+      case _ => ()
+    }
+
+    val outboundMessages = outboundSource.map(TextMessage.Strict(_))
+
+    Flow
+      .fromSinkAndSourceCoupled(inboundSink, outboundMessages)
+      .watchTermination() { (mat, doneFuture) =>
+        doneFuture.onComplete(_ => subscriptionManager ! ConnectionClosed(connId))
+        mat
+      }
+  }
+
+  private def handleWsMessage(
+      text: String,
+      connId: String,
+      queue: org.apache.pekko.stream.scaladsl.SourceQueueWithComplete[String]
+  ): Unit = {
+    def sendResponse(json: String): Unit = queue.offer(json)
+
+    def errorResponse(id: JValue, code: Int, message: String): String = {
+      val resp = JObject(
+        "jsonrpc" -> JString("2.0"),
+        "id"      -> id,
+        "error"   -> JObject("code" -> JInt(code), "message" -> JString(message))
+      )
+      compact(render(resp))
+    }
+
+    val parsed = try { Some(parse(text)) } catch { case _: Exception => None }
+    parsed match {
+      case None =>
+        sendResponse(errorResponse(JNull, -32700, "Parse error"))
+
+      case Some(json) =>
+        val id = (json \ "id").toOption.getOrElse(JNull)
+        val method = (json \ "method") match {
+          case JString(m) => m
+          case _          => ""
+        }
+        val params = (json \ "params").toOption
+
+        method match {
+          case "eth_subscribe" =>
+            val subType = params.flatMap {
+              case JArray(JString(t) :: _) => Some(t)
+              case _ => None
+            }
+            val subParams = params.flatMap {
+              case JArray(_ :: p :: _) => Some(p)
+              case _ => None
+            }
+            subType match {
+              case None =>
+                sendResponse(errorResponse(id, -32602, "Invalid params: missing subscription type"))
+              case Some(t) =>
+                (subscriptionManager ? Subscribe(connId, t, subParams)).foreach {
+                  case SubscribeResponse(Right(subId)) =>
+                    val hex = "0x" + subId.toHexString
+                    sendResponse(compact(render(JObject(
+                      "jsonrpc" -> JString("2.0"),
+                      "id"      -> id,
+                      "result"  -> JString(hex)
+                    ))))
+                  case SubscribeResponse(Left(err)) =>
+                    sendResponse(errorResponse(id, -32602, err))
+                  case _ =>
+                    sendResponse(errorResponse(id, -32603, "Internal error"))
+                }
+            }
+
+          case "eth_unsubscribe" =>
+            val subIdOpt = params.flatMap {
+              case JArray(JString(s) :: _) =>
+                val hex = s.stripPrefix("0x").stripPrefix("0X")
+                try { Some(java.lang.Long.parseLong(hex, 16)) } catch { case _: Exception => None }
+              case _ => None
+            }
+            subIdOpt match {
+              case None =>
+                sendResponse(errorResponse(id, -32602, "Invalid params: missing subscription id"))
+              case Some(subId) =>
+                (subscriptionManager ? Unsubscribe(connId, subId)).foreach {
+                  case UnsubscribeResponse(found) =>
+                    sendResponse(compact(render(JObject(
+                      "jsonrpc" -> JString("2.0"),
+                      "id"      -> id,
+                      "result"  -> JBool(found)
+                    ))))
+                  case _ =>
+                    sendResponse(errorResponse(id, -32603, "Internal error"))
+                }
+            }
+
+          case "" =>
+            sendResponse(errorResponse(id, -32600, "Invalid request"))
+
+          case _ =>
+            // All other JSON-RPC methods: delegate to standard controller
+            val requestOpt = try {
+              Some(json.extract[JsonRpcRequest])
+            } catch { case _: Exception => None }
+            requestOpt match {
+              case None =>
+                sendResponse(errorResponse(id, -32600, "Invalid request"))
+              case Some(req) =>
+                jsonRpcController.handleRequest(req).unsafeToFuture().foreach { resp =>
+                  sendResponse(Serialization.write(resp))
+                }
+            }
+        }
+    }
+  }
+}
+
+object JsonRpcWsServer {
+
+  trait JsonRpcWsServerConfig {
+    val enabled: Boolean
+    val interface: String
+    val port: Int
+  }
+
+  object JsonRpcWsServerConfig {
+    def apply(fukuiiConfig: com.typesafe.config.Config): JsonRpcWsServerConfig = {
+      val wsConfig = fukuiiConfig.getConfig("network.rpc.ws")
+      new JsonRpcWsServerConfig {
+        override val enabled: Boolean = wsConfig.getBoolean("enabled")
+        override val interface: String = wsConfig.getString("interface")
+        override val port: Int = wsConfig.getInt("port")
+      }
+    }
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
@@ -264,6 +264,33 @@ class BlockPreparator(
     vm.run(contextWithSimFlags)
   }
 
+  /** Like [[runVM]] but uses a one-off VM instance with the given [[ExecutionTracer]] attached.
+    * Called by [[StxLedger.simulateTransactionWithTracer]] for debug_traceTransaction / trace_call etc.
+    *
+    * Besu reference: DebugTraceTransaction.java — creates DebugOperationTracer, passes to TransactionSimulator
+    * core-geth reference: eth/tracers/api.go traceTx() — wraps evm.Config.Tracer
+    */
+  private[ledger] def runVMWithTracer(
+      stx: SignedTransaction,
+      senderAddress: Address,
+      blockHeader: BlockHeader,
+      world: InMemoryWorldStateProxy,
+      tracer: ExecutionTracer
+  )(implicit blockchainConfig: BlockchainConfig): PR = {
+    val tracerVm = new VMImpl(Some(tracer))
+    val evmConfig = EvmConfig.forBlock(blockHeader.number, blockHeader.unixTimestamp, blockchainConfig)
+    val context: PC = ProgramContext(stx, blockHeader, senderAddress, world, evmConfig)
+    val contextWithSimFlags = {
+      var ctx = context
+      if (_simulatePrecompileRelocations.nonEmpty)
+        ctx = ctx.copy(precompileRelocations = _simulatePrecompileRelocations)
+      if (_simulateTraceTransfers)
+        ctx = ctx.copy(traceTransfers = true)
+      ctx
+    }
+    tracerVm.run(contextWithSimFlags)
+  }
+
   /** Calculate total gas to be refunded See YP, eq (72)
     *
     * EIP-3529: Changes max refund from gasUsed / 2 to gasUsed / 5

--- a/src/main/scala/com/chipprbots/ethereum/ledger/StxLedger.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/StxLedger.scala
@@ -11,6 +11,7 @@ import com.chipprbots.ethereum.domain.SignedTransactionWithSender
 import com.chipprbots.ethereum.domain.Transaction
 import com.chipprbots.ethereum.nodebuilder.BlockchainConfigBuilder
 import com.chipprbots.ethereum.vm.EvmConfig
+import com.chipprbots.ethereum.vm.ExecutionTracer
 
 class StxLedger(
     blockchain: BlockchainImpl,
@@ -65,6 +66,83 @@ class StxLedger(
     val totalGasToRefund = blockPreparator.calcTotalGasToRefund(tx, result, blockHeader.number)
 
     TxResult(result.world, tx.tx.gasLimit - totalGasToRefund, result.logs, result.returnData, result.error)
+  }
+
+  /** Like [[simulateTransaction]] but attaches a tracer and fires the tx-level lifecycle hooks.
+    *
+    * Besu reference: DebugTraceTransaction.java — creates DebugOperationTracer, passes via processTracing
+    * core-geth reference: eth/tracers/api.go traceTx() — wraps evm.Config.Tracer, calls CaptureStart/CaptureEnd
+    *
+    * Caller is responsible for selecting the tracer and extracting [[tracer.getResult]] afterwards.
+    */
+  def simulateTransactionWithTracer(
+      stx: SignedTransactionWithSender,
+      blockHeader: BlockHeader,
+      world: Option[InMemoryWorldStateProxy],
+      tracer: ExecutionTracer
+  ): TxResult = {
+    val tx = stx.tx
+
+    val world1 = world.getOrElse(
+      InMemoryWorldStateProxy(
+        evmCodeStorage = evmCodeStorage,
+        mptStorage = blockchain.getReadOnlyMptStorage(),
+        getBlockHashByNumber = (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
+        accountStartNonce = blockchainConfig.accountStartNonce,
+        stateRootHash = blockHeader.stateRoot,
+        noEmptyAccounts = EvmConfig.forBlock(blockHeader.number, blockchainConfig).noEmptyAccounts,
+        ethCompatibleStorage = blockchainConfig.ethCompatibleStorage
+      )
+    )
+
+    val senderAddress = stx.senderAddress
+    val world2 =
+      if (world1.getAccount(senderAddress).isEmpty)
+        world1.saveAccount(senderAddress, Account.empty(blockchainConfig.accountStartNonce))
+      else
+        world1
+
+    val worldForTx = blockPreparator.updateSenderAccountBeforeExecution(tx, senderAddress, world2)
+    tracer.onTxStart(senderAddress, tx.tx.receivingAddress, tx.tx.gasLimit, tx.tx.value, tx.tx.payload)
+    val result = blockPreparator.runVMWithTracer(tx, senderAddress, blockHeader, worldForTx, tracer)
+    val totalGasToRefund = blockPreparator.calcTotalGasToRefund(tx, result, blockHeader.number)
+    val gasUsed = tx.tx.gasLimit - totalGasToRefund
+    tracer.onTxEnd(gasUsed, result.returnData, result.error.map(_.toString))
+
+    TxResult(result.world, gasUsed, result.logs, result.returnData, result.error)
+  }
+
+  /** Advances a world state through prior transactions in a block to reach the state
+    * just before transaction at [[txIndex]].  Used by [[DebugTracingService]] and [[TraceService]]
+    * for historical trace replay.
+    *
+    * Besu reference: BlockReplay.beforeTransactionInBlock() — replays all transactions up to target index
+    * core-geth reference: eth/tracers/api.go computeTxEnv() — builds state via ApplyMessage for each prior tx
+    *
+    * @param blockHeader block header containing the transactions
+    * @param txs         all transactions in the block with recovered sender addresses
+    * @param txIndex     index of the target transaction (0-based); returns parent state if 0
+    * @param parentStateRoot state root of the parent block (baseline)
+    * @return world state at the point just before txs(txIndex) executes
+    */
+  def advanceWorldToTx(
+      blockHeader: BlockHeader,
+      txs: Seq[SignedTransactionWithSender],
+      txIndex: Int,
+      parentStateRoot: org.apache.pekko.util.ByteString
+  ): InMemoryWorldStateProxy = {
+    val world0 = InMemoryWorldStateProxy(
+      evmCodeStorage = evmCodeStorage,
+      mptStorage = blockchain.getReadOnlyMptStorage(),
+      getBlockHashByNumber = (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
+      accountStartNonce = blockchainConfig.accountStartNonce,
+      stateRootHash = parentStateRoot,
+      noEmptyAccounts = EvmConfig.forBlock(blockHeader.number, blockchainConfig).noEmptyAccounts,
+      ethCompatibleStorage = blockchainConfig.ethCompatibleStorage
+    )
+    (0 until txIndex).foldLeft(world0) { (world, i) =>
+      simulateTransaction(txs(i), blockHeader, Some(world)).worldState
+    }
   }
 
   def binarySearchGasEstimation(

--- a/src/main/scala/com/chipprbots/ethereum/network/BlockedIPRegistry.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/BlockedIPRegistry.scala
@@ -1,0 +1,20 @@
+package com.chipprbots.ethereum.network
+
+import scala.jdk.CollectionConverters._
+
+/** Thread-safe runtime IP blocklist.
+  *
+  * Initialized from config `blocked-ips` at startup. Can be modified at runtime via `admin_blockIP` /
+  * `admin_unblockIP` RPC methods. Designed to be checked by discovery (DiscoveryService) and P2P
+  * (RLPxConnectionHandler) layers — wired in feat/network-autoblocker.
+  */
+class BlockedIPRegistry(initialIPs: Set[String]) {
+  private val blocked = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
+  initialIPs.foreach(blocked.add)
+
+  def isBlocked(ip: String): Boolean = blocked.contains(ip)
+  def block(ip: String): Boolean     = blocked.add(ip)
+  def unblock(ip: String): Boolean   = blocked.remove(ip)
+  def all: Set[String]               = blocked.asScala.toSet
+  def size: Int                      = blocked.size()
+}

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -71,6 +71,12 @@ class PeerManagerActor(
     */
   private var peerStatusCache: Map[PeerId, PeerActor.Status] = Map.empty
 
+  /** Peers that should always remain connected. On disconnect, a reconnect is scheduled after 30s.
+    * Keyed by hex node ID (the userInfo portion of the enode URI), matching PeerId.value for handshaked peers.
+    * Mirrors Besu's DefaultP2PNetwork.maintainedPeers set.
+    */
+  private var maintainedPeersByNodeId: Map[String, URI] = Map.empty
+
   implicit class ConnectedPeersOps(connectedPeers: ConnectedPeers) {
 
     /** Number of new connections the node should try to open at any given time. */
@@ -248,6 +254,16 @@ class PeerManagerActor(
 
     case ConnectToPeer(uri) =>
       connectWith(uri, connectedPeers)
+
+    case AddMaintainedPeer(uri) =>
+      val nodeId  = uri.getUserInfo
+      val wasAdded = !maintainedPeersByNodeId.contains(nodeId)
+      maintainedPeersByNodeId = maintainedPeersByNodeId + (nodeId -> uri)
+      sender() ! AddMaintainedPeerResponse(wasAdded)
+      connectWith(uri, connectedPeers)
+
+    case RemoveMaintainedPeer(nodeId) =>
+      maintainedPeersByNodeId = maintainedPeersByNodeId - nodeId
   }
 
   private def getBlacklistDuration(reason: Long): FiniteDuration = {
@@ -381,6 +397,11 @@ class PeerManagerActor(
       terminatedPeersIds.foreach { peerId =>
         peerStatusCache = peerStatusCache - peerId
         peerEventBus ! Publish(PeerEvent.PeerDisconnected(peerId))
+        // Reconnect maintained peers — mirrors Besu's checkMaintainedConnectionPeers scheduler.
+        maintainedPeersByNodeId.get(peerId.value) foreach { uri =>
+          log.debug("Maintained peer {} disconnected — scheduling reconnect in 30s", uri)
+          context.system.scheduler.scheduleOnce(30.seconds, self, ConnectToPeer(uri))(context.dispatcher)
+        }
       }
       // Try to replace a lost connection with another one.
       if (newConnectedPeers.outgoingConnectionDemand > 0) {
@@ -675,6 +696,14 @@ object PeerManagerActor {
 
   case class RemoveFromBlacklistRequest(address: String)
   case class RemoveFromBlacklistResponse(removed: Boolean)
+
+  /** Besu alignment: admin_addPeer / admin_removePeer maintained-peers set.
+    * AddMaintainedPeer returns wasAdded=false if the peer was already in the set (duplicate call).
+    * RemoveMaintainedPeer removes from the set by hex node ID (enode userInfo).
+    */
+  case class AddMaintainedPeer(uri: URI)
+  case class AddMaintainedPeerResponse(wasAdded: Boolean)
+  case class RemoveMaintainedPeer(nodeId: String)
 
   /** Default blacklist duration when none specified (permanent blacklist). Set to 365 days as a practical "permanent"
     * duration.

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -316,6 +316,13 @@ class PeerManagerActor(
       // Use short blacklist to allow quick reconnection attempts
       case TcpSubsystemError | DisconnectRequested | TimeoutOnReceivingAMessage =>
         peerConfiguration.shortBlacklistDuration
+      // Permanent blacklist for protocol violations.
+      // Besu: PeerDenylistManager.java triggers denylist on BREACH_OF_PROTOCOL and
+      // INCOMPATIBLE_P2P_PROTOCOL_VERSION (maintained peers are exempt in Besu, but we
+      // apply permanent duration here — maintained peers are reconnected anyway via the
+      // Terminated handler regardless of IP blacklist state).
+      case BreachOfProtocol | IncompatibleP2pProtocolVersion | NullNodeIdentityReceived =>
+        DefaultPermanentBlacklistDuration
       case _ => peerConfiguration.longBlacklistDuration
     }
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -77,11 +77,28 @@ class PeerManagerActor(
     */
   private var maintainedPeersByNodeId: Map[String, URI] = Map.empty
 
+  /** Trusted peers bypass the max-peer limit and are always accepted.
+    * core-geth reference: p2p/server.go — trusted map[enode.ID]bool in run loop.
+    * Keyed by lowercase hex node ID.
+    */
+  private var trustedPeersByNodeId: Set[String] = Set.empty
+
+  /** Runtime max-outgoing-peers override set by admin_maxPeers.
+    * core-geth reference: eth/api_admin.go MaxPeers — sets handler.maxPeers + p2pServer.MaxPeers.
+    */
+  private var maxOutgoingPeersOverride: Option[Int] = None
+
+  private def effectiveMaxOutgoing: Int =
+    maxOutgoingPeersOverride.getOrElse(peerConfiguration.maxOutgoingPeers)
+
   implicit class ConnectedPeersOps(connectedPeers: ConnectedPeers) {
 
-    /** Number of new connections the node should try to open at any given time. */
+    /** Number of new connections the node should try to open at any given time.
+      * Uses effectiveMaxOutgoing so admin_maxPeers overrides take effect.
+      */
     def outgoingConnectionDemand: Int =
-      PeerManagerActor.outgoingConnectionDemand(connectedPeers, peerConfiguration)
+      if (connectedPeers.outgoingHandshakedPeersCount >= peerConfiguration.minOutgoingPeers) 0
+      else effectiveMaxOutgoing - connectedPeers.outgoingPeersCount
 
     def canConnectTo(node: Node): Boolean = {
       val socketAddress = node.tcpSocketAddress
@@ -264,6 +281,27 @@ class PeerManagerActor(
 
     case RemoveMaintainedPeer(nodeId) =>
       maintainedPeersByNodeId = maintainedPeersByNodeId - nodeId
+
+    // ── Geth-compatible trusted peer / max-peers management ───────────────
+    // core-geth references: node/api.go AddTrustedPeer/RemoveTrustedPeer, eth/api_admin.go MaxPeers
+
+    case AddTrustedPeer(uri) =>
+      val nodeId = uri.getUserInfo.toLowerCase
+      trustedPeersByNodeId = trustedPeersByNodeId + nodeId
+      sender() ! AddTrustedPeerResponse(success = true)
+      // Attempt connection immediately (like AddMaintainedPeer) so the trusted
+      // peer is dialled even if we're currently at the max-peer limit.
+      connectWith(uri, connectedPeers)
+
+    case RemoveTrustedPeer(nodeId) =>
+      // Removes trust but does NOT disconnect the live connection.
+      // core-geth: server.RemoveTrustedPeer does not call removePeer.
+      trustedPeersByNodeId = trustedPeersByNodeId - nodeId.toLowerCase
+      sender() ! RemoveTrustedPeerResponse(success = true)
+
+    case SetMaxPeers(n) =>
+      maxOutgoingPeersOverride = Some(n)
+      sender() ! SetMaxPeersResponse(success = true)
   }
 
   private def getBlacklistDuration(reason: Long): FiniteDuration = {
@@ -317,12 +355,15 @@ class PeerManagerActor(
   }
 
   private def connectWith(uri: URI, connectedPeers: ConnectedPeers): Unit = {
-    val nodeId = ByteString(Hex.decode(uri.getUserInfo))
+    val nodeIdHex     = uri.getUserInfo.toLowerCase
+    val nodeId        = ByteString(Hex.decode(nodeIdHex))
     val remoteAddress = new InetSocketAddress(uri.getHost, uri.getPort)
 
     val alreadyConnectedToPeer =
       connectedPeers.hasHandshakedWith(nodeId) || connectedPeers.isConnectionHandled(remoteAddress)
-    val isOutgoingPeersNotMaxValue = connectedPeers.outgoingPeersCount < peerConfiguration.maxOutgoingPeers
+    // Trusted peers bypass the max peer limit (core-geth: trustedConn flag skips maxPeers check)
+    val isTrusted = trustedPeersByNodeId.contains(nodeIdHex)
+    val isOutgoingPeersNotMaxValue = isTrusted || connectedPeers.outgoingPeersCount < effectiveMaxOutgoing
 
     val validConnection = for {
       validHandler <- validateConnection(remoteAddress, OutgoingConnectionAlreadyHandled(uri), !alreadyConnectedToPeer)
@@ -704,6 +745,17 @@ object PeerManagerActor {
   case class AddMaintainedPeer(uri: URI)
   case class AddMaintainedPeerResponse(wasAdded: Boolean)
   case class RemoveMaintainedPeer(nodeId: String)
+
+  /** core-geth alignment: admin_addTrustedPeer / admin_removeTrustedPeer / admin_maxPeers.
+    * Trusted peers bypass the max-peer limit and are always accepted.
+    * core-geth references: node/api.go AddTrustedPeer/RemoveTrustedPeer, eth/api_admin.go MaxPeers
+    */
+  case class AddTrustedPeer(uri: URI)
+  case class AddTrustedPeerResponse(success: Boolean)
+  case class RemoveTrustedPeer(nodeId: String)
+  case class RemoveTrustedPeerResponse(success: Boolean)
+  case class SetMaxPeers(n: Int)
+  case class SetMaxPeersResponse(success: Boolean)
 
   /** Default blacklist duration when none specified (permanent blacklist). Set to 365 days as a practical "permanent"
     * duration.

--- a/src/main/scala/com/chipprbots/ethereum/network/StaticNodesLoader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/StaticNodesLoader.scala
@@ -1,0 +1,102 @@
+package com.chipprbots.ethereum.network
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+import com.chipprbots.ethereum.utils.Logger
+
+/** Loads static peer nodes from a JSON file at startup.
+  *
+  * Besu reference:
+  *   ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/StaticNodesParser.java
+  *   - fromPath(): reads static-nodes.json → Set[EnodeURLImpl]
+  *   - Each parsed peer is added to MaintainedPeers (DefaultP2PNetwork.Builder.maintainedPeers)
+  *   - Missing file: returns empty set + debug log (not an error)
+  *   - Malformed entry: throws with warning log (stops startup)
+  *   - Empty file: returns empty set
+  *
+  * We follow the same file location convention as Besu and core-geth: ${datadir}/static-nodes.json
+  * Entries are enode URLs: ["enode://pubkey@host:port", ...]
+  * Each valid entry is added to PeerManagerActor.maintainedPeersByNodeId via AddMaintainedPeer.
+  */
+object StaticNodesLoader extends Logger {
+
+  /** File name relative to the datadir. Matches Besu and core-geth convention. */
+  val FileName: String = "static-nodes.json"
+
+  /** Load static nodes from ${datadir}/static-nodes.json.
+    *
+    * @param datadir path to the node data directory
+    * @return sequence of enode URIs; empty on missing file, malformed entries skipped with warning
+    */
+  def load(datadir: String): Seq[URI] = load(java.nio.file.Paths.get(datadir))
+
+  def load(datadir: Path): Seq[URI] = {
+    val filePath = datadir.resolve(FileName)
+    if (!Files.exists(filePath)) {
+      log.debug("Static nodes file {} does not exist — no static peers will be dialled", filePath)
+      Seq.empty
+    } else {
+      Try(new String(Files.readAllBytes(filePath), "UTF-8")) match {
+        case Failure(_) =>
+          log.warn("Unable to read static nodes file {}", filePath)
+          Seq.empty
+        case Success(content) =>
+          parseContent(content, filePath)
+      }
+    }
+  }
+
+  private def parseContent(content: String, filePath: Path): Seq[URI] = {
+    val trimmed = content.trim
+    if (trimmed.isEmpty || trimmed == "[]") {
+      Seq.empty
+    } else {
+      Try(parse(trimmed)) match {
+        case Failure(ex) =>
+          log.warn("Static nodes file {} contains invalid JSON: {}", filePath, ex.getMessage)
+          Seq.empty
+        case Success(JArray(entries)) =>
+          entries.flatMap(decodeEntry(_, filePath))
+        case Success(_) =>
+          log.warn("Static nodes file {} must contain a JSON array of enode URL strings", filePath)
+          Seq.empty
+      }
+    }
+  }
+
+  private def decodeEntry(entry: JValue, filePath: Path): Option[URI] = entry match {
+    case JString(url) =>
+      Try(new URI(url)) match {
+        case Failure(ex) =>
+          log.warn("Skipping malformed enode URL '{}' in {}: {}", url, filePath, ex.getMessage)
+          None
+        case Success(uri) if isValidEnodeUri(uri) => Some(uri)
+        case Success(uri) =>
+          log.warn("Skipping invalid enode URL '{}' in {} — expected enode://pubkey@host:port", uri, filePath)
+          None
+      }
+    case other =>
+      log.warn("Skipping non-string entry {} in static nodes file {}", other, filePath)
+      None
+  }
+
+  /** Validates that a URI is a well-formed enode URL with a non-empty pubkey and a valid port.
+    *
+    * Besu: StaticNodesParser.decodeString() calls checkArgument(enode.isListening(), "Static node must
+    * be configured with a valid listening port.") — we do the equivalent check here.
+    */
+  private def isValidEnodeUri(uri: URI): Boolean =
+    uri.getScheme == "enode" &&
+      uri.getUserInfo != null && uri.getUserInfo.nonEmpty &&
+      uri.getHost != null && uri.getHost.nonEmpty &&
+      uri.getPort > 0
+}

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -537,7 +537,8 @@ trait EthMiningServiceBuilder {
     with OmmersPoolBuilder
     with SyncControllerBuilder
     with PendingTransactionsManagerBuilder
-    with TxPoolConfigBuilder =>
+    with TxPoolConfigBuilder
+    with ActorSystemBuilder =>
 
   lazy val ethMiningService = new EthMiningService(
     blockchainReader,
@@ -548,7 +549,8 @@ trait EthMiningServiceBuilder {
     pendingTransactionsManager,
     txPoolConfig.getTransactionFromPoolTimeout,
     this,
-    coinbaseProvider
+    coinbaseProvider,
+    system
   )
 }
 trait EthTxServiceBuilder {

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -674,10 +674,29 @@ trait ApisBuilder extends ApisBase {
     val Test = "test"
     val Iele = "iele"
     val Qa = "qa"
+    val Admin = "admin"
   }
 
   import Apis._
-  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa)
+  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin)
+}
+
+trait AdminServiceBuilder {
+  this: PeerManagerActorBuilder
+    with NodeStatusBuilder
+    with BlockchainBuilder
+    with InstanceConfigProvider =>
+
+  lazy val blockedIPRegistry: BlockedIPRegistry = new BlockedIPRegistry(Set.empty)
+
+  lazy val adminService: AdminService = new AdminService(
+    nodeStatusHolder,
+    peerManager,
+    blockchainReader,
+    instanceConfig.config.getConfig("network.rpc.net").getDuration("peer-manager-timeout").toMillis.millis,
+    instanceConfig.config.getString("datadir"),
+    blockedIPRegistry
+  )
 }
 
 trait JSONRpcConfigBuilder {
@@ -703,7 +722,8 @@ trait JSONRpcControllerBuilder {
     with JSONRpcConfigBuilder
     with QaServiceBuilder
     with FukuiiServiceBuilder
-    with McpServiceBuilder =>
+    with McpServiceBuilder
+    with AdminServiceBuilder =>
 
   protected def testService: Option[TestService] = None
 
@@ -725,6 +745,7 @@ trait JSONRpcControllerBuilder {
       mcpService,
       ethProofService,
       ethSimulateService,
+      adminService,
       jsonRpcConfig
     )
 }
@@ -1017,6 +1038,7 @@ trait Node
     with QaServiceBuilder
     with FukuiiServiceBuilder
     with McpServiceBuilder
+    with AdminServiceBuilder
     with KeyStoreBuilder
     with ApisBuilder
     with JSONRpcConfigBuilder

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -674,10 +674,11 @@ trait ApisBuilder extends ApisBase {
     val Qa = "qa"
     val Admin = "admin"
     val TxPool = "txpool"
+    val Trace = "trace"
   }
 
   import Apis._
-  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin, TxPool)
+  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin, TxPool, Trace)
 }
 
 trait AdminServiceBuilder {
@@ -710,6 +711,38 @@ trait TxPoolServiceBuilder {
   )
 }
 
+trait DebugTracingServiceBuilder {
+  this: BlockchainBuilder
+    with StxLedgerBuilder
+    with StorageBuilder
+    with MiningBuilder =>
+
+  lazy val debugTracingService: com.chipprbots.ethereum.jsonrpc.DebugTracingService =
+    new com.chipprbots.ethereum.jsonrpc.DebugTracingService(
+      blockchain,
+      blockchainReader,
+      mining,
+      stxLedger,
+      storagesInstance.storages.transactionMappingStorage
+    )
+}
+
+trait TraceServiceBuilder {
+  this: BlockchainBuilder
+    with StxLedgerBuilder
+    with StorageBuilder
+    with MiningBuilder =>
+
+  lazy val traceService: com.chipprbots.ethereum.jsonrpc.TraceService =
+    new com.chipprbots.ethereum.jsonrpc.TraceService(
+      blockchain,
+      blockchainReader,
+      mining,
+      stxLedger,
+      storagesInstance.storages.transactionMappingStorage
+    )
+}
+
 trait JSONRpcConfigBuilder {
   self: ApisBuilder with InstanceConfigProvider =>
 
@@ -735,7 +768,9 @@ trait JSONRpcControllerBuilder {
     with FukuiiServiceBuilder
     with McpServiceBuilder
     with AdminServiceBuilder
-    with TxPoolServiceBuilder =>
+    with TxPoolServiceBuilder
+    with DebugTracingServiceBuilder
+    with TraceServiceBuilder =>
 
   protected def testService: Option[TestService] = None
 
@@ -759,6 +794,8 @@ trait JSONRpcControllerBuilder {
       ethSimulateService,
       adminService,
       txPoolService,
+      debugTracingService,
+      traceService,
       jsonRpcConfig
     )
 }
@@ -1053,6 +1090,8 @@ trait Node
     with McpServiceBuilder
     with AdminServiceBuilder
     with TxPoolServiceBuilder
+    with DebugTracingServiceBuilder
+    with TraceServiceBuilder
     with KeyStoreBuilder
     with ApisBuilder
     with JSONRpcConfigBuilder

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -675,10 +675,11 @@ trait ApisBuilder extends ApisBase {
     val Iele = "iele"
     val Qa = "qa"
     val Admin = "admin"
+    val TxPool = "txpool"
   }
 
   import Apis._
-  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin)
+  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin, TxPool)
 }
 
 trait AdminServiceBuilder {
@@ -696,6 +697,16 @@ trait AdminServiceBuilder {
     instanceConfig.config.getConfig("network.rpc.net").getDuration("peer-manager-timeout").toMillis.millis,
     instanceConfig.config.getString("datadir"),
     blockedIPRegistry
+  )
+}
+
+trait TxPoolServiceBuilder {
+  this: PendingTransactionsManagerBuilder with TxPoolConfigBuilder =>
+
+  lazy val txPoolService: TxPoolService = new TxPoolService(
+    pendingTransactionsManager,
+    txPoolConfig.getTransactionFromPoolTimeout,
+    txPoolConfig
   )
 }
 
@@ -723,7 +734,8 @@ trait JSONRpcControllerBuilder {
     with QaServiceBuilder
     with FukuiiServiceBuilder
     with McpServiceBuilder
-    with AdminServiceBuilder =>
+    with AdminServiceBuilder
+    with TxPoolServiceBuilder =>
 
   protected def testService: Option[TestService] = None
 
@@ -746,6 +758,7 @@ trait JSONRpcControllerBuilder {
       ethProofService,
       ethSimulateService,
       adminService,
+      txPoolService,
       jsonRpcConfig
     )
 }
@@ -1039,6 +1052,7 @@ trait Node
     with FukuiiServiceBuilder
     with McpServiceBuilder
     with AdminServiceBuilder
+    with TxPoolServiceBuilder
     with KeyStoreBuilder
     with ApisBuilder
     with JSONRpcConfigBuilder

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -675,10 +675,11 @@ trait ApisBuilder extends ApisBase {
     val Admin = "admin"
     val TxPool = "txpool"
     val Trace = "trace"
+    val Subscribe = "subscribe"
   }
 
   import Apis._
-  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin, TxPool, Trace)
+  override def available: List[String] = List(Eth, Web3, Net, Personal, Fukuii, Mcp, Debug, Test, Iele, Qa, Admin, TxPool, Trace, Subscribe)
 }
 
 trait AdminServiceBuilder {
@@ -885,6 +886,30 @@ trait JSONRpcIpcServerBuilder {
   self: ActorSystemBuilder with JSONRpcControllerBuilder with JSONRpcConfigBuilder =>
 
   lazy val jsonRpcIpcServer = new JsonRpcIpcServer(jsonRpcController, jsonRpcConfig.ipcServerConfig)
+}
+
+trait SubscriptionManagerBuilder {
+  self: ActorSystemBuilder with BlockchainBuilder =>
+
+  lazy val subscriptionManager: ActorRef =
+    system.actorOf(
+      com.chipprbots.ethereum.jsonrpc.SubscriptionManager.props(blockchainReader),
+      "subscription-manager"
+    )
+}
+
+trait JSONRpcWsServerBuilder {
+  self: ActorSystemBuilder
+    with JSONRpcControllerBuilder
+    with JSONRpcConfigBuilder
+    with SubscriptionManagerBuilder =>
+
+  lazy val jsonRpcWsServer: com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcWsServer =
+    new com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcWsServer(
+      jsonRpcController,
+      subscriptionManager,
+      jsonRpcConfig.wsServerConfig
+    )(system)
 }
 
 trait OmmersPoolBuilder {
@@ -1100,6 +1125,8 @@ trait Node
     with SSLContextBuilder
     with JSONRpcHttpServerBuilder
     with JSONRpcIpcServerBuilder
+    with SubscriptionManagerBuilder
+    with JSONRpcWsServerBuilder
     with EngineApiBuilder
     with ShutdownHookBuilder
     with Logger

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -9,8 +9,6 @@ import org.apache.pekko.util.ByteString
 
 import com.typesafe.config.ConfigFactory
 
-import com.chipprbots.ethereum.utils.InstanceConfigProvider
-
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.implicits._
@@ -686,6 +684,7 @@ trait AdminServiceBuilder {
   this: PeerManagerActorBuilder
     with NodeStatusBuilder
     with BlockchainBuilder
+    with BlockchainConfigBuilder
     with InstanceConfigProvider =>
 
   lazy val blockedIPRegistry: BlockedIPRegistry = new BlockedIPRegistry(Set.empty)
@@ -694,6 +693,7 @@ trait AdminServiceBuilder {
     nodeStatusHolder,
     peerManager,
     blockchainReader,
+    blockchainConfig,
     instanceConfig.config.getConfig("network.rpc.net").getDuration("peer-manager-timeout").toMillis.millis,
     instanceConfig.config.getString("datadir"),
     blockedIPRegistry

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -19,6 +19,7 @@ import com.chipprbots.ethereum.metrics.Metrics
 import com.chipprbots.ethereum.metrics.MetricsConfig
 import com.chipprbots.ethereum.network.PeerManagerActor
 import com.chipprbots.ethereum.network.ServerActor
+import com.chipprbots.ethereum.network.StaticNodesLoader
 import com.chipprbots.ethereum.network.discovery.PeerDiscoveryManager
 import com.chipprbots.ethereum.nodebuilder.tooling.PeriodicConsistencyCheck
 import com.chipprbots.ethereum.nodebuilder.tooling.StorageConsistencyChecker
@@ -52,6 +53,7 @@ abstract class BaseNode extends Node {
 
     // Phase 3: P2P networking
     startPeerManager()
+    loadStaticNodes()
     startPortForwarding()
     startServer()
     startDiscoveryManager()
@@ -122,6 +124,23 @@ abstract class BaseNode extends Node {
   }
 
   private[this] def startPeerManager(): Unit = peerManager ! PeerManagerActor.StartConnecting
+
+  /** Load static peer nodes from ${datadir}/static-nodes.json and add each to the maintained-peers set.
+    *
+    * Besu reference: StaticNodesParser.fromPath() → DefaultP2PNetwork adds each to MaintainedPeers.
+    * Static peers are maintained connections: the node will always attempt to reconnect on disconnect.
+    */
+  private[this] def loadStaticNodes(): Unit = {
+    val datadir = instanceConfig.config.getString("datadir")
+    val nodes   = StaticNodesLoader.load(datadir)
+    if (nodes.nonEmpty) {
+      log.info("Loading {} static peer(s) from {}/{}", nodes.size, datadir, StaticNodesLoader.FileName)
+      nodes.foreach { uri =>
+        peerManager ! PeerManagerActor.AddMaintainedPeer(uri)
+        log.debug("Static peer added: {}", uri)
+      }
+    }
+  }
 
   private[this] def startServer(): Unit = server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -46,6 +46,7 @@ abstract class BaseNode extends Node {
 
     // Phase 2: API servers (user-facing, ready as early as possible)
     startJsonRpcHttpServer()
+    startJsonRpcWsServer()
     startJsonRpcIpcServer()
     startEngineApiServer()
 
@@ -136,6 +137,9 @@ abstract class BaseNode extends Node {
       case Left(error) if jsonRpcConfig.httpServerConfig.enabled          => log.error(error)
       case _                                                              => // Nothing
     }
+
+  private[this] def startJsonRpcWsServer(): Unit =
+    if (jsonRpcConfig.wsServerConfig.enabled) jsonRpcWsServer.run()
 
   private[this] def startJsonRpcIpcServer(): Unit =
     if (jsonRpcConfig.ipcServerConfig.enabled) jsonRpcIpcServer.run()

--- a/src/main/scala/com/chipprbots/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/com/chipprbots/ethereum/transactions/PendingTransactionsManager.scala
@@ -26,6 +26,7 @@ import com.chipprbots.ethereum.network.PeerEventBusActor.Subscribe
 import com.chipprbots.ethereum.network.PeerEventBusActor.SubscriptionClassifier
 import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.PeerManagerActor
+import com.chipprbots.ethereum.jsonrpc.NewPendingTransaction
 import com.chipprbots.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import com.chipprbots.ethereum.network.p2p.messages.Codes
 import com.chipprbots.ethereum.network.p2p.messages.ETH66
@@ -177,6 +178,7 @@ class PendingTransactionsManager(
         val timestamp = System.currentTimeMillis()
         transactionsToAdd.foreach(t => pendingTransactions.put(t.tx.hash, PendingTransaction(t, timestamp)))
         updatePendingNonces(transactionsToAdd)
+        transactionsToAdd.foreach(t => context.system.eventStream.publish(NewPendingTransaction(t)))
         val peers = connectedPeers.values.toSeq
         if (peers.nonEmpty) {
           self ! NotifyPeers(transactionsToAdd.toSeq, peers)
@@ -205,6 +207,7 @@ class PendingTransactionsManager(
       val newPendingTx = SignedTransactionWithSender(newStx, newStxSender)
       pendingTransactions.put(newStx.hash, PendingTransaction(newPendingTx, timestamp, receivedFromLocalSource = true))
       updatePendingNonces(Seq(newPendingTx))
+      context.system.eventStream.publish(NewPendingTransaction(newPendingTx))
 
       val peers = connectedPeers.values.toSeq
       if (peers.nonEmpty) {

--- a/src/main/scala/com/chipprbots/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/com/chipprbots/ethereum/transactions/PendingTransactionsManager.scala
@@ -66,7 +66,11 @@ object PendingTransactionsManager {
 
   case class RemoveTransactions(signedTransactions: Seq[SignedTransaction])
 
-  case class PendingTransaction(stx: SignedTransactionWithSender, addTimestamp: Long)
+  case class PendingTransaction(
+      stx: SignedTransactionWithSender,
+      addTimestamp: Long,
+      receivedFromLocalSource: Boolean = false
+  )
 
   case object ClearPendingTransactions
 }
@@ -199,7 +203,7 @@ class PendingTransactionsManager(
 
       val timestamp = System.currentTimeMillis()
       val newPendingTx = SignedTransactionWithSender(newStx, newStxSender)
-      pendingTransactions.put(newStx.hash, PendingTransaction(newPendingTx, timestamp))
+      pendingTransactions.put(newStx.hash, PendingTransaction(newPendingTx, timestamp, receivedFromLocalSource = true))
       updatePendingNonces(Seq(newPendingTx))
 
       val peers = connectedPeers.values.toSeq

--- a/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
@@ -1,0 +1,177 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.utils.Hex
+
+/** Native callTracer matching go-ethereum's eth/tracers/native/call.go.
+  *
+  * Produces a nested call tree for debug_traceTransaction/debug_traceCall:
+  * {{{
+  * {
+  *   "type": "CALL",
+  *   "from": "0x...",
+  *   "to": "0x...",
+  *   "gas": 123456,
+  *   "gasUsed": 45678,
+  *   "value": "0x0",
+  *   "input": "0x...",
+  *   "output": "0x...",
+  *   "error": "execution reverted",
+  *   "revertReason": "ERC20: ...",
+  *   "calls": [ ... ]
+  * }
+  * }}}
+  *
+  * Besu reference: FlatTraceGenerator produces OpenEthereum flat trace format (different schema).
+  * This tracer matches go-ethereum's callTracer nested call tree format, which is the standard
+  * for debug_traceTransaction with {tracer: "callTracer"}.
+  *
+  * @param onlyTopCall when true, only capture the top-level call (skip sub-calls)
+  */
+class CallTracer(onlyTopCall: Boolean = false) extends ExecutionTracer {
+
+  private case class CallFrame(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString,
+      var gasUsed: BigInt = 0,
+      var output: ByteString = ByteString.empty,
+      var error: Option[String] = None,
+      var revertReason: Option[String] = None,
+      calls: mutable.ArrayBuffer[CallFrame] = mutable.ArrayBuffer.empty
+  )
+
+  private val callStack             = mutable.Stack[CallFrame]()
+  private var rootFrame: Option[CallFrame] = None
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    val opCode = if (to.isDefined) "CALL" else "CREATE"
+    val frame = CallFrame(
+      opCode = opCode,
+      from = from,
+      to = to.getOrElse(Address(0)),
+      gas = gas,
+      value = value,
+      input = input
+    )
+    callStack.push(frame)
+    rootFrame = Some(frame)
+  }
+
+  override def onTxEnd(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (callStack.nonEmpty) {
+      val frame = callStack.pop()
+      frame.gasUsed = gasUsed
+      frame.output = output
+      frame.error = error
+      if (error.exists(_.contains("execution reverted")) && output.length >= 4) {
+        frame.revertReason = parseRevertReason(output)
+      }
+    }
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    if (onlyTopCall) return
+
+    val frame = CallFrame(
+      opCode = opCode,
+      from = from,
+      to = to,
+      gas = gas,
+      value = value,
+      input = input
+    )
+    callStack.push(frame)
+  }
+
+  override def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (onlyTopCall) return
+    if (callStack.size <= 1) return // don't pop the root frame
+
+    val frame = callStack.pop()
+    frame.gasUsed = gasUsed
+    frame.output = output
+    frame.error = error
+    if (error.exists(_.contains("execution reverted")) && output.length >= 4) {
+      frame.revertReason = parseRevertReason(output)
+    }
+
+    if (callStack.nonEmpty) {
+      callStack.top.calls += frame
+    }
+  }
+
+  override def getResult: JValue = rootFrame match {
+    case Some(frame) => encodeFrame(frame)
+    case None        => JNull
+  }
+
+  private def encodeFrame(frame: CallFrame): JValue = {
+    var obj: JObject = ("type" -> frame.opCode) ~
+      ("from" -> encodeAddress(frame.from)) ~
+      ("to" -> encodeAddress(frame.to)) ~
+      ("gas" -> JInt(frame.gas.bigInteger)) ~
+      ("gasUsed" -> JInt(frame.gasUsed.bigInteger))
+
+    if (frame.opCode == "CALL" || frame.opCode == "CREATE" || frame.opCode == "CREATE2") {
+      obj = obj ~ ("value" -> encodeHex(frame.value))
+    }
+
+    obj = obj ~
+      ("input" -> encodeHexBytes(frame.input)) ~
+      ("output" -> encodeHexBytes(frame.output))
+
+    frame.error.foreach(e => obj = obj ~ ("error" -> JString(e)))
+    frame.revertReason.foreach(r => obj = obj ~ ("revertReason" -> JString(r)))
+
+    if (frame.calls.nonEmpty) {
+      obj = obj ~ ("calls" -> JArray(frame.calls.toList.map(encodeFrame)))
+    }
+
+    obj
+  }
+
+  private def encodeAddress(addr: Address): JString =
+    JString("0x" + Hex.toHexString(addr.bytes.toArray))
+
+  private def encodeHex(value: BigInt): JString =
+    JString("0x" + value.toString(16))
+
+  private def encodeHexBytes(bs: ByteString): JString =
+    if (bs.isEmpty) JString("0x")
+    else JString("0x" + Hex.toHexString(bs.toArray))
+
+  /** Parse Solidity revert reason from ABI-encoded error data.
+    * Format: 0x08c379a0 + offset + length + utf8 string
+    */
+  private def parseRevertReason(data: ByteString): Option[String] = {
+    if (data.length < 68) return None
+    val selector = data.take(4)
+    if (selector != ByteString(0x08, 0xc3, 0x79, 0xa0)) return None
+    try {
+      val offset = BigInt(1, data.slice(4, 36).toArray).toInt
+      val length = BigInt(1, data.slice(36 + offset, 68 + offset).toArray).toInt
+      if (data.length < 68 + offset + length) return None
+      Some(new String(data.slice(68 + offset, 68 + offset + length).toArray, "UTF-8"))
+    } catch {
+      case _: Exception => None
+    }
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/CallTracer.scala
@@ -127,8 +127,8 @@ class CallTracer(onlyTopCall: Boolean = false) extends ExecutionTracer {
     var obj: JObject = ("type" -> frame.opCode) ~
       ("from" -> encodeAddress(frame.from)) ~
       ("to" -> encodeAddress(frame.to)) ~
-      ("gas" -> JInt(frame.gas.bigInteger)) ~
-      ("gasUsed" -> JInt(frame.gasUsed.bigInteger))
+      ("gas" -> JString("0x" + frame.gas.toString(16))) ~
+      ("gasUsed" -> JString("0x" + frame.gasUsed.toString(16)))
 
     if (frame.opCode == "CALL" || frame.opCode == "CREATE" || frame.opCode == "CREATE2") {
       obj = obj ~ ("value" -> encodeHex(frame.value))

--- a/src/main/scala/com/chipprbots/ethereum/vm/ExecutionTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/ExecutionTracer.scala
@@ -1,0 +1,78 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.domain.Address
+
+/** Pluggable execution tracer interface — Fukuii's equivalent of Besu's OperationTracer.
+  *
+  * Besu reference: evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
+  *
+  * Mapping to Besu hooks:
+  *   - onStep       → tracePostExecution (after each opcode; prevState gives pre-execution view)
+  *   - onTxStart    → traceStartTransaction
+  *   - onTxEnd      → traceEndTransaction
+  *   - onCallEnter  → traceContextEnter (entering a sub-call frame)
+  *   - onCallExit   → traceContextExit  (exiting a sub-call frame)
+  *
+  * Divergence from Besu: Besu separates tracePreExecution/tracePostExecution; Fukuii uses a
+  * single post-execution hook with both prevState and nextState available. Semantically
+  * equivalent — prevState provides the pre-execution view.
+  *
+  * Implementations:
+  *   - StructLogTracer: opcode-by-opcode trace (go-ethereum structLog format)
+  *   - CallTracer: nested call tree (go-ethereum native callTracer)
+  *   - PrestateTracer: pre-transaction state snapshot (go-ethereum native prestateTracer)
+  *   - VmTracer: Parity/OpenEthereum vmTrace format
+  *
+  * All methods have default no-op implementations so each tracer only overrides what it needs.
+  */
+trait ExecutionTracer {
+
+  /** Called after each opcode execution in the VM exec loop.
+    * Corresponds to Besu's tracePostExecution. prevState gives the pre-execution view.
+    */
+  def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = ()
+
+  /** Called once for the top-level transaction before execution begins.
+    * Corresponds to Besu's traceStartTransaction.
+    */
+  def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = ()
+
+  /** Called once when the top-level transaction returns.
+    * Corresponds to Besu's traceEndTransaction.
+    */
+  def onTxEnd(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = ()
+
+  /** Called when entering an internal CALL/CALLCODE/DELEGATECALL/STATICCALL/CREATE/CREATE2.
+    * Only fires for internal sub-calls (callDepth > 0), not the top-level transaction.
+    * Corresponds to Besu's traceContextEnter.
+    *
+    * @param opCode the opcode name: "CALL", "STATICCALL", "DELEGATECALL", "CALLCODE", "CREATE", "CREATE2"
+    * @param from   calling address
+    * @param to     called address (for CREATE/CREATE2, the newly computed address)
+    * @param gas    gas allocated to the sub-call
+    * @param value  ETH value transferred
+    * @param input  call data or init code
+    */
+  def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = ()
+
+  /** Called when an internal CALL/CREATE returns.
+    * Corresponds to Besu's traceContextExit.
+    */
+  def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = ()
+
+  /** Returns the tracer-specific result as a JSON value for the RPC response. */
+  def getResult: org.json4s.JValue
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/PrestateTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/PrestateTracer.scala
@@ -1,0 +1,214 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+import com.chipprbots.ethereum.utils.Hex
+
+/** Native prestateTracer matching go-ethereum's eth/tracers/native/prestate.go.
+  *
+  * Besu reference: StateTraceGenerator generates state diffs; this tracer also supports
+  * go-ethereum's pre-state snapshot mode.
+  *
+  * Default mode — returns pre-transaction state for all touched accounts:
+  * {{{
+  * { "0xaddr": { "balance": "0x...", "nonce": 1, "code": "0x...", "storage": {"0xkey": "0xval"} } }
+  * }}}
+  *
+  * diffMode — returns pre and post state (post only includes changed fields):
+  * {{{
+  * { "pre": { "0xaddr": { ... } }, "post": { "0xaddr": { ... } } }
+  * }}}
+  *
+  * @param preWorld  world state snapshot before transaction execution
+  * @param diffMode  when true, return {pre, post} diff instead of just prestate
+  */
+class PrestateTracer[W <: WorldStateProxy[W, S], S <: Storage[S]](
+    val preWorld: W,
+    diffMode: Boolean = false
+) extends ExecutionTracer {
+
+  private val touchedAddresses   = mutable.LinkedHashSet[Address]()
+  private val touchedStorageKeys = mutable.HashMap[Address, mutable.LinkedHashSet[UInt256]]()
+  private var postWorld: Option[W] = None
+
+  def setPostWorld(world: W): Unit = {
+    postWorld = Some(world)
+  }
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    touchedAddresses += from
+    to.foreach(addr => touchedAddresses += addr)
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    touchedAddresses += from
+    touchedAddresses += to
+  }
+
+  override def onStep[W2 <: WorldStateProxy[W2, S2], S2 <: Storage[S2]](
+      opCode: OpCode,
+      prevState: ProgramState[W2, S2],
+      nextState: ProgramState[W2, S2]
+  ): Unit = {
+    val opName = opCode.toString
+    if (opName == "SLOAD" || opName == "SSTORE") {
+      val stack = prevState.stack
+      if (stack.size >= 1) {
+        val addr = prevState.env.ownerAddr
+        val key  = stack.toSeq.head
+        touchedAddresses += addr
+        touchedStorageKeys.getOrElseUpdate(addr, mutable.LinkedHashSet.empty) += key
+      }
+    }
+    opName match {
+      case "BALANCE" | "EXTCODESIZE" | "EXTCODECOPY" | "EXTCODEHASH" =>
+        val stack = prevState.stack
+        if (stack.size >= 1) {
+          val addrUint = stack.toSeq.head
+          touchedAddresses += Address(addrUint)
+        }
+      case "SELFDESTRUCT" =>
+        val stack = prevState.stack
+        if (stack.size >= 1) {
+          val beneficiary = stack.toSeq.head
+          touchedAddresses += Address(beneficiary)
+          touchedAddresses += prevState.env.ownerAddr
+        }
+      case _ => ()
+    }
+  }
+
+  override def getResult: JValue = {
+    if (diffMode) {
+      postWorld match {
+        case Some(pw) => encodeDiff(pw)
+        case None     => encodePrestate()
+      }
+    } else {
+      encodePrestate()
+    }
+  }
+
+  private def encodePrestate(): JValue = {
+    val fields = touchedAddresses.toList.flatMap { addr =>
+      preWorld.getAccount(addr).map { account =>
+        val addrHex = "0x" + Hex.toHexString(addr.bytes.toArray)
+        addrHex -> encodeAccountState(addr, account, preWorld)
+      }
+    }
+    JObject(fields.map { case (k, v) => JField(k, v) })
+  }
+
+  private def encodeDiff(pw: W): JValue = {
+    val preFields  = mutable.ListBuffer[JField]()
+    val postFields = mutable.ListBuffer[JField]()
+
+    touchedAddresses.foreach { addr =>
+      val addrHex     = "0x" + Hex.toHexString(addr.bytes.toArray)
+      val preAccount  = preWorld.getAccount(addr)
+      val postAccount = pw.getAccount(addr)
+
+      preAccount.foreach { acc =>
+        preFields += JField(addrHex, encodeAccountState(addr, acc, preWorld))
+      }
+
+      postAccount.foreach { postAcc =>
+        val preAcc = preAccount.getOrElse(com.chipprbots.ethereum.domain.Account.empty(0))
+        val diff   = encodeAccountDiff(addr, preAcc, postAcc, pw)
+        if (diff != JNothing) {
+          postFields += JField(addrHex, diff)
+        }
+      }
+
+      if (preAccount.isEmpty && postAccount.isDefined) {
+        postFields += JField(addrHex, encodeAccountState(addr, postAccount.get, pw))
+      }
+    }
+
+    ("pre" -> JObject(preFields.toList)) ~ ("post" -> JObject(postFields.toList))
+  }
+
+  private def encodeAccountState(addr: Address, account: com.chipprbots.ethereum.domain.Account, world: W): JValue = {
+    var obj: JObject = ("balance" -> JString("0x" + account.balance.toBigInt.toString(16))) ~
+      ("nonce" -> JInt(account.nonce.bigInteger))
+
+    val code = world.getCode(addr)
+    if (code.nonEmpty) {
+      obj = obj ~ ("code" -> JString("0x" + Hex.toHexString(code.toArray)))
+    }
+
+    val storageKeys = touchedStorageKeys.getOrElse(addr, Set.empty)
+    if (storageKeys.nonEmpty) {
+      val storage = world.getStorage(addr)
+      val storageFields = storageKeys.toList.flatMap { key =>
+        val value = storage.load(key.toBigInt)
+        if (value != BigInt(0)) {
+          val keyHex = "0x" + key.toBigInt.toString(16).reverse.padTo(64, '0').reverse
+          val valHex = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(JField(keyHex, JString(valHex)))
+        } else None
+      }
+      if (storageFields.nonEmpty) {
+        obj = obj ~ ("storage" -> JObject(storageFields))
+      }
+    }
+
+    obj
+  }
+
+  private def encodeAccountDiff(
+      addr: Address,
+      preAcc: com.chipprbots.ethereum.domain.Account,
+      postAcc: com.chipprbots.ethereum.domain.Account,
+      pw: W
+  ): JValue = {
+    var fields = List.empty[JField]
+
+    if (preAcc.balance != postAcc.balance) {
+      fields :+= JField("balance", JString("0x" + postAcc.balance.toBigInt.toString(16)))
+    }
+    if (preAcc.nonce != postAcc.nonce) {
+      fields :+= JField("nonce", JInt(postAcc.nonce.bigInteger))
+    }
+
+    val preCode  = preWorld.getCode(addr)
+    val postCode = pw.getCode(addr)
+    if (preCode != postCode && postCode.nonEmpty) {
+      fields :+= JField("code", JString("0x" + Hex.toHexString(postCode.toArray)))
+    }
+
+    val storageKeys = touchedStorageKeys.getOrElse(addr, Set.empty)
+    if (storageKeys.nonEmpty) {
+      val preStorage  = preWorld.getStorage(addr)
+      val postStorage = pw.getStorage(addr)
+      val storageFields = storageKeys.toList.flatMap { key =>
+        val preVal  = preStorage.load(key.toBigInt)
+        val postVal = postStorage.load(key.toBigInt)
+        if (preVal != postVal) {
+          val keyHex = "0x" + key.toBigInt.toString(16).reverse.padTo(64, '0').reverse
+          val valHex = "0x" + postVal.toString(16).reverse.padTo(64, '0').reverse
+          Some(JField(keyHex, JString(valHex)))
+        } else None
+      }
+      if (storageFields.nonEmpty) {
+        fields :+= JField("storage", JObject(storageFields))
+      }
+    }
+
+    if (fields.isEmpty) JNothing else JObject(fields)
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/StructLogTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/StructLogTracer.scala
@@ -1,0 +1,112 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.UInt256
+
+/** A single step in EVM execution, matching go-ethereum's structLog format. */
+case class StructLog(
+    pc: Int,
+    op: String,
+    gas: BigInt,
+    gasCost: BigInt,
+    depth: Int,
+    stack: Seq[BigInt],
+    memory: Option[Seq[String]],
+    storage: Option[Map[String, String]],
+    error: Option[String]
+)
+
+/** Collects opcode-by-opcode execution trace in go-ethereum structLog format.
+  *
+  * Besu reference: evm/src/main/java/org/hyperledger/besu/evm/tracing/StreamingOperationTracer.java
+  *
+  * Besu streams structLog to a PrintStream; Fukuii collects to a buffer for in-memory access.
+  * Output format is equivalent: per-opcode pc, op, gas, gasCost, depth, stack, memory, storage.
+  *
+  * @param enableMemory  include memory snapshot per step (expensive)
+  * @param enableStorage include storage diff per step (expensive)
+  * @param limit         maximum number of steps to capture (0 = unlimited)
+  */
+class StructLogTracer(
+    enableMemory: Boolean = false,
+    enableStorage: Boolean = false,
+    limit: Int = 0
+) extends ExecutionTracer {
+  private val steps       = scala.collection.mutable.ArrayBuffer[StructLog]()
+  private var _gas: BigInt             = 0
+  private var _failed: Boolean         = false
+  private var _returnValue: ByteString = ByteString.empty
+
+  override def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = {
+    if (limit > 0 && steps.size >= limit) return
+
+    val gasCost = prevState.gas - nextState.gas
+
+    val memorySnapshot = if (enableMemory) {
+      val mem = prevState.memory
+      if (mem.size > 0) {
+        val words = (0 until mem.size by 32).map { offset =>
+          val word = mem.load(UInt256(offset), UInt256(32))._1
+          word.toArray.map("%02x".format(_)).mkString
+        }
+        Some(words.toSeq)
+      } else Some(Seq.empty)
+    } else None
+
+    val storageSnapshot = if (enableStorage) {
+      opCode match {
+        case SLOAD if prevState.stack.size >= 1 =>
+          val slot  = prevState.stack.toSeq.head.toBigInt
+          val value = nextState.stack.toSeq.head.toBigInt
+          val k = "0x" + slot.toString(16).reverse.padTo(64, '0').reverse
+          val v = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(Map(k -> v))
+        case SSTORE if prevState.stack.size >= 2 =>
+          val slot  = prevState.stack.toSeq(0).toBigInt
+          val value = prevState.stack.toSeq(1).toBigInt
+          val k = "0x" + slot.toString(16).reverse.padTo(64, '0').reverse
+          val v = "0x" + value.toString(16).reverse.padTo(64, '0').reverse
+          Some(Map(k -> v))
+        case _ => None
+      }
+    } else None
+
+    val error = nextState.error.map(_.toString)
+
+    steps += StructLog(
+      pc      = prevState.pc,
+      op      = opCode.toString,
+      gas     = prevState.gas,
+      gasCost = gasCost,
+      depth   = prevState.env.callDepth + 1, // go-ethereum uses 1-based depth
+      stack   = prevState.stack.toSeq.map(_.toBigInt),
+      memory  = memorySnapshot,
+      storage = storageSnapshot,
+      error   = error
+    )
+  }
+
+  def setResult(gas: BigInt, returnValue: ByteString, failed: Boolean): Unit = {
+    _gas = gas
+    _returnValue = returnValue
+    _failed = failed
+  }
+
+  def getSteps: Seq[StructLog]  = steps.toSeq
+  def gas: BigInt               = _gas
+  def failed: Boolean           = _failed
+  def returnValue: ByteString   = _returnValue
+
+  /** Not used for StructLogTracer — response is built by DebugTracingJsonMethodsImplicits using
+    * getSteps/gas/failed/returnValue. Exists to satisfy the ExecutionTracer trait.
+    */
+  override def getResult: JValue = JNothing
+}

--- a/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
@@ -52,38 +52,49 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]](
 
   /** Message call - Θ function in YP
     */
-  private[vm] def call(context: PC, ownerAddr: Address): PR =
-    if (!isValidCall(context))
-      invalidCallResult(context, Set.empty, Set.empty)
-    else {
-      val recipientAddr = context.recipientAddr.getOrElse(
-        throw new IllegalArgumentException("Recipient address must be defined for message call")
-      )
-
-      def makeTransfer = context.world.transfer(context.callerAddr, recipientAddr, context.endowment)
-      val world1 = if (context.doTransfer) makeTransfer else context.world
-      val context1: PC = context.copy(world = world1)
-
-      if (PrecompiledContracts.isDefinedAt(context1))
-        PrecompiledContracts.run(context1)
+  private[vm] def call(context: PC, ownerAddr: Address): PR = {
+    val isSubCall = context.callDepth > 0
+    if (isSubCall)
+      tracer.foreach(_.onCallEnter(
+        callTypeName(context), context.callerAddr,
+        context.recipientAddr.getOrElse(Address(0)), context.startGas, context.endowment, context.inputData
+      ))
+    val result =
+      if (!isValidCall(context))
+        invalidCallResult(context, Set.empty, Set.empty)
       else {
-        val code = resolveCode(world1, recipientAddr)
-        val env = ExecEnv(context1, code, ownerAddr)
+        val recipientAddr = context.recipientAddr.getOrElse(
+          throw new IllegalArgumentException("Recipient address must be defined for message call")
+        )
 
-        // EIP-7702: If code was resolved from a delegation, warm the delegation target
-        val delegationTarget = try {
-          SetCodeTransaction.parseDelegation(world1.getCode(recipientAddr))
-        } catch {
-          case _: Exception => None
+        def makeTransfer = context.world.transfer(context.callerAddr, recipientAddr, context.endowment)
+        val world1 = if (context.doTransfer) makeTransfer else context.world
+        val context1: PC = context.copy(world = world1)
+
+        if (PrecompiledContracts.isDefinedAt(context1))
+          PrecompiledContracts.run(context1)
+        else {
+          val code = resolveCode(world1, recipientAddr)
+          val env = ExecEnv(context1, code, ownerAddr)
+
+          // EIP-7702: If code was resolved from a delegation, warm the delegation target
+          val delegationTarget = try {
+            SetCodeTransaction.parseDelegation(world1.getCode(recipientAddr))
+          } catch {
+            case _: Exception => None
+          }
+          val initialState: PS = ProgramState(this, context1, env)
+          val warmState = delegationTarget match {
+            case Some(target) => initialState.addAccessedAddress(target)
+            case None         => initialState
+          }
+          exec(warmState).toResult
         }
-        val initialState: PS = ProgramState(this, context1, env)
-        val warmState = delegationTarget match {
-          case Some(target) => initialState.addAccessedAddress(target)
-          case None => initialState
-        }
-        exec(warmState).toResult
       }
-    }
+    if (isSubCall)
+      tracer.foreach(_.onCallExit(context.startGas - result.gasRemaining, result.returnData, result.error.map(_.toString)))
+    result
+  }
 
   /** EIP-7702: Resolve delegation code one level deep. If the account has a delegation prefix (0xef0100), load the
     * target's code instead.
@@ -102,80 +113,90 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]](
   private[vm] def create(
       context: PC,
       salt: Option[UInt256] = None
-  ): (PR, Address) =
-    if (!isValidCall(context))
-      (invalidCallResult(context, Set.empty, Set.empty), Address(0))
-    else {
-      require(context.recipientAddr.isEmpty, "recipient address must be empty for contract creation")
-      require(context.doTransfer, "contract creation will always transfer funds")
+  ): (PR, Address) = {
+    val isSubCall = context.callDepth > 0
+    val opName    = if (salt.isDefined) "CREATE2" else "CREATE"
+    if (isSubCall)
+      tracer.foreach(_.onCallEnter(opName, context.callerAddr, Address(0),
+        context.startGas, context.endowment, context.inputData))
+    val (result, newAddress) =
+      if (!isValidCall(context))
+        (invalidCallResult(context, Set.empty, Set.empty), Address(0))
+      else {
+        require(context.recipientAddr.isEmpty, "recipient address must be empty for contract creation")
+        require(context.doTransfer, "contract creation will always transfer funds")
 
-      // EIP-3860: Check initcode size limit
-      val maxInitCodeSize = context.evmConfig.maxInitCodeSize
-      if (context.evmConfig.eip3860Enabled && maxInitCodeSize.exists(max => context.inputData.size > max)) {
-        // Exceptional abort: initcode too large (consumes all gas)
-        return (
-          invalidCallResult(context, Set.empty, Set.empty).copy(error = Some(InitCodeSizeLimit), gasRemaining = 0),
-          Address(0)
-        )
-      }
-
-      if (DebugTrace.enabledForBlock(context.blockHeader.number)) {
-        val callerAccountNonce = context.world.getAccount(context.callerAddr).map(_.nonce)
-        callerAccountNonce.foreach { n =>
-          val nonceForCreate = n - 1
-          // Address must be encoded as a single RLP string (20 bytes), not as a Seq[Byte].
-          val rlpPreimage =
-            rlp.encode(RLPList(RLPValue(context.callerAddr.bytes.toArray), nonceForCreate.toRLPEncodable))
-          val hash = kec256(rlpPreimage)
-          val derived = Address(hash)
-          log.info(
-            s"TRACE_CREATE_ADDR block=${context.blockHeader.number} caller=${context.callerAddr} " +
-              s"callerNonce=$n nonceForCreate=$nonceForCreate rlp=${Hex.toHexString(rlpPreimage.toArray)} " +
-              s"hash=${Hex.toHexString(hash.toArray)} derived=$derived"
+        // EIP-3860: Check initcode size limit
+        val maxInitCodeSize = context.evmConfig.maxInitCodeSize
+        if (context.evmConfig.eip3860Enabled && maxInitCodeSize.exists(max => context.inputData.size > max)) {
+          // Exceptional abort: initcode too large (consumes all gas)
+          return (
+            invalidCallResult(context, Set.empty, Set.empty).copy(error = Some(InitCodeSizeLimit), gasRemaining = 0),
+            Address(0)
           )
         }
+
+        if (DebugTrace.enabledForBlock(context.blockHeader.number)) {
+          val callerAccountNonce = context.world.getAccount(context.callerAddr).map(_.nonce)
+          callerAccountNonce.foreach { n =>
+            val nonceForCreate = n - 1
+            // Address must be encoded as a single RLP string (20 bytes), not as a Seq[Byte].
+            val rlpPreimage =
+              rlp.encode(RLPList(RLPValue(context.callerAddr.bytes.toArray), nonceForCreate.toRLPEncodable))
+            val hash = kec256(rlpPreimage)
+            val derived = Address(hash)
+            log.info(
+              s"TRACE_CREATE_ADDR block=${context.blockHeader.number} caller=${context.callerAddr} " +
+                s"callerNonce=$n nonceForCreate=$nonceForCreate rlp=${Hex.toHexString(rlpPreimage.toArray)} " +
+                s"hash=${Hex.toHexString(hash.toArray)} derived=$derived"
+            )
+          }
+        }
+
+        val contractAddr = salt
+          .map(s => context.world.create2Address(context.callerAddr, s, context.inputData))
+          .getOrElse(context.world.createAddress(context.callerAddr))
+
+        // EIP-684: revert a CREATE if the target address already has non-empty code/nonce.
+        // EIP-7610 (Prague+): additionally revert if the address has non-empty storage.
+        val isPrague = context.evmConfig.blockchainConfig.isPragueTimestamp(context.blockHeader.unixTimestamp) ||
+          context.evmConfig.blockchainConfig.isOsakaTimestamp(context.blockHeader.unixTimestamp)
+        val conflict =
+          if (isPrague) context.world.nonEmptyCodeOrNonceOrStorageAccount(contractAddr)
+          else context.world.nonEmptyCodeOrNonceAccount(contractAddr)
+
+        /** Specification of https://eips.ethereum.org/EIPS/eip-1283 states, that `originalValue` should be taken from
+          * world which is left after `a reversion happens on the current transaction`, so in current scope
+          * `context.originalWorld`.
+          *
+          * But ets test expects that it should be taken from world after the new account initialisation, which clears
+          * account storage. As it seems other implementations encountered similar problems with this ambiguity:
+          * ambiguity: https://gist.github.com/holiman/0154f00d5fcec5f89e85894cbb46fcb2 - explanation of geth and parity
+          * treating this situation differently. https://github.com/mana-ethereum/mana/pull/579 - elixir eth client
+          * dealing with same problem.
+          */
+        val originInitialisedAccount = context.originalWorld.initialiseAccount(contractAddr)
+
+        val world1: W =
+          context.world.initialiseAccount(contractAddr).transfer(context.callerAddr, contractAddr, context.endowment)
+
+        val code = if (conflict) ByteString(INVALID.code) else context.inputData
+
+        val env = ExecEnv(context, code, contractAddr).copy(inputData = ByteString.empty)
+
+        val initialState: PS =
+          ProgramState(this, context.copy(world = world1, originalWorld = originInitialisedAccount): PC, env)
+            .addAccessedAddress(contractAddr)
+
+        val execResult = exec(initialState).toResult
+
+        val newContractResult = saveNewContract(context, contractAddr, execResult, env.evmConfig)
+        (newContractResult, contractAddr)
       }
-
-      val newAddress = salt
-        .map(s => context.world.create2Address(context.callerAddr, s, context.inputData))
-        .getOrElse(context.world.createAddress(context.callerAddr))
-
-      // EIP-684: revert a CREATE if the target address already has non-empty code/nonce.
-      // EIP-7610 (Prague+): additionally revert if the address has non-empty storage.
-      val isPrague = context.evmConfig.blockchainConfig.isPragueTimestamp(context.blockHeader.unixTimestamp) ||
-        context.evmConfig.blockchainConfig.isOsakaTimestamp(context.blockHeader.unixTimestamp)
-      val conflict =
-        if (isPrague) context.world.nonEmptyCodeOrNonceOrStorageAccount(newAddress)
-        else context.world.nonEmptyCodeOrNonceAccount(newAddress)
-
-      /** Specification of https://eips.ethereum.org/EIPS/eip-1283 states, that `originalValue` should be taken from
-        * world which is left after `a reversion happens on the current transaction`, so in current scope
-        * `context.originalWorld`.
-        *
-        * But ets test expects that it should be taken from world after the new account initialisation, which clears
-        * account storage. As it seems other implementations encountered similar problems with this ambiguity:
-        * ambiguity: https://gist.github.com/holiman/0154f00d5fcec5f89e85894cbb46fcb2 - explanation of geth and parity
-        * treating this situation differently. https://github.com/mana-ethereum/mana/pull/579 - elixir eth client
-        * dealing with same problem.
-        */
-      val originInitialisedAccount = context.originalWorld.initialiseAccount(newAddress)
-
-      val world1: W =
-        context.world.initialiseAccount(newAddress).transfer(context.callerAddr, newAddress, context.endowment)
-
-      val code = if (conflict) ByteString(INVALID.code) else context.inputData
-
-      val env = ExecEnv(context, code, newAddress).copy(inputData = ByteString.empty)
-
-      val initialState: PS =
-        ProgramState(this, context.copy(world = world1, originalWorld = originInitialisedAccount): PC, env)
-          .addAccessedAddress(newAddress)
-
-      val execResult = exec(initialState).toResult
-
-      val newContractResult = saveNewContract(context, newAddress, execResult, env.evmConfig)
-      (newContractResult, newAddress)
-    }
+    if (isSubCall)
+      tracer.foreach(_.onCallExit(context.startGas - result.gasRemaining, result.returnData, result.error.map(_.toString)))
+    (result, newAddress)
+  }
 
   @tailrec
   final private[vm] def exec(state: ProgramState[W, S]): ProgramState[W, S] = {
@@ -221,6 +242,16 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]](
         state.withError(InvalidOpCode(byte)).halt
     }
   }
+
+  /** Derives the EVM opcode name for a sub-call from its ProgramContext.
+    * All four CALL variants reach VM.call() via the same method but differ in staticCtx/doTransfer/endowment
+    * (verified against OpCode.scala CallOp.exec() lines ~1125-1143).
+    */
+  private def callTypeName(context: PC): String =
+    if (context.staticCtx) "STATICCALL"
+    else if (!context.doTransfer && context.endowment == UInt256.Zero) "DELEGATECALL"
+    else if (!context.doTransfer) "CALLCODE"
+    else "CALL"
 
   protected def isValidCall(context: PC): Boolean =
     context.endowment <= context.world.getBalance(context.callerAddr) &&

--- a/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/VM.scala
@@ -17,7 +17,9 @@ import com.chipprbots.ethereum.rlp.UInt256RLPImplicits._
 import com.chipprbots.ethereum.utils.DebugTrace
 import com.chipprbots.ethereum.utils.Logger
 
-class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
+class VM[W <: WorldStateProxy[W, S], S <: Storage[S]](
+    val tracer: Option[ExecutionTracer] = None
+) extends Logger {
 
   type PC = ProgramContext[W, S]
   type PR = ProgramResult[W, S]
@@ -201,6 +203,7 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
             error = newState.error.map(_.toString)
           )
         }
+        tracer.foreach(_.onStep(opCode, state, newState))
         import newState._
         log.trace(
           s"$opCode | pc: $pc | depth: ${env.callDepth} | gasUsed: ${state.gas - gas} | gas: $gas | stack: $stack"

--- a/src/main/scala/com/chipprbots/ethereum/vm/VmTracer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/VmTracer.scala
@@ -1,0 +1,173 @@
+package com.chipprbots.ethereum.vm
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+import com.chipprbots.ethereum.utils.Hex
+
+/** Parity-format vmTrace tracer for trace_replayBlockTransactions / trace_replayTransaction.
+  *
+  * Besu reference: ethereum/api/.../results/tracing/vm/VmTraceGenerator.java
+  *
+  * Produces the vmTrace field matching OpenEthereum / Besu format:
+  * {{{
+  * {
+  *   "code": "0x...",
+  *   "ops": [
+  *     {
+  *       "cost": 3,
+  *       "ex": {
+  *         "mem": {"data": "0x...", "off": 32},
+  *         "push": ["0x1"],
+  *         "store": {"key": "0x0", "val": "0x1"},
+  *         "used": 21000
+  *       },
+  *       "pc": 0,
+  *       "sub": null
+  *     }
+  *   ]
+  * }
+  * }}}
+  *
+  * Frame stack mirrors the call depth. onCallEnter pushes a new frame; onCallExit encodes it
+  * and attaches it as the `sub` field on the triggering CALL/CREATE op in the parent frame.
+  *
+  * Divergence from Besu: VmTraceGenerator post-processes TraceFrames; this tracer streams
+  * during execution. Semantically equivalent for standard use cases.
+  */
+class VmTracer extends ExecutionTracer {
+
+  private case class VmFrame(
+      var code: ByteString = ByteString.empty,
+      ops: mutable.ArrayBuffer[VmOp] = mutable.ArrayBuffer.empty
+  )
+
+  private case class VmOp(
+      pc: Int,
+      cost: BigInt,
+      exUsed: BigInt,
+      exPush: Seq[BigInt],
+      exMem: Option[(BigInt, ByteString)],  // (offset, data written)
+      exStore: Option[(BigInt, BigInt)],     // (key, value written)
+      var sub: Option[JValue] = None
+  )
+
+  private val frameStack              = mutable.Stack[VmFrame]()
+  private var rootFrame: Option[VmFrame] = None
+
+  override def onTxStart(from: Address, to: Option[Address], gas: BigInt, value: BigInt, input: ByteString): Unit = {
+    val frame = VmFrame()
+    frameStack.push(frame)
+    rootFrame = Some(frame)
+  }
+
+  override def onStep[W <: WorldStateProxy[W, S], S <: Storage[S]](
+      opCode: OpCode,
+      prevState: ProgramState[W, S],
+      nextState: ProgramState[W, S]
+  ): Unit = {
+    if (frameStack.isEmpty) return
+    val frame = frameStack.top
+
+    if (frame.code.isEmpty) {
+      frame.code = prevState.env.program.code
+    }
+
+    val cost   = prevState.gas - nextState.gas
+    val exUsed = nextState.gas
+
+    val exPush: Seq[BigInt] =
+      if (opCode.alpha > 0)
+        nextState.stack.toSeq.take(opCode.alpha).map(_.toBigInt)
+      else
+        Seq.empty
+
+    val exMem: Option[(BigInt, ByteString)] = opCode match {
+      case MSTORE if prevState.stack.size >= 2 =>
+        val offset = prevState.stack.toSeq.head
+        val data   = nextState.memory.load(offset, UInt256(32))._1
+        Some((offset.toBigInt, data))
+      case MSTORE8 if prevState.stack.size >= 2 =>
+        val offset = prevState.stack.toSeq.head
+        val data   = nextState.memory.load(offset, UInt256(1))._1
+        Some((offset.toBigInt, data))
+      case _ =>
+        None
+    }
+
+    val exStore: Option[(BigInt, BigInt)] = opCode match {
+      case SSTORE if prevState.stack.size >= 2 =>
+        val key = prevState.stack.toSeq(0).toBigInt
+        val v   = prevState.stack.toSeq(1).toBigInt
+        Some((key, v))
+      case _ =>
+        None
+    }
+
+    frame.ops += VmOp(
+      pc      = prevState.pc,
+      cost    = cost,
+      exUsed  = exUsed,
+      exPush  = exPush,
+      exMem   = exMem,
+      exStore = exStore
+    )
+  }
+
+  override def onCallEnter(
+      opCode: String,
+      from: Address,
+      to: Address,
+      gas: BigInt,
+      value: BigInt,
+      input: ByteString
+  ): Unit = {
+    val frame = VmFrame()
+    frameStack.push(frame)
+  }
+
+  override def onCallExit(gasUsed: BigInt, output: ByteString, error: Option[String]): Unit = {
+    if (frameStack.size <= 1) return
+    val frame   = frameStack.pop()
+    val encoded = encodeFrame(frame)
+    if (frameStack.nonEmpty && frameStack.top.ops.nonEmpty) {
+      frameStack.top.ops.last.sub = Some(encoded)
+    }
+  }
+
+  override def getResult: JValue = rootFrame match {
+    case Some(frame) => encodeFrame(frame)
+    case None        => JNull
+  }
+
+  private def encodeFrame(frame: VmFrame): JValue =
+    ("code" -> encodeHexBytes(frame.code)) ~
+      ("ops" -> JArray(frame.ops.toList.map(encodeOp)))
+
+  private def encodeOp(op: VmOp): JValue = {
+    val ex: JValue =
+      ("mem" -> op.exMem.map { case (off, data) =>
+        ("data" -> encodeHexBytes(data)) ~ ("off" -> JInt(off.bigInteger))
+      }.getOrElse(JNull: JValue)) ~
+        ("push" -> JArray(op.exPush.map(v => JString("0x" + v.toString(16))).toList)) ~
+        ("store" -> op.exStore.map { case (k, v) =>
+          ("key" -> JString("0x" + k.toString(16))) ~ ("val" -> JString("0x" + v.toString(16)))
+        }.getOrElse(JNull: JValue)) ~
+        ("used" -> JInt(op.exUsed.bigInteger))
+
+    ("cost" -> JInt(op.cost.bigInteger)) ~
+      ("ex" -> ex) ~
+      ("pc" -> JInt(op.pc)) ~
+      ("sub" -> op.sub.getOrElse(JNull: JValue))
+  }
+
+  private def encodeHexBytes(bs: ByteString): JString =
+    if (bs.isEmpty) JString("0x")
+    else JString("0x" + Hex.toHexString(bs.toArray))
+}

--- a/src/test/scala/com/chipprbots/ethereum/consensus/blocks/GasLimitCalculationSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/blocks/GasLimitCalculationSpec.scala
@@ -2,6 +2,8 @@ package com.chipprbots.ethereum.consensus.blocks
 
 import org.apache.pekko.util.ByteString
 
+import scala.concurrent.duration._
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -73,7 +75,10 @@ class GasLimitCalculationSpec extends AnyFlatSpec with Matchers {
         headerExtraData = ByteString.empty,
         blockCacheSize = 1,
         miningEnabled = false,
-        gasLimitTarget = target
+        gasLimitTarget = target,
+        notifyUrls = Seq.empty,
+        staleThreshold = 7,
+        recommitInterval = 0.seconds
       )
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/consensus/blocks/OlympiaGasLimitSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/blocks/OlympiaGasLimitSpec.scala
@@ -2,6 +2,8 @@ package com.chipprbots.ethereum.consensus.blocks
 
 import org.apache.pekko.util.ByteString
 
+import scala.concurrent.duration._
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -39,7 +41,10 @@ class OlympiaGasLimitSpec extends AnyFlatSpec with Matchers {
           headerExtraData = ByteString.empty,
           blockCacheSize = 1,
           miningEnabled = false,
-          gasLimitTarget = target
+          gasLimitTarget = target,
+          notifyUrls = Seq.empty,
+          staleThreshold = 7,
+          recommitInterval = 0.seconds
         ),
         new DifficultyCalculator {
           def calculateDifficulty(blockNumber: BigInt, blockTimestamp: Long, parent: BlockHeader)(implicit

--- a/src/test/scala/com/chipprbots/ethereum/consensus/mining/MiningConfigs.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/mining/MiningConfigs.scala
@@ -2,6 +2,8 @@ package com.chipprbots.ethereum.consensus.mining
 
 import org.apache.pekko.util.ByteString
 
+import scala.concurrent.duration._
+
 import com.chipprbots.ethereum.Timeouts
 import com.chipprbots.ethereum.consensus.pow.EthashConfig
 import com.chipprbots.ethereum.domain.Address
@@ -26,7 +28,10 @@ object MiningConfigs {
     headerExtraData = ByteString.empty,
     blockCacheSize = blockCacheSize,
     miningEnabled = false,
-    gasLimitTarget = BigInt(8_000_000)
+    gasLimitTarget = BigInt(8_000_000),
+    notifyUrls = Seq.empty,
+    staleThreshold = 7,
+    recommitInterval = 0.seconds
   )
 
   final val fullMiningConfig: FullMiningConfig[EthashConfig] = FullMiningConfig(miningConfig, ethashConfig)

--- a/src/test/scala/com/chipprbots/ethereum/consensus/pow/WorkNotifierSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/pow/WorkNotifierSpec.scala
@@ -1,0 +1,115 @@
+package com.chipprbots.ethereum.consensus.pow
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Millis
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.testing.Tags._
+
+class WorkNotifierSpec
+    extends TestKit(ActorSystem("WorkNotifierSpec"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with Eventually
+    with BeforeAndAfterAll {
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+
+  val testWork: WorkNotifier.WorkPackage = WorkNotifier.WorkPackage(
+    powHeaderHash = ByteString(Array.fill(32)(0xab.toByte)),
+    dagSeed = ByteString(Array.fill(32)(0xcd.toByte)),
+    target = ByteString(Array.fill(32)(0xef.toByte)),
+    blockNumber = BigInt(12345)
+  )
+
+  "WorkNotifier" should "POST a 4-element JSON array to the configured URL" taggedAs UnitTest in {
+    val received = new ConcurrentLinkedQueue[String]()
+
+    val route = post {
+      entity(as[String]) { body =>
+        received.add(body)
+        complete("ok")
+      }
+    }
+
+    val binding = Await.result(Http().newServerAt("127.0.0.1", 0).bind(route), 5.seconds)
+    val port = binding.localAddress.getPort
+
+    WorkNotifier.notify(Seq(s"http://127.0.0.1:$port"), testWork)
+
+    eventually {
+      received.size() shouldEqual 1
+    }
+
+    val body = received.peek()
+    body should startWith("[")
+    body should endWith("]")
+    // Verify 4 elements present by counting comma-separated quoted strings
+    body.count(_ == '"') shouldEqual 8 // 4 pairs of quotes
+    // Block number is present as 0x3039 (12345 in hex)
+    body should include("0x3039")
+
+    Await.result(binding.unbind(), 5.seconds)
+  }
+
+  it should "send independent POSTs to multiple URLs" taggedAs UnitTest in {
+    val received1 = new ConcurrentLinkedQueue[String]()
+    val received2 = new ConcurrentLinkedQueue[String]()
+
+    val route1 = post { entity(as[String]) { b => received1.add(b); complete("ok") } }
+    val route2 = post { entity(as[String]) { b => received2.add(b); complete("ok") } }
+
+    val binding1 = Await.result(Http().newServerAt("127.0.0.1", 0).bind(route1), 5.seconds)
+    val binding2 = Await.result(Http().newServerAt("127.0.0.1", 0).bind(route2), 5.seconds)
+
+    val port1 = binding1.localAddress.getPort
+    val port2 = binding2.localAddress.getPort
+
+    WorkNotifier.notify(Seq(s"http://127.0.0.1:$port1", s"http://127.0.0.1:$port2"), testWork)
+
+    eventually {
+      received1.size() shouldEqual 1
+      received2.size() shouldEqual 1
+    }
+
+    received1.peek() should include("0x3039")
+    received2.peek() should include("0x3039")
+
+    Await.result(binding1.unbind(), 5.seconds)
+    Await.result(binding2.unbind(), 5.seconds)
+  }
+
+  it should "not block the caller when a URL is unreachable" taggedAs UnitTest in {
+    val start = System.currentTimeMillis()
+    // Port 19999 — nothing listening there
+    WorkNotifier.notify(Seq("http://127.0.0.1:19999"), testWork)
+    val elapsed = System.currentTimeMillis() - start
+    // Fire-and-forget: should return in well under 1 second
+    elapsed should be < 500L
+  }
+
+  it should "skip notification when URLs list is empty" taggedAs UnitTest in {
+    // No exception, no POST attempted — just a no-op
+    WorkNotifier.notify(Seq.empty, testWork)
+    // If we reach here without exception, the test passes
+    succeed
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/FlatAccountStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/FlatAccountStorageSpec.scala
@@ -1,0 +1,72 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Tests for FlatAccountStorage — O(1) account reads by keccak256(address).
+  *
+  * Verified against Besu BonsaiFullFlatDbStrategy.getFlatAccount:
+  *   storage.get(ACCOUNT_INFO_STATE, accountHash.getBytes()) → RLP(account)
+  */
+class FlatAccountStorageSpec extends AnyFlatSpec with Matchers {
+
+  "FlatAccountStorage" should "store and retrieve an account by hash" taggedAs UnitTest in new TestSetup {
+    val hash = ByteString(Array.fill(32)(0xAA.toByte))
+    val rlpAccount = ByteString(Array.fill(64)(0x01.toByte))
+
+    storage.put(hash, rlpAccount).commit()
+    storage.getAccount(hash) shouldBe Some(rlpAccount)
+  }
+
+  it should "return None for missing hash" taggedAs UnitTest in new TestSetup {
+    val hash = ByteString(Array.fill(32)(0xBB.toByte))
+    storage.getAccount(hash) shouldBe None
+  }
+
+  it should "store multiple accounts in batch" taggedAs UnitTest in new TestSetup {
+    val accounts = (1 to 5).map { i =>
+      ByteString(Array.fill(32)(i.toByte)) -> ByteString(Array.fill(64)(i.toByte))
+    }
+
+    storage.putAccountsBatch(accounts).commit()
+
+    accounts.foreach { case (hash, expected) =>
+      storage.getAccount(hash) shouldBe Some(expected)
+    }
+  }
+
+  it should "overwrite existing account on re-put" taggedAs UnitTest in new TestSetup {
+    val hash = ByteString(Array.fill(32)(0xCC.toByte))
+    val v1 = ByteString(Array.fill(64)(0x01.toByte))
+    val v2 = ByteString(Array.fill(64)(0x02.toByte))
+
+    storage.put(hash, v1).commit()
+    storage.getAccount(hash) shouldBe Some(v1)
+
+    storage.put(hash, v2).commit()
+    storage.getAccount(hash) shouldBe Some(v2)
+  }
+
+  it should "return Stream.empty from seekFrom with non-RocksDB backend" taggedAs UnitTest in new TestSetup {
+    import cats.effect.unsafe.IORuntime
+    implicit val runtime: IORuntime = IORuntime.global
+
+    val hash = ByteString(Array.fill(32)(0xAA.toByte))
+    val rlpAccount = ByteString(Array.fill(64)(0x01.toByte))
+    storage.put(hash, rlpAccount).commit()
+
+    // EphemDataSource is not RocksDB — seekFrom falls through to Stream.empty
+    val results = storage.seekFrom(ByteString(Array.fill(32)(0x00.toByte))).compile.toVector.unsafeRunSync()
+    results shouldBe empty
+  }
+
+  trait TestSetup {
+    val dataSource = EphemDataSource()
+    val storage = new FlatAccountStorage(dataSource)
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/FlatSlotStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/FlatSlotStorageSpec.scala
@@ -1,0 +1,79 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Tests for FlatSlotStorage — O(1) slot reads by (accountHash, slotHash).
+  *
+  * Verified against Besu BonsaiFlatDbStrategy:
+  *   - putFlatAccountStorageValueByStorageSlotHash: key = accountHash ++ slotHash
+  *   - storageToPairStream: seekFrom(accountHash ++ startSlotHash), takeWhile prefix matches
+  */
+class FlatSlotStorageSpec extends AnyFlatSpec with Matchers {
+
+  "FlatSlotStorage" should "store and retrieve a slot by account and slot hash" taggedAs UnitTest in new TestSetup {
+    val accountHash = ByteString(Array.fill(32)(0xAA.toByte))
+    val slotHash = ByteString(Array.fill(32)(0x01.toByte))
+    val value = ByteString(Array.fill(32)(0xFF.toByte))
+
+    storage.putSlotsBatch(accountHash, Seq(slotHash -> value)).commit()
+    storage.getSlot(accountHash, slotHash) shouldBe Some(value)
+  }
+
+  it should "return None for missing slot" taggedAs UnitTest in new TestSetup {
+    val accountHash = ByteString(Array.fill(32)(0xAA.toByte))
+    val slotHash = ByteString(Array.fill(32)(0x01.toByte))
+    storage.getSlot(accountHash, slotHash) shouldBe None
+  }
+
+  it should "store multiple slots for an account in batch" taggedAs UnitTest in new TestSetup {
+    val accountHash = ByteString(Array.fill(32)(0xBB.toByte))
+    val slots = (1 to 5).map { i =>
+      ByteString(Array.fill(32)(i.toByte)) -> ByteString(Array.fill(32)((i * 10).toByte))
+    }
+
+    storage.putSlotsBatch(accountHash, slots).commit()
+
+    slots.foreach { case (slotHash, expected) =>
+      storage.getSlot(accountHash, slotHash) shouldBe Some(expected)
+    }
+  }
+
+  it should "isolate slots between different accounts" taggedAs UnitTest in new TestSetup {
+    val account1 = ByteString(Array.fill(32)(0x01.toByte))
+    val account2 = ByteString(Array.fill(32)(0x02.toByte))
+    val slotHash = ByteString(Array.fill(32)(0xAA.toByte))
+    val value1 = ByteString(Array.fill(32)(0x11.toByte))
+    val value2 = ByteString(Array.fill(32)(0x22.toByte))
+
+    storage.putSlotsBatch(account1, Seq(slotHash -> value1)).commit()
+    storage.putSlotsBatch(account2, Seq(slotHash -> value2)).commit()
+
+    storage.getSlot(account1, slotHash) shouldBe Some(value1)
+    storage.getSlot(account2, slotHash) shouldBe Some(value2)
+  }
+
+  it should "return Stream.empty from seekStorageRange with non-RocksDB backend" taggedAs UnitTest in new TestSetup {
+    import cats.effect.unsafe.IORuntime
+    implicit val runtime: IORuntime = IORuntime.global
+
+    val accountHash = ByteString(Array.fill(32)(0xAA.toByte))
+    val slotHash = ByteString(Array.fill(32)(0x01.toByte))
+    val value = ByteString(Array.fill(32)(0xFF.toByte))
+    storage.putSlotsBatch(accountHash, Seq(slotHash -> value)).commit()
+
+    // EphemDataSource is not RocksDB — seekStorageRange falls through to Stream.empty
+    val results = storage.seekStorageRange(accountHash, ByteString(Array.fill(32)(0x00.toByte))).compile.toVector.unsafeRunSync()
+    results shouldBe empty
+  }
+
+  trait TestSetup {
+    val dataSource = EphemDataSource()
+    val storage = new FlatSlotStorage(dataSource)
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/AdminServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/AdminServiceSpec.scala
@@ -1,0 +1,115 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicReference
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+import com.chipprbots.ethereum.network.BlockedIPRegistry
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.NodeStatus
+import com.chipprbots.ethereum.utils.ServerStatus
+
+/** Unit tests for AdminService — Besu admin_* namespace.
+  *
+  * Besu reference:
+  *   AdminNodeInfo.java, AdminPeers.java, AdminAddPeer.java, AdminRemovePeer.java, AdminChangeLogLevel.java
+  *   DefaultP2PNetwork.java (peer management)
+  */
+class AdminServiceSpec extends AnyFlatSpec with Matchers {
+
+  implicit val runtime: IORuntime = IORuntime.global
+
+  "AdminService.nodeInfo" should "return P2P info when server is listening" taggedAs UnitTest in new TestSetup {
+    val result = service.nodeInfo(AdminService.AdminNodeInfoRequest()).unsafeRunSync()
+
+    result shouldBe a[Right[_, _]]
+    val info = result.toOption.get
+    info.enode shouldBe defined
+    info.enode.get should startWith("enode://")
+    info.id should not be empty
+    info.ip shouldBe defined
+    info.listenAddr shouldBe defined
+    info.ports should contain key "listener"
+  }
+
+  it should "return minimal info when server is not listening" taggedAs UnitTest in new TestSetup {
+    val notListeningStatus = NodeStatus(
+      com.chipprbots.ethereum.crypto.generateKeyPair(new java.security.SecureRandom),
+      ServerStatus.NotListening,
+      ServerStatus.NotListening
+    )
+    val holder = new AtomicReference(notListeningStatus)
+    val svc = new AdminService(holder, null, null, 5.seconds, "/tmp", new BlockedIPRegistry(Set.empty))
+    val result = svc.nodeInfo(AdminService.AdminNodeInfoRequest()).unsafeRunSync()
+
+    val info = result.toOption.get
+    info.enode shouldBe None
+    info.listenAddr shouldBe None
+    info.ports shouldBe empty
+  }
+
+  "AdminService.changeLogLevel" should "accept valid log level INFO" taggedAs UnitTest in new TestSetup {
+    val result = service.changeLogLevel(AdminService.AdminChangeLogLevelRequest("INFO", None)).unsafeRunSync()
+    result shouldBe a[Right[_, _]]
+  }
+
+  it should "accept valid log level DEBUG with package filter" taggedAs UnitTest in new TestSetup {
+    val result = service.changeLogLevel(
+      AdminService.AdminChangeLogLevelRequest("DEBUG", Some(List("com.chipprbots")))
+    ).unsafeRunSync()
+    result shouldBe a[Right[_, _]]
+  }
+
+  it should "reject invalid log level" taggedAs UnitTest in new TestSetup {
+    val result = service.changeLogLevel(AdminService.AdminChangeLogLevelRequest("VERBOSE", None)).unsafeRunSync()
+    result shouldBe a[Left[_, _]]
+  }
+
+  "AdminService.blockIP / unblockIP / listBlockedIPs" should "manage blocklist correctly" taggedAs UnitTest in new TestSetup {
+    val blockResult = service.blockIP(AdminService.AdminBlockIPRequest("1.2.3.4")).unsafeRunSync()
+    blockResult shouldBe Right(AdminService.AdminBlockIPResponse(true))
+
+    val listResult = service.listBlockedIPs(AdminService.AdminListBlockedIPsRequest()).unsafeRunSync()
+    listResult.toOption.get.ips should contain("1.2.3.4")
+
+    val unblockResult = service.unblockIP(AdminService.AdminUnblockIPRequest("1.2.3.4")).unsafeRunSync()
+    unblockResult shouldBe Right(AdminService.AdminUnblockIPResponse(true))
+
+    val listAfter = service.listBlockedIPs(AdminService.AdminListBlockedIPsRequest()).unsafeRunSync()
+    listAfter.toOption.get.ips should not contain "1.2.3.4"
+  }
+
+  it should "return false when unblocking an IP not in the list" taggedAs UnitTest in new TestSetup {
+    val result = service.unblockIP(AdminService.AdminUnblockIPRequest("9.9.9.9")).unsafeRunSync()
+    result shouldBe Right(AdminService.AdminUnblockIPResponse(false))
+  }
+
+  "AdminService.getDatadir" should "return configured datadir" taggedAs UnitTest in new TestSetup {
+    val result = service.getDatadir(AdminService.AdminDatadirRequest()).unsafeRunSync()
+    result shouldBe Right(AdminService.AdminDatadirResponse("/tmp/test-datadir"))
+  }
+
+  trait TestSetup {
+    val keyPair = com.chipprbots.ethereum.crypto.generateKeyPair(new java.security.SecureRandom)
+    val listenAddr = new InetSocketAddress("127.0.0.1", 30305)
+    val nodeStatus = NodeStatus(keyPair, ServerStatus.Listening(listenAddr), ServerStatus.NotListening)
+    val nodeStatusHolder = new AtomicReference(nodeStatus)
+    val registry = new BlockedIPRegistry(Set.empty)
+
+    val service = new AdminService(
+      nodeStatusHolder,
+      null, // peerManager — not used in unit tests (admin_peers / admin_addPeer / admin_removePeer need actor)
+      null, // blockchainReader — not used in unit tests
+      5.seconds,
+      "/tmp/test-datadir",
+      registry
+    )
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/AdminServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/AdminServiceSpec.scala
@@ -3,7 +3,8 @@ package com.chipprbots.ethereum.jsonrpc
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicReference
 
-import cats.effect.IO
+import org.apache.pekko.util.ByteString
+
 import cats.effect.unsafe.IORuntime
 
 import org.scalatest.flatspec.AnyFlatSpec
@@ -11,8 +12,12 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.branch.EmptyBranch
 import com.chipprbots.ethereum.network.BlockedIPRegistry
 import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.Config
 import com.chipprbots.ethereum.utils.NodeStatus
 import com.chipprbots.ethereum.utils.ServerStatus
 
@@ -39,6 +44,23 @@ class AdminServiceSpec extends AnyFlatSpec with Matchers {
     info.ports should contain key "listener"
   }
 
+  it should "return protocols.eth with genesis, head, difficulty, network" taggedAs UnitTest in new TestSetup {
+    val result = service.nodeInfo(AdminService.AdminNodeInfoRequest()).unsafeRunSync()
+    val info   = result.toOption.get
+    info.protocols should contain key "eth"
+    val eth = info.protocols("eth")
+    eth.genesis should startWith("0x")
+    eth.head should startWith("0x")
+    eth.difficulty should startWith("0x")
+    eth.network shouldBe Config.blockchains.blockchainConfig.networkId
+  }
+
+  it should "return activeFork as a non-empty string" taggedAs UnitTest in new TestSetup {
+    val result = service.nodeInfo(AdminService.AdminNodeInfoRequest()).unsafeRunSync()
+    val info   = result.toOption.get
+    info.activeFork should not be empty
+  }
+
   it should "return minimal info when server is not listening" taggedAs UnitTest in new TestSetup {
     val notListeningStatus = NodeStatus(
       com.chipprbots.ethereum.crypto.generateKeyPair(new java.security.SecureRandom),
@@ -46,7 +68,15 @@ class AdminServiceSpec extends AnyFlatSpec with Matchers {
       ServerStatus.NotListening
     )
     val holder = new AtomicReference(notListeningStatus)
-    val svc = new AdminService(holder, null, null, 5.seconds, "/tmp", new BlockedIPRegistry(Set.empty))
+    val svc = new AdminService(
+      holder,
+      null,
+      stubBlockchainReader,
+      Config.blockchains.blockchainConfig,
+      5.seconds,
+      "/tmp",
+      new BlockedIPRegistry(Set.empty)
+    )
     val result = svc.nodeInfo(AdminService.AdminNodeInfoRequest()).unsafeRunSync()
 
     val info = result.toOption.get
@@ -97,16 +127,24 @@ class AdminServiceSpec extends AnyFlatSpec with Matchers {
   }
 
   trait TestSetup {
-    val keyPair = com.chipprbots.ethereum.crypto.generateKeyPair(new java.security.SecureRandom)
+    val keyPair    = com.chipprbots.ethereum.crypto.generateKeyPair(new java.security.SecureRandom)
     val listenAddr = new InetSocketAddress("127.0.0.1", 30305)
     val nodeStatus = NodeStatus(keyPair, ServerStatus.Listening(listenAddr), ServerStatus.NotListening)
     val nodeStatusHolder = new AtomicReference(nodeStatus)
     val registry = new BlockedIPRegistry(Set.empty)
 
+    /** Minimal BlockchainReader stub — only overrides the three methods used by nodeInfo. */
+    val stubBlockchainReader: BlockchainReader = new BlockchainReader(null, null, null, null, null, null, null) {
+      override val genesisHeader = Fixtures.Blocks.Block3125369.header
+      override def getBestBranch() = EmptyBranch
+      override def getChainWeightByHash(hash: ByteString) = None
+    }
+
     val service = new AdminService(
       nodeStatusHolder,
       null, // peerManager — not used in unit tests (admin_peers / admin_addPeer / admin_removePeer need actor)
-      null, // blockchainReader — not used in unit tests
+      stubBlockchainReader,
+      Config.blockchains.blockchainConfig,
       5.seconds,
       "/tmp/test-datadir",
       registry

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
@@ -18,10 +18,15 @@ import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
 import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.BlockHeader
 import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
 import com.chipprbots.ethereum.jsonrpc.DebugTracingService._
+import com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy
 import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.ledger.TxResult
 import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.vm.ExecutionTracer
 
 /** Unit tests for DebugTracingService.
   *
@@ -82,7 +87,7 @@ class DebugTracingServiceSpec
 
       (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
       (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
-      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+      (mockLedger.simulateTransactionWithTracer(_: SignedTransactionWithSender, _: BlockHeader, _: Option[InMemoryWorldStateProxy], _: ExecutionTracer)).expects(*, *, *, *).returning(null.asInstanceOf[TxResult])
 
       val result = service
         .traceTransaction(TraceTransactionRequest(txHash))
@@ -143,7 +148,7 @@ class DebugTracingServiceSpec
     "return a call trace result for the latest block" taggedAs (UnitTest, RPCTest) in new TestSetup {
       blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(block.header.difficulty), saveAsBestBlock = true)
 
-      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+      (mockLedger.simulateTransactionWithTracer(_: SignedTransactionWithSender, _: BlockHeader, _: Option[InMemoryWorldStateProxy], _: ExecutionTracer)).expects(*, *, *, *).returning(null.asInstanceOf[TxResult])
 
       val callTx = EthInfoService.CallTx(
         from = None,

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
@@ -1,0 +1,181 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
+
+import cats.effect.unsafe.IORuntime
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.NormalPatience
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.jsonrpc.DebugTracingService._
+import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Unit tests for DebugTracingService.
+  *
+  * Besu reference: DebugTraceTransaction.java, DebugTraceBlock.java,
+  *   DebugTraceBlockByNumber.java, DebugTraceCall.java
+  *
+  * core-geth reference: eth/tracers/api.go
+  */
+class DebugTracingServiceSpec
+    extends TestKit(ActorSystem("DebugTracingServiceSpec"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with MockFactory
+    with ScalaFutures
+    with NormalPatience {
+
+  implicit val runtime: IORuntime = IORuntime.global
+
+  // ── traceTransaction ────────────────────────────────────────────────────────
+
+  "DebugTracingService.traceTransaction" should
+    "return InvalidParams when transaction is not found in mapping storage" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      val unknownHash: ByteString = ByteString(Array.fill(32)(0xff.toByte))
+      (txMappingStorage.get _).expects(unknownHash).returning(None)
+
+      val result = service
+        .traceTransaction(TraceTransactionRequest(unknownHash))
+        .unsafeRunSync()
+
+      result.isLeft shouldBe true
+    }
+
+  it should "return InvalidParams when block hash is not in storage" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      val txHash: ByteString = block.body.transactionList.head.hash
+      val missingBlockHash   = ByteString(Array.fill(32)(0xee.toByte))
+      (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(missingBlockHash, 0)))
+
+      val result = service
+        .traceTransaction(TraceTransactionRequest(txHash))
+        .unsafeRunSync()
+
+      result.isLeft shouldBe true
+    }
+
+  it should "return a trace result for a valid transaction" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      val txHash: ByteString = block.body.transactionList.head.hash
+      val txIndex             = 0
+
+      blockchainWriter.storeBlock(block).commit()
+      // Inject a parent header at the exact parentHash the block references
+      storagesInstance.storages.blockHeadersStorage
+        .put(block.header.parentHash, block.header.copy(number = block.header.number - 1))
+        .commit()
+
+      (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
+      (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
+      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+
+      val result = service
+        .traceTransaction(TraceTransactionRequest(txHash))
+        .unsafeRunSync()
+
+      result.isRight shouldBe true
+    }
+
+  // ── traceBlockByHash ─────────────────────────────────────────────────────────
+
+  "DebugTracingService.traceBlockByHash" should
+    "return InvalidParams when block is not found" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val unknownHash: ByteString = ByteString(Array.fill(32)(0xdd.toByte))
+
+      val result = service
+        .traceBlockByHash(TraceBlockByHashRequest(unknownHash))
+        .unsafeRunSync()
+
+      result.isLeft shouldBe true
+    }
+
+  it should "return an empty trace list for a block with no transactions" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+      blockchainWriter.storeBlock(emptyBlock).commit()
+      storagesInstance.storages.blockHeadersStorage
+        .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+        .commit()
+
+      val result = service
+        .traceBlockByHash(TraceBlockByHashRequest(emptyBlock.header.hash))
+        .unsafeRunSync()
+
+      result shouldBe Right(TraceBlockByHashResponse(Seq.empty))
+    }
+
+  // ── traceBlockByNumber ───────────────────────────────────────────────────────
+
+  "DebugTracingService.traceBlockByNumber" should
+    "return an empty trace list for a block with no transactions" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+      blockchainWriter.save(emptyBlock, Nil, ChainWeight.totalDifficultyOnly(emptyBlock.header.difficulty), saveAsBestBlock = true)
+      storagesInstance.storages.blockHeadersStorage
+        .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+        .commit()
+
+      val result = service
+        .traceBlockByNumber(TraceBlockByNumberRequest(BlockParam.WithNumber(emptyBlock.header.number)))
+        .unsafeRunSync()
+
+      result shouldBe Right(TraceBlockByNumberResponse(Seq.empty))
+    }
+
+  // ── traceCall ────────────────────────────────────────────────────────────────
+
+  "DebugTracingService.traceCall" should
+    "return a call trace result for the latest block" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(block.header.difficulty), saveAsBestBlock = true)
+
+      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+
+      val callTx = EthInfoService.CallTx(
+        from = None,
+        to = None,
+        gas = None,
+        gasPrice = 0,
+        value = 0,
+        data = ByteString.empty
+      )
+      val result = service
+        .traceCall(TraceCallRequest(callTx, BlockParam.Latest))
+        .unsafeRunSync()
+
+      result.isRight shouldBe true
+    }
+
+  // ── TestSetup ────────────────────────────────────────────────────────────────
+
+  class TestSetup(implicit system: ActorSystem) extends EphemBlockchainTestSetup {
+
+    val block: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+
+    val mockLedger: StxLedger              = mock[StxLedger]
+    val txMappingStorage: TransactionMappingStorage = mock[TransactionMappingStorage]
+    val mockWorld = null.asInstanceOf[com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy]
+
+    lazy val service: DebugTracingService = new DebugTracingService(
+      blockchain,
+      blockchainReader,
+      mining,
+      mockLedger,
+      txMappingStorage
+    )
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/DebugTracingServiceSpec.scala
@@ -165,6 +165,33 @@ class DebugTracingServiceSpec
       result.isRight shouldBe true
     }
 
+  // ── intermediateRoots ────────────────────────────────────────────────────────
+
+  "DebugTracingService.intermediateRoots" should
+    "return InvalidParams when block is not found" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      import com.chipprbots.ethereum.jsonrpc.DebugTracingService.IntermediateRootsRequest
+      val result = service
+        .intermediateRoots(IntermediateRootsRequest(block.header.hash))
+        .unsafeRunSync()
+      result.isLeft shouldBe true
+      result.left.get.message should include("Block not found")
+    }
+
+  it should "return empty list for a block with no transactions" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    import com.chipprbots.ethereum.jsonrpc.DebugTracingService.{IntermediateRootsRequest, IntermediateRootsResponse}
+    val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+    blockchainWriter.storeBlock(emptyBlock).commit()
+    storagesInstance.storages.blockHeadersStorage
+      .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+      .commit()
+
+    val result = service
+      .intermediateRoots(IntermediateRootsRequest(emptyBlock.header.hash))
+      .unsafeRunSync()
+
+    result shouldBe Right(IntermediateRootsResponse(Seq.empty))
+  }
+
   // ── TestSetup ────────────────────────────────────────────────────────────────
 
   class TestSetup(implicit system: ActorSystem) extends EphemBlockchainTestSetup {

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -21,6 +21,7 @@ import com.chipprbots.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import com.chipprbots.ethereum.NormalPatience
 import com.chipprbots.ethereum.WithActorSystemShutDown
 import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.blockchain.sync.SyncProtocol
 import com.chipprbots.ethereum.consensus.blocks.PendingBlock
 import com.chipprbots.ethereum.consensus.blocks.PendingBlockAndState
 import com.chipprbots.ethereum.consensus.mining.CoinbaseProvider
@@ -196,7 +197,7 @@ class EthMiningServiceSpec
     import scala.concurrent.duration._
     val response = Await.result(workFuture, 10.seconds)
 
-    response shouldEqual Right(GetWorkResponse(powHash, seedHash, target))
+    response shouldEqual Right(GetWorkResponse(powHash, seedHash, target, block.header.number))
   }
 
   it should "generate and submit work when generating block for mining with restricted ethash generator" taggedAs (
@@ -338,6 +339,74 @@ class EthMiningServiceSpec
     status2.toOption.get.hashRate shouldEqual BigInt(100)
   }
 
+  // core-geth alignment: GetWork returns 4-element array including block number (work[3])
+  it should "return a 4-element GetWorkResponse including blockNumber" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    (blockGenerator
+      .generateBlock(
+        _: Block,
+        _: Seq[SignedTransaction],
+        _: Address,
+        _: Seq[BlockHeader],
+        _: Option[InMemoryWorldStateProxy]
+      )(_: BlockchainConfig))
+      .expects(parentBlock, *, *, *, *, *)
+      .returning(PendingBlockAndState(PendingBlock(block, Nil), fakeWorld))
+
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
+
+    val workFuture = ethMiningService.getWork(GetWorkRequest()).unsafeToFuture()
+
+    pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    pendingTransactionsManager.reply(PendingTransactionsManager.PendingTransactionsResponse(Nil))
+    ommersPool.expectMsg(OmmersPool.GetOmmers(parentBlock.hash))
+    ommersPool.reply(OmmersPool.Ommers(Nil))
+
+    import scala.concurrent.Await
+    import scala.concurrent.duration._
+    val result = Await.result(workFuture, 10.seconds)
+
+    result shouldBe Symbol("right")
+    val workResponse = result.toOption.get
+    workResponse.blockNumber shouldEqual block.header.number
+    workResponse.powHeaderHash should not be empty
+    workResponse.dagSeed should not be empty
+    workResponse.target should not be empty
+  }
+
+  // core-geth alignment: submitWork rejects shares older than staleThreshold blocks
+  it should "reject submitWork when submission is beyond stale threshold" taggedAs (UnitTest, RPCTest) in
+    new TestSetup {
+      override lazy val miningConfig = MiningConfigs.miningConfig.copy(staleThreshold = 0)
+
+      // Save both blocks so best = block.number (1)
+      blockchainWriter.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
+      blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(block.header.difficulty), true)
+
+      // getPrepared returns parentBlock (number=0); best=1; diff=1 > threshold=0 → stale
+      (blockGenerator.getPrepared _).expects(*).returning(Some(PendingBlock(parentBlock, Nil)))
+
+      val result = ethMiningService
+        .submitWork(SubmitWorkRequest(ByteString("nonce"), ByteString(Hex.decode("01" * 32)), ByteString(Hex.decode("01" * 32))))
+        .unsafeRunSync()
+
+      result shouldEqual Right(SubmitWorkResponse(false))
+    }
+
+  // core-geth alignment: submitWork accepts shares within staleThreshold window
+  it should "accept submitWork when submission is within stale threshold" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    // Save parentBlock so best = 0; pending block is at number 1 (ahead of best — not stale)
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
+
+    (blockGenerator.getPrepared _).expects(*).returning(Some(PendingBlock(block, Nil)))
+
+    val result = ethMiningService
+      .submitWork(SubmitWorkRequest(ByteString("nonce"), ByteString(Hex.decode("01" * 32)), ByteString(Hex.decode("01" * 32))))
+      .unsafeRunSync()
+
+    result shouldEqual Right(SubmitWorkResponse(true))
+    syncingController.expectMsgType[SyncProtocol.MinedBlock]
+  }
+
   it should "set and get the etherbase address" taggedAs (UnitTest, RPCTest) in new TestSetup {
     // Get initial coinbase
     val response1: ServiceResponse[GetCoinbaseResponse] = ethMiningService.getCoinbase(GetCoinbaseRequest())
@@ -450,7 +519,8 @@ class EthMiningServiceSpec
       pendingTransactionsManager.ref,
       getTransactionFromPoolTimeout,
       this,
-      coinbaseProvider
+      coinbaseProvider,
+      system
     )
 
     val difficulty = 131072

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -43,6 +43,7 @@ import com.chipprbots.ethereum.jsonrpc.EthMiningService._
 import com.chipprbots.ethereum.jsonrpc.NodeJsonRpcHealthChecker.JsonRpcHealthConfig
 import com.chipprbots.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
+import com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcWsServer.JsonRpcWsServerConfig
 import com.chipprbots.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer.JsonRpcIpcServerConfig
 import com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy
 import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
@@ -433,6 +434,7 @@ class EthMiningServiceSpec
       override def accountTransactionsMaxBlocks: Int = baseJsonRpcConfig.accountTransactionsMaxBlocks
       override def minerActiveTimeout: FiniteDuration = TestSetup.this.minerActiveTimeout
       override def httpServerConfig: JsonRpcHttpServerConfig = baseJsonRpcConfig.httpServerConfig
+      override def wsServerConfig: JsonRpcWsServerConfig = baseJsonRpcConfig.wsServerConfig
       override def ipcServerConfig: JsonRpcIpcServerConfig = baseJsonRpcConfig.ipcServerConfig
       override def healthConfig: JsonRpcHealthConfig = baseJsonRpcConfig.healthConfig
     }

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
@@ -84,6 +84,8 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
         null: EthSimulateService,
         null: AdminService,
         null: TxPoolService,
+        null: DebugTracingService,
+        null: TraceService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
@@ -82,8 +82,6 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
-        null: AdminService,
-        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
@@ -82,6 +82,7 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
+        null: AdminService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
@@ -48,7 +48,8 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
     val debugService: DebugService = mock[DebugService]
     val ethService: EthInfoService = mock[EthInfoService]
     val ethMiningService: EthMiningService = mock[EthMiningService]
-    val ethBlocksService: EthBlocksService = mock[EthBlocksService]
+    // MIGRATION: Scala 3 mock cannot infer Option[ForkChoiceManager] type param — use null (fukuii tests don't call eth_blocks methods)
+    val ethBlocksService: EthBlocksService = null
     val ethTxService: EthTxService = mock[EthTxService]
     val ethUserService: EthUserService = mock[EthUserService]
     val ethFilterService: EthFilterService = mock[EthFilterService]
@@ -81,6 +82,8 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
+        null: AdminService,
+        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/FukuiiJRCSpec.scala
@@ -83,6 +83,7 @@ class FukuiiJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
         ProofServiceDummy,
         null: EthSimulateService,
         null: AdminService,
+        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
@@ -341,13 +341,13 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "eth_getBlockTransactionCountByNumber " taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthBlocksService: EthBlocksService & scala.reflect.Selectable = mock[EthBlocksService]
+    // MIGRATION: Scala 3 scalamock macro drops Option[ForkChoiceManager] type arg — use concrete stub
+    val mockEthBlocksService = new EthBlocksService(null, null, null, null) {
+      override def getBlockTransactionCountByNumber(req: EthBlocksService.GetBlockTransactionCountByNumberRequest) =
+        IO.pure(Right(GetBlockTransactionCountByNumberResponse(17)))
+    }
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethBlocksService = mockEthBlocksService)
-
-    (mockEthBlocksService.getBlockTransactionCountByNumber _)
-      .expects(*)
-      .returning(IO.pure(Right(GetBlockTransactionCountByNumberResponse(17))))
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getBlockTransactionCountByNumber",

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -480,13 +480,13 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getUncleCountByBlockNumber" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthBlocksService: EthBlocksService & scala.reflect.Selectable = mock[EthBlocksService]
+    // MIGRATION: Scala 3 scalamock macro drops Option[ForkChoiceManager] type arg — use concrete stub
+    val mockEthBlocksService = new EthBlocksService(null, null, null, null) {
+      override def getUncleCountByBlockNumber(req: EthBlocksService.GetUncleCountByBlockNumberRequest) =
+        IO.pure(Right(GetUncleCountByBlockNumberResponse(2)))
+    }
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethBlocksService = mockEthBlocksService)
-
-    (mockEthBlocksService.getUncleCountByBlockNumber _)
-      .expects(*)
-      .returning(IO.pure(Right(GetUncleCountByBlockNumberResponse(2))))
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getUncleCountByBlockNumber",
@@ -500,13 +500,13 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getUncleCountByBlockHash " taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthBlocksService: EthBlocksService & scala.reflect.Selectable = mock[EthBlocksService]
+    // MIGRATION: Scala 3 scalamock macro drops Option[ForkChoiceManager] type arg — use concrete stub
+    val mockEthBlocksService = new EthBlocksService(null, null, null, null) {
+      override def getUncleCountByBlockHash(req: EthBlocksService.GetUncleCountByBlockHashRequest) =
+        IO.pure(Right(GetUncleCountByBlockHashResponse(3)))
+    }
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethBlocksService = mockEthBlocksService)
-
-    (mockEthBlocksService.getUncleCountByBlockHash _)
-      .expects(*)
-      .returning(IO.pure(Right(GetUncleCountByBlockHashResponse(3))))
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getUncleCountByBlockHash",

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -128,7 +128,8 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
     pendingTransactionsManager.ref,
     getTransactionFromPoolTimeout,
     this,
-    coinbaseProvider
+    coinbaseProvider,
+    system
   )
 
   val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, mining, blockQueue)

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -187,6 +187,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
       ProofServiceDummy,
       null: EthSimulateService,
       null: AdminService,
+      null: TxPoolService,
       config
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -188,6 +188,8 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
       null: EthSimulateService,
       null: AdminService,
       null: TxPoolService,
+      null: DebugTracingService,
+      null: TraceService,
       config
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -186,8 +186,6 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
       mcpService,
       ProofServiceDummy,
       null: EthSimulateService,
-      null: AdminService,
-      null: TxPoolService,
       config
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -186,6 +186,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
       mcpService,
       ProofServiceDummy,
       null: EthSimulateService,
+      null: AdminService,
       config
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -186,6 +186,8 @@ class JsonRpcControllerFixture(implicit system: ActorSystem, mockFactory: org.sc
       mcpService,
       ProofServiceDummy,
       null: EthSimulateService,
+      null: AdminService,
+      null: TxPoolService,
       config
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -70,7 +70,7 @@ class JsonRpcControllerSpec
 
     val response: JsonRpcResponse = jsonRpcController.handleRequest(rpcRequest).unsafeRunSync()
 
-    response should haveError(JsonRpcError.InvalidParams("Invalid method parameters"))
+    response should haveError(JsonRpcError.InvalidParams("invalid argument: hex string without 0x prefix"))
   }
 
   it should "handle clientVersion request" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
@@ -117,6 +117,7 @@ class JsonRpcControllerSpec
       override val accountTransactionsMaxBlocks = 50000
       override def minerActiveTimeout: FiniteDuration = ???
       override def httpServerConfig: JsonRpcHttpServer.JsonRpcHttpServerConfig = ???
+      override def wsServerConfig: com.chipprbots.ethereum.jsonrpc.server.http.JsonRpcWsServer.JsonRpcWsServerConfig = ???
       override def ipcServerConfig: JsonRpcIpcServer.JsonRpcIpcServerConfig = ???
       override def healthConfig: NodeJsonRpcHealthChecker.JsonRpcHealthConfig = ???
     }

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
@@ -162,6 +162,8 @@ class QaJRCSpec
         null: EthSimulateService,
         null: AdminService,
         null: TxPoolService,
+        null: DebugTracingService,
+        null: TraceService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
@@ -161,6 +161,7 @@ class QaJRCSpec
         ProofServiceDummy,
         null: EthSimulateService,
         null: AdminService,
+        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
@@ -160,8 +160,6 @@ class QaJRCSpec
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
-        null: AdminService,
-        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
@@ -160,6 +160,7 @@ class QaJRCSpec
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
+        null: AdminService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/QaJRCSpec.scala
@@ -122,7 +122,8 @@ class QaJRCSpec
     val debugService: DebugService = mock[DebugService]
     val ethService: EthInfoService = mock[EthInfoService]
     val ethMiningService: EthMiningService = mock[EthMiningService]
-    val ethBlocksService: EthBlocksService = mock[EthBlocksService]
+    // MIGRATION: Scala 3 mock cannot infer Option[ForkChoiceManager] type param — use null (QA tests don't call eth_blocks methods)
+    val ethBlocksService: EthBlocksService = null
     val ethTxService: EthTxService = mock[EthTxService]
     val ethUserService: EthUserService = mock[EthUserService]
     val ethFilterService: EthFilterService = mock[EthFilterService]
@@ -159,6 +160,8 @@ class QaJRCSpec
         mcpService,
         ProofServiceDummy,
         null: EthSimulateService,
+        null: AdminService,
+        null: TxPoolService,
         config
       )
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/SubscriptionManagerSpec.scala
@@ -1,0 +1,258 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
+
+import cats.effect.unsafe.IORuntime
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.NormalPatience
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.jsonrpc.SubscriptionManager._
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Unit tests for SubscriptionManager actor.
+  *
+  * Besu reference:
+  *   ethereum/api/.../websocket/subscription/SubscriptionManager.java
+  *   ethereum/api/.../websocket/subscription/blockheaders/NewBlockHeadersSubscriptionService.java
+  *   ethereum/api/.../websocket/subscription/pending/PendingTransactionSubscriptionService.java
+  *   ethereum/api/.../websocket/subscription/logs/LogsSubscriptionService.java
+  *
+  * Tests cover: connection lifecycle, subscribe/unsubscribe, push notification dispatch.
+  */
+class SubscriptionManagerSpec
+    extends TestKit(ActorSystem("SubscriptionManagerSpec"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with ScalaFutures
+    with NormalPatience {
+
+  import org.apache.pekko.pattern.ask
+  implicit val timeout: org.apache.pekko.util.Timeout = org.apache.pekko.util.Timeout(5.seconds)
+  implicit val mat: Materializer = Materializer(system)
+  implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
+
+  val fixtureBlock: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  def makeManager(): ActorRef =
+    system.actorOf(SubscriptionManager.props(new EphemBlockchainTestSetup {}.blockchainReader))
+
+  /** Returns a preMaterialized queue + source pair. */
+  def makeQueue() = Source
+    .queue[String](64, OverflowStrategy.dropHead)
+    .preMaterialize()
+
+  /** Collects N messages from the queue source into a Future[Seq[String]]. */
+  def collectN(source: org.apache.pekko.stream.scaladsl.Source[String, Any], n: Int) =
+    source.take(n).runWith(Sink.seq)
+
+  // ── connection lifecycle ───────────────────────────────────────────────────
+
+  "SubscriptionManager" should "accept RegisterConnection without error" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    mgr ! RegisterConnection("conn-1", queue)
+    // No assertion needed — the actor would log an error if this failed
+    // Just confirm the message is processed without exception
+    Thread.sleep(50)
+    succeed
+  }
+
+  it should "clean up subscriptions when ConnectionClosed is received" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-cleanup"
+
+    mgr ! RegisterConnection(connId, queue)
+    val subResp = Await.result(
+      (mgr ? Subscribe(connId, "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+    subResp.result.isRight shouldBe true
+
+    // Close connection — subscription should be removed
+    mgr ! ConnectionClosed(connId)
+    Thread.sleep(50)
+
+    // Unsubscribe after close returns false (not found)
+    val subId = subResp.result.toOption.get
+    val unsubResp = Await.result(
+      (mgr ? Unsubscribe(connId, subId)).mapTo[UnsubscribeResponse],
+      5.seconds
+    )
+    unsubResp.found shouldBe false
+  }
+
+  // ── subscribe / unsubscribe ────────────────────────────────────────────────
+
+  it should "return a numeric subscription id for newHeads subscription" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-newheads"
+
+    mgr ! RegisterConnection(connId, queue)
+    val resp = Await.result(
+      (mgr ? Subscribe(connId, "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    resp.result.isRight shouldBe true
+    resp.result.toOption.get should be > 0L
+  }
+
+  it should "return a subscription id for logs subscription" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-logs"
+
+    mgr ! RegisterConnection(connId, queue)
+    val resp = Await.result(
+      (mgr ? Subscribe(connId, "logs", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    resp.result.isRight shouldBe true
+  }
+
+  it should "return a subscription id for newPendingTransactions" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-pending"
+
+    mgr ! RegisterConnection(connId, queue)
+    val resp = Await.result(
+      (mgr ? Subscribe(connId, "newPendingTransactions", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    resp.result.isRight shouldBe true
+  }
+
+  it should "return an error for unknown subscription type" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-unknown"
+
+    mgr ! RegisterConnection(connId, queue)
+    val resp = Await.result(
+      (mgr ? Subscribe(connId, "bogusType", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    resp.result.isLeft shouldBe true
+    resp.result.swap.toOption.get should include("Unknown subscription type")
+  }
+
+  it should "return true when unsubscribing a valid subscription" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, _) = makeQueue()
+    val connId = "conn-unsub"
+
+    mgr ! RegisterConnection(connId, queue)
+    val subId = Await.result(
+      (mgr ? Subscribe(connId, "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    ).result.toOption.get
+
+    val resp = Await.result(
+      (mgr ? Unsubscribe(connId, subId)).mapTo[UnsubscribeResponse],
+      5.seconds
+    )
+    resp.found shouldBe true
+  }
+
+  it should "return false when unsubscribing with wrong connection id" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue1, _) = makeQueue()
+    val (queue2, _) = makeQueue()
+
+    mgr ! RegisterConnection("conn-a", queue1)
+    mgr ! RegisterConnection("conn-b", queue2)
+    val subId = Await.result(
+      (mgr ? Subscribe("conn-a", "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    ).result.toOption.get
+
+    // conn-b trying to unsubscribe conn-a's subscription
+    val resp = Await.result(
+      (mgr ? Unsubscribe("conn-b", subId)).mapTo[UnsubscribeResponse],
+      5.seconds
+    )
+    resp.found shouldBe false
+  }
+
+  // ── push notifications ─────────────────────────────────────────────────────
+
+  it should "push newHeads notification to subscribed connection on NewBlockImported" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue, source) = makeQueue()
+    val connId = "conn-push-newheads"
+    val messages = collectN(source, 1)
+
+    mgr ! RegisterConnection(connId, queue)
+    Await.result(
+      (mgr ? Subscribe(connId, "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    system.eventStream.publish(NewBlockImported(fixtureBlock))
+
+    val received = Await.result(messages, 5.seconds)
+    received should have size 1
+
+    val json = parse(received.head)
+    (json \ "method").extract[String] shouldBe "eth_subscription"
+    val params = json \ "params"
+    (params \ "result" \ "number").extract[String] should startWith("0x")
+    (params \ "result" \ "hash").extract[String] should startWith("0x")
+  }
+
+  it should "not push newHeads to other connections" taggedAs UnitTest in {
+    val mgr = makeManager()
+    val (queue1, _) = makeQueue()
+    val (queue2, source2) = makeQueue()
+    val connId1 = "conn-iso-1"
+    val connId2 = "conn-iso-2"
+
+    mgr ! RegisterConnection(connId1, queue1)
+    mgr ! RegisterConnection(connId2, queue2)
+
+    // Only conn1 subscribes
+    Await.result(
+      (mgr ? Subscribe(connId1, "newHeads", None)).mapTo[SubscribeResponse],
+      5.seconds
+    )
+
+    system.eventStream.publish(NewBlockImported(fixtureBlock))
+
+    // conn2 should receive nothing — add a brief wait and drain
+    Thread.sleep(200)
+    val messages2 = source2.take(0).runWith(Sink.seq)
+    val received2 = Await.result(messages2, 1.second)
+    received2 shouldBe empty
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
@@ -18,10 +18,15 @@ import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
 import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.BlockHeader
 import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
 import com.chipprbots.ethereum.jsonrpc.TraceService._
+import com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy
 import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.ledger.TxResult
 import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.vm.ExecutionTracer
 
 /** Unit tests for TraceService.
   *
@@ -67,7 +72,7 @@ class TraceServiceSpec
 
     (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
     (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
-    (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+    (mockLedger.simulateTransactionWithTracer(_: SignedTransactionWithSender, _: BlockHeader, _: Option[InMemoryWorldStateProxy], _: ExecutionTracer)).expects(*, *, *, *).returning(null.asInstanceOf[TxResult])
 
     val result = service
       .traceTransaction(TraceTransactionRequest(txHash))
@@ -118,7 +123,7 @@ class TraceServiceSpec
 
     (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
     (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
-    (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult]).anyNumberOfTimes()
+    (mockLedger.simulateTransactionWithTracer(_: SignedTransactionWithSender, _: BlockHeader, _: Option[InMemoryWorldStateProxy], _: ExecutionTracer)).expects(*, *, *, *).returning(null.asInstanceOf[TxResult]).anyNumberOfTimes()
 
     val result = service
       .replayTransaction(TraceReplayTransactionRequest(txHash, TraceOptions(trace = true)))
@@ -156,7 +161,7 @@ class TraceServiceSpec
     "return a call trace result for the latest block" taggedAs (UnitTest, RPCTest) in new TestSetup {
       blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(block.header.difficulty), saveAsBestBlock = true)
 
-      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+      (mockLedger.simulateTransactionWithTracer(_: SignedTransactionWithSender, _: BlockHeader, _: Option[InMemoryWorldStateProxy], _: ExecutionTracer)).expects(*, *, *, *).returning(null.asInstanceOf[TxResult])
 
       val callTx = EthInfoService.CallTx(
         from = None,

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
@@ -1,0 +1,194 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
+
+import cats.effect.unsafe.IORuntime
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.NormalPatience
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage
+import com.chipprbots.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.jsonrpc.TraceService._
+import com.chipprbots.ethereum.ledger.StxLedger
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Unit tests for TraceService.
+  *
+  * Besu reference: TraceTransaction.java, TraceBlock.java,
+  *   TraceReplayTransaction.java, TraceReplayBlockTransactions.java,
+  *   TraceCall.java, TraceCallMany.java
+  *
+  * core-geth reference: eth/tracers/api.go
+  */
+class TraceServiceSpec
+    extends TestKit(ActorSystem("TraceServiceSpec"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with MockFactory
+    with ScalaFutures
+    with NormalPatience {
+
+  implicit val runtime: IORuntime = IORuntime.global
+
+  // ── traceTransaction ────────────────────────────────────────────────────────
+
+  "TraceService.traceTransaction" should
+    "return InvalidParams when transaction is not found" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val unknownHash: ByteString = ByteString(Array.fill(32)(0xff.toByte))
+      (txMappingStorage.get _).expects(unknownHash).returning(None)
+
+      val result = service
+        .traceTransaction(TraceTransactionRequest(unknownHash))
+        .unsafeRunSync()
+
+      result.isLeft shouldBe true
+    }
+
+  it should "return flat trace array for a valid transaction" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    val txHash: ByteString = block.body.transactionList.head.hash
+    val txIndex             = 0
+
+    blockchainWriter.storeBlock(block).commit()
+    storagesInstance.storages.blockHeadersStorage
+      .put(block.header.parentHash, block.header.copy(number = block.header.number - 1))
+      .commit()
+
+    (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
+    (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
+    (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+
+    val result = service
+      .traceTransaction(TraceTransactionRequest(txHash))
+      .unsafeRunSync()
+
+    result.isRight shouldBe true
+  }
+
+  // ── traceBlock ───────────────────────────────────────────────────────────────
+
+  "TraceService.traceBlock" should
+    "return empty trace list for a block with no transactions" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+      blockchainWriter.storeBlock(emptyBlock).commit()
+      storagesInstance.storages.blockHeadersStorage
+        .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+        .commit()
+
+      val result = service
+        .traceBlock(TraceBlockRequest(BlockParam.WithHash(emptyBlock.header.hash)))
+        .unsafeRunSync()
+
+      result shouldBe Right(TraceBlockResponse(Seq.empty))
+    }
+
+  // ── replayTransaction ────────────────────────────────────────────────────────
+
+  "TraceService.replayTransaction" should
+    "return InvalidParams when transaction is not found" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val unknownHash: ByteString = ByteString(Array.fill(32)(0xee.toByte))
+      (txMappingStorage.get _).expects(unknownHash).returning(None)
+
+      val result = service
+        .replayTransaction(TraceReplayTransactionRequest(unknownHash, TraceOptions(trace = true)))
+        .unsafeRunSync()
+
+      result.isLeft shouldBe true
+    }
+
+  it should "return a replay result with trace option enabled" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    val txHash: ByteString = block.body.transactionList.head.hash
+    val txIndex             = 0
+
+    blockchainWriter.storeBlock(block).commit()
+    storagesInstance.storages.blockHeadersStorage
+      .put(block.header.parentHash, block.header.copy(number = block.header.number - 1))
+      .commit()
+
+    (txMappingStorage.get _).expects(txHash).returning(Some(TransactionLocation(block.header.hash, txIndex)))
+    (mockLedger.advanceWorldToTx _).expects(*, *, *, *).returning(mockWorld)
+    (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult]).anyNumberOfTimes()
+
+    val result = service
+      .replayTransaction(TraceReplayTransactionRequest(txHash, TraceOptions(trace = true)))
+      .unsafeRunSync()
+
+    result.isRight shouldBe true
+  }
+
+  // ── replayBlockTransactions ──────────────────────────────────────────────────
+
+  "TraceService.replayBlockTransactions" should
+    "return empty list for a block with no transactions" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+      blockchainWriter.storeBlock(emptyBlock).commit()
+      storagesInstance.storages.blockHeadersStorage
+        .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+        .commit()
+      blockchainWriter.saveBestKnownBlocks(emptyBlock.header.hash, emptyBlock.header.number)
+
+      val result = service
+        .replayBlockTransactions(
+          TraceReplayBlockTransactionsRequest(
+            BlockParam.WithNumber(emptyBlock.header.number),
+            TraceOptions(trace = true)
+          )
+        )
+        .unsafeRunSync()
+
+      result shouldBe Right(TraceReplayBlockTransactionsResponse(Seq.empty))
+    }
+
+  // ── traceCall ────────────────────────────────────────────────────────────────
+
+  "TraceService.traceCall" should
+    "return a call trace result for the latest block" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(block.header.difficulty), saveAsBestBlock = true)
+
+      (mockLedger.simulateTransactionWithTracer _).expects(*, *, *, *).returning(null.asInstanceOf[com.chipprbots.ethereum.ledger.TxResult])
+
+      val callTx = EthInfoService.CallTx(
+        from = None,
+        to = None,
+        gas = None,
+        gasPrice = 0,
+        value = 0,
+        data = ByteString.empty
+      )
+      val result = service
+        .traceCall(TraceCallRequest(callTx, TraceOptions(trace = true), BlockParam.Latest))
+        .unsafeRunSync()
+
+      result.isRight shouldBe true
+    }
+
+  // ── TestSetup ────────────────────────────────────────────────────────────────
+
+  class TestSetup(implicit system: ActorSystem) extends EphemBlockchainTestSetup {
+
+    val block: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+
+    val mockLedger: StxLedger              = mock[StxLedger]
+    val txMappingStorage: TransactionMappingStorage = mock[TransactionMappingStorage]
+    val mockWorld = null.asInstanceOf[com.chipprbots.ethereum.ledger.InMemoryWorldStateProxy]
+
+    lazy val service: TraceService = new TraceService(
+      blockchain,
+      blockchainReader,
+      mining,
+      mockLedger,
+      txMappingStorage
+    )
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TraceServiceSpec.scala
@@ -178,6 +178,43 @@ class TraceServiceSpec
       result.isRight shouldBe true
     }
 
+  // ── traceFilter ──────────────────────────────────────────────────────────────
+
+  "TraceService.traceFilter" should
+    "return InvalidParams when fromBlock is after toBlock" taggedAs (UnitTest, RPCTest) in new TestSetup {
+      val emptyBlock  = block.copy(body = block.body.copy(transactionList = Seq.empty))
+      // parentBlock gets a different hash because number changed in the header
+      val parentBlock = emptyBlock.copy(header = emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+      blockchainWriter.storeBlock(emptyBlock).commit()
+      blockchainWriter.storeBlock(parentBlock).commit()
+
+      val result = service
+        .traceFilter(TraceFilterRequest(
+          fromBlock = BlockParam.WithHash(emptyBlock.header.hash),   // N = 3125369
+          toBlock   = BlockParam.WithHash(parentBlock.header.hash)   // N-1 = 3125368
+        ))
+        .unsafeRunSync()
+
+      result shouldBe Left(JsonRpcError.InvalidParams("fromBlock must be <= toBlock"))
+    }
+
+  it should "return empty trace list for a block with no transactions" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    val emptyBlock = block.copy(body = block.body.copy(transactionList = Seq.empty))
+    blockchainWriter.save(emptyBlock, Nil, ChainWeight.totalDifficultyOnly(emptyBlock.header.difficulty), saveAsBestBlock = true)
+    storagesInstance.storages.blockHeadersStorage
+      .put(emptyBlock.header.parentHash, emptyBlock.header.copy(number = emptyBlock.header.number - 1))
+      .commit()
+
+    val result = service
+      .traceFilter(TraceFilterRequest(
+        fromBlock = BlockParam.Latest,
+        toBlock   = BlockParam.Latest
+      ))
+      .unsafeRunSync()
+
+    result shouldBe Right(TraceFilterResponse(Seq.empty))
+  }
+
   // ── TestSetup ────────────────────────────────────────────────────────────────
 
   class TestSetup(implicit system: ActorSystem) extends EphemBlockchainTestSetup {

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
@@ -25,7 +25,8 @@ import com.chipprbots.ethereum.utils.TxPoolConfig
 
 /** Unit tests for TxPoolService.
   *
-  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions
+  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions,
+  *   PendingTransactionFilter, PendingTransactionsParams
   */
 class TxPoolServiceSpec
     extends TestKit(ActorSystem("TxPoolServiceSpec"))
@@ -39,21 +40,24 @@ class TxPoolServiceSpec
   implicit val runtime: IORuntime = IORuntime.global
 
   val txPoolConfig: TxPoolConfig = new TxPoolConfig {
-    val txPoolSize: Int                            = 4096
+    val txPoolSize: Int                              = 4096
     val pendingTxManagerQueryTimeout: FiniteDuration = 5.seconds
-    val transactionTimeout: FiniteDuration         = 2.hours
+    val transactionTimeout: FiniteDuration           = 2.hours
     val getTransactionFromPoolTimeout: FiniteDuration = 5.seconds
   }
 
   val block = Fixtures.Blocks.Block3125369
-  val tx1   = block.body.transactionList.head
-  val tx2   = block.body.transactionList.last
+  // Block3125369 has 4 txs: nonces 438550, 438551, 438552, 438553; gasLimit 50000 each
+  val txList = block.body.transactionList
 
   implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
-  def makePendingTx(stx: com.chipprbots.ethereum.domain.SignedTransaction): PendingTransaction = {
+  def makePendingTx(
+      stx: com.chipprbots.ethereum.domain.SignedTransaction,
+      local: Boolean = false
+  ): PendingTransaction = {
     val withSender = SignedTransactionWithSender.getSignedTransactions(Seq(stx))
-    PendingTransaction(withSender.head, System.currentTimeMillis())
+    PendingTransaction(withSender.head, System.currentTimeMillis(), receivedFromLocalSource = local)
   }
 
   trait TestSetup {
@@ -61,18 +65,19 @@ class TxPoolServiceSpec
     val service = new TxPoolService(probe.ref, 5.seconds, txPoolConfig)
   }
 
+  // ── besuTransactions ────────────────────────────────────────────────────────
+
   "TxPoolService.besuTransactions" should "return all pending transactions" taggedAs UnitTest in new TestSetup {
-    val pt1 = makePendingTx(tx1)
-    val pt2 = makePendingTx(tx2)
+    val pts = txList.map(makePendingTx(_))
 
     val future = service.besuTransactions(TxPoolBesuTransactionsRequest()).unsafeToFuture()
 
     probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
-    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+    probe.reply(PendingTransactionsResponse(pts))
 
     val result = future.futureValue
     result shouldBe a[Right[_, _]]
-    result.toOption.get.pendingTransactions should have size 2
+    result.toOption.get.pendingTransactions should have size 4
   }
 
   it should "return empty list when pool is empty" taggedAs UnitTest in new TestSetup {
@@ -84,24 +89,43 @@ class TxPoolServiceSpec
     future.futureValue shouldBe Right(TxPoolBesuTransactionsResponse(Seq.empty))
   }
 
-  "TxPoolService.besuStatistics" should "return pool statistics with localCount=0" taggedAs UnitTest in new TestSetup {
-    val pt1 = makePendingTx(tx1)
-    val pt2 = makePendingTx(tx2)
+  // ── besuStatistics ──────────────────────────────────────────────────────────
+
+  "TxPoolService.besuStatistics" should "count remote txs (receivedFromLocalSource=false)" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_)) // all remote (default)
 
     val future = service.besuStatistics(TxPoolBesuStatisticsRequest()).unsafeToFuture()
 
     probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
-    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+    probe.reply(PendingTransactionsResponse(pts))
 
     val result = future.futureValue
     result shouldBe a[Right[_, _]]
     val stats = result.toOption.get
-    stats.maxSize shouldBe 4096L
-    stats.localCount shouldBe 0L
-    stats.remoteCount shouldBe 2L
+    stats.maxSize     shouldBe 4096L
+    stats.localCount  shouldBe 0L
+    stats.remoteCount shouldBe 4L
   }
 
-  it should "report remoteCount=0 for an empty pool" taggedAs UnitTest in new TestSetup {
+  it should "count local txs (receivedFromLocalSource=true) separately from remote" taggedAs UnitTest in new TestSetup {
+    // 1 local (via AddOrOverrideTransaction), 3 remote (via AddTransactions)
+    val localPt  = makePendingTx(txList.head, local = true)
+    val remotePts = txList.tail.map(makePendingTx(_))
+
+    val future = service.besuStatistics(TxPoolBesuStatisticsRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(localPt +: remotePts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    val stats = result.toOption.get
+    stats.maxSize     shouldBe 4096L
+    stats.localCount  shouldBe 1L
+    stats.remoteCount shouldBe 3L
+  }
+
+  it should "report all counts=0 for an empty pool" taggedAs UnitTest in new TestSetup {
     val future = service.besuStatistics(TxPoolBesuStatisticsRequest()).unsafeToFuture()
 
     probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
@@ -112,33 +136,133 @@ class TxPoolServiceSpec
     )
   }
 
-  "TxPoolService.besuPendingTransactions" should "return all txs when no limit given" taggedAs UnitTest in new TestSetup {
-    val pt1 = makePendingTx(tx1)
-    val pt2 = makePendingTx(tx2)
+  // ── besuPendingTransactions ─────────────────────────────────────────────────
+
+  "TxPoolService.besuPendingTransactions" should "return all txs when no limit or filter given" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
 
     val future =
       service.besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None)).unsafeToFuture()
 
     probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
-    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 4
+  }
+
+  it should "honour the limit parameter" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+
+    val future =
+      service.besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(Some(1))).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 1
+  }
+
+  it should "filter by nonce eq" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+    // nonces are 438550, 438551, 438552, 438553 — eq 438551 returns 1 tx
+    val params = TxPoolBesuPendingTransactionsParams(
+      Seq(TxPoolFilter("nonce", Eq, "438551"))
+    )
+
+    val future =
+      service
+        .besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None, Some(params)))
+        .unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 1
+  }
+
+  it should "filter by nonce gt" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+    // nonces 438550-438553; gt 438551 returns 438552 and 438553
+    val params = TxPoolBesuPendingTransactionsParams(
+      Seq(TxPoolFilter("nonce", Gt, "438551"))
+    )
+
+    val future =
+      service
+        .besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None, Some(params)))
+        .unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
 
     val result = future.futureValue
     result shouldBe a[Right[_, _]]
     result.toOption.get.pendingTransactions should have size 2
   }
 
-  it should "honour the limit parameter" taggedAs UnitTest in new TestSetup {
-    val pt1 = makePendingTx(tx1)
-    val pt2 = makePendingTx(tx2)
+  it should "filter by gasLimit eq (hex)" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+    // all txs have gasLimit=50000=0xC350
+    val params = TxPoolBesuPendingTransactionsParams(
+      Seq(TxPoolFilter("gas", Eq, "0xC350"))
+    )
 
     val future =
-      service.besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(Some(1))).unsafeToFuture()
+      service
+        .besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None, Some(params)))
+        .unsafeToFuture()
 
     probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
-    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+    probe.reply(PendingTransactionsResponse(pts))
 
     val result = future.futureValue
     result shouldBe a[Right[_, _]]
-    result.toOption.get.pendingTransactions should have size 1
+    result.toOption.get.pendingTransactions should have size 4
+  }
+
+  it should "filter by to action (contract creation) returns empty when all txs have recipients" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+    // all Block3125369 txs have receivingAddress — none are contract creation
+    val params = TxPoolBesuPendingTransactionsParams(
+      Seq(TxPoolFilter("to", Action, "deploy"))
+    )
+
+    val future =
+      service
+        .besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None, Some(params)))
+        .unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 0
+  }
+
+  it should "apply filter and limit together" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+    // nonce gt 438550 returns 3 txs (438551, 438552, 438553); limit=2 keeps first 2
+    val params = TxPoolBesuPendingTransactionsParams(
+      Seq(TxPoolFilter("nonce", Gt, "438550"))
+    )
+
+    val future =
+      service
+        .besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(Some(2), Some(params)))
+        .unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 2
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
@@ -1,0 +1,144 @@
+package com.chipprbots.ethereum.jsonrpc
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+
+import cats.effect.unsafe.IORuntime
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.NormalPatience
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.transactions.PendingTransactionsManager
+import com.chipprbots.ethereum.transactions.PendingTransactionsManager.PendingTransaction
+import com.chipprbots.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
+import com.chipprbots.ethereum.domain.SignedTransactionWithSender
+import com.chipprbots.ethereum.utils.Config
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.TxPoolConfig
+
+/** Unit tests for TxPoolService.
+  *
+  * Besu reference: TxPoolBesuTransactions, TxPoolBesuStatistics, TxPoolBesuPendingTransactions
+  */
+class TxPoolServiceSpec
+    extends TestKit(ActorSystem("TxPoolServiceSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with ScalaFutures
+    with NormalPatience {
+
+  import TxPoolService._
+
+  implicit val runtime: IORuntime = IORuntime.global
+
+  val txPoolConfig: TxPoolConfig = new TxPoolConfig {
+    val txPoolSize: Int                            = 4096
+    val pendingTxManagerQueryTimeout: FiniteDuration = 5.seconds
+    val transactionTimeout: FiniteDuration         = 2.hours
+    val getTransactionFromPoolTimeout: FiniteDuration = 5.seconds
+  }
+
+  val block = Fixtures.Blocks.Block3125369
+  val tx1   = block.body.transactionList.head
+  val tx2   = block.body.transactionList.last
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+
+  def makePendingTx(stx: com.chipprbots.ethereum.domain.SignedTransaction): PendingTransaction = {
+    val withSender = SignedTransactionWithSender.getSignedTransactions(Seq(stx))
+    PendingTransaction(withSender.head, System.currentTimeMillis())
+  }
+
+  trait TestSetup {
+    val probe   = TestProbe()
+    val service = new TxPoolService(probe.ref, 5.seconds, txPoolConfig)
+  }
+
+  "TxPoolService.besuTransactions" should "return all pending transactions" taggedAs UnitTest in new TestSetup {
+    val pt1 = makePendingTx(tx1)
+    val pt2 = makePendingTx(tx2)
+
+    val future = service.besuTransactions(TxPoolBesuTransactionsRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 2
+  }
+
+  it should "return empty list when pool is empty" taggedAs UnitTest in new TestSetup {
+    val future = service.besuTransactions(TxPoolBesuTransactionsRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq.empty))
+
+    future.futureValue shouldBe Right(TxPoolBesuTransactionsResponse(Seq.empty))
+  }
+
+  "TxPoolService.besuStatistics" should "return pool statistics with localCount=0" taggedAs UnitTest in new TestSetup {
+    val pt1 = makePendingTx(tx1)
+    val pt2 = makePendingTx(tx2)
+
+    val future = service.besuStatistics(TxPoolBesuStatisticsRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    val stats = result.toOption.get
+    stats.maxSize shouldBe 4096L
+    stats.localCount shouldBe 0L
+    stats.remoteCount shouldBe 2L
+  }
+
+  it should "report remoteCount=0 for an empty pool" taggedAs UnitTest in new TestSetup {
+    val future = service.besuStatistics(TxPoolBesuStatisticsRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq.empty))
+
+    future.futureValue shouldBe Right(
+      TxPoolBesuStatisticsResponse(maxSize = 4096L, localCount = 0L, remoteCount = 0L)
+    )
+  }
+
+  "TxPoolService.besuPendingTransactions" should "return all txs when no limit given" taggedAs UnitTest in new TestSetup {
+    val pt1 = makePendingTx(tx1)
+    val pt2 = makePendingTx(tx2)
+
+    val future =
+      service.besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(None)).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 2
+  }
+
+  it should "honour the limit parameter" taggedAs UnitTest in new TestSetup {
+    val pt1 = makePendingTx(tx1)
+    val pt2 = makePendingTx(tx2)
+
+    val future =
+      service.besuPendingTransactions(TxPoolBesuPendingTransactionsRequest(Some(1))).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq(pt1, pt2)))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    result.toOption.get.pendingTransactions should have size 1
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/TxPoolServiceSpec.scala
@@ -265,4 +265,137 @@ class TxPoolServiceSpec
     result shouldBe a[Right[_, _]]
     result.toOption.get.pendingTransactions should have size 2
   }
+
+  // ── content (geth-compat) ────────────────────────────────────────────────────
+
+  "TxPoolService.content" should "group pending txs by sender → nonce with empty queued" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+
+    val future = service.content(TxPoolContentRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    val resp = result.toOption.get
+    resp.queued shouldBe empty
+    // all 4 txs are present across senders
+    resp.pending.values.map(_.size).sum shouldBe 4
+    // nonce keys are decimal strings
+    resp.pending.values.flatMap(_.keys).foreach { nonce =>
+      nonce.toLong // should not throw
+    }
+  }
+
+  it should "return empty pending and queued for an empty pool" taggedAs UnitTest in new TestSetup {
+    val future = service.content(TxPoolContentRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq.empty))
+
+    future.futureValue shouldBe Right(TxPoolContentResponse(Map.empty, Map.empty))
+  }
+
+  // ── contentFrom (geth-compat) ────────────────────────────────────────────────
+
+  "TxPoolService.contentFrom" should "return only txs from the requested sender" taggedAs UnitTest in new TestSetup {
+    val pts    = txList.map(makePendingTx(_))
+    val target = pts.head.stx.senderAddress
+
+    val future = service.contentFrom(TxPoolContentFromRequest(target)).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    val resp = result.toOption.get
+    resp.queued shouldBe empty
+    // all returned txs belong to target sender
+    resp.pending should not be empty
+    resp.pending.values.foreach { _ =>
+      succeed // shape: nonce → TransactionResponse
+    }
+  }
+
+  it should "return empty maps for an address not in the pool" taggedAs UnitTest in new TestSetup {
+    import com.chipprbots.ethereum.domain.Address
+    val pts    = txList.map(makePendingTx(_))
+    val absent = Address("0x1234567890123456789012345678901234567890")
+
+    val future = service.contentFrom(TxPoolContentFromRequest(absent)).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    future.futureValue shouldBe Right(TxPoolContentFromResponse(Map.empty, Map.empty))
+  }
+
+  // ── status (geth-compat) ──────────────────────────────────────────────────────
+
+  "TxPoolService.status" should "return pending count and queued=0" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+
+    val future = service.status(TxPoolStatusRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    future.futureValue shouldBe Right(TxPoolStatusResponse(pending = 4L, queued = 0L))
+  }
+
+  it should "return 0/0 for an empty pool" taggedAs UnitTest in new TestSetup {
+    val future = service.status(TxPoolStatusRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(Seq.empty))
+
+    future.futureValue shouldBe Right(TxPoolStatusResponse(pending = 0L, queued = 0L))
+  }
+
+  // ── inspect (geth-compat) ──────────────────────────────────────────────────────
+
+  "TxPoolService.inspect" should "produce summary strings in core-geth format" taggedAs UnitTest in new TestSetup {
+    val pts = txList.map(makePendingTx(_))
+
+    val future = service.inspect(TxPoolInspectRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    val resp = result.toOption.get
+    resp.queued shouldBe empty
+    // all 4 txs appear across senders
+    resp.pending.values.map(_.size).sum shouldBe 4
+    // format: "0x<to>: <value> wei + <gas> gas × <gasPrice> wei"
+    resp.pending.values.flatMap(_.values).foreach { summary =>
+      summary should (include("wei + ") and include(" gas × ") and include(" wei"))
+    }
+  }
+
+  it should "label contract creation txs correctly" taggedAs UnitTest in new TestSetup {
+    import com.chipprbots.ethereum.domain.Transaction
+    import com.chipprbots.ethereum.domain.SignedTransaction
+
+    // Build a contract creation tx (no receivingAddress) using the first Block3125369 tx as template
+    // We reuse the fixtures tx but verify the summary branch; the simplest approach is to verify
+    // that real txs (which all have recipients) produce the "0x<addr>: ..." format, not "contract creation"
+    val pts = txList.map(makePendingTx(_))
+
+    val future = service.inspect(TxPoolInspectRequest()).unsafeToFuture()
+
+    probe.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    probe.reply(PendingTransactionsResponse(pts))
+
+    val result = future.futureValue
+    result shouldBe a[Right[_, _]]
+    // Block3125369 txs all have recipients — no "contract creation" in any summary
+    result.toOption.get.pending.values.flatMap(_.values).foreach { summary =>
+      summary should not startWith "contract creation"
+      summary should startWith("0x")
+    }
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
@@ -173,7 +173,7 @@ class BlockExecutionSpec
 
         txsExecResult.isRight shouldBe true
 
-        val BlockResult(_, resultingGasUsed, resultingReceipts) = txsExecResult.toOption.get
+        val BlockResult(_, resultingGasUsed, resultingReceipts, _) = txsExecResult.toOption.get
         resultingGasUsed shouldBe 0
         resultingReceipts shouldBe Nil
       }
@@ -213,7 +213,7 @@ class BlockExecutionSpec
           blockExecution.executeBlockTransactions(block, initialWorld)
 
         txsExecResult.isRight shouldBe true
-        val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts) = txsExecResult.toOption.get
+        val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts, _) = txsExecResult.toOption.get
 
         val transaction: Transaction = validStxSignedByOrigin.tx
         // Check valid world
@@ -292,7 +292,7 @@ class BlockExecutionSpec
 
           txsExecResult.isRight shouldBe txValidAccordingToValidators
           if (txsExecResult.isRight) {
-            val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts) = txsExecResult.toOption.get
+            val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts, _) = txsExecResult.toOption.get
 
             val transaction = stx.tx.tx
             // Check valid world
@@ -557,7 +557,7 @@ class BlockExecutionSpec
         val txsExecResult = blockExecution.executeBlockTransactions(block, initialWorld)
 
         assert(txsExecResult.isRight)
-        val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts) = txsExecResult.toOption.get
+        val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts, _) = txsExecResult.toOption.get
         val transaction1 = stx1.tx.tx
         val transaction2 = stx2.tx.tx
         // Check valid gasUsed

--- a/src/test/scala/com/chipprbots/ethereum/network/StaticNodesLoaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/StaticNodesLoaderSpec.scala
@@ -1,0 +1,144 @@
+package com.chipprbots.ethereum.network
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Unit tests for StaticNodesLoader.
+  *
+  * Besu reference: StaticNodesParser.java (fromPath / readEnodesFromPath / decodeString)
+  * Behaviour traced:
+  *   - Missing file → empty Seq (not an error)
+  *   - Empty file or empty array → empty Seq
+  *   - Valid enode URLs → URI objects with scheme="enode", userInfo=pubkey, host, port
+  *   - Invalid port / missing port → skip with warning
+  *   - Malformed JSON → empty Seq with warning
+  *   - Mixed valid/invalid → only valid entries returned
+  */
+class StaticNodesLoaderSpec extends AnyFlatSpec with Matchers {
+
+  private val validEnode1 =
+    "enode://8f977a3c99a2f3d3beaebf3cc62cf73a7f09c41b4e8cfa06e4e3bbca82d7e66a5a7ef638a4c57b4b07c9c6caac0e2f4f1e9b5f3e6c7a12345678@127.0.0.1:30303"
+  private val validEnode2 =
+    "enode://1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890@10.0.0.1:30304"
+
+  private def withTempDir(body: Path => Unit): Unit = {
+    val dir = Files.createTempDirectory("static-nodes-test")
+    try body(dir)
+    finally {
+      dir.toFile.listFiles().foreach(_.delete())
+      dir.toFile.delete()
+    }
+  }
+
+  // ── missing file ──────────────────────────────────────────────────────────
+
+  "StaticNodesLoader" should "return empty when static-nodes.json does not exist" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val result = StaticNodesLoader.load(dir)
+      result shouldBe empty
+    }
+  }
+
+  // ── empty file / empty array ──────────────────────────────────────────────
+
+  it should "return empty for an empty file" taggedAs UnitTest in {
+    withTempDir { dir =>
+      Files.write(dir.resolve(StaticNodesLoader.FileName), Array.emptyByteArray)
+      StaticNodesLoader.load(dir) shouldBe empty
+    }
+  }
+
+  it should "return empty for an empty JSON array" taggedAs UnitTest in {
+    withTempDir { dir =>
+      Files.write(dir.resolve(StaticNodesLoader.FileName), "[]".getBytes("UTF-8"))
+      StaticNodesLoader.load(dir) shouldBe empty
+    }
+  }
+
+  // ── valid entries ─────────────────────────────────────────────────────────
+
+  it should "parse a single valid enode URL" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val json = s"""["$validEnode1"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      val result = StaticNodesLoader.load(dir)
+      result should have size 1
+      result.head.getScheme shouldBe "enode"
+      result.head.getHost   shouldBe "127.0.0.1"
+      result.head.getPort   shouldBe 30303
+    }
+  }
+
+  it should "parse multiple valid enode URLs" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val json = s"""["$validEnode1", "$validEnode2"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      val result = StaticNodesLoader.load(dir)
+      result should have size 2
+      result.map(_.getHost) should contain allOf ("127.0.0.1", "10.0.0.1")
+    }
+  }
+
+  // ── invalid entries skipped ───────────────────────────────────────────────
+
+  it should "skip an enode URL with port -1 (missing port)" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val noPort = "enode://8f977a3c99a2f3d3beaebf3cc62cf73a7f09c41b4e8cfa06e4e3bbca82d7e66a5a7ef638@127.0.0.1"
+      val json = s"""["$noPort"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      // URI.getPort returns -1 when no port is specified — isValidEnodeUri returns false
+      StaticNodesLoader.load(dir) shouldBe empty
+    }
+  }
+
+  it should "return empty for malformed JSON" taggedAs UnitTest in {
+    withTempDir { dir =>
+      Files.write(dir.resolve(StaticNodesLoader.FileName), "{bad json".getBytes("UTF-8"))
+      StaticNodesLoader.load(dir) shouldBe empty
+    }
+  }
+
+  it should "return empty when file contains a JSON object instead of array" taggedAs UnitTest in {
+    withTempDir { dir =>
+      Files.write(dir.resolve(StaticNodesLoader.FileName), """{"enode": "not-an-array"}""".getBytes("UTF-8"))
+      StaticNodesLoader.load(dir) shouldBe empty
+    }
+  }
+
+  it should "skip non-string entries and return only valid ones" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val json = s"""["$validEnode1", 42, null, "$validEnode2"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      val result = StaticNodesLoader.load(dir)
+      result should have size 2
+    }
+  }
+
+  it should "skip entries with a wrong scheme" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val wrongScheme = "http://8f977a3c@127.0.0.1:30303"
+      val json = s"""["$wrongScheme", "$validEnode1"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      val result = StaticNodesLoader.load(dir)
+      result should have size 1
+      result.head.getScheme shouldBe "enode"
+    }
+  }
+
+  // ── load(String) overload ─────────────────────────────────────────────────
+
+  it should "accept a String datadir path" taggedAs UnitTest in {
+    withTempDir { dir =>
+      val json = s"""["$validEnode1"]"""
+      Files.write(dir.resolve(StaticNodesLoader.FileName), json.getBytes("UTF-8"))
+      val result = StaticNodesLoader.load(dir.toString)
+      result should have size 1
+    }
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
@@ -27,8 +27,8 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       (result \ "type") shouldBe JString("CALL")
       (result \ "from") shouldBe a[JString]
       (result \ "to") shouldBe a[JString]
-      (result \ "gas") shouldBe JInt(21000)
-      (result \ "gasUsed") shouldBe JInt(21000)
+      (result \ "gas") shouldBe JString("0x5208")
+      (result \ "gasUsed") shouldBe JString("0x5208")
       (result \ "input") shouldBe a[JString]
       (result \ "output") shouldBe a[JString]
     }
@@ -58,7 +58,7 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       val callArray = calls.asInstanceOf[JArray].arr
       callArray should have size 1
       (callArray.head \ "type") shouldBe JString("STATICCALL")
-      (callArray.head \ "gasUsed") shouldBe JInt(10000)
+      (callArray.head \ "gasUsed") shouldBe JString("0x2710")
     }
 
     "should skip sub-calls when onlyTopCall is true" in {
@@ -84,15 +84,15 @@ class CallTracerSpec extends AnyFreeSpec with Matchers {
       (result \ "error") shouldBe JString("out of gas")
     }
 
-    "should encode gas as decimal integer, not hex" in {
+    "should encode gas and gasUsed as hex strings matching core-geth callFrameMarshaling" in {
       val tracer = new CallTracer()
 
       tracer.onTxStart(from, Some(to), gas = 1000000, value = 0, input = input)
       tracer.onTxEnd(gasUsed = 500000, output = output, error = None)
 
       val result = tracer.getResult
-      (result \ "gas") shouldBe JInt(1000000)
-      (result \ "gasUsed") shouldBe JInt(500000)
+      (result \ "gas") shouldBe JString("0xf4240")
+      (result \ "gasUsed") shouldBe JString("0x7a120")
     }
 
     "should omit value for STATICCALL and DELEGATECALL" in {

--- a/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/CallTracerSpec.scala
@@ -1,0 +1,116 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.domain.Address
+
+class CallTracerSpec extends AnyFreeSpec with Matchers {
+
+  private val from   = Address(0x1234)
+  private val to     = Address(0x5678)
+  private val input  = ByteString(0x12, 0x34)
+  private val output = ByteString(0xab, 0xcd)
+
+  "CallTracer" - {
+    "should produce a root CALL frame for a simple transaction" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 21000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "type") shouldBe JString("CALL")
+      (result \ "from") shouldBe a[JString]
+      (result \ "to") shouldBe a[JString]
+      (result \ "gas") shouldBe JInt(21000)
+      (result \ "gasUsed") shouldBe JInt(21000)
+      (result \ "input") shouldBe a[JString]
+      (result \ "output") shouldBe a[JString]
+    }
+
+    "should produce a CREATE frame when to is None" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, to = None, gas = 100000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 50000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "type") shouldBe JString("CREATE")
+    }
+
+    "should build a nested call tree" in {
+      val tracer = new CallTracer()
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val result    = tracer.getResult
+      val calls     = result \ "calls"
+      calls shouldBe a[JArray]
+      val callArray = calls.asInstanceOf[JArray].arr
+      callArray should have size 1
+      (callArray.head \ "type") shouldBe JString("STATICCALL")
+      (callArray.head \ "gasUsed") shouldBe JInt(10000)
+    }
+
+    "should skip sub-calls when onlyTopCall is true" in {
+      val tracer = new CallTracer(onlyTopCall = true)
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "calls") shouldBe JNothing
+    }
+
+    "should include error on failure" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 100000, output = ByteString.empty, error = Some("out of gas"))
+
+      val result = tracer.getResult
+      (result \ "error") shouldBe JString("out of gas")
+    }
+
+    "should encode gas as decimal integer, not hex" in {
+      val tracer = new CallTracer()
+
+      tracer.onTxStart(from, Some(to), gas = 1000000, value = 0, input = input)
+      tracer.onTxEnd(gasUsed = 500000, output = output, error = None)
+
+      val result = tracer.getResult
+      (result \ "gas") shouldBe JInt(1000000)
+      (result \ "gasUsed") shouldBe JInt(500000)
+    }
+
+    "should omit value for STATICCALL and DELEGATECALL" in {
+      val tracer = new CallTracer()
+      val inner  = Address(0xabcd)
+
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = input)
+      tracer.onCallEnter("STATICCALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+      tracer.onCallExit(gasUsed = 10000, output = output, error = None)
+      tracer.onTxEnd(gasUsed = 60000, output = output, error = None)
+
+      val calls = (tracer.getResult \ "calls").asInstanceOf[JArray].arr
+      (calls.head \ "value") shouldBe JNothing
+    }
+
+    "should return JNull when no transaction was traced" in {
+      val tracer = new CallTracer()
+      tracer.getResult shouldBe JNull
+    }
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/vm/PrestateTracerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/PrestateTracerSpec.scala
@@ -1,0 +1,123 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.json4s.JsonAST._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.domain.Account
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.UInt256
+
+class PrestateTracerSpec extends AnyFreeSpec with Matchers {
+
+  private val from = Address(0x1234)
+  private val to   = Address(0x5678)
+
+  private def worldWith(entries: (Address, Account)*): MockWorldState =
+    MockWorldState(accounts = entries.toMap)
+
+  "PrestateTracer" - {
+    "default mode should return touched account states" in {
+      val account = Account(nonce = 1, balance = UInt256(1000))
+      val world   = worldWith(from -> account)
+      val tracer  = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      result shouldBe a[JObject]
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 1
+    }
+
+    "default mode should include balance and nonce" in {
+      val account = Account(nonce = 5, balance = UInt256(9999))
+      val world   = worldWith(from -> account)
+      val tracer  = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result      = tracer.getResult
+      val obj         = result.asInstanceOf[JObject]
+      val accountJson = obj.obj.head._2
+      (accountJson \ "nonce") shouldBe JInt(5)
+      (accountJson \ "balance") shouldBe a[JString]
+    }
+
+    "diffMode should return pre and post objects" in {
+      val preAccount  = Account(nonce = 1, balance = UInt256(1000))
+      val postAccount = Account(nonce = 2, balance = UInt256(500))
+      val preWorld    = worldWith(from -> preAccount)
+      val postWorld   = worldWith(from -> postAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result = tracer.getResult
+      (result \ "pre") shouldBe a[JObject]
+      (result \ "post") shouldBe a[JObject]
+    }
+
+    "diffMode post should only include changed fields" in {
+      val preAccount  = Account(nonce = 1, balance = UInt256(1000))
+      val postAccount = Account(nonce = 1, balance = UInt256(500))
+      val preWorld    = worldWith(from -> preAccount)
+      val postWorld   = worldWith(from -> postAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result      = tracer.getResult
+      val postObj     = result \ "post"
+      val fromHex     = "0x" + com.chipprbots.ethereum.utils.Hex.toHexString(from.bytes.toArray)
+      val accountPost = postObj \ fromHex
+      (accountPost \ "balance") shouldBe a[JString]
+      (accountPost \ "nonce") shouldBe JNothing
+    }
+
+    "should track addresses from onCallEnter" in {
+      val inner   = Address(0xabcd)
+      val account = Account(nonce = 0, balance = UInt256(100))
+      val world   = worldWith(from -> account, to -> account, inner -> account)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](world)
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 0, input = ByteString.empty)
+      tracer.onCallEnter("CALL", to, inner, gas = 50000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 3
+    }
+
+    "should omit accounts that don't exist in world" in {
+      val world  = worldWith(from -> Account(nonce = 0, balance = UInt256(100)))
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](world)
+
+      tracer.onTxStart(from, Some(to), gas = 21000, value = 0, input = ByteString.empty)
+
+      val result = tracer.getResult
+      val fields = result.asInstanceOf[JObject].obj.map(_._1)
+      fields should have size 1
+    }
+
+    "diffMode should show newly created accounts in post" in {
+      val preWorld   = worldWith(from -> Account(nonce = 1, balance = UInt256(1000)))
+      val newAccount = Account(nonce = 0, balance = UInt256(500))
+      val postWorld  = worldWith(from -> Account(nonce = 2, balance = UInt256(500)), to -> newAccount)
+
+      val tracer = new PrestateTracer[MockWorldState, MockStorage](preWorld, diffMode = true)
+      tracer.onTxStart(from, Some(to), gas = 100000, value = 500, input = ByteString.empty)
+      tracer.setPostWorld(postWorld)
+
+      val result  = tracer.getResult
+      val postObj = result \ "post"
+      val toHex   = "0x" + com.chipprbots.ethereum.utils.Hex.toHexString(to.bytes.toArray)
+      (postObj \ toHex) should not be JNothing
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Aligns Fukuii's PoW mining stack with core-geth's canonical implementation, adding
work push notification, stale submission protection, and Prometheus observability.

**Reference:** core-geth is the canonical PoW reference. Besu deprecated PoW mining
after ETH's merge (2022) — `PoWMiningCoordinator.java` is a 72-line stub with no
`eth_getWork` / `eth_submitWork`. All behaviour traced from core-geth.

### 1. 4-element `eth_getWork` response (core-geth `consensus/ethash/api.go`)

| Before | After |
|--------|-------|
| `[sealhash, seed, target]` (3 elements) | `[sealhash, seed, target, blockNumber]` (4 elements) |

- `GetWorkResponse` gains `blockNumber: BigInt` field
- JSON encoder updated to emit 4-element array
- Matches core-geth `GetWork()` return format: `work[3] = hexutil.EncodeUint64(block.NumberU64())`
- Required for pool compatibility (pools use block number to detect stale work)

### 2. Stale submission window (core-geth `consensus/ethash/sealer.go`)

| Before | After |
|--------|-------|
| No stale check — stale nonces silently fell through | Rejects if `bestBlock - pendingBlock.number > staleThreshold` |

- `staleThreshold = 7` default (matches core-geth `staleThreshold` constant in `remoteSealer`)
- Configurable via `mining.stale-threshold`
- Stale rejections logged at DEBUG and counted in `PoWMiningMetrics`

### 3. Work push notification — `WorkNotifier.scala` (core-geth `consensus/ethash/sealer.go` `notifyWork()`)

New object: `WorkNotifier`
- POSTs 4-element JSON array `["sealhash","seed","target","blockNum"]` to configured pool endpoints
- Fire-and-forget: each URL gets an independent `Future` via pekko-http `Http().singleRequest`
- Failures log at WARN only — never block the mining loop
- Wired into `EthMiningService.getWork()` when `mining.notify-urls` is non-empty
- Matches core-geth's 1-second-timeout, async, best-effort semantics (we use 3s for pool latency)

### 4. PoW mining metrics — `PoWMiningMetrics.scala`

New object: `PoWMiningMetrics` — mirrors `EngineApiMetrics` pattern exactly (`AtomicLong` + `metrics.gauge()`):

| Metric | Type | Wire-up |
|--------|------|---------|
| `pow_getwork_total` | gauge (counter) | `eth_getWork` call |
| `pow_blocks_mined_total` | gauge (counter) | successful `eth_submitWork` |
| `pow_stale_shares_total` | gauge (counter) | rejected stale submission |
| `pow_hashrate_current` | gauge | `eth_submitHashRate` aggregate |
| `pow_last_block_mined_timestamp` | gauge | Unix epoch on successful block |
| `pow_last_mining_duration_ms` | gauge | `getWork` → `submitWork` duration |

### 5. Config additions (`MiningConfig`)

```hocon
mining {
  block-cache-size = 30          # Fixed typo: was "block-cashe-size"
  notify-urls = []               # --miner.notify equivalent
  stale-threshold = 7            # core-geth staleThreshold
  recommit-interval = "0s"       # reserved, disabled by default
}
```

- Typo `block-cashe-size` fixed in `src/main/resources/conf/base/mining.conf` and `ops/barad-dur/fukuii-conf-1/base.conf`
- `MiningConfig.apply()` reads new keys with safe defaults — no existing config files break

### Core-geth references

| File | Behaviour traced |
|------|-----------------|
| `consensus/ethash/api.go` (lines 89-127) | `GetWork()` 4-element return, `SubmitWork()` stale check via `remoteSealer` |
| `consensus/ethash/sealer.go` (lines 407-447) | `notifyWork()` — async HTTP POST, 1s timeout, per-URL goroutines |
| `consensus/ethash/sealer.go` (line 480) | `staleThreshold = 7` constant in `remoteSealer` |
| `consensus/ethash/ethash.go` (lines 579-590) | `hashrate metrics.Meter` aggregate |

## Test plan

- [x] `sbt testOnly *WorkNotifierSpec` — 4/4 pass (POST format, multi-URL, fire-and-forget, empty no-op)
- [x] `sbt testOnly *EthMiningServiceSpec` — 19/19 pass (includes 3 new: 4-element response, stale reject, stale accept)
- [x] `sbt compile` — clean (pre-existing warnings only)
- [ ] Manual: `eth_getWork` on live node → verify 4-element array
- [ ] Manual: `notify-urls` configured → verify HTTP POST to pool endpoint on new work

🤖 Generated with [Claude Code](https://claude.com/claude-code)