### PR TITLE
chore(gitignore): ignore external/ — transient hive workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ run-*.sh
 !run-classic.sh
 !run-mordor.sh
 
+# Transient hive workspace — matches _hive-sim.yml layout
+external/
+


### PR DESCRIPTION
The hive CI pipeline (_hive-sim.yml) clones ethereum/hive into
external/hive so it does not shadow the fukuii adapter dir under
./hive. Local runs follow the same layout; ignoring external/ keeps
the working tree clean when running the hive engine simulator from
the repo root.

https://claude.ai/code/session_01BYReA7Skndcmn4UvfF3Nu6