### PR TITLE
fix(engine-api): hive engine-suite 321/403 (79.7%) — NewPayload/FCU/proposer/receipts

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -123,8 +123,8 @@ if [ -n "$HIVE_MINER" ]; then
 fi
 
 exec java \
-    -Xmx2g \
-    -Xms512m \
+    -Xmx1g \
+    -Xms256m \
     -Xss4M \
     -XX:+UseG1GC \
     $FLAGS \

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -295,8 +295,14 @@ class EngineApiController(
           // overlay the version error. UnsupportedFork (-38005) does not apply forkchoice —
           // the CL called the wrong method entirely.
           if (code == InvalidAttrs) {
-            engineApiService.forkchoiceUpdated(fcs, None).map { _ =>
-              JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
+            // If head is unknown (syncing), return SYNCING payload status without the
+            // attrs error — validation presupposes a known head. Hive's 'Invalid
+            // PayloadAttributes, Missing BeaconRoot, Syncing=True' expects no error.
+            engineApiService.forkchoiceUpdated(fcs, None).map {
+              case Right(response) if response.payloadStatus.status == PayloadStatus.Syncing =>
+                JsonRpcResponse("2.0", Some(encodeForkchoiceUpdatedResponse(response)), None, reqId(request))
+              case _ =>
+                JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
             }
           } else {
             IO.pure(

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -143,6 +143,11 @@ class EngineApiController(
             Some(InvalidParams -> "newPayloadV3 requires withdrawals field")
           case 3 if !hasAllCancunFields =>
             Some(InvalidParams -> "newPayloadV3 requires blobGasUsed and excessBlobGas")
+          // V3 requires the parentBeaconBlockRoot third param; we parse it after this check but
+          // the expected rejection code for missing is -32602. The test framework's
+          // `NewPayloadV3 After Cancun, Nil Beacon Root` variant exercises this.
+          case 3 if params.lift(2).forall(_ == org.json4s.JNull) =>
+            Some(InvalidParams -> "newPayloadV3 requires parentBeaconBlockRoot")
           case 2 if isCancunPayload =>
             Some(UnsupportedFork -> "newPayloadV2 cannot be used post-Cancun, use V3")
           case 2 if isShanghaiPayload && !hasWithdrawals =>
@@ -246,11 +251,16 @@ class EngineApiController(
         val versionError: Option[(Int, String)] = (version, payloadAttrs) match {
           case (3, Some(_)) if !isCancunTimestamp && hasBeaconRoot =>
             Some(UnsupportedFork -> "forkchoiceUpdatedV3 with beacon root before Cancun activation")
+          case (2, Some(_)) if isCancunTimestamp && hasBeaconRoot =>
+            // V2 attrs are NOT supposed to carry a beacon root. If the CL still sends one at
+            // a Cancun timestamp it's an attribute-shape error → -38003. (hive "Non-Null
+            // Beacon Root" variant)
+            Some(InvalidAttrs -> "forkchoiceUpdatedV2 attrs must not include parentBeaconBlockRoot")
           case (2, Some(_)) if isCancunTimestamp =>
-            // hive expects -38003 INVALID_PAYLOAD_ATTRIBUTES when V2 attrs are sent post-Cancun
-            // (specifically the "ForkchoiceUpdatedV2 To Request Cancun Payload" tests).
-            Some(InvalidAttrs -> "forkchoiceUpdatedV2 cannot be used post-Cancun, use V3")
-          case (v, Some(_)) if v < 3 && isCancunTimestamp =>
+            // V2 attrs without beacon root, post-Cancun → wrong method for this fork. hive
+            // "Missing Beacon Root" variant expects -38005 UNSUPPORTED_FORK.
+            Some(UnsupportedFork -> "forkchoiceUpdatedV2 cannot be used post-Cancun, use V3")
+          case (v, Some(_)) if v < 2 && isCancunTimestamp =>
             Some(UnsupportedFork -> s"forkchoiceUpdatedV$v cannot be used post-Cancun, use V3")
           case (1, Some(_)) if isShanghaiTimestamp =>
             Some(UnsupportedFork -> "forkchoiceUpdatedV1 cannot be used post-Shanghai, use V2")

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -121,9 +121,17 @@ class EngineApiController(
         //   newPayloadV2: pre-OR-post-Shanghai,  withdrawals present iff post-Shanghai
         //   newPayloadV3: timestamp ≥ cancun,    withdrawals present
         val InvalidParams = -32602
+        // Per engine-api spec and hive's engine-cancun / engine-withdrawals suites:
+        //   -32602 (Invalid params): payload shape is wrong for the RPC version (e.g.
+        //     V3 called pre-Cancun, V2 payload missing withdrawals post-Shanghai)
+        //   -38005 (Unsupported fork): the RPC method itself is not for this fork family
         val versionError: Option[(Int, String)] = version match {
+          case 3 if !isCancunPayload =>
+            Some(InvalidParams -> "newPayloadV3 cannot be used pre-Cancun, use V2")
           case 3 if !hasWithdrawals =>
-            Some(UnsupportedFork -> "newPayloadV3 requires withdrawals field")
+            Some(InvalidParams -> "newPayloadV3 requires withdrawals field")
+          case 2 if isCancunPayload =>
+            Some(UnsupportedFork -> "newPayloadV2 cannot be used post-Cancun, use V3")
           case 2 if isShanghaiPayload && !hasWithdrawals =>
             Some(InvalidParams -> "newPayloadV2 post-Shanghai payload must include withdrawals")
           case 2 if !isShanghaiPayload && hasWithdrawals =>
@@ -225,6 +233,10 @@ class EngineApiController(
         val versionError: Option[(Int, String)] = (version, payloadAttrs) match {
           case (3, Some(_)) if !isCancunTimestamp && hasBeaconRoot =>
             Some(UnsupportedFork -> "forkchoiceUpdatedV3 with beacon root before Cancun activation")
+          case (2, Some(_)) if isCancunTimestamp =>
+            // hive expects -38003 INVALID_PAYLOAD_ATTRIBUTES when V2 attrs are sent post-Cancun
+            // (specifically the "ForkchoiceUpdatedV2 To Request Cancun Payload" tests).
+            Some(InvalidAttrs -> "forkchoiceUpdatedV2 cannot be used post-Cancun, use V3")
           case (v, Some(_)) if v < 3 && isCancunTimestamp =>
             Some(UnsupportedFork -> s"forkchoiceUpdatedV$v cannot be used post-Cancun, use V3")
           case (1, Some(_)) if isShanghaiTimestamp =>
@@ -286,7 +298,7 @@ class EngineApiController(
     }
   }
 
-  private def handleGetPayload(request: JsonRpcRequest, @annotation.unused version: Int = 1): IO[JsonRpcResponse] = {
+  private def handleGetPayload(request: JsonRpcRequest, version: Int = 1): IO[JsonRpcResponse] = {
     val payloadIdHex = request.params match {
       case Some(JArray(List(JString(id)))) => id
       case _                               => ""
@@ -294,6 +306,24 @@ class EngineApiController(
     val payloadId = hexToByteString(payloadIdHex)
     engineApiService.getPayload(payloadId).map {
       case Right(block) =>
+        // Validate the RPC version matches the payload's fork timestamp. Hive's
+        // "GetPayloadV2 To Request Cancun Payload" and "GetPayloadV3 To Request Shanghai
+        // Payload" tests exercise this — V2 for a Cancun-ts payload and V3 for a
+        // Shanghai-ts payload must both return -38005 UNSUPPORTED_FORK.
+        val cfg = com.chipprbots.ethereum.utils.Config.blockchains.blockchainConfig
+        val ts = block.header.unixTimestamp
+        val isCancunPayload = cfg.isCancunTimestamp(ts)
+        val isShanghaiPayload = cfg.isShanghaiTimestamp(ts)
+        val forkError: Option[String] = version match {
+          case 2 if isCancunPayload => Some("getPayloadV2 cannot return a Cancun payload; use V3")
+          case 3 if !isCancunPayload => Some("getPayloadV3 can only return Cancun-or-later payloads")
+          case 1 if isShanghaiPayload => Some("getPayloadV1 cannot return a Shanghai-or-later payload; use V2")
+          case _ => None
+        }
+        forkError match {
+          case Some(msg) =>
+            JsonRpcResponse("2.0", None, Some(JsonRpcError(UnsupportedFork, msg, None)), reqId(request))
+          case None =>
         val payload = blockToExecutionPayload(block)
         // V1 returns bare ExecutionPayload.
         // V2+ wraps it in ExecutionPayloadEnvelope per Engine API spec.
@@ -335,6 +365,7 @@ class EngineApiController(
             )
         }
         JsonRpcResponse("2.0", Some(result), None, reqId(request))
+        }
       case Left(err) =>
         JsonRpcResponse("2.0", None, Some(JsonRpcError(-38001, err, None)), reqId(request))
     }

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -111,19 +111,34 @@ class EngineApiController(
         }
         var payload = payloadOpt.toOption.get
         val hasWithdrawals = payload.withdrawals.isDefined
+        val blockchainConfig = com.chipprbots.ethereum.utils.Config.blockchains.blockchainConfig
+        val isShanghaiPayload = blockchainConfig.isShanghaiTimestamp(payload.timestamp)
+        val isCancunPayload = blockchainConfig.isCancunTimestamp(payload.timestamp)
 
-        // Version enforcement: only reject truly incompatible combinations.
-        // V1/V2 accept any payload fields (backward compatible).
-        // V3 requires withdrawals (Cancun payloads always have them).
-        val versionError: Option[String] = version match {
+        // Version enforcement on payload shape (not on method-of-fork — that's -38005).
+        // Hive withdrawals suite expects -32602 (InvalidParamsError) for shape mismatches:
+        //   newPayloadV1: timestamp < shanghai,  withdrawals absent
+        //   newPayloadV2: pre-OR-post-Shanghai,  withdrawals present iff post-Shanghai
+        //   newPayloadV3: timestamp ≥ cancun,    withdrawals present
+        val InvalidParams = -32602
+        val versionError: Option[(Int, String)] = version match {
           case 3 if !hasWithdrawals =>
-            Some("newPayloadV3 requires withdrawals field")
+            Some(UnsupportedFork -> "newPayloadV3 requires withdrawals field")
+          case 2 if isShanghaiPayload && !hasWithdrawals =>
+            Some(InvalidParams -> "newPayloadV2 post-Shanghai payload must include withdrawals")
+          case 2 if !isShanghaiPayload && hasWithdrawals =>
+            Some(InvalidParams -> "newPayloadV2 pre-Shanghai payload must not include withdrawals")
+          case 1 if hasWithdrawals =>
+            Some(InvalidParams -> "newPayloadV1 must not include withdrawals")
+          case 1 if isShanghaiPayload =>
+            Some(UnsupportedFork -> "newPayloadV1 cannot be used post-Shanghai, use V2")
           case _ => None
         }
 
         if (versionError.isDefined) {
+          val (code, msg) = versionError.get
           IO.pure(
-            JsonRpcResponse("2.0", None, Some(JsonRpcError(UnsupportedFork, versionError.get, None)), reqId(request))
+            JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
           )
         } else {
           // V3+: params[1] is expectedBlobVersionedHashes, params[2] is parentBeaconBlockRoot.
@@ -199,37 +214,42 @@ class EngineApiController(
         val isShanghaiTimestamp = attrTimestamp.exists(blockchainConfig.isShanghaiTimestamp)
         val isCancunTimestamp = attrTimestamp.exists(blockchainConfig.isCancunTimestamp)
 
-        // Engine API version matrix:
-        //   V1: timestamp < shanghai,  withdrawals absent,  beaconRoot absent
-        //   V2: shanghai ≤ ts < cancun, withdrawals present, beaconRoot absent
-        //   V3: timestamp ≥ cancun,     withdrawals present, beaconRoot present
-        // The hive withdrawals suite ("Sent shanghai fcu using PayloadAttributesV1, error is
-        // expected") fails every test that doesn't enforce this.
-        val versionError: Option[String] = (version, payloadAttrs) match {
+        // Engine API version matrix. -38005 UNSUPPORTED_FORK only when the RPC method itself is
+        // wrong for the current fork; -38003 INVALID_PAYLOAD_ATTRIBUTES for attribute-shape
+        // violations. V2 is permissive — it accepts V1-shape attrs pre-Shanghai. The hive
+        // withdrawals suite checks exact codes.
+        //   V1: timestamp < shanghai (hard error if post-Shanghai),        withdrawals absent
+        //   V2: accepts pre-Shanghai (V1-shape) OR post-Shanghai (V2-shape), beaconRoot absent
+        //   V3: timestamp ≥ cancun,                                         withdrawals + beaconRoot present
+        val InvalidAttrs = -38003
+        val versionError: Option[(Int, String)] = (version, payloadAttrs) match {
           case (3, Some(_)) if !isCancunTimestamp && hasBeaconRoot =>
-            Some("forkchoiceUpdatedV3 with beacon root before Cancun activation")
+            Some(UnsupportedFork -> "forkchoiceUpdatedV3 with beacon root before Cancun activation")
           case (v, Some(_)) if v < 3 && isCancunTimestamp =>
-            Some(s"forkchoiceUpdatedV$v cannot be used post-Cancun, use V3")
+            Some(UnsupportedFork -> s"forkchoiceUpdatedV$v cannot be used post-Cancun, use V3")
           case (1, Some(_)) if isShanghaiTimestamp =>
-            Some("forkchoiceUpdatedV1 cannot be used post-Shanghai, use V2")
+            Some(UnsupportedFork -> "forkchoiceUpdatedV1 cannot be used post-Shanghai, use V2")
           case (1, Some(_)) if hasWithdrawals =>
-            Some("forkchoiceUpdatedV1 attrs must not include withdrawals")
-          case (2, Some(_)) if isShanghaiTimestamp && !hasWithdrawals =>
-            Some("forkchoiceUpdatedV2 attrs must include withdrawals post-Shanghai")
+            Some(InvalidAttrs -> "forkchoiceUpdatedV1 attrs must not include withdrawals")
+          // V2 pre-Shanghai: V1-shape attrs are OK; withdrawals field is NOT allowed.
           case (2, Some(_)) if !isShanghaiTimestamp && hasWithdrawals =>
-            Some("forkchoiceUpdatedV2 attrs must not include withdrawals pre-Shanghai")
+            Some(InvalidAttrs -> "forkchoiceUpdatedV2 attrs must not include withdrawals pre-Shanghai")
+          // V2 post-Shanghai: withdrawals field is required.
+          case (2, Some(_)) if isShanghaiTimestamp && !hasWithdrawals =>
+            Some(InvalidAttrs -> "forkchoiceUpdatedV2 attrs must include withdrawals post-Shanghai")
           case (2, Some(_)) if hasBeaconRoot =>
-            Some("forkchoiceUpdatedV2 attrs must not include parentBeaconBlockRoot")
+            Some(InvalidAttrs -> "forkchoiceUpdatedV2 attrs must not include parentBeaconBlockRoot")
           case (3, Some(_)) if !hasWithdrawals =>
-            Some("forkchoiceUpdatedV3 attrs must include withdrawals")
+            Some(InvalidAttrs -> "forkchoiceUpdatedV3 attrs must include withdrawals")
           case (3, Some(_)) if isCancunTimestamp && !hasBeaconRoot =>
-            Some("forkchoiceUpdatedV3 attrs must include parentBeaconBlockRoot post-Cancun")
+            Some(InvalidAttrs -> "forkchoiceUpdatedV3 attrs must include parentBeaconBlockRoot post-Cancun")
           case _ => None
         }
 
         if (versionError.isDefined) {
+          val (code, msg) = versionError.get
           IO.pure(
-            JsonRpcResponse("2.0", None, Some(JsonRpcError(UnsupportedFork, versionError.get, None)), reqId(request))
+            JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
           )
         } else {
           engineApiService.forkchoiceUpdated(fcs, payloadAttrs).map {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -548,10 +548,31 @@ class EngineApiController(
       }
       .getOrElse(BigInt(0))
 
-    val bodies = (0L until count.toLong.min(1024L)).map { offset =>
-      engineApiService.getPayloadBodyByNumber(start + offset).map(encodePayloadBody).getOrElse(JNull)
-    }.toList
-    IO.pure(JsonRpcResponse("2.0", Some(JArray(bodies)), None, reqId(request)))
+    // Spec: start<1 or count<1 → -32602 invalid params.
+    if (start < 1 || count < 1) {
+      IO.pure(
+        JsonRpcResponse(
+          "2.0",
+          None,
+          Some(com.chipprbots.ethereum.jsonrpc.JsonRpcError.InvalidParams("start and count must be >= 1")),
+          reqId(request)
+        )
+      )
+    } else {
+      // Spec: truncate the response at the latest known canonical block — do NOT emit
+      // trailing nulls for numbers past the tip. Hive's GetPayloadBodiesByRange test
+      // checks the array length against min(count, latest-start+1).
+      val latest = engineApiService.getLatestBlockNumber
+      if (start > latest) {
+        IO.pure(JsonRpcResponse("2.0", Some(JArray(Nil)), None, reqId(request)))
+      } else {
+        val effectiveCount = count.min(latest - start + 1).min(1024)
+        val bodies = (0L until effectiveCount.toLong).map { offset =>
+          engineApiService.getPayloadBodyByNumber(start + offset).map(encodePayloadBody).getOrElse(JNull)
+        }.toList
+        IO.pure(JsonRpcResponse("2.0", Some(JArray(bodies)), None, reqId(request)))
+      }
+    }
   }
 
   private def encodePayloadBody(body: (Seq[ByteString], Option[Seq[org.json4s.JValue]])): JValue = {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -123,13 +123,26 @@ class EngineApiController(
         val InvalidParams = -32602
         // Per engine-api spec and hive's engine-cancun / engine-withdrawals suites:
         //   -32602 (Invalid params): payload shape is wrong for the RPC version (e.g.
-        //     V3 called pre-Cancun, V2 payload missing withdrawals post-Shanghai)
-        //   -38005 (Unsupported fork): the RPC method itself is not for this fork family
+        //     V3 called pre-Cancun with V1-shape payload missing all Cancun fields)
+        //   -38005 (Unsupported fork): method is wrong for the fork — applies when the
+        //     payload IS shaped for Cancun (all Cancun fields present, even if zero) but
+        //     timestamp is pre-Cancun, OR when V1/V2 is called for a Cancun payload.
+        //
+        // For V3 pre-Cancun we have to distinguish the two cases:
+        //   - payload has all Cancun fields (blobGasUsed + excessBlobGas present) → -38005
+        //     (the CL sent a valid Cancun-shape payload to the wrong fork)
+        //   - at least one Cancun field is nil → -32602 (params shape wrong for method)
+        val hasAllCancunFields =
+          payload.blobGasUsed.isDefined && payload.excessBlobGas.isDefined
         val versionError: Option[(Int, String)] = version match {
+          case 3 if !isCancunPayload && hasAllCancunFields =>
+            Some(UnsupportedFork -> "newPayloadV3 cannot be used pre-Cancun")
           case 3 if !isCancunPayload =>
             Some(InvalidParams -> "newPayloadV3 cannot be used pre-Cancun, use V2")
           case 3 if !hasWithdrawals =>
             Some(InvalidParams -> "newPayloadV3 requires withdrawals field")
+          case 3 if !hasAllCancunFields =>
+            Some(InvalidParams -> "newPayloadV3 requires blobGasUsed and excessBlobGas")
           case 2 if isCancunPayload =>
             Some(UnsupportedFork -> "newPayloadV2 cannot be used post-Cancun, use V3")
           case 2 if isShanghaiPayload && !hasWithdrawals =>

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -300,6 +300,14 @@ class EngineApiController(
         // blockValue depends on receipts (effectiveGasPrice per tx). Fetch once so V2/V3/V4 share.
         lazy val receipts = engineApiService.getPayloadReceipts(payloadId)
         lazy val blockValueHex = computeBlockValue(block, receipts)
+        lazy val blobsBundleJson: JObject = {
+          val bundle = engineApiService.getPayloadBlobsBundle(payloadId)
+          JObject(
+            "commitments" -> JArray(bundle.commitments.toList.map(c => JString(byteStringToHex(c)))),
+            "proofs" -> JArray(bundle.proofs.toList.map(p => JString(byteStringToHex(p)))),
+            "blobs" -> JArray(bundle.blobs.toList.map(b => JString(byteStringToHex(b))))
+          )
+        }
         val result: JValue = version match {
           case 1 => payload
           case 2 =>
@@ -311,11 +319,7 @@ class EngineApiController(
             JObject(
               "executionPayload" -> payload,
               "blockValue" -> JString(blockValueHex),
-              "blobsBundle" -> JObject(
-                "commitments" -> JArray(Nil),
-                "proofs" -> JArray(Nil),
-                "blobs" -> JArray(Nil)
-              ),
+              "blobsBundle" -> blobsBundleJson,
               "shouldOverrideBuilder" -> JBool(false)
             )
           case _ => // V4+: add executionRequests (EIP-7685)
@@ -323,11 +327,7 @@ class EngineApiController(
             JObject(
               "executionPayload" -> payload,
               "blockValue" -> JString(blockValueHex),
-              "blobsBundle" -> JObject(
-                "commitments" -> JArray(Nil),
-                "proofs" -> JArray(Nil),
-                "blobs" -> JArray(Nil)
-              ),
+              "blobsBundle" -> blobsBundleJson,
               "shouldOverrideBuilder" -> JBool(false),
               "executionRequests" -> JArray(
                 executionRequests.toList.map(r => JString(byteStringToHex(r)))

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -283,9 +283,21 @@ class EngineApiController(
 
         if (versionError.isDefined) {
           val (code, msg) = versionError.get
-          IO.pure(
-            JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
-          )
+          // Per engine-API step ordering (apply forkchoiceState, THEN validate attrs):
+          // InvalidAttrs errors STILL require the forkchoice to be applied first. Hive
+          // 'Invalid PayloadAttributes, Missing BeaconRoot' asserts HeaderByNumber reflects
+          // the new head even on -38003. Forward an attrs-less FCU to the service, then
+          // overlay the version error. UnsupportedFork (-38005) does not apply forkchoice —
+          // the CL called the wrong method entirely.
+          if (code == InvalidAttrs) {
+            engineApiService.forkchoiceUpdated(fcs, None).map { _ =>
+              JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
+            }
+          } else {
+            IO.pure(
+              JsonRpcResponse("2.0", None, Some(JsonRpcError(code, msg, None)), reqId(request))
+            )
+          }
         } else {
           engineApiService.forkchoiceUpdated(fcs, payloadAttrs).map {
             case Right(response) =>

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -126,10 +126,19 @@ class EngineApiController(
             JsonRpcResponse("2.0", None, Some(JsonRpcError(UnsupportedFork, versionError.get, None)), reqId(request))
           )
         } else {
-          // V3+: second param is versionedHashes, third is parentBeaconBlockRoot
+          // V3+: params[1] is expectedBlobVersionedHashes, params[2] is parentBeaconBlockRoot.
+          // Previously we skipped params[1] entirely, which silently dropped the EIP-4844
+          // versioned-hash check the CL relies on — every "NewPayloadV3 Versioned Hashes"
+          // hive test passed the payload regardless of what the CL claimed to have seen.
           if (version >= 3) {
+            val expectedBlobVersionedHashes = params.lift(1).collect { case JArray(items) =>
+              items.collect { case JString(hex) => hexToByteString(hex) }
+            }
             val parentBeaconBlockRoot = params.lift(2).collect { case JString(hex) => hexToByteString(hex) }
-            payload = payload.copy(parentBeaconBlockRoot = parentBeaconBlockRoot)
+            payload = payload.copy(
+              expectedBlobVersionedHashes = expectedBlobVersionedHashes,
+              parentBeaconBlockRoot = parentBeaconBlockRoot
+            )
           }
 
           // V4: fourth param is executionRequests (EIP-7685)

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -193,16 +193,37 @@ class EngineApiController(
         // Post-Cancun timestamp: V2 without beacon root → UnsupportedFork
         // Pre-Cancun timestamp: V3 with beacon root → UnsupportedFork
         val hasBeaconRoot = payloadAttrs.exists(_.parentBeaconBlockRoot.isDefined)
+        val hasWithdrawals = payloadAttrs.exists(_.withdrawals.isDefined)
         val attrTimestamp = payloadAttrs.map(_.timestamp)
-        val isCancunTimestamp = attrTimestamp.exists(ts =>
-          com.chipprbots.ethereum.utils.Config.blockchains.blockchainConfig.isCancunTimestamp(ts)
-        )
+        val blockchainConfig = com.chipprbots.ethereum.utils.Config.blockchains.blockchainConfig
+        val isShanghaiTimestamp = attrTimestamp.exists(blockchainConfig.isShanghaiTimestamp)
+        val isCancunTimestamp = attrTimestamp.exists(blockchainConfig.isCancunTimestamp)
 
+        // Engine API version matrix:
+        //   V1: timestamp < shanghai,  withdrawals absent,  beaconRoot absent
+        //   V2: shanghai ≤ ts < cancun, withdrawals present, beaconRoot absent
+        //   V3: timestamp ≥ cancun,     withdrawals present, beaconRoot present
+        // The hive withdrawals suite ("Sent shanghai fcu using PayloadAttributesV1, error is
+        // expected") fails every test that doesn't enforce this.
         val versionError: Option[String] = (version, payloadAttrs) match {
           case (3, Some(_)) if !isCancunTimestamp && hasBeaconRoot =>
             Some("forkchoiceUpdatedV3 with beacon root before Cancun activation")
           case (v, Some(_)) if v < 3 && isCancunTimestamp =>
             Some(s"forkchoiceUpdatedV$v cannot be used post-Cancun, use V3")
+          case (1, Some(_)) if isShanghaiTimestamp =>
+            Some("forkchoiceUpdatedV1 cannot be used post-Shanghai, use V2")
+          case (1, Some(_)) if hasWithdrawals =>
+            Some("forkchoiceUpdatedV1 attrs must not include withdrawals")
+          case (2, Some(_)) if isShanghaiTimestamp && !hasWithdrawals =>
+            Some("forkchoiceUpdatedV2 attrs must include withdrawals post-Shanghai")
+          case (2, Some(_)) if !isShanghaiTimestamp && hasWithdrawals =>
+            Some("forkchoiceUpdatedV2 attrs must not include withdrawals pre-Shanghai")
+          case (2, Some(_)) if hasBeaconRoot =>
+            Some("forkchoiceUpdatedV2 attrs must not include parentBeaconBlockRoot")
+          case (3, Some(_)) if !hasWithdrawals =>
+            Some("forkchoiceUpdatedV3 attrs must include withdrawals")
+          case (3, Some(_)) if isCancunTimestamp && !hasBeaconRoot =>
+            Some("forkchoiceUpdatedV3 attrs must include parentBeaconBlockRoot post-Cancun")
           case _ => None
         }
 

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -148,6 +148,11 @@ class EngineApiController(
           // `NewPayloadV3 After Cancun, Nil Beacon Root` variant exercises this.
           case 3 if params.lift(2).forall(_ == org.json4s.JNull) =>
             Some(InvalidParams -> "newPayloadV3 requires parentBeaconBlockRoot")
+          // V3 also requires a non-null expectedBlobVersionedHashes array (params[1]).
+          // Hive 'NewPayloadV3 Versioned Hashes, Nil Hashes' sends null here and expects
+          // -32602 rather than VALID/ACCEPTED.
+          case 3 if params.lift(1).forall(_ == org.json4s.JNull) =>
+            Some(InvalidParams -> "newPayloadV3 requires expectedBlobVersionedHashes")
           case 2 if isCancunPayload =>
             Some(UnsupportedFork -> "newPayloadV2 cannot be used post-Cancun, use V3")
           case 2 if isShanghaiPayload && !hasWithdrawals =>

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -297,17 +297,20 @@ class EngineApiController(
         val payload = blockToExecutionPayload(block)
         // V1 returns bare ExecutionPayload.
         // V2+ wraps it in ExecutionPayloadEnvelope per Engine API spec.
+        // blockValue depends on receipts (effectiveGasPrice per tx). Fetch once so V2/V3/V4 share.
+        lazy val receipts = engineApiService.getPayloadReceipts(payloadId)
+        lazy val blockValueHex = computeBlockValue(block, receipts)
         val result: JValue = version match {
           case 1 => payload
           case 2 =>
             JObject(
               "executionPayload" -> payload,
-              "blockValue" -> JString(computeBlockValue(block))
+              "blockValue" -> JString(blockValueHex)
             )
           case 3 =>
             JObject(
               "executionPayload" -> payload,
-              "blockValue" -> JString(computeBlockValue(block)),
+              "blockValue" -> JString(blockValueHex),
               "blobsBundle" -> JObject(
                 "commitments" -> JArray(Nil),
                 "proofs" -> JArray(Nil),
@@ -319,7 +322,7 @@ class EngineApiController(
             val executionRequests = engineApiService.getPayloadExecutionRequests(payloadId)
             JObject(
               "executionPayload" -> payload,
-              "blockValue" -> JString(computeBlockValue(block)),
+              "blockValue" -> JString(blockValueHex),
               "blobsBundle" -> JObject(
                 "commitments" -> JArray(Nil),
                 "proofs" -> JArray(Nil),
@@ -337,11 +340,21 @@ class EngineApiController(
     }
   }
 
-  /** blockValue = sum of (gasUsed_i * (effectiveGasPrice_i - baseFeePerGas)) across txs. Represents total miner
-    * priority-fee revenue for the block. Without receipts we approximate using per-tx gas limit — tests typically check
-    * envelope presence, not exact value.
+  /** blockValue = Σ gasUsedByTx_i × (effectiveGasPrice_i − baseFeePerGas). Miner's priority-fee
+    * revenue for the block. Per EIP-3675 V2 envelope, this is what the CL reads to pick the
+    * highest-value payload across builders.
+    *
+    * For each tx:
+    *   - gasUsedByTx = receipt.cumulativeGas − previousReceipt.cumulativeGas (since receipts
+    *     record CUMULATIVE gas, not per-tx).
+    *   - effectiveGasPrice = for legacy / access-list txs: tx.gasPrice. For EIP-1559 / blob:
+    *     min(maxFeePerGas, baseFee + maxPriorityFeePerGas).
     */
-  private def computeBlockValue(block: Block): String = {
+  private def computeBlockValue(
+      block: Block,
+      receipts: Seq[com.chipprbots.ethereum.domain.Receipt]
+  ): String = {
+    import com.chipprbots.ethereum.domain.{TransactionWithAccessList, TransactionWithDynamicFee, BlobTransaction, SetCodeTransaction}
     val baseFee = block.header.extraFields match {
       case BlockHeader.HeaderExtraFields.HefPostOlympia(bf)               => bf
       case BlockHeader.HeaderExtraFields.HefPostShanghai(bf, _)           => bf
@@ -349,9 +362,24 @@ class EngineApiController(
       case BlockHeader.HeaderExtraFields.HefPostPrague(bf, _, _, _, _, _) => bf
       case _                                                              => BigInt(0)
     }
-    s"0x${BigInt(0).toString(16)}"
-    // No receipts available here; return 0x0 which satisfies the envelope schema.
-    // Future: thread receipt data through EngineApiService to compute exact priority fees.
+    if (receipts.isEmpty) return "0x0"
+    val txs = block.body.transactionList
+    // derive per-tx gas used from cumulative deltas
+    val gasUsedPerTx: Seq[BigInt] = receipts.map(_.cumulativeGasUsed).scanLeft(BigInt(0)) { (prev, cum) =>
+      cum
+    }.sliding(2, 1).collect { case Seq(prev, cur) => cur - prev }.toSeq
+    val totalPriorityFee: BigInt = txs.zip(gasUsedPerTx).map { case (stx, gasUsed) =>
+      val effectiveGasPrice: BigInt = stx.tx match {
+        case t: TransactionWithDynamicFee => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+        case t: BlobTransaction           => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+        case t: SetCodeTransaction        => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+        case t: TransactionWithAccessList => t.gasPrice
+        case _                            => stx.tx.gasPrice
+      }
+      val priorityPerGas = (effectiveGasPrice - baseFee).max(0)
+      gasUsed * priorityPerGas
+    }.sum
+    s"0x${totalPriorityFee.toString(16)}"
   }
 
   private def blockToExecutionPayload(block: Block): JObject = {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiDomain.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiDomain.scala
@@ -30,6 +30,10 @@ case class ExecutionPayload(
     excessBlobGas: Option[BigInt] = None,
     // Cancun+ (passed as separate newPayload param, not in payload object)
     parentBeaconBlockRoot: Option[ByteString] = None,
+    // EIP-4844 (V3+, passed as separate newPayload param at index 1). Each entry is the
+    // `SHA256(kzg_commitment)` of a blob; must equal the concatenation of every blob tx's
+    // `blobVersionedHashes` in this payload, in order. None when the CL is a pre-Cancun client.
+    expectedBlobVersionedHashes: Option[Seq[ByteString]] = None,
     // Prague/Electra+ (EIP-7685, passed as separate newPayload param)
     executionRequests: Option[Seq[ByteString]] = None
 )

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -452,25 +452,7 @@ class EngineApiService(
         Left("invalid forkchoice state: finalized block is not an ancestor of head")
       } else {
 
-        // Validate payload attributes BEFORE applying forkchoice. Per Engine API spec +
-        // hive 'Invalid PayloadAttributes' test: when we reject the FCU with -38003, the
-        // forkchoice state must NOT be applied (HeaderByNumber should still reflect the
-        // prior head). Moving the attrs-check above applyForkChoiceState keeps that
-        // invariant.
-        val invalidAttrsMsg: Option[String] = payloadAttributes.flatMap { attrs =>
-          if (attrs.timestamp == 0) Some("invalid payload attributes: zero timestamp")
-          else {
-            blockchainReader.getBlockHeaderByHash(forkChoiceState.headBlockHash).flatMap { parent =>
-              if (attrs.timestamp <= parent.unixTimestamp)
-                Some("invalid payload attributes: timestamp too low")
-              else None
-            }
-          }
-        }
-        if (invalidAttrsMsg.isDefined) {
-          EngineApiMetrics.recordForkchoiceUpdated("INVALID")
-          Left("ATTR:" + invalidAttrsMsg.get)
-        } else forkChoiceManager.applyForkChoiceState(forkChoiceState) match {
+        forkChoiceManager.applyForkChoiceState(forkChoiceState) match {
           case Left(_) =>
             // Head not known — return SYNCING so CL knows we need newPayload
             EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
@@ -488,7 +470,24 @@ class EngineApiService(
               }
             }
 
-            {
+            // Validate payload attributes AFTER applying forkchoice — per engine-API spec
+            // step ordering (apply forkchoiceState, THEN check attrs) and hive's
+            // 'Invalid PayloadAttributes' test, which asserts the forkchoice IS applied
+            // even when attrs are rejected with -38003.
+            val invalidAttrsMsg: Option[String] = payloadAttributes.flatMap { attrs =>
+              if (attrs.timestamp == 0) Some("invalid payload attributes: zero timestamp")
+              else {
+                blockchainReader.getBlockHeaderByHash(forkChoiceState.headBlockHash).flatMap { parent =>
+                  if (attrs.timestamp <= parent.unixTimestamp)
+                    Some("invalid payload attributes: timestamp too low")
+                  else None
+                }
+              }
+            }
+            if (invalidAttrsMsg.isDefined) {
+              EngineApiMetrics.recordForkchoiceUpdated("INVALID")
+              Left("ATTR:" + invalidAttrsMsg.get)
+            } else {
 
               val payloadId = payloadAttributes.map { attrs =>
                 // Deterministic payload ID MUST be unique for every distinct attribute

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -487,12 +487,27 @@ class EngineApiService(
             } else {
 
               val payloadId = payloadAttributes.map { attrs =>
-                // Generate a payload ID from the attributes (deterministic)
+                // Deterministic payload ID MUST be unique for every distinct attribute
+                // combination — hive 'Unique Payload ID' test sends FCUs differing only in
+                // a single withdrawal field or beaconRoot and expects the IDs to differ.
+                // Include withdrawals + beaconRoot in the hash.
+                val withdrawalBytes: Array[Byte] =
+                  attrs.withdrawals.toSeq.flatMap { ws =>
+                    ws.flatMap { w =>
+                      w.index.toByteArray.toSeq ++
+                        w.validatorIndex.toByteArray.toSeq ++
+                        w.address.bytes.toArray.toSeq ++
+                        w.amount.toByteArray.toSeq
+                    }
+                  }.toArray
+                val beaconRootBytes = attrs.parentBeaconBlockRoot.map(_.toArray).getOrElse(Array.emptyByteArray)
                 val idBytes = kec256(
                   forkChoiceState.headBlockHash.toArray ++
                     BigInt(attrs.timestamp).toByteArray ++
                     attrs.prevRandao.toArray ++
-                    attrs.suggestedFeeRecipient.bytes.toArray
+                    attrs.suggestedFeeRecipient.bytes.toArray ++
+                    withdrawalBytes ++
+                    beaconRootBytes
                 )
                 val id = ByteString(idBytes.take(8))
 

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -50,6 +50,18 @@ class EngineApiService(
   // Value" test fails with want=N, got=0.
   private val pendingPayloadReceipts =
     new java.util.concurrent.ConcurrentHashMap[ByteString, Seq[com.chipprbots.ethereum.domain.Receipt]]()
+  // EIP-4844 blob sidecars (blobs, commitments, proofs) for each payload's blob txs. The hive
+  // engine-cancun suite's VerifyBlobBundle asserts (a) matching counts, (b) byte-equality
+  // against the sidecars the test submitted via eth_sendRawTransaction. We capture sidecars
+  // during the proposer's GetPendingTransactions call and hand them to engine_getPayloadV3's
+  // blobsBundle envelope.
+  case class BlobsBundleData(
+      blobs: Seq[ByteString],
+      commitments: Seq[ByteString],
+      proofs: Seq[ByteString]
+  )
+  private val pendingPayloadBlobsBundle =
+    new java.util.concurrent.ConcurrentHashMap[ByteString, BlobsBundleData]()
 
   /** Blocks that returned INVALID via newPayload. Maps blockHash → latestValidHash. forkchoiceUpdated should not accept
     * these as head. Children of invalid blocks inherit the latestValidHash of their invalid parent.
@@ -432,8 +444,10 @@ class EngineApiService(
                         if (parentBaseFee - delta < 0) BigInt(0) else parentBaseFee - delta
                       }
 
-                    // Fetch pending transactions from the tx pool, filtering by chain ID
-                    val pendingTxs: Seq[SignedTransaction] =
+                    // Fetch pending transactions from the tx pool, filtering by chain ID.
+                    // Also capture the network-wrapped raw bytes for EIP-4844 blob txs so
+                    // engine_getPayloadV3 can emit them in the blobsBundle envelope.
+                    val (pendingTxs, blobTxRawBytesFromPool): (Seq[SignedTransaction], Map[ByteString, ByteString]) =
                       try {
                         import com.chipprbots.ethereum.transactions.PendingTransactionsManager._
                         val future =
@@ -451,12 +465,34 @@ class EngineApiService(
                           txChainId.forall(_ == expectedChainId)
                         }
                         if (txs.nonEmpty) log.info("Payload includes {} pending transactions", txs.size)
-                        txs
+                        (txs, response.blobTxNetworkBytes)
                       } catch {
                         case e: Exception =>
                           log.error("Failed to fetch pending txs: {}", e.getMessage)
-                          Seq.empty
+                          (Seq.empty[SignedTransaction], Map.empty[ByteString, ByteString])
                       }
+
+                    // EIP-4844 / EIP-7691: cap blob-gas included in the payload at the fork's
+                    // MAX_BLOB_GAS_PER_BLOCK (6 blobs Cancun, 9 blobs Prague). Without this cap
+                    // the proposer packs every pool blob tx into one block and getPayloadV3's
+                    // blobsBundle grows past the test's `ExpectedIncludedBlobCount`.
+                    val pendingTxsForBlock = {
+                      val maxBlobGas =
+                        if (blockchainConfig.isPragueTimestamp(attrs.timestamp))
+                          BlobGasUtils.PRAGUE_MAX_BLOB_GAS
+                        else BlobGasUtils.CANCUN_MAX_BLOB_GAS
+                      pendingTxs.foldLeft((Seq.empty[SignedTransaction], BigInt(0))) {
+                        case ((kept, blobGas), stx) =>
+                          stx.tx match {
+                            case b: com.chipprbots.ethereum.domain.BlobTransaction =>
+                              val add = BigInt(b.blobVersionedHashes.size) * BlobGasUtils.GAS_PER_BLOB
+                              if (blobGas + add <= maxBlobGas) (kept :+ stx, blobGas + add)
+                              else (kept, blobGas) // skip this blob tx, smaller ones later may still fit
+                            case _ =>
+                              (kept :+ stx, blobGas)
+                          }
+                      }._1
+                    }
 
                     val emptyWithdrawalsRoot = ByteString(
                       kec256(
@@ -546,7 +582,7 @@ class EngineApiService(
                       nonce = ByteString(new Array[Byte](8)),
                       extraFields = initialExtraFields
                     )
-                    val body = BlockBody(pendingTxs.toList, Nil, withdrawals = attrs.withdrawals)
+                    val body = BlockBody(pendingTxsForBlock.toList, Nil, withdrawals = attrs.withdrawals)
                     val skeletonBlock = Block(header, body)
 
                     // Route EVERY post-merge proposer build through executeForProposer (which
@@ -639,6 +675,12 @@ class EngineApiService(
                     if (executionRequests.nonEmpty) pendingPayloadRequests.put(id, executionRequests)
                     // Stash receipts so getPayloadV2+ can compute the blockValue envelope field.
                     if (receipts.nonEmpty) pendingPayloadReceipts.put(id, receipts)
+                    // EIP-4844: collect the blob sidecars for every blob tx in the built payload
+                    // so engine_getPayloadV3 can emit the blobsBundle envelope. Without this the
+                    // envelope has empty arrays while the payload body has blob txs; the hive
+                    // engine-cancun VerifyBlobBundle step fails with "expected N blob, got 0".
+                    val bundle = buildBlobsBundle(payload.body.transactionList, blobTxRawBytesFromPool)
+                    if (bundle.blobs.nonEmpty) pendingPayloadBlobsBundle.put(id, bundle)
                     log.info(
                       "Built payload {} for block {} (baseFee={}, parent={}, fork={}, requests={})",
                       id.toArray.map("%02x".format(_)).mkString,
@@ -696,6 +738,49 @@ class EngineApiService(
     */
   def getPayloadReceipts(payloadId: ByteString): Seq[com.chipprbots.ethereum.domain.Receipt] =
     Option(pendingPayloadReceipts.get(payloadId)).getOrElse(Nil)
+
+  /** EIP-4844 sidecars for the blob txs included in this payload, for engine_getPayloadV3's
+    * blobsBundle envelope. Empty when the payload has no blob txs.
+    */
+  def getPayloadBlobsBundle(payloadId: ByteString): BlobsBundleData =
+    Option(pendingPayloadBlobsBundle.get(payloadId)).getOrElse(BlobsBundleData(Nil, Nil, Nil))
+
+  /** Parse the EIP-4844 network-wrapped raw bytes (`0x03 || rlp([tx_payload, blobs, commitments,
+    * proofs])`) the pool captured for each blob tx, and return the concatenated sidecars for
+    * every blob tx actually included in the built payload, in payload order.
+    */
+  private def buildBlobsBundle(
+      txs: Seq[SignedTransaction],
+      blobTxRawBytes: Map[ByteString, ByteString]
+  ): BlobsBundleData = {
+    import com.chipprbots.ethereum.rlp.{rawDecode, RLPList, RLPValue}
+    val blobTxHashes = txs.collect {
+      case stx if stx.tx.isInstanceOf[com.chipprbots.ethereum.domain.BlobTransaction] => stx.hash
+    }
+    val allBlobs = Seq.newBuilder[ByteString]
+    val allCommitments = Seq.newBuilder[ByteString]
+    val allProofs = Seq.newBuilder[ByteString]
+    blobTxHashes.foreach { h =>
+      blobTxRawBytes.get(h) match {
+        case Some(raw) if raw.length > 1 && raw(0) == 0x03 =>
+          try {
+            rawDecode(raw.toArray.drop(1)) match {
+              case RLPList(_, blobs: RLPList, commitments: RLPList, proofs: RLPList) =>
+                blobs.items.foreach { case RLPValue(b) => allBlobs += ByteString(b); case _ => }
+                commitments.items.foreach { case RLPValue(c) => allCommitments += ByteString(c); case _ => }
+                proofs.items.foreach { case RLPValue(p) => allProofs += ByteString(p); case _ => }
+              case _ =>
+                log.warn("Blob tx {} sidecar RLP shape unexpected; skipping", h.toArray.map("%02x".format(_)).mkString)
+            }
+          } catch {
+            case e: Exception =>
+              log.warn("Failed to decode blob tx {} sidecar: {}", h.toArray.map("%02x".format(_)).mkString, e.getMessage)
+          }
+        case _ => // tx from network / historical — we didn't store a sidecar
+      }
+    }
+    BlobsBundleData(allBlobs.result(), allCommitments.result(), allProofs.result())
+  }
 
   /** engine_exchangeCapabilities — return supported Engine API methods. */
   def exchangeCapabilities(clCapabilities: Seq[String]): IO[Seq[String]] = IO {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -424,8 +424,20 @@ class EngineApiService(
       val finalizedHash = forkChoiceState.finalizedBlockHash
       val safeUnknown = safeHash != zeroHash && blockchainReader.getBlockHeaderByHash(safeHash).isEmpty
       val finalizedUnknown = finalizedHash != zeroHash && blockchainReader.getBlockHeaderByHash(finalizedHash).isEmpty
+      // Head-known-but-unvalidated: the block was stored optimistically (storeBlockByHashOnly,
+      // no receipts, no canonical number mapping) because its parent chain isn't traceable.
+      // In this state we're still syncing, so ALL status flavors — including safe/finalized
+      // unknown — should yield SYNCING, not -38002. Hive's 'Invalid NewPayload, *VersionedHashes,
+      // Syncing=True' tests rely on this.
+      val headOptimistic =
+        blockExistsByHash && !blockFullyStored && !isGenesis &&
+          blockchainReader.getReceiptsByHash(forkChoiceState.headBlockHash).isEmpty
+
       if (!blockExistsByHash && !isGenesis) {
         // Head unknown — client is still syncing to this head
+        EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
+        Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
+      } else if (headOptimistic) {
         EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
         Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
       } else if (safeUnknown || finalizedUnknown) {
@@ -438,14 +450,6 @@ class EngineApiService(
       } else if (headHeader.isDefined && !isAncestorOrEqual(finalizedHash, forkChoiceState.headBlockHash, zeroHash)) {
         EngineApiMetrics.recordForkchoiceUpdated("INVALID")
         Left("invalid forkchoice state: finalized block is not an ancestor of head")
-      } else if (
-        blockExistsByHash && !blockFullyStored && !isGenesis &&
-        // executed sidechains have receipts stored; parent-unknown ACCEPTED blocks do not.
-        blockchainReader.getReceiptsByHash(forkChoiceState.headBlockHash).isEmpty
-      ) {
-        // Block stored by hash only AND never executed (parent unknown ACCEPTED) — not fully validated
-        EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
-        Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
       } else {
 
         // Validate payload attributes BEFORE applying forkchoice. Per Engine API spec +

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -288,14 +288,11 @@ class EngineApiService(
                   if (extendsCanonical) blockchainWriter.storeBlock(block).commit()
                   else blockchainWriter.storeBlockByHashOnly(block).commit()
                   blockchainWriter.storeReceipts(block.header.hash, receipts).commit()
-                  // Remove applied txs from the pending pool. Without this, the next proposer-mode
-                  // build (engine_forkchoiceUpdated + attrs → getPayload) re-includes the same txs,
-                  // and their nonces collide with the now-canonical state — every EmptyTxs=False
-                  // hive test ends up with NONCE_MISMATCH_TOO_LOW instead of the expected field
-                  // mismatch. Mirrors what BlockImporter does on non-engine block import.
-                  if (block.body.transactionList.nonEmpty && pendingTransactionsManager != null)
-                    pendingTransactionsManager ! com.chipprbots.ethereum.transactions.PendingTransactionsManager
-                      .RemoveTransactions(block.body.transactionList)
+                  // NB: do NOT remove txs from the pool here. A newPayload'd block is stored
+                  // but not yet canonical (no FCU has advanced bestBlock); the same txs must
+                  // remain available for an alternative sibling payload on the same parent
+                  // (hive 'Sidechain Reorg' test). Pool removal happens in forkchoiceUpdated
+                  // once the block is promoted.
                   System.err.println(
                     s"[ENGINE-API] newPayload #${payload.blockNumber}: EXECUTED OK " +
                       s"(${block.body.numberOfTxs} txs, sidechain=${!extendsCanonical}, " +
@@ -458,7 +455,17 @@ class EngineApiService(
             Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
 
           case Right(()) =>
-            // Ancestry already validated above; proceed with payload attributes check
+            // Ancestry already validated above. FCU has now advanced best-block; purge the
+            // head block's txs from the mempool so the next proposer build doesn't re-queue
+            // them (would otherwise cause NONCE_MISMATCH_TOO_LOW). Walks back from head to
+            // the prior best to cover multi-block forkchoice jumps.
+            if (pendingTransactionsManager != null) {
+              blockchainReader.getBlockByHash(forkChoiceState.headBlockHash).foreach { headBlock =>
+                if (headBlock.body.transactionList.nonEmpty)
+                  pendingTransactionsManager ! com.chipprbots.ethereum.transactions.PendingTransactionsManager
+                    .RemoveTransactions(headBlock.body.transactionList)
+              }
+            }
 
             // Validate payload attributes if present. Per Engine API spec, invalid payload
             // attributes (zero or parent-relative timestamp) yield JSON-RPC -38003, NOT a

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -141,12 +141,31 @@ class EngineApiService(
           } else None
         }
       }
-      if (headerInvalid.isDefined) {
+      // EIP-4844 (newPayloadV3): the CL declares which versioned hashes it expects this
+      // payload to carry. Derive our own ordered list from the payload's blob txs and
+      // compare. Mismatch ⇒ INVALID (same response shape as an INCORRECT_* header error).
+      val versionedHashesInvalid: Option[String] = payload.expectedBlobVersionedHashes.flatMap { expected =>
+        val payloadHashes: Seq[ByteString] =
+          block.body.transactionList.flatMap {
+            case stx if stx.tx.isInstanceOf[com.chipprbots.ethereum.domain.BlobTransaction] =>
+              stx.tx.asInstanceOf[com.chipprbots.ethereum.domain.BlobTransaction].blobVersionedHashes
+            case _ => Nil
+          }
+        if (expected == payloadHashes) None
+        else
+          Some(
+            s"INVALID_VERSIONED_HASHES: expected ${expected.length} got ${payloadHashes.length} (first mismatch at index " +
+              expected.zip(payloadHashes).indexWhere { case (e, p) => e != p } + ")"
+          )
+      }
+
+      val preExecError = headerInvalid.orElse(versionedHashesInvalid)
+      if (preExecError.isDefined) {
         val latestValid = parentHeader.map(_.hash).getOrElse(zeroHash)
         invalidBlocks.put(payload.blockHash, latestValid)
         blockchainWriter.removeBlockByHash(payload.blockHash).commit()
         EngineApiMetrics.recordNewPayload("INVALID", payload.blockNumber.toLong, payload.timestamp)
-        PayloadStatusV1(Invalid, latestValidHash = Some(latestValid), validationError = Some(headerInvalid.get))
+        PayloadStatusV1(Invalid, latestValidHash = Some(latestValid), validationError = Some(preExecError.get))
       } else {
 
         // Tracks the tx-level reason for an execution failure so we can surface it in

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -117,7 +117,12 @@ class EngineApiService(
       // the engine MUST return INVALID (not INVALID_BLOCK_HASH). V1 accepts either; returning
       // INVALID universally is compliant with all versions. latestValidHash must be null —
       // the corruption is in the payload itself, not attributable to any specific ancestor.
-      blockchainWriter.removeBlockByHash(payload.blockHash).commit()
+      //
+      // Do NOT call removeBlockByHash here: payload.blockHash can collide with a legitimate
+      // block (the hive "ParentHash equals BlockHash on NewPayload" test sets blockHash =
+      // parentHash, which is the real parent's hash). Removing it would delete the parent.
+      // We never stored anything under payload.blockHash in this call, so there is nothing
+      // safe and correct to remove.
       PayloadStatusV1(Invalid, latestValidHash = None, validationError = Some("block hash mismatch"))
     } else if ({
       // EIP-4844 versioned-hash check must run BEFORE the "already stored" dedup. The hive
@@ -236,7 +241,17 @@ class EngineApiService(
         // PayloadStatus.validationError (for EEST exception mapping, e.g.
         // INSUFFICIENT_ACCOUNT_FUNDS, NONCE_MISMATCH_TOO_LOW).
         val executionErrorReason = new java.util.concurrent.atomic.AtomicReference[Option[String]](None)
-        val executionResult = if (parentKnown) {
+
+        // Parent is "validated" iff it's canonical (has a number→hash mapping to itself) or
+        // it's a known sidechain that we executed (has receipts stored). A parent we only
+        // know by hash (via storeBlockByHashOnly, i.e. optimistic accept with unknown grand-
+        // parent) has unverified ancestry, and a child built on it must NOT be claimed as
+        // VALID — hive's "Invalid NewPayload, ParentHash" test expects ACCEPTED/SYNCING.
+        val parentValidated = parentHeader.exists { p =>
+          blockchainReader.getBlockHeaderByNumber(p.number).exists(_.hash == p.hash) ||
+          blockchainReader.getReceiptsByHash(p.hash).isDefined
+        }
+        val executionResult = if (parentKnown && parentValidated) {
           try
             blockExecution.executeAndValidateBlockFull(block, alreadyValidated = true) match {
               case Right((receipts, derivedRequests)) =>
@@ -341,8 +356,9 @@ class EngineApiService(
             )
 
           case None =>
-            // Parent unknown — store block BY HASH ONLY (not by number) so it doesn't
-            // appear in eth_getBlockByNumber but can be deduped by hash.
+            // Parent unknown OR parent known but unvalidated (optimistic chain). Store by
+            // hash only so the block doesn't appear in eth_getBlockByNumber / eth_getBlock-
+            // ByHash, but can be deduped and retroactively invalidated later.
             blockchainWriter.storeBlockByHashOnly(block).commit()
             // Record parent→child so that if the (still-unknown) ancestor chain is later
             // revealed as INVALID, we can retroactively invalidate this block too. Required

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -141,10 +141,13 @@ class EngineApiService(
       }
     }) {
       // VersionedHashes mismatch: INVALID per EIP-4844 with latestValidHash=parent.hash.
-      // Record in invalidBlocks so a subsequent forkchoiceUpdated(head=this) short-circuits
-      // to INVALID (preventing the "unknown safe block hash" detour).
+      // Do NOT add to invalidBlocks — the mismatch is between the CL-supplied
+      // `expectedBlobVersionedHashes` argument and the payload's actual blob txs, not a
+      // property of the block itself. A later newPayload call with the SAME blockHash but
+      // matching versioned hashes must be accepted as VALID (hive 'Invalid NewPayload,
+      // VersionedHashes, Syncing=True' sends exactly that pattern and then expects FCU to
+      // return VALID, not 'head block was previously invalidated').
       val lvh = blockchainReader.getBlockHeaderByHash(payload.parentHash).map(_.hash).getOrElse(zeroHash)
-      markInvalidRecursive(payload.blockHash, lvh)
       PayloadStatusV1(Invalid, latestValidHash = Some(lvh), validationError = Some("INVALID_VERSIONED_HASHES"))
     } else if (
       blockchainReader.getBlockHeaderByHash(payload.blockHash).exists { h =>

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -112,24 +112,12 @@ class EngineApiService(
         s"[ENGINE-API] newPayload #${payload.blockNumber}: block-hash mismatch " +
           s"computed=${block.header.hashAsHexString} payload=${com.chipprbots.ethereum.utils.ByteStringUtils.hash2string(payload.blockHash)}"
       )
-      // Per EIP-3675: INVALID_BLOCK_HASH is only appropriate when we cannot attribute the
-      // corruption to a known-valid ancestor. If the parent IS known, the hive framework
-      // expects INVALID with latestValidHash = parent.hash (not null), because the corruption
-      // is diagnostically about THIS block, not about whether we have ancestors at all.
-      val parentOpt = blockchainReader.getBlockHeaderByHash(payload.parentHash)
+      // Per engine-API spec + hive tests: hash mismatch always returns INVALID_BLOCK_HASH
+      // with latestValidHash = null. The block hash check is a structural / integrity
+      // check — we cannot attribute the error to a specific ancestor because the payload
+      // itself is corrupted. Do NOT store the block and do NOT surface a parent.hash.
       blockchainWriter.removeBlockByHash(payload.blockHash).commit()
-      parentOpt match {
-        case Some(parent) =>
-          markInvalidRecursive(payload.blockHash, parent.hash)
-          PayloadStatusV1(
-            Invalid,
-            latestValidHash = Some(parent.hash),
-            validationError = Some("block hash mismatch")
-          )
-        case None =>
-          markInvalidRecursive(payload.blockHash, zeroHash)
-          PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
-      }
+      PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
     } else if ({
       // EIP-4844 versioned-hash check must run BEFORE the "already stored" dedup. The hive
       // "NewPayloadV3 Versioned Hashes, Non-Empty Hashes" tests call newPayloadV3 twice for

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -112,12 +112,13 @@ class EngineApiService(
         s"[ENGINE-API] newPayload #${payload.blockNumber}: block-hash mismatch " +
           s"computed=${block.header.hashAsHexString} payload=${com.chipprbots.ethereum.utils.ByteStringUtils.hash2string(payload.blockHash)}"
       )
-      // Per engine-API spec + hive tests: hash mismatch always returns INVALID_BLOCK_HASH
-      // with latestValidHash = null. The block hash check is a structural / integrity
-      // check — we cannot attribute the error to a specific ancestor because the payload
-      // itself is corrupted. Do NOT store the block and do NOT surface a parent.hash.
+      // Hash mismatch: integrity error of the payload envelope. Per execution-apis PR #338
+      // (https://github.com/ethereum/execution-apis/pull/338), starting from Shanghai (V2+)
+      // the engine MUST return INVALID (not INVALID_BLOCK_HASH). V1 accepts either; returning
+      // INVALID universally is compliant with all versions. latestValidHash must be null —
+      // the corruption is in the payload itself, not attributable to any specific ancestor.
       blockchainWriter.removeBlockByHash(payload.blockHash).commit()
-      PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
+      PayloadStatusV1(Invalid, latestValidHash = None, validationError = Some("block hash mismatch"))
     } else if ({
       // EIP-4844 versioned-hash check must run BEFORE the "already stored" dedup. The hive
       // "NewPayloadV3 Versioned Hashes, Non-Empty Hashes" tests call newPayloadV3 twice for

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -528,31 +528,27 @@ class EngineApiService(
                     val body = BlockBody(pendingTxs.toList, Nil, withdrawals = attrs.withdrawals)
                     val skeletonBlock = Block(header, body)
 
-                    // Execute full Prague flow (preambles + txs + withdrawals + system calls + deposit collection).
-                    // Fall back to BlockPreparator.prepareBlock (tx-only) for pre-Prague so we don't
-                    // needlessly touch the Prague system contracts.
+                    // Route EVERY post-merge proposer build through executeForProposer (which
+                    // goes through BlockExecution.executeBlock — txs, payBlockReward, withdrawals
+                    // via processWithdrawals, Prague system calls, then persistState).
+                    // The previous `if (isPrague) …  else BlockPreparator.prepareBlock` branch
+                    // was broken for Shanghai/Cancun: BlockPreparator.prepareBlock does NOT call
+                    // processWithdrawals, so the proposer-built header contained a stateRoot that
+                    // did not reflect the withdrawals — every withdrawals hive test came back with
+                    // "Block has invalid state root hash" on its own payload round-trip.
+                    // executeBlock early-returns cleanly on pre-Prague (processPragueSystemCalls
+                    // is a no-op outside Prague), so there's nothing to lose by using it always.
                     import com.chipprbots.ethereum.consensus.validators.std.MptListValidator.intByteArraySerializable
                     import com.chipprbots.ethereum.ledger.BloomFilter
                     import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
                     import com.chipprbots.ethereum.domain.Receipt
                     val (receipts, gasUsedTotal, finalStateRoot, executionRequests) =
-                      if (isPrague) {
-                        blockExecution.executeForProposer(skeletonBlock) match {
-                          case Right(result) =>
-                            (result.receipts, result.gasUsed, result.worldState.stateRootHash, result.executionRequests)
-                          case Left(err) =>
-                            log.error("Proposer-mode Prague execution failed: {}", err)
-                            (Seq.empty[Receipt], BigInt(0), parent.header.stateRoot, Seq.empty[ByteString])
-                        }
-                      } else {
-                        val prepared = mining.blockPreparator
-                          .prepareBlock(evmCodeStorage, skeletonBlock, parent.header, None)
-                        (
-                          prepared.blockResult.receipts,
-                          prepared.blockResult.gasUsed,
-                          prepared.stateRootHash,
-                          Seq.empty[ByteString]
-                        )
+                      blockExecution.executeForProposer(skeletonBlock) match {
+                        case Right(result) =>
+                          (result.receipts, result.gasUsed, result.worldState.stateRootHash, result.executionRequests)
+                        case Left(err) =>
+                          log.error("Proposer-mode execution failed: {}", err)
+                          (Seq.empty[Receipt], BigInt(0), parent.header.stateRoot, Seq.empty[ByteString])
                       }
 
                     val receiptsLogs = BloomFilter.EmptyBloomFilter.toArray +: receipts.map(_.logsBloomFilter.toArray)
@@ -654,7 +650,11 @@ class EngineApiService(
 
   /** engine_getPayloadV1/V2/V3/V4 — Return a previously built payload by ID. */
   def getPayload(payloadId: ByteString): IO[Either[String, Block]] = IO {
-    Option(pendingPayloads.remove(payloadId)) match {
+    // Do NOT remove: the engine-api spec allows the CL to call getPayload multiple times for
+    // the same id (e.g. first getPayloadV1 then getPayloadV2 for the same payload, as the
+    // hive engine-withdrawals "Withdrawals Fork on Block N" tests do). Removing on the first
+    // read makes any follow-up call fail with "Payload not available".
+    Option(pendingPayloads.get(payloadId)) match {
       case Some(block) => Right(block)
       case None        => Left("Payload not available")
     }

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -141,7 +141,10 @@ class EngineApiService(
       }
     }) {
       // VersionedHashes mismatch: INVALID per EIP-4844 with latestValidHash=parent.hash.
+      // Record in invalidBlocks so a subsequent forkchoiceUpdated(head=this) short-circuits
+      // to INVALID (preventing the "unknown safe block hash" detour).
       val lvh = blockchainReader.getBlockHeaderByHash(payload.parentHash).map(_.hash).getOrElse(zeroHash)
+      markInvalidRecursive(payload.blockHash, lvh)
       PayloadStatusV1(Invalid, latestValidHash = Some(lvh), validationError = Some("INVALID_VERSIONED_HASHES"))
     } else if (
       blockchainReader.getBlockHeaderByHash(payload.blockHash).exists { h =>
@@ -415,14 +418,20 @@ class EngineApiService(
         .map(_.hash)
         .getOrElse(ByteString.empty)
 
-      // Validate safe/finalized hashes FIRST, before any SYNCING shortcut.
-      // Per Engine API spec 5.4: safeBlockHash and finalizedBlockHash must be ancestors of headBlockHash.
-      // If either is unknown or not an ancestor → -38002 invalid forkchoice state.
+      // Per Engine API spec 5.4 + hive "In-Order Consecutive Payload Execution": if the
+      // head itself is unknown, return SYNCING first — we can't meaningfully validate
+      // safe/finalized ancestry against a head we don't have. The safe/finalized unknown
+      // checks are only -38002 errors once we KNOW the head; otherwise the CL is still
+      // driving us to sync and the correct response is SYNCING.
       val safeHash = forkChoiceState.safeBlockHash
       val finalizedHash = forkChoiceState.finalizedBlockHash
       val safeUnknown = safeHash != zeroHash && blockchainReader.getBlockHeaderByHash(safeHash).isEmpty
       val finalizedUnknown = finalizedHash != zeroHash && blockchainReader.getBlockHeaderByHash(finalizedHash).isEmpty
-      if (safeUnknown || finalizedUnknown) {
+      if (!blockExistsByHash && !isGenesis) {
+        // Head unknown — client is still syncing to this head
+        EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
+        Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
+      } else if (safeUnknown || finalizedUnknown) {
         val msg = if (safeUnknown) "unknown safe block hash" else "unknown finalized block hash"
         EngineApiMetrics.recordForkchoiceUpdated("INVALID")
         Left(msg)

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -67,7 +67,30 @@ class EngineApiService(
     * these as head. Children of invalid blocks inherit the latestValidHash of their invalid parent.
     */
   private val invalidBlocks = new java.util.concurrent.ConcurrentHashMap[ByteString, ByteString]()
+  // Index of optimistically-accepted (by-hash-only) blocks, keyed by parentHash → set of child
+  // hashes. Used to recursively invalidate descendants when an ancestor is later revealed as
+  // INVALID. The hive "Invalid Missing Ancestor Syncing ReOrg" family (24 tests) hangs without
+  // this because the test waits up to its internal timeout for our client to detect the invalid
+  // chain through an optimistically-accepted descendant.
+  private val acceptedChildrenByParent =
+    new java.util.concurrent.ConcurrentHashMap[ByteString, java.util.Set[ByteString]]()
   private val zeroHash = ByteString(new Array[Byte](32))
+
+  /** Mark `hash` as INVALID and recursively invalidate every optimistically-accepted descendant.
+    * All descendants inherit the same `latestValidHash`.
+    */
+  private def markInvalidRecursive(hash: ByteString, lvh: ByteString): Unit = {
+    invalidBlocks.put(hash, lvh)
+    val children = Option(acceptedChildrenByParent.remove(hash))
+    children.foreach { set =>
+      val iter = set.iterator()
+      while (iter.hasNext) {
+        val child = iter.next()
+        blockchainWriter.removeBlockByHash(child).commit()
+        markInvalidRecursive(child, lvh)
+      }
+    }
+  }
 
   /** Return the latest block number from the blockchain storage. */
   def getLatestBlockNumber: BigInt =
@@ -97,16 +120,35 @@ class EngineApiService(
       blockchainWriter.removeBlockByHash(payload.blockHash).commit()
       parentOpt match {
         case Some(parent) =>
-          invalidBlocks.put(payload.blockHash, parent.hash)
+          markInvalidRecursive(payload.blockHash, parent.hash)
           PayloadStatusV1(
             Invalid,
             latestValidHash = Some(parent.hash),
             validationError = Some("block hash mismatch")
           )
         case None =>
-          invalidBlocks.put(payload.blockHash, zeroHash)
+          markInvalidRecursive(payload.blockHash, zeroHash)
           PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
       }
+    } else if ({
+      // EIP-4844 versioned-hash check must run BEFORE the "already stored" dedup. The hive
+      // "NewPayloadV3 Versioned Hashes, Non-Empty Hashes" tests call newPayloadV3 twice for
+      // the same payload — once with matching hashes (expected VALID, block gets stored),
+      // and again with tampered hashes (expected INVALID). Without this early check the
+      // tampered second call hits the dedup branch and silently returns VALID.
+      payload.expectedBlobVersionedHashes.exists { expected =>
+        val payloadHashes: Seq[ByteString] =
+          block.body.transactionList.flatMap {
+            case stx if stx.tx.isInstanceOf[com.chipprbots.ethereum.domain.BlobTransaction] =>
+              stx.tx.asInstanceOf[com.chipprbots.ethereum.domain.BlobTransaction].blobVersionedHashes
+            case _ => Nil
+          }
+        expected != payloadHashes
+      }
+    }) {
+      // VersionedHashes mismatch: INVALID per EIP-4844 with latestValidHash=parent.hash.
+      val lvh = blockchainReader.getBlockHeaderByHash(payload.parentHash).map(_.hash).getOrElse(zeroHash)
+      PayloadStatusV1(Invalid, latestValidHash = Some(lvh), validationError = Some("INVALID_VERSIONED_HASHES"))
     } else if (
       blockchainReader.getBlockHeaderByHash(payload.blockHash).exists { h =>
         blockchainReader.getBlockHeaderByNumber(h.number).exists(_.hash == payload.blockHash)
@@ -118,8 +160,8 @@ class EngineApiService(
       // Parent was previously marked INVALID — child inherits invalidity.
       // Propagate the parent's latestValidHash (the last valid ancestor).
       val propagatedLvh = invalidBlocks.get(payload.parentHash) // non-null: containsKey guard
-      invalidBlocks.put(payload.blockHash, propagatedLvh)
       blockchainWriter.removeBlockByHash(payload.blockHash).commit()
+      markInvalidRecursive(payload.blockHash, propagatedLvh)
       EngineApiMetrics.recordNewPayload("INVALID", payload.blockNumber.toLong, payload.timestamp)
       PayloadStatusV1(
         Invalid,
@@ -195,8 +237,8 @@ class EngineApiService(
       val preExecError = headerInvalid.orElse(versionedHashesInvalid)
       if (preExecError.isDefined) {
         val latestValid = parentHeader.map(_.hash).getOrElse(zeroHash)
-        invalidBlocks.put(payload.blockHash, latestValid)
         blockchainWriter.removeBlockByHash(payload.blockHash).commit()
+        markInvalidRecursive(payload.blockHash, latestValid)
         EngineApiMetrics.recordNewPayload("INVALID", payload.blockNumber.toLong, payload.timestamp)
         PayloadStatusV1(Invalid, latestValidHash = Some(latestValid), validationError = Some(preExecError.get))
       } else {
@@ -218,8 +260,8 @@ class EngineApiService(
                     suppliedRequests != derivedRequests
                 if (requestsMismatch) {
                   val lvh = parentHeader.map(_.hash).getOrElse(zeroHash)
-                  invalidBlocks.put(payload.blockHash, lvh)
                   blockchainWriter.removeBlockByHash(payload.blockHash).commit()
+                  markInvalidRecursive(payload.blockHash, lvh)
                   executionErrorReason.set(
                     Some(
                       s"INVALID_REQUESTS: executionRequests mismatch " +
@@ -267,8 +309,8 @@ class EngineApiService(
                   case _ =>
                     // Genuine validation failure (wrong stateRoot, gasUsed, receipts, etc.)
                     val lvh = parentHeader.map(_.hash).getOrElse(zeroHash)
-                    invalidBlocks.put(payload.blockHash, lvh)
                     blockchainWriter.removeBlockByHash(payload.blockHash).commit()
+                    markInvalidRecursive(payload.blockHash, lvh)
                     executionErrorReason.set(Some(error.reason.toString))
                     System.err.println(
                       s"[ENGINE-API] newPayload #${payload.blockNumber}: INVALID: ${error.reason}"
@@ -313,6 +355,13 @@ class EngineApiService(
             // Parent unknown — store block BY HASH ONLY (not by number) so it doesn't
             // appear in eth_getBlockByNumber but can be deduped by hash.
             blockchainWriter.storeBlockByHashOnly(block).commit()
+            // Record parent→child so that if the (still-unknown) ancestor chain is later
+            // revealed as INVALID, we can retroactively invalidate this block too. Required
+            // by hive's "Invalid Missing Ancestor Syncing ReOrg" tests.
+            acceptedChildrenByParent.computeIfAbsent(
+              payload.parentHash,
+              _ => java.util.concurrent.ConcurrentHashMap.newKeySet[ByteString]()
+            ).add(payload.blockHash)
             System.err.println(
               s"[ENGINE-API] newPayload #${payload.blockNumber}: ACCEPTED (parent unknown)"
             )

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -448,17 +448,34 @@ class EngineApiService(
         Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
       } else {
 
-        forkChoiceManager.applyForkChoiceState(forkChoiceState) match {
+        // Validate payload attributes BEFORE applying forkchoice. Per Engine API spec +
+        // hive 'Invalid PayloadAttributes' test: when we reject the FCU with -38003, the
+        // forkchoice state must NOT be applied (HeaderByNumber should still reflect the
+        // prior head). Moving the attrs-check above applyForkChoiceState keeps that
+        // invariant.
+        val invalidAttrsMsg: Option[String] = payloadAttributes.flatMap { attrs =>
+          if (attrs.timestamp == 0) Some("invalid payload attributes: zero timestamp")
+          else {
+            blockchainReader.getBlockHeaderByHash(forkChoiceState.headBlockHash).flatMap { parent =>
+              if (attrs.timestamp <= parent.unixTimestamp)
+                Some("invalid payload attributes: timestamp too low")
+              else None
+            }
+          }
+        }
+        if (invalidAttrsMsg.isDefined) {
+          EngineApiMetrics.recordForkchoiceUpdated("INVALID")
+          Left("ATTR:" + invalidAttrsMsg.get)
+        } else forkChoiceManager.applyForkChoiceState(forkChoiceState) match {
           case Left(_) =>
             // Head not known — return SYNCING so CL knows we need newPayload
             EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
             Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
 
           case Right(()) =>
-            // Ancestry already validated above. FCU has now advanced best-block; purge the
-            // head block's txs from the mempool so the next proposer build doesn't re-queue
-            // them (would otherwise cause NONCE_MISMATCH_TOO_LOW). Walks back from head to
-            // the prior best to cover multi-block forkchoice jumps.
+            // FCU has advanced best-block; purge the head block's txs from the mempool
+            // so the next proposer build doesn't re-queue them (would cause
+            // NONCE_MISMATCH_TOO_LOW).
             if (pendingTransactionsManager != null) {
               blockchainReader.getBlockByHash(forkChoiceState.headBlockHash).foreach { headBlock =>
                 if (headBlock.body.transactionList.nonEmpty)
@@ -467,24 +484,7 @@ class EngineApiService(
               }
             }
 
-            // Validate payload attributes if present. Per Engine API spec, invalid payload
-            // attributes (zero or parent-relative timestamp) yield JSON-RPC -38003, NOT a
-            // PayloadStatus.INVALID. We tunnel the condition up via Left with a marker prefix
-            // so the controller can map it to the correct error code.
-            val invalidAttrsMsg: Option[String] = payloadAttributes.flatMap { attrs =>
-              if (attrs.timestamp == 0) Some("invalid payload attributes: zero timestamp")
-              else {
-                blockchainReader.getBlockHeaderByHash(forkChoiceState.headBlockHash).flatMap { parent =>
-                  if (attrs.timestamp <= parent.unixTimestamp)
-                    Some("invalid payload attributes: timestamp too low")
-                  else None
-                }
-              }
-            }
-            if (invalidAttrsMsg.isDefined) {
-              EngineApiMetrics.recordForkchoiceUpdated("INVALID")
-              Left("ATTR:" + invalidAttrsMsg.get)
-            } else {
+            {
 
               val payloadId = payloadAttributes.map { attrs =>
                 // Deterministic payload ID MUST be unique for every distinct attribute

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -44,6 +44,12 @@ class EngineApiService(
   // EIP-7685 executionRequests associated with each payloadId, returned by getPayloadV4.
   private val pendingPayloadRequests =
     new java.util.concurrent.ConcurrentHashMap[ByteString, Seq[ByteString]]()
+  // Receipts produced while building each payload. Used by engine_getPayloadV2+ to compute the
+  // `blockValue` field (sum of priority-fee revenue) per EIP-3675 V2 envelope spec. Without this
+  // the envelope returns blockValue=0x0 and the hive engine-withdrawals "GetPayloadV2 Block
+  // Value" test fails with want=N, got=0.
+  private val pendingPayloadReceipts =
+    new java.util.concurrent.ConcurrentHashMap[ByteString, Seq[com.chipprbots.ethereum.domain.Receipt]]()
 
   /** Blocks that returned INVALID via newPayload. Maps blockHash → latestValidHash. forkchoiceUpdated should not accept
     * these as head. Children of invalid blocks inherit the latestValidHash of their invalid parent.
@@ -68,12 +74,27 @@ class EngineApiService(
 
     if (block.header.hash != payload.blockHash) {
       System.err.println(
-        s"[ENGINE-API] newPayload #${payload.blockNumber}: INVALID_BLOCK_HASH " +
+        s"[ENGINE-API] newPayload #${payload.blockNumber}: block-hash mismatch " +
           s"computed=${block.header.hashAsHexString} payload=${com.chipprbots.ethereum.utils.ByteStringUtils.hash2string(payload.blockHash)}"
       )
-      invalidBlocks.put(payload.blockHash, zeroHash)
+      // Per EIP-3675: INVALID_BLOCK_HASH is only appropriate when we cannot attribute the
+      // corruption to a known-valid ancestor. If the parent IS known, the hive framework
+      // expects INVALID with latestValidHash = parent.hash (not null), because the corruption
+      // is diagnostically about THIS block, not about whether we have ancestors at all.
+      val parentOpt = blockchainReader.getBlockHeaderByHash(payload.parentHash)
       blockchainWriter.removeBlockByHash(payload.blockHash).commit()
-      PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
+      parentOpt match {
+        case Some(parent) =>
+          invalidBlocks.put(payload.blockHash, parent.hash)
+          PayloadStatusV1(
+            Invalid,
+            latestValidHash = Some(parent.hash),
+            validationError = Some("block hash mismatch")
+          )
+        case None =>
+          invalidBlocks.put(payload.blockHash, zeroHash)
+          PayloadStatusV1(InvalidBlockHash("block hash mismatch"))
+      }
     } else if (
       blockchainReader.getBlockHeaderByHash(payload.blockHash).exists { h =>
         blockchainReader.getBlockHeaderByNumber(h.number).exists(_.hash == payload.blockHash)
@@ -616,6 +637,8 @@ class EngineApiService(
                     pendingPayloads.put(id, payload)
                     // Also stash executionRequests so getPayloadV4 can emit them.
                     if (executionRequests.nonEmpty) pendingPayloadRequests.put(id, executionRequests)
+                    // Stash receipts so getPayloadV2+ can compute the blockValue envelope field.
+                    if (receipts.nonEmpty) pendingPayloadReceipts.put(id, receipts)
                     log.info(
                       "Built payload {} for block {} (baseFee={}, parent={}, fork={}, requests={})",
                       id.toArray.map("%02x".format(_)).mkString,
@@ -666,6 +689,13 @@ class EngineApiService(
     */
   def getPayloadExecutionRequests(payloadId: ByteString): Seq[ByteString] =
     Option(pendingPayloadRequests.remove(payloadId)).getOrElse(Nil)
+
+  /** Receipts produced while building this payload. Used by engine_getPayloadV2+ to compute the
+    * `blockValue` envelope field. `get` (not `remove`) because the CL may call getPayloadV1 and
+    * then getPayloadV2 for the same id (hive withdrawals tests rely on this).
+    */
+  def getPayloadReceipts(payloadId: ByteString): Seq[com.chipprbots.ethereum.domain.Receipt] =
+    Option(pendingPayloadReceipts.get(payloadId)).getOrElse(Nil)
 
   /** engine_exchangeCapabilities — return supported Engine API methods. */
   def exchangeCapabilities(clCapabilities: Seq[String]): IO[Seq[String]] = IO {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -187,6 +187,14 @@ class EngineApiService(
                   if (extendsCanonical) blockchainWriter.storeBlock(block).commit()
                   else blockchainWriter.storeBlockByHashOnly(block).commit()
                   blockchainWriter.storeReceipts(block.header.hash, receipts).commit()
+                  // Remove applied txs from the pending pool. Without this, the next proposer-mode
+                  // build (engine_forkchoiceUpdated + attrs → getPayload) re-includes the same txs,
+                  // and their nonces collide with the now-canonical state — every EmptyTxs=False
+                  // hive test ends up with NONCE_MISMATCH_TOO_LOW instead of the expected field
+                  // mismatch. Mirrors what BlockImporter does on non-engine block import.
+                  if (block.body.transactionList.nonEmpty && pendingTransactionsManager != null)
+                    pendingTransactionsManager ! com.chipprbots.ethereum.transactions.PendingTransactionsManager
+                      .RemoveTransactions(block.body.transactionList)
                   System.err.println(
                     s"[ENGINE-API] newPayload #${payload.blockNumber}: EXECUTED OK " +
                       s"(${block.body.numberOfTxs} txs, sidechain=${!extendsCanonical}, " +

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -545,7 +545,7 @@ class EngineApiService(
                           (pendingTransactionsManager ? GetPendingTransactions).mapTo[PendingTransactionsResponse]
                         val response = Await.result(future, 3.seconds)
                         val expectedChainId = blockchainConfig.chainId
-                        val txs = response.pendingTransactions.map(_.stx.tx).filter { stx =>
+                        val filtered = response.pendingTransactions.map(_.stx.tx).filter { stx =>
                           val txChainId: Option[BigInt] = stx.tx match {
                             case t: com.chipprbots.ethereum.domain.TransactionWithAccessList => Some(t.chainId)
                             case t: com.chipprbots.ethereum.domain.TransactionWithDynamicFee => Some(t.chainId)
@@ -554,6 +554,15 @@ class EngineApiService(
                             case _ => None // legacy txs don't have explicit chainID
                           }
                           txChainId.forall(_ == expectedChainId)
+                        }
+                        // Sort by (sender, nonce) so execution processes each sender's txs
+                        // in nonce order. The pool returns them in arrival order — a blob-tx
+                        // producer like hive's NewPayloadV3 tests sends nonces N, N+1, ...,
+                        // and without this sort execution hits NONCE_MISMATCH_TOO_HIGH when
+                        // tx with nonce N+2 runs before nonce N.
+                        val txs = filtered.sortBy { stx =>
+                          val sender = SignedTransaction.getSender(stx).map(_.bytes.toArray.toSeq).getOrElse(Seq.empty)
+                          (sender, stx.tx.nonce)
                         }
                         if (txs.nonEmpty) log.info("Payload includes {} pending transactions", txs.size)
                         (txs, response.blobTxNetworkBytes)

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -423,6 +423,7 @@ class EngineApiService(
 
                     // Determine which fork is active at the proposed block's timestamp so we emit
                     // the correct HeaderExtraFields variant and header fields.
+                    val isShanghai = blockchainConfig.isShanghaiTimestamp(attrs.timestamp)
                     val isCancun = blockchainConfig.isCancunTimestamp(attrs.timestamp)
                     val isPrague = blockchainConfig.isPragueTimestamp(attrs.timestamp)
                     val withdrawals: Seq[com.chipprbots.ethereum.domain.Withdrawal] =
@@ -465,8 +466,15 @@ class EngineApiService(
                           childExcessBlobGas,
                           parentBeaconBlockRoot
                         )
-                      else
+                      else if (isShanghai)
                         HefPostShanghai(baseFee, computedWithdrawalsRoot)
+                      else
+                        // Paris (post-merge, pre-Shanghai): HefPostOlympia holds only baseFee.
+                        // Using HefPostShanghai here breaks the blockHash round-trip: getPayloadV1
+                        // returns a payload with no withdrawals field, and newPayloadV1 reconstructs
+                        // the header as HefPostOlympia — different RLP, different hash, so every
+                        // Paris payload we build fails its own newPayload round-trip.
+                        HefPostOlympia(baseFee)
 
                     // Build post-merge header with skeleton (difficulty=0 so payBlockReward skips PoW rewards)
                     val blockNumber = parent.header.number + 1

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainWriter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainWriter.scala
@@ -122,8 +122,19 @@ class BlockchainWriter(
       }
     }
     if (buf.nonEmpty) {
+      // Rewrite number→hash AND tx-location for every block on the newly canonical branch.
+      // Without the tx-location rewrite, eth_getTransactionReceipt returns the old (now
+      // sidechain) block via the stale mapping — hive's 'Transaction Re-Org, Re-Org to
+      // Different Block' checks that the receipt reflects the new canonical block.
       val batch = buf.foldLeft(blockNumberMappingStorage.emptyBatchUpdate) { case (acc, (num, hash)) =>
-        acc.and(blockNumberMappingStorage.put(num, hash))
+        val withNumberMapping = acc.and(blockNumberMappingStorage.put(num, hash))
+        reader.getBlockBodyByHash(hash) match {
+          case Some(body) =>
+            body.transactionList.zipWithIndex.foldLeft(withNumberMapping) { case (a, (tx, idx)) =>
+              a.and(transactionMappingStorage.put(tx.hash, TransactionLocation(hash, idx)))
+            }
+          case None => withNumberMapping
+        }
       }
       batch.commit()
     }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthBlocksService.scala
@@ -120,7 +120,19 @@ class EthBlocksService(
     val blockOpt = blockchainReader.getBlockByHash(blockHash).orElse(blockQueue.getBlockByHash(blockHash))
     val weight = blockchainReader.getChainWeightByHash(blockHash).orElse(blockQueue.getChainWeightByHash(blockHash))
 
-    val blockResponseOpt = blockOpt.map(block => BlockResponse(block, weight, fullTxs = fullTxs))
+    // Hide engine-API optimistic blocks (ACCEPTED with unknown parent, stored via
+    // storeBlockByHashOnly) — they skip the number→hash mapping and haven't been executed.
+    // Exposing them via eth_getBlockByHash breaks hive's "Invalid NewPayload, ParentHash" test,
+    // which expects the altered payload to NOT be queryable. A block is "exposed" if either
+    // (a) it lives at its advertised number in the canonical index, or (b) it's a known
+    // sidechain (has receipts stored, i.e. was fully executed on the fork-choice sidechain path).
+    val isExposed = blockOpt.exists { b =>
+      blockchainReader.getBlockHeaderByNumber(b.header.number).exists(_.hash == b.header.hash) ||
+      blockchainReader.getReceiptsByHash(b.header.hash).isDefined
+    }
+    val blockResponseOpt =
+      if (!isExposed) None
+      else blockOpt.map(block => BlockResponse(block, weight, fullTxs = fullTxs))
     Right(BlockByBlockHashResponse(blockResponseOpt))
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
@@ -205,10 +205,13 @@ class EthTxService(
           IO.pure(Left(JsonRpcError.InvalidRequest))
         } else {
           // EIP-3860 (Shanghai+): reject contract-creation txs whose initcode exceeds the
-          // per-EVM-config maximum. Derived from the CURRENT chain tip's fork state, so
-          // we don't admit post-Shanghai-illegal txs into the pool when we're post-Shanghai.
-          val bestNum = blockchainReader.getBestBlockNumber()
-          val evmConfig = com.chipprbots.ethereum.vm.EvmConfig.forBlock(bestNum, blockchainConfig)
+          // per-EVM-config maximum. Derived from the CURRENT chain tip's fork state. Must
+          // use the timestamp-aware forBlock variant — Shanghai activates by timestamp on
+          // post-merge chains, not block number.
+          val tip = blockchainReader.getBestBlock().map(_.header)
+          val bestNum = tip.map(_.number).getOrElse(blockchainReader.getBestBlockNumber())
+          val ts = tip.map(_.unixTimestamp).getOrElse(0L)
+          val evmConfig = com.chipprbots.ethereum.vm.EvmConfig.forBlock(bestNum, ts, blockchainConfig)
           val tx = signedTransaction.tx
           val initCodeTooLarge =
             tx.isContractInit &&

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
@@ -191,14 +191,35 @@ class EthTxService(
 
     Try(req.data.toArray.toSignedTransactionWithSidecar) match {
       case Success((signedTransaction, rawBytesOpt)) =>
-        if (SignedTransaction.getSender(signedTransaction).isDefined) {
-          pendingTransactionsManager ! PendingTransactionsManager.AddOrOverrideTransaction(
-            signedTransaction,
-            rawBytesOpt.map(org.apache.pekko.util.ByteString(_))
-          )
-          IO.pure(Right(SendRawTransactionResponse(signedTransaction.hash)))
-        } else {
+        if (SignedTransaction.getSender(signedTransaction).isEmpty) {
           IO.pure(Left(JsonRpcError.InvalidRequest))
+        } else {
+          // EIP-3860 (Shanghai+): reject contract-creation txs whose initcode exceeds the
+          // per-EVM-config maximum. Derived from the CURRENT chain tip's fork state, so
+          // we don't admit post-Shanghai-illegal txs into the pool when we're post-Shanghai.
+          val bestNum = blockchainReader.getBestBlockNumber()
+          val evmConfig = com.chipprbots.ethereum.vm.EvmConfig.forBlock(bestNum, blockchainConfig)
+          val tx = signedTransaction.tx
+          val initCodeTooLarge =
+            tx.isContractInit &&
+              evmConfig.eip3860Enabled &&
+              evmConfig.maxInitCodeSize.exists(max => tx.payload.size > max)
+          if (initCodeTooLarge) {
+            IO.pure(
+              Left(
+                JsonRpcError.InvalidParams(
+                  s"INITCODE_SIZE_EXCEEDED: initcode size ${tx.payload.size} exceeds max " +
+                    s"${evmConfig.maxInitCodeSize.getOrElse(BigInt(0))}"
+                )
+              )
+            )
+          } else {
+            pendingTransactionsManager ! PendingTransactionsManager.AddOrOverrideTransaction(
+              signedTransaction,
+              rawBytesOpt.map(org.apache.pekko.util.ByteString(_))
+            )
+            IO.pure(Right(SendRawTransactionResponse(signedTransaction.hash)))
+          }
         }
       case Failure(_) =>
         IO.pure(Left(JsonRpcError.InvalidRequest))

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
@@ -117,6 +117,16 @@ class EthTxService(
       val result: Option[TransactionReceiptResponse] = for {
         TransactionLocation(blockHash, txIndex) <- transactionMappingStorage.get(req.txHash)
         Block(header, body) <- blockchainReader.getBlockByHash(blockHash)
+        // Only surface receipts for CANONICAL transactions. Under engine-API, a block
+        // may be stored (with receipts + tx-location mapping) immediately after newPayload
+        // but not promoted to canonical until a subsequent forkchoiceUpdated — hive's
+        // 'Transaction Re-Org' test expects eth_getTransactionReceipt to return nil
+        // in that window. Require BOTH (a) the block lives at its number in the canonical
+        // index, AND (b) its number is <= the client's best-block pointer (i.e. FCU has
+        // advanced past it). (a) alone is true right after newPayload's storeBlock but
+        // (b) flips only when the subsequent FCU updates saveBestKnownBlocks.
+        _ <- blockchainReader.getBlockHeaderByNumber(header.number).filter(_.hash == blockHash)
+        bestNum = blockchainReader.getBestBlockNumber() if header.number <= bestNum
         stx <- body.transactionList.lift(txIndex)
         receipts <- blockchainReader.getReceiptsByHash(blockHash)
         receipt: Receipt <- receipts.lift(txIndex)

--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockExecution.scala
@@ -130,17 +130,26 @@ class BlockExecution(
 
   protected def buildInitialWorld(block: Block, parentHeader: BlockHeader, isProposer: Boolean = false)(implicit
       blockchainConfig: BlockchainConfig
-  ): InMemoryWorldStateProxy =
+  ): InMemoryWorldStateProxy = {
+    // `isProposer` originally switched to `getReadOnlyMptStorage()` to keep proposer-mode tx
+    // state from leaking into the canonical DB. That did not actually work: ReadOnlyNodeStorage
+    // buffers writes but its `persist()` still flushes them to the wrapped storage, which is
+    // what `InMemoryWorldStateProxy.persistState` ends up calling. Meanwhile the read-only
+    // wrapping broke the Shanghai withdrawals stateRoot: proposer-computed and newPayload-computed
+    // roots diverged for reasons we haven't fully isolated (likely buffered-node read ordering
+    // inside SerializingMptStorage/MerklePatriciaTrie). Use the writable backing in both modes;
+    // we still get idempotence because the MPT hash is deterministic given the same inputs.
+    val _ = isProposer
     InMemoryWorldStateProxy(
       evmCodeStorage = evmCodeStorage,
-      if (isProposer) blockchain.getReadOnlyMptStorage()
-      else blockchain.getBackingMptStorage(block.header.number),
+      blockchain.getBackingMptStorage(block.header.number),
       (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
       accountStartNonce = blockchainConfig.accountStartNonce,
       stateRootHash = parentHeader.stateRoot,
       noEmptyAccounts = EvmConfig.forBlock(block.header.number, blockchainConfig).noEmptyAccounts,
       ethCompatibleStorage = blockchainConfig.ethCompatibleStorage
     )
+  }
 
   /** This function runs transactions
     *

--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockExecution.scala
@@ -80,22 +80,29 @@ class BlockExecution(
     * calls (EIP-7002/7251), collects deposit requests (EIP-6110), and returns the full BlockResult with receipts +
     * executionRequests populated. No pre- or post-execution validation against the header is performed — caller is
     * responsible for filling in header fields (stateRoot, receiptsRoot, gasUsed, requestsHash, etc.) from the result.
+    *
+    * Executes against a read-only-backed WorldStateProxy so tx effects do NOT persist to RocksDB. A proposer block is
+    * speculative until the CL promotes it via `forkchoiceUpdated(head=hash(block))`; leaking its state would cause a
+    * subsequent `newPayload` for the same slot (e.g. a tampered sibling) to fail with stale nonces / balances instead
+    * of the expected stateRoot / receiptsRoot mismatch. Matches the read-only pattern used by `eth_call`,
+    * `eth_estimateGas`, and `debug_traceTransaction`.
     */
   def executeForProposer(
       block: Block
   )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, BlockResult] =
-    executeBlock(block)
+    executeBlock(block, isProposer = true)
 
   /** Executes a block (executes transactions and pays rewards) */
   private def executeBlock(
-      block: Block
+      block: Block,
+      isProposer: Boolean = false
   )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, BlockResult] =
     try
       for {
         parentHeader <- blockchainReader
           .getBlockHeaderByHash(block.header.parentHash)
           .toRight(MissingParentError) // Should not never occur because validated earlier
-        initialWorld = buildInitialWorld(block, parentHeader)
+        initialWorld = buildInitialWorld(block, parentHeader, isProposer)
         execResult <- executeBlockTransactions(block, initialWorld)
         worldAfterReward <- Either
           .catchOnly[MPTException](blockPreparator.payBlockReward(block, execResult.worldState))
@@ -109,7 +116,9 @@ class BlockExecution(
         worldAfterSystemCalls = systemCallResult._1
         systemRequests = systemCallResult._2
         depositRequest = collectDepositRequests(execResult.receipts)
-        // State root hash needs to be up-to-date for validateBlockAfterExecution
+        // State root hash needs to be up-to-date for validateBlockAfterExecution. In proposer mode the
+        // backing MPT storage is read-only, so persistState computes the trie hash in-memory without
+        // writing to RocksDB — exactly what we want for a speculative payload.
         worldPersisted = InMemoryWorldStateProxy.persistState(worldAfterSystemCalls)
       } yield execResult.copy(
         worldState = worldPersisted,
@@ -119,12 +128,13 @@ class BlockExecution(
       case e: MPTException => Left(BlockExecutionError.MPTError(e))
     }
 
-  protected def buildInitialWorld(block: Block, parentHeader: BlockHeader)(implicit
+  protected def buildInitialWorld(block: Block, parentHeader: BlockHeader, isProposer: Boolean = false)(implicit
       blockchainConfig: BlockchainConfig
   ): InMemoryWorldStateProxy =
     InMemoryWorldStateProxy(
       evmCodeStorage = evmCodeStorage,
-      blockchain.getBackingMptStorage(block.header.number),
+      if (isProposer) blockchain.getReadOnlyMptStorage()
+      else blockchain.getBackingMptStorage(block.header.number),
       (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
       accountStartNonce = blockchainConfig.accountStartNonce,
       stateRootHash = parentHeader.stateRoot,

--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
@@ -50,10 +50,11 @@ class BlockPreparator(
       block: Block,
       worldStateProxy: InMemoryWorldStateProxy
   )(implicit blockchainConfig: BlockchainConfig): InMemoryWorldStateProxy = {
-    // Post-merge: no PoW rewards, no ommer rewards. Process withdrawals instead.
+    // Post-merge: no PoW rewards, no ommer rewards. EIP-4895 withdrawals are applied by
+    // BlockExecution.processWithdrawals after payBlockReward returns; applying them here
+    // too would double-credit every withdrawal and break state-root validation.
     if (block.header.isPostMerge) {
-      val worldAfterWithdrawals = processWithdrawals(block, worldStateProxy)
-      return worldAfterWithdrawals
+      return worldStateProxy
     }
 
     val blockNumber = block.header.number
@@ -77,29 +78,6 @@ class BlockPreparator(
     // ECIP-1111: After Olympia activation, credit baseFee * gasUsed to treasury
     creditBaseFeeToTreasury(block.header, blockchainConfig.treasuryAddress, worldAfterOmmers)
   }
-
-  /** EIP-4895: Process withdrawals from the beacon chain. Each withdrawal credits the target address with the specified
-    * amount (in Gwei, converted to Wei).
-    */
-  private def processWithdrawals(
-      block: Block,
-      world: InMemoryWorldStateProxy
-  )(implicit blockchainConfig: BlockchainConfig): InMemoryWorldStateProxy =
-    block.body.withdrawals match {
-      case Some(withdrawals) =>
-        withdrawals.foldLeft(world) { (ws, withdrawal) =>
-          val weiAmount = UInt256(withdrawal.amount * BigInt("1000000000")) // Gwei → Wei
-          log.debug(
-            "Processing withdrawal idx={} validator={} to {} amount={} Gwei",
-            withdrawal.index,
-            withdrawal.validatorIndex,
-            withdrawal.address,
-            withdrawal.amount
-          )
-          increaseAccountBalance(withdrawal.address, weiAmount)(ws)
-        }
-      case None => world
-    }
 
   /** ECIP-1111: Credit baseFee revenue to the treasury address. This runs AFTER block rewards and ommer rewards,
     * matching core-geth's Finalize() order.

--- a/src/main/scala/com/chipprbots/ethereum/testmode/TestModeBlockExecution.scala
+++ b/src/main/scala/com/chipprbots/ethereum/testmode/TestModeBlockExecution.scala
@@ -33,12 +33,11 @@ class TestModeBlockExecution(
 
   override protected def buildInitialWorld(block: Block, parentHeader: BlockHeader, isProposer: Boolean = false)(
       implicit blockchainConfig: BlockchainConfig
-  ): InMemoryWorldStateProxy =
+  ): InMemoryWorldStateProxy = {
+    val _ = isProposer // see BlockExecution.buildInitialWorld: read-only did not hold invariants
     TestModeWorldStateProxy(
       evmCodeStorage = evmCodeStorage,
-      nodesKeyValueStorage =
-        if (isProposer) blockchain.getReadOnlyMptStorage()
-        else blockchain.getBackingMptStorage(block.header.number),
+      nodesKeyValueStorage = blockchain.getBackingMptStorage(block.header.number),
       getBlockHashByNumber = (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
       accountStartNonce = blockchainConfig.accountStartNonce,
       stateRootHash = parentHeader.stateRoot,
@@ -46,4 +45,5 @@ class TestModeBlockExecution(
       ethCompatibleStorage = blockchainConfig.ethCompatibleStorage,
       saveStoragePreimage = saveStoragePreimage
     )
+  }
 }

--- a/src/main/scala/com/chipprbots/ethereum/testmode/TestModeBlockExecution.scala
+++ b/src/main/scala/com/chipprbots/ethereum/testmode/TestModeBlockExecution.scala
@@ -31,12 +31,14 @@ class TestModeBlockExecution(
       blockValidation
     ) {
 
-  override protected def buildInitialWorld(block: Block, parentHeader: BlockHeader)(implicit
-      blockchainConfig: BlockchainConfig
+  override protected def buildInitialWorld(block: Block, parentHeader: BlockHeader, isProposer: Boolean = false)(
+      implicit blockchainConfig: BlockchainConfig
   ): InMemoryWorldStateProxy =
     TestModeWorldStateProxy(
       evmCodeStorage = evmCodeStorage,
-      nodesKeyValueStorage = blockchain.getBackingMptStorage(block.header.number),
+      nodesKeyValueStorage =
+        if (isProposer) blockchain.getReadOnlyMptStorage()
+        else blockchain.getBackingMptStorage(block.header.number),
       getBlockHashByNumber = (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
       accountStartNonce = blockchainConfig.accountStartNonce,
       stateRootHash = parentHeader.stateRoot,

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -317,23 +317,23 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
       result.latestValidHash shouldBe Some(validBlock.header.hash)
     }
 
-    "return INVALID_BLOCK_HASH with null latestValidHash on hash mismatch" taggedAs UnitTest in
+    "return INVALID with null latestValidHash on hash mismatch (parent known)" taggedAs UnitTest in
       new EngineApiTestSetup {
-        // engine-API spec: hash mismatch is a structural integrity error — return
-        // INVALID_BLOCK_HASH with latestValidHash=null regardless of whether the parent
-        // is known. The corruption is in the payload envelope, not attributable to a
-        // specific ancestor. This aligns with hive "Bad Hash on NewPayload" tests.
+        // Per execution-apis PR #338 (Shanghai+): hash mismatch returns INVALID (not
+        // INVALID_BLOCK_HASH) with latestValidHash=null. The corruption is in the
+        // payload envelope, not attributable to a specific ancestor. Aligns with hive
+        // "Bad Hash on NewPayload" tests.
         val (validBlock, _) = buildValidBlock1()
         val payload = blockToPayload(validBlock)
         val badPayload = payload.copy(blockHash = ByteString(Array.fill(32)(0xff.toByte)))
 
         val result = engineApi.newPayload(badPayload).unsafeRunSync()
 
-        result.status shouldBe a[InvalidBlockHash]
+        result.status shouldBe Invalid
         result.latestValidHash shouldBe None
       }
 
-    "return INVALID_BLOCK_HASH when blockHash doesn't match AND parent is unknown" taggedAs UnitTest in
+    "return INVALID with null latestValidHash on hash mismatch (parent unknown)" taggedAs UnitTest in
       new EngineApiTestSetup {
         val (validBlock, _) = buildValidBlock1()
         val payload = blockToPayload(validBlock)
@@ -344,7 +344,8 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
 
         val result = engineApi.newPayload(badPayload).unsafeRunSync()
 
-        result.status shouldBe a[InvalidBlockHash]
+        result.status shouldBe Invalid
+        result.latestValidHash shouldBe None
       }
 
     "return INVALID for block with modified stateRoot" taggedAs UnitTest in new EngineApiTestSetup {

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -347,6 +347,28 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
       result.validationError should not be empty
     }
 
+    "return INVALID when newPayloadV3 expectedBlobVersionedHashes mismatches payload txs" taggedAs UnitTest in
+      new EngineApiTestSetup {
+        // EIP-4844 / Engine API V3: the CL passes expectedBlobVersionedHashes as the 2nd param
+        // to engine_newPayloadV3; the EL must compare the CL's list against the concatenation
+        // of every blob tx's blobVersionedHashes in the payload and reject on mismatch. The
+        // payload built here has no blob txs (derived list is empty), but we declare a single
+        // expected hash — so the comparison must fail and return INVALID with
+        // latestValidHash = parent.hash.
+        val (validBlock, _) = buildValidBlock1()
+        val payload = blockToPayload(validBlock)
+        val fakeHash = ByteString(kec256(Array[Byte](0xde.toByte, 0xad.toByte, 0xbe.toByte, 0xef.toByte)))
+        val payloadWithMismatchedHashes = payload.copy(
+          expectedBlobVersionedHashes = Some(Seq(fakeHash))
+        )
+
+        val result = engineApi.newPayload(payloadWithMismatchedHashes).unsafeRunSync()
+
+        result.status shouldBe Invalid
+        result.latestValidHash shouldBe Some(genesisHeader.hash)
+        result.validationError.getOrElse("") should include("INVALID_VERSIONED_HASHES")
+      }
+
     "return INVALID for block with modified gasUsed" taggedAs UnitTest in new EngineApiTestSetup {
       val (validBlock, _) = buildValidBlock1()
       val payload = blockToPayload(validBlock)

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -317,19 +317,20 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
       result.latestValidHash shouldBe Some(validBlock.header.hash)
     }
 
-    "return INVALID with parent.hash when blockHash doesn't match header and parent is known" taggedAs UnitTest in
+    "return INVALID_BLOCK_HASH with null latestValidHash on hash mismatch" taggedAs UnitTest in
       new EngineApiTestSetup {
-        // Per EIP-3675 and the hive "Corrupted Block Hash Payload" test: when the parent is
-        // known we must distinguish this block from "we have no ancestry at all" — hive expects
-        // INVALID with latestValidHash = parent.hash, not INVALID_BLOCK_HASH with null.
+        // engine-API spec: hash mismatch is a structural integrity error — return
+        // INVALID_BLOCK_HASH with latestValidHash=null regardless of whether the parent
+        // is known. The corruption is in the payload envelope, not attributable to a
+        // specific ancestor. This aligns with hive "Bad Hash on NewPayload" tests.
         val (validBlock, _) = buildValidBlock1()
         val payload = blockToPayload(validBlock)
         val badPayload = payload.copy(blockHash = ByteString(Array.fill(32)(0xff.toByte)))
 
         val result = engineApi.newPayload(badPayload).unsafeRunSync()
 
-        result.status shouldBe Invalid
-        result.latestValidHash shouldBe Some(genesisHeader.hash)
+        result.status shouldBe a[InvalidBlockHash]
+        result.latestValidHash shouldBe None
       }
 
     "return INVALID_BLOCK_HASH when blockHash doesn't match AND parent is unknown" taggedAs UnitTest in

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -317,15 +317,34 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
       result.latestValidHash shouldBe Some(validBlock.header.hash)
     }
 
-    "return INVALID_BLOCK_HASH when blockHash doesn't match header" taggedAs UnitTest in new EngineApiTestSetup {
-      val (validBlock, _) = buildValidBlock1()
-      val payload = blockToPayload(validBlock)
-      val badPayload = payload.copy(blockHash = ByteString(Array.fill(32)(0xff.toByte)))
+    "return INVALID with parent.hash when blockHash doesn't match header and parent is known" taggedAs UnitTest in
+      new EngineApiTestSetup {
+        // Per EIP-3675 and the hive "Corrupted Block Hash Payload" test: when the parent is
+        // known we must distinguish this block from "we have no ancestry at all" — hive expects
+        // INVALID with latestValidHash = parent.hash, not INVALID_BLOCK_HASH with null.
+        val (validBlock, _) = buildValidBlock1()
+        val payload = blockToPayload(validBlock)
+        val badPayload = payload.copy(blockHash = ByteString(Array.fill(32)(0xff.toByte)))
 
-      val result = engineApi.newPayload(badPayload).unsafeRunSync()
+        val result = engineApi.newPayload(badPayload).unsafeRunSync()
 
-      result.status shouldBe a[InvalidBlockHash]
-    }
+        result.status shouldBe Invalid
+        result.latestValidHash shouldBe Some(genesisHeader.hash)
+      }
+
+    "return INVALID_BLOCK_HASH when blockHash doesn't match AND parent is unknown" taggedAs UnitTest in
+      new EngineApiTestSetup {
+        val (validBlock, _) = buildValidBlock1()
+        val payload = blockToPayload(validBlock)
+        val badPayload = payload.copy(
+          parentHash = ByteString(kec256(Array[Byte](9, 9, 9))),
+          blockHash = ByteString(Array.fill(32)(0xff.toByte))
+        )
+
+        val result = engineApi.newPayload(badPayload).unsafeRunSync()
+
+        result.status shouldBe a[InvalidBlockHash]
+      }
 
     "return INVALID for block with modified stateRoot" taggedAs UnitTest in new EngineApiTestSetup {
       val (validBlock, _) = buildValidBlock1()

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -376,6 +376,10 @@ class EthTxServiceSpec
         )
       )
       .commit()
+    // eth_getTransactionReceipt now requires the block to be on the canonical chain
+    // (block.number <= bestBlockNumber). Promote the fixture block to best so the
+    // receipt surfaces — mirrors what ChainImporter/BlockImporter do on real imports.
+    blockchainWriter.saveBestKnownBlocks(blockWithTx.header.hash, blockWithTx.header.number)
 
     val request: GetTransactionReceiptRequest = GetTransactionReceiptRequest(contractCreatingTransaction.hash)
     val response: ServiceResponse[GetTransactionReceiptResponse] = ethTxService.getTransactionReceipt(request)

--- a/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
@@ -659,6 +659,52 @@ class BlockExecutionSpec
 
     }
 
+    "EIP-4895 withdrawal processing" should {
+
+      "credit the withdrawal amount exactly once per block" taggedAs UnitTest in new BlockExecutionTestSetup {
+        // Regression: processWithdrawals used to run twice — once inside BlockPreparator.payBlockReward
+        // for post-merge blocks, and again in BlockExecution.executeBlock after payBlockReward
+        // returned. Every withdrawal credited 2× Gwei → 2× Wei, state root diverged, and the
+        // ethereum/engine-withdrawals hive suite stuck at 1/35. Check exactly-once semantics by
+        // calling payBlockReward (which for post-merge must be a no-op) and confirming the
+        // withdrawal recipient's balance has not changed under it.
+        val recipient = Address(ByteString(Array.fill[Byte](20)(0x42.toByte)))
+        val withdrawal = com.chipprbots.ethereum.domain.Withdrawal(
+          index = BigInt(0),
+          validatorIndex = BigInt(0),
+          address = recipient,
+          amount = BigInt(1) // 1 Gwei
+        )
+
+        // Build a post-merge header (difficulty=0, baseFee set → isPostMerge = true)
+        val postMergeHeader = validBlockParentHeader.copy(
+          parentHash = validBlockParentHeader.hash,
+          number = validBlockParentHeader.number + 1,
+          difficulty = 0,
+          extraFields = com.chipprbots.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostShanghai(
+            baseFee = BigInt(1000000000),
+            withdrawalsRoot = com.chipprbots.ethereum.domain.BlockHeader.EmptyMpt
+          )
+        )
+        val block = Block(
+          postMergeHeader,
+          BlockBody(transactionList = Nil, uncleNodesList = Nil, withdrawals = Some(Seq(withdrawal)))
+        )
+
+        val world = readOnceAtParent
+        val balanceBefore = world.getAccount(recipient).map(_.balance.toBigInt).getOrElse(BigInt(0))
+
+        // payBlockReward on a post-merge block must now be a no-op — withdrawals are applied
+        // by BlockExecution after payBlockReward returns.
+        val worldAfter = mining.blockPreparator.payBlockReward(block, world)
+        val balanceAfterReward =
+          worldAfter.getAccount(recipient).map(_.balance.toBigInt).getOrElse(BigInt(0))
+
+        balanceAfterReward shouldBe balanceBefore
+      }
+
+    }
+
   }
 
   trait BlockExecutionTestSetup extends BlockchainSetup {

--- a/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
@@ -616,9 +616,64 @@ class BlockExecutionSpec
       }
     }
 
+    "executeForProposer" should {
+
+      "not persist state changes to the backing MPT storage" taggedAs UnitTest in new BlockExecutionTestSetup {
+        // Regression: Engine API forkchoiceUpdated payload-build path used to commit tx effects to
+        // RocksDB. A subsequent newPayload for a tampered sibling block would then fail with
+        // NONCE_MISMATCH_TOO_LOW instead of the expected stateRoot/receiptsRoot mismatch.
+        // executeForProposer must run against read-only MPT storage so no writes reach the DB.
+
+        val validBlockBodyWithTxs: BlockBody = validBlockBodyWithNoTxs.copy(
+          transactionList = Seq(validStxSignedByOrigin)
+        )
+        val block = Block(validBlockHeader, validBlockBodyWithTxs)
+
+        val nonceBefore = readOnceAtParent.getAccount(originAddress).map(_.nonce.toBigInt).getOrElse(BigInt(-1))
+
+        val result = blockExecution.executeForProposer(block)
+        assert(result.isRight, s"executeForProposer failed: $result")
+
+        // Origin nonce must be unchanged in committed state — proposer build is ephemeral.
+        val nonceAfter = readOnceAtParent.getAccount(originAddress).map(_.nonce.toBigInt).getOrElse(BigInt(-1))
+
+        nonceAfter shouldBe nonceBefore
+      }
+
+      "be idempotent — calling twice with the same block produces the same stateRoot" taggedAs UnitTest in
+        new BlockExecutionTestSetup {
+          // If state leaked between calls, the second executeForProposer would see a post-tx nonce
+          // and return a different stateRoot (or fail outright with NONCE_MISMATCH_TOO_LOW).
+          val validBlockBodyWithTxs: BlockBody = validBlockBodyWithNoTxs.copy(
+            transactionList = Seq(validStxSignedByOrigin)
+          )
+          val block = Block(validBlockHeader, validBlockBodyWithTxs)
+
+          val firstResult = blockExecution.executeForProposer(block)
+          val secondResult = blockExecution.executeForProposer(block)
+
+          assert(firstResult.isRight && secondResult.isRight)
+          firstResult.toOption.get.worldState.stateRootHash shouldBe
+            secondResult.toOption.get.worldState.stateRootHash
+        }
+
+    }
+
   }
 
   trait BlockExecutionTestSetup extends BlockchainSetup {
+    /** Read-only view of the account trie rooted at the parent block's stateRoot. */
+    def readOnceAtParent: InMemoryWorldStateProxy =
+      InMemoryWorldStateProxy(
+        evmCodeStorage = blockchainStorages.evmCodeStorage,
+        mptStorage = blockchain.getReadOnlyMptStorage(),
+        getBlockHashByNumber = (n: BigInt) => blockchainReader.getBlockHeaderByNumber(n).map(_.hash),
+        accountStartNonce = blockchainConfig.accountStartNonce,
+        stateRootHash = validBlockParentHeader.stateRoot,
+        noEmptyAccounts = false,
+        ethCompatibleStorage = true
+      )
+
 
     override lazy val blockValidation =
       new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))


### PR DESCRIPTION
## Summary

Hive engine-suite: **321/403 (79.7%) passing** — up from ~114/408 (~28%) at branch-off. 32 commits addressing NewPayload, FCU, proposer-mode, receipt lookup, and adjacent engine-API correctness.

## Results by suite

| Suite | Final | Baseline | Δ |
|---|---|---|---|
| engine-api | **105/129** | 94/129 | +11 |
| engine-auth | **8/8** | 8/8 | — |
| engine-exchange-capabilities | **5/5** | 2/5 | +3 |
| engine-withdrawals | **21/35** | 10/27 | +11 |
| engine-cancun | **182/226** | 0/~180 | +182 |
| **Total** | **321/403 (79.7%)** | ~114/~408 | **+207** |

## Remaining 82 failures (follow-up)

- ~30 devp2p sync tests (separate PR)
- 11 Fork ID peering CRC audit
- 8 Withdrawals Fork Re-Org (JSON-RPC -32700 under concurrent tx submission)
- ~13 cancun blob edge cases
- Various smaller items
