### PR TITLE
fix(p2p): RLP decoder crash, listenPort, real IP, networkId check

### DIFF
--- a/src/main/resources/conf/base/network.conf
+++ b/src/main/resources/conf/base/network.conf
@@ -9,6 +9,12 @@ network {
       # Previously 9076 (Mantis default), which broke inbound peer connections
       # since peers expect TCP and UDP on the same port.
       port = 30303
+
+      # IP address or hostname to advertise in the enode URL and to peers.
+      # Required when binding to 0.0.0.0 or :: so that other nodes can dial back.
+      # Defaults to null (auto-resolved via InetAddress.getLocalHost when bound to unspecified address).
+      # Example: advertised-address = "1.2.3.4"
+      advertised-address = null
     }
 
     # Try automatic port forwarding via UPnP

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -361,77 +361,81 @@ class EngineApiController(
         val isCancunPayload = cfg.isCancunTimestamp(ts)
         val isShanghaiPayload = cfg.isShanghaiTimestamp(ts)
         val forkError: Option[String] = version match {
-          case 2 if isCancunPayload => Some("getPayloadV2 cannot return a Cancun payload; use V3")
-          case 3 if !isCancunPayload => Some("getPayloadV3 can only return Cancun-or-later payloads")
+          case 2 if isCancunPayload   => Some("getPayloadV2 cannot return a Cancun payload; use V3")
+          case 3 if !isCancunPayload  => Some("getPayloadV3 can only return Cancun-or-later payloads")
           case 1 if isShanghaiPayload => Some("getPayloadV1 cannot return a Shanghai-or-later payload; use V2")
-          case _ => None
+          case _                      => None
         }
         forkError match {
           case Some(msg) =>
             JsonRpcResponse("2.0", None, Some(JsonRpcError(UnsupportedFork, msg, None)), reqId(request))
           case None =>
-        val payload = blockToExecutionPayload(block)
-        // V1 returns bare ExecutionPayload.
-        // V2+ wraps it in ExecutionPayloadEnvelope per Engine API spec.
-        // blockValue depends on receipts (effectiveGasPrice per tx). Fetch once so V2/V3/V4 share.
-        lazy val receipts = engineApiService.getPayloadReceipts(payloadId)
-        lazy val blockValueHex = computeBlockValue(block, receipts)
-        lazy val blobsBundleJson: JObject = {
-          val bundle = engineApiService.getPayloadBlobsBundle(payloadId)
-          JObject(
-            "commitments" -> JArray(bundle.commitments.toList.map(c => JString(byteStringToHex(c)))),
-            "proofs" -> JArray(bundle.proofs.toList.map(p => JString(byteStringToHex(p)))),
-            "blobs" -> JArray(bundle.blobs.toList.map(b => JString(byteStringToHex(b))))
-          )
-        }
-        val result: JValue = version match {
-          case 1 => payload
-          case 2 =>
-            JObject(
-              "executionPayload" -> payload,
-              "blockValue" -> JString(blockValueHex)
-            )
-          case 3 =>
-            JObject(
-              "executionPayload" -> payload,
-              "blockValue" -> JString(blockValueHex),
-              "blobsBundle" -> blobsBundleJson,
-              "shouldOverrideBuilder" -> JBool(false)
-            )
-          case _ => // V4+: add executionRequests (EIP-7685)
-            val executionRequests = engineApiService.getPayloadExecutionRequests(payloadId)
-            JObject(
-              "executionPayload" -> payload,
-              "blockValue" -> JString(blockValueHex),
-              "blobsBundle" -> blobsBundleJson,
-              "shouldOverrideBuilder" -> JBool(false),
-              "executionRequests" -> JArray(
-                executionRequests.toList.map(r => JString(byteStringToHex(r)))
+            val payload = blockToExecutionPayload(block)
+            // V1 returns bare ExecutionPayload.
+            // V2+ wraps it in ExecutionPayloadEnvelope per Engine API spec.
+            // blockValue depends on receipts (effectiveGasPrice per tx). Fetch once so V2/V3/V4 share.
+            lazy val receipts = engineApiService.getPayloadReceipts(payloadId)
+            lazy val blockValueHex = computeBlockValue(block, receipts)
+            lazy val blobsBundleJson: JObject = {
+              val bundle = engineApiService.getPayloadBlobsBundle(payloadId)
+              JObject(
+                "commitments" -> JArray(bundle.commitments.toList.map(c => JString(byteStringToHex(c)))),
+                "proofs" -> JArray(bundle.proofs.toList.map(p => JString(byteStringToHex(p)))),
+                "blobs" -> JArray(bundle.blobs.toList.map(b => JString(byteStringToHex(b))))
               )
-            )
-        }
-        JsonRpcResponse("2.0", Some(result), None, reqId(request))
+            }
+            val result: JValue = version match {
+              case 1 => payload
+              case 2 =>
+                JObject(
+                  "executionPayload" -> payload,
+                  "blockValue" -> JString(blockValueHex)
+                )
+              case 3 =>
+                JObject(
+                  "executionPayload" -> payload,
+                  "blockValue" -> JString(blockValueHex),
+                  "blobsBundle" -> blobsBundleJson,
+                  "shouldOverrideBuilder" -> JBool(false)
+                )
+              case _ => // V4+: add executionRequests (EIP-7685)
+                val executionRequests = engineApiService.getPayloadExecutionRequests(payloadId)
+                JObject(
+                  "executionPayload" -> payload,
+                  "blockValue" -> JString(blockValueHex),
+                  "blobsBundle" -> blobsBundleJson,
+                  "shouldOverrideBuilder" -> JBool(false),
+                  "executionRequests" -> JArray(
+                    executionRequests.toList.map(r => JString(byteStringToHex(r)))
+                  )
+                )
+            }
+            JsonRpcResponse("2.0", Some(result), None, reqId(request))
         }
       case Left(err) =>
         JsonRpcResponse("2.0", None, Some(JsonRpcError(-38001, err, None)), reqId(request))
     }
   }
 
-  /** blockValue = Σ gasUsedByTx_i × (effectiveGasPrice_i − baseFeePerGas). Miner's priority-fee
-    * revenue for the block. Per EIP-3675 V2 envelope, this is what the CL reads to pick the
-    * highest-value payload across builders.
+  /** blockValue = Σ gasUsedByTx_i × (effectiveGasPrice_i − baseFeePerGas). Miner's priority-fee revenue for the block.
+    * Per EIP-3675 V2 envelope, this is what the CL reads to pick the highest-value payload across builders.
     *
     * For each tx:
-    *   - gasUsedByTx = receipt.cumulativeGas − previousReceipt.cumulativeGas (since receipts
-    *     record CUMULATIVE gas, not per-tx).
-    *   - effectiveGasPrice = for legacy / access-list txs: tx.gasPrice. For EIP-1559 / blob:
-    *     min(maxFeePerGas, baseFee + maxPriorityFeePerGas).
+    *   - gasUsedByTx = receipt.cumulativeGas − previousReceipt.cumulativeGas (since receipts record CUMULATIVE gas, not
+    *     per-tx).
+    *   - effectiveGasPrice = for legacy / access-list txs: tx.gasPrice. For EIP-1559 / blob: min(maxFeePerGas, baseFee
+    *     + maxPriorityFeePerGas).
     */
   private def computeBlockValue(
       block: Block,
       receipts: Seq[com.chipprbots.ethereum.domain.Receipt]
   ): String = {
-    import com.chipprbots.ethereum.domain.{TransactionWithAccessList, TransactionWithDynamicFee, BlobTransaction, SetCodeTransaction}
+    import com.chipprbots.ethereum.domain.{
+      TransactionWithAccessList,
+      TransactionWithDynamicFee,
+      BlobTransaction,
+      SetCodeTransaction
+    }
     val baseFee = block.header.extraFields match {
       case BlockHeader.HeaderExtraFields.HefPostOlympia(bf)               => bf
       case BlockHeader.HeaderExtraFields.HefPostShanghai(bf, _)           => bf
@@ -442,20 +446,28 @@ class EngineApiController(
     if (receipts.isEmpty) return "0x0"
     val txs = block.body.transactionList
     // derive per-tx gas used from cumulative deltas
-    val gasUsedPerTx: Seq[BigInt] = receipts.map(_.cumulativeGasUsed).scanLeft(BigInt(0)) { (prev, cum) =>
-      cum
-    }.sliding(2, 1).collect { case Seq(prev, cur) => cur - prev }.toSeq
-    val totalPriorityFee: BigInt = txs.zip(gasUsedPerTx).map { case (stx, gasUsed) =>
-      val effectiveGasPrice: BigInt = stx.tx match {
-        case t: TransactionWithDynamicFee => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
-        case t: BlobTransaction           => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
-        case t: SetCodeTransaction        => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
-        case t: TransactionWithAccessList => t.gasPrice
-        case _                            => stx.tx.gasPrice
+    val gasUsedPerTx: Seq[BigInt] = receipts
+      .map(_.cumulativeGasUsed)
+      .scanLeft(BigInt(0)) { (prev, cum) =>
+        cum
       }
-      val priorityPerGas = (effectiveGasPrice - baseFee).max(0)
-      gasUsed * priorityPerGas
-    }.sum
+      .sliding(2, 1)
+      .collect { case Seq(prev, cur) => cur - prev }
+      .toSeq
+    val totalPriorityFee: BigInt = txs
+      .zip(gasUsedPerTx)
+      .map { case (stx, gasUsed) =>
+        val effectiveGasPrice: BigInt = stx.tx match {
+          case t: TransactionWithDynamicFee => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+          case t: BlobTransaction           => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+          case t: SetCodeTransaction        => (baseFee + t.maxPriorityFeePerGas).min(t.maxFeePerGas)
+          case t: TransactionWithAccessList => t.gasPrice
+          case _                            => stx.tx.gasPrice
+        }
+        val priorityPerGas = (effectiveGasPrice - baseFee).max(0)
+        gasUsed * priorityPerGas
+      }
+      .sum
     s"0x${totalPriorityFee.toString(16)}"
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -76,8 +76,8 @@ class EngineApiService(
     new java.util.concurrent.ConcurrentHashMap[ByteString, java.util.Set[ByteString]]()
   private val zeroHash = ByteString(new Array[Byte](32))
 
-  /** Mark `hash` as INVALID and recursively invalidate every optimistically-accepted descendant.
-    * All descendants inherit the same `latestValidHash`.
+  /** Mark `hash` as INVALID and recursively invalidate every optimistically-accepted descendant. All descendants
+    * inherit the same `latestValidHash`.
     */
   private def markInvalidRecursive(hash: ByteString, lvh: ByteString): Unit = {
     invalidBlocks.put(hash, lvh)
@@ -368,10 +368,12 @@ class EngineApiService(
             // Record parent→child so that if the (still-unknown) ancestor chain is later
             // revealed as INVALID, we can retroactively invalidate this block too. Required
             // by hive's "Invalid Missing Ancestor Syncing ReOrg" tests.
-            acceptedChildrenByParent.computeIfAbsent(
-              payload.parentHash,
-              _ => java.util.concurrent.ConcurrentHashMap.newKeySet[ByteString]()
-            ).add(payload.blockHash)
+            acceptedChildrenByParent
+              .computeIfAbsent(
+                payload.parentHash,
+                _ => java.util.concurrent.ConcurrentHashMap.newKeySet[ByteString]()
+              )
+              .add(payload.blockHash)
             System.err.println(
               s"[ENGINE-API] newPayload #${payload.blockNumber}: ACCEPTED (parent unknown)"
             )
@@ -583,8 +585,8 @@ class EngineApiService(
                         if (blockchainConfig.isPragueTimestamp(attrs.timestamp))
                           BlobGasUtils.PRAGUE_MAX_BLOB_GAS
                         else BlobGasUtils.CANCUN_MAX_BLOB_GAS
-                      pendingTxs.foldLeft((Seq.empty[SignedTransaction], BigInt(0))) {
-                        case ((kept, blobGas), stx) =>
+                      pendingTxs
+                        .foldLeft((Seq.empty[SignedTransaction], BigInt(0))) { case ((kept, blobGas), stx) =>
                           stx.tx match {
                             case b: com.chipprbots.ethereum.domain.BlobTransaction =>
                               val add = BigInt(b.blobVersionedHashes.size) * BlobGasUtils.GAS_PER_BLOB
@@ -593,7 +595,8 @@ class EngineApiService(
                             case _ =>
                               (kept :+ stx, blobGas)
                           }
-                      }._1
+                        }
+                        ._1
                     }
 
                     val emptyWithdrawalsRoot = ByteString(
@@ -834,22 +837,22 @@ class EngineApiService(
   def getPayloadExecutionRequests(payloadId: ByteString): Seq[ByteString] =
     Option(pendingPayloadRequests.remove(payloadId)).getOrElse(Nil)
 
-  /** Receipts produced while building this payload. Used by engine_getPayloadV2+ to compute the
-    * `blockValue` envelope field. `get` (not `remove`) because the CL may call getPayloadV1 and
-    * then getPayloadV2 for the same id (hive withdrawals tests rely on this).
+  /** Receipts produced while building this payload. Used by engine_getPayloadV2+ to compute the `blockValue` envelope
+    * field. `get` (not `remove`) because the CL may call getPayloadV1 and then getPayloadV2 for the same id (hive
+    * withdrawals tests rely on this).
     */
   def getPayloadReceipts(payloadId: ByteString): Seq[com.chipprbots.ethereum.domain.Receipt] =
     Option(pendingPayloadReceipts.get(payloadId)).getOrElse(Nil)
 
-  /** EIP-4844 sidecars for the blob txs included in this payload, for engine_getPayloadV3's
-    * blobsBundle envelope. Empty when the payload has no blob txs.
+  /** EIP-4844 sidecars for the blob txs included in this payload, for engine_getPayloadV3's blobsBundle envelope. Empty
+    * when the payload has no blob txs.
     */
   def getPayloadBlobsBundle(payloadId: ByteString): BlobsBundleData =
     Option(pendingPayloadBlobsBundle.get(payloadId)).getOrElse(BlobsBundleData(Nil, Nil, Nil))
 
-  /** Parse the EIP-4844 network-wrapped raw bytes (`0x03 || rlp([tx_payload, blobs, commitments,
-    * proofs])`) the pool captured for each blob tx, and return the concatenated sidecars for
-    * every blob tx actually included in the built payload, in payload order.
+  /** Parse the EIP-4844 network-wrapped raw bytes (`0x03 || rlp([tx_payload, blobs, commitments, proofs])`) the pool
+    * captured for each blob tx, and return the concatenated sidecars for every blob tx actually included in the built
+    * payload, in payload order.
     */
   private def buildBlobsBundle(
       txs: Seq[SignedTransaction],
@@ -865,7 +868,7 @@ class EngineApiService(
     blobTxHashes.foreach { h =>
       blobTxRawBytes.get(h) match {
         case Some(raw) if raw.length > 1 && raw(0) == 0x03 =>
-          try {
+          try
             rawDecode(raw.toArray.drop(1)) match {
               case RLPList(_, blobs: RLPList, commitments: RLPList, proofs: RLPList) =>
                 blobs.items.foreach { case RLPValue(b) => allBlobs += ByteString(b); case _ => }
@@ -874,9 +877,13 @@ class EngineApiService(
               case _ =>
                 log.warn("Blob tx {} sidecar RLP shape unexpected; skipping", h.toArray.map("%02x".format(_)).mkString)
             }
-          } catch {
+          catch {
             case e: Exception =>
-              log.warn("Failed to decode blob tx {} sidecar: {}", h.toArray.map("%02x".format(_)).mkString, e.getMessage)
+              log.warn(
+                "Failed to decode blob tx {} sidecar: {}",
+                h.toArray.map("%02x".format(_)).mkString,
+                e.getMessage
+              )
           }
         case _ => // tx from network / historical — we didn't store a sidecar
       }

--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
@@ -62,8 +62,8 @@ trait BlockHeaderValidatorSkeleton extends BlockHeaderValidator {
       _ <- validateEvenMore(blockHeader)
     } yield BlockHeaderValid
 
-  /** EIP-4844 / EIP-7691: validate blobGasUsed ≤ MAX_BLOB_GAS_PER_BLOCK, is a multiple of GAS_PER_BLOB,
-    * and excessBlobGas equals calcExcessBlobGas(parent). Runs only when the header declares blob fields.
+  /** EIP-4844 / EIP-7691: validate blobGasUsed ≤ MAX_BLOB_GAS_PER_BLOCK, is a multiple of GAS_PER_BLOB, and
+    * excessBlobGas equals calcExcessBlobGas(parent). Runs only when the header declares blob fields.
     */
   private def validateBlobGasAgainstParent(
       blockHeader: BlockHeader,

--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
@@ -145,8 +145,8 @@ object StdBlockValidator extends BlockValidator {
   }
 
   /** EIP-4895: if the header declares a withdrawalsRoot, it must equal the trie root computed from
-    * block.body.withdrawals (indexed like transactions/receipts). Pre-Shanghai headers have no
-    * withdrawalsRoot and no withdrawals in the body — no-op.
+    * block.body.withdrawals (indexed like transactions/receipts). Pre-Shanghai headers have no withdrawalsRoot and no
+    * withdrawals in the body — no-op.
     */
   private def validateWithdrawalsRoot(block: Block): Either[BlockError, BlockValid] =
     block.header.withdrawalsRoot match {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdSignedTransactionValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdSignedTransactionValidator.scala
@@ -48,9 +48,9 @@ object StdSignedTransactionValidator extends SignedTransactionValidator {
       _ <- validateBlockHasEnoughGasLimitForTx(stx, accumGasUsed, blockHeader.gasLimit)
     } yield SignedTransactionValid
 
-  /** EIP-1559: reject txs whose maxFeePerGas cannot cover the block's baseFee, and reject txs
-    * where maxPriorityFeePerGas > maxFeePerGas. Applies to all dynamic-fee transaction
-    * variants (type 2 / 3 / 4). Legacy and Type-1 txs are post-paid at tx.gasPrice.
+  /** EIP-1559: reject txs whose maxFeePerGas cannot cover the block's baseFee, and reject txs where
+    * maxPriorityFeePerGas > maxFeePerGas. Applies to all dynamic-fee transaction variants (type 2 / 3 / 4). Legacy and
+    * Type-1 txs are post-paid at tx.gasPrice.
     */
   private def validateMaxFeeAgainstBaseFee(
       stx: SignedTransaction,

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -365,28 +365,31 @@ class NetworkPeerManagerActor(
     )
 
     peerWithInfo.foreach { pwi =>
-      val response: AccountRange = try {
-        mptStorageOpt match {
-          case Some(storage) if isStateRootFresh(msg.rootHash) =>
-            com.chipprbots.ethereum.network.snapserver.SnapServer.serveAccountRange(
-              requestId = msg.requestId,
-              rootHash = msg.rootHash,
-              startingHash = msg.startingHash,
-              limitHash = msg.limitHash,
-              responseBytes = msg.responseBytes,
-              storage = storage
+      val response: AccountRange =
+        try
+          mptStorageOpt match {
+            case Some(storage) if isStateRootFresh(msg.rootHash) =>
+              com.chipprbots.ethereum.network.snapserver.SnapServer.serveAccountRange(
+                requestId = msg.requestId,
+                rootHash = msg.rootHash,
+                startingHash = msg.startingHash,
+                limitHash = msg.limitHash,
+                responseBytes = msg.responseBytes,
+                storage = storage
+              )
+            case _ =>
+              // Per SNAP/1: respond with empty when state root isn't within the recent
+              // window we can serve. Hive's "Test 11" sends genesis stateRoot (older than
+              // 127 blocks) and expects an empty response.
+              AccountRange(msg.requestId, Seq.empty, Seq.empty)
+          }
+        catch {
+          case t: Throwable =>
+            log.error(
+              s"serveAccountRange threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
             )
-          case _ =>
-            // Per SNAP/1: respond with empty when state root isn't within the recent
-            // window we can serve. Hive's "Test 11" sends genesis stateRoot (older than
-            // 127 blocks) and expects an empty response.
             AccountRange(msg.requestId, Seq.empty, Seq.empty)
         }
-      } catch {
-        case t: Throwable =>
-          log.error(s"serveAccountRange threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-          AccountRange(msg.requestId, Seq.empty, Seq.empty)
-      }
       pwi.peer.ref ! PeerActor.SendMessage(response)
     }
   }
@@ -414,9 +417,9 @@ class NetworkPeerManagerActor(
     }
   }
 
-  /** Per SNAP/1: nodes only need to serve state for "recent" roots — geth uses a 128-block
-    * window. Looks up the requested rootHash in a cached set of recent canonical state
-    * roots. Returns true (serve) if blockchainReader isn't injected.
+  /** Per SNAP/1: nodes only need to serve state for "recent" roots — geth uses a 128-block window. Looks up the
+    * requested rootHash in a cached set of recent canonical state roots. Returns true (serve) if blockchainReader isn't
+    * injected.
     */
   private def isStateRootFresh(rootHash: ByteString): Boolean = blockchainReader match {
     case None => true
@@ -542,24 +545,27 @@ class NetworkPeerManagerActor(
     )
 
     peerWithInfo.foreach { pwi =>
-      val response: TrieNodes = try {
-        mptStorageOpt match {
-          case Some(storage) =>
-            com.chipprbots.ethereum.network.snapserver.SnapServer.serveTrieNodes(
-              requestId = msg.requestId,
-              rootHash = msg.rootHash,
-              paths = msg.paths,
-              responseBytes = msg.responseBytes,
-              storage = storage
+      val response: TrieNodes =
+        try
+          mptStorageOpt match {
+            case Some(storage) =>
+              com.chipprbots.ethereum.network.snapserver.SnapServer.serveTrieNodes(
+                requestId = msg.requestId,
+                rootHash = msg.rootHash,
+                paths = msg.paths,
+                responseBytes = msg.responseBytes,
+                storage = storage
+              )
+            case None =>
+              TrieNodes(msg.requestId, Seq.empty)
+          }
+        catch {
+          case t: Throwable =>
+            log.error(
+              s"serveTrieNodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
             )
-          case None =>
             TrieNodes(msg.requestId, Seq.empty)
         }
-      } catch {
-        case t: Throwable =>
-          log.error(s"serveTrieNodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-          TrieNodes(msg.requestId, Seq.empty)
-      }
       pwi.peer.ref ! PeerActor.SendMessage(response)
     }
   }
@@ -583,33 +589,36 @@ class NetworkPeerManagerActor(
     )
 
     peerWithInfo.foreach { pwi =>
-      val response: ByteCodes = try {
-        // Look up each requested code hash in EvmCodeStorage. Stop accumulating when we
-        // would exceed the peer's responseBytes soft limit (per SNAP/1 spec, the server
-        // is allowed to truncate the response prefix early — proofs aren't needed for
-        // bytecodes since each code is keyed by its keccak256 hash).
-        val maxBytes = msg.responseBytes.toInt.max(0)
-        val codes: Seq[ByteString] = evmCodeStorage match {
-          case Some(storage) =>
-            val collected = scala.collection.mutable.ListBuffer.empty[ByteString]
-            var totalBytes = 0
-            val it = msg.hashes.iterator
-            while (it.hasNext && (totalBytes < maxBytes || collected.isEmpty)) {
-              val codeHash = it.next()
-              storage.get(codeHash).foreach { code =>
-                collected += code
-                totalBytes += code.size
+      val response: ByteCodes =
+        try {
+          // Look up each requested code hash in EvmCodeStorage. Stop accumulating when we
+          // would exceed the peer's responseBytes soft limit (per SNAP/1 spec, the server
+          // is allowed to truncate the response prefix early — proofs aren't needed for
+          // bytecodes since each code is keyed by its keccak256 hash).
+          val maxBytes = msg.responseBytes.toInt.max(0)
+          val codes: Seq[ByteString] = evmCodeStorage match {
+            case Some(storage) =>
+              val collected = scala.collection.mutable.ListBuffer.empty[ByteString]
+              var totalBytes = 0
+              val it = msg.hashes.iterator
+              while (it.hasNext && (totalBytes < maxBytes || collected.isEmpty)) {
+                val codeHash = it.next()
+                storage.get(codeHash).foreach { code =>
+                  collected += code
+                  totalBytes += code.size
+                }
               }
-            }
-            collected.toList
-          case None => Seq.empty
+              collected.toList
+            case None => Seq.empty
+          }
+          ByteCodes(requestId = msg.requestId, codes = codes)
+        } catch {
+          case t: Throwable =>
+            log.error(
+              s"serveByteCodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
+            )
+            ByteCodes(msg.requestId, Seq.empty)
         }
-        ByteCodes(requestId = msg.requestId, codes = codes)
-      } catch {
-        case t: Throwable =>
-          log.error(s"serveByteCodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-          ByteCodes(msg.requestId, Seq.empty)
-      }
       pwi.peer.ref ! PeerActor.SendMessage(response)
     }
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
@@ -1,5 +1,6 @@
 package com.chipprbots.ethereum.network
 
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicReference
 
@@ -26,7 +27,10 @@ class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: Ac
   import ServerActor._
   import context.system
 
-  override def receive: Receive = { case StartServer(address) =>
+  private var advertisedAddressOverride: Option[InetAddress] = None
+
+  override def receive: Receive = { case StartServer(address, advertisedAddress) =>
+    advertisedAddressOverride = advertisedAddress
     IO(Tcp) ! Bind(self, address)
     context.become(waitingForBindingResult)
   }
@@ -34,14 +38,22 @@ class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: Ac
   def waitingForBindingResult: Receive = {
     case Bound(localAddress) =>
       val nodeStatus = nodeStatusHolder.get()
+      // Resolve the address to advertise in enode URL and to peers.
+      // When bound to an unspecified address (:: or 0.0.0.0), peers cannot dial back using
+      // that address — fall back to the configured advertised-address or InetAddress.getLocalHost.
+      val advertisedHost: InetAddress = advertisedAddressOverride.getOrElse {
+        if (localAddress.getAddress.isAnyLocalAddress) InetAddress.getLocalHost
+        else localAddress.getAddress
+      }
+      val advertisedAddress = new InetSocketAddress(advertisedHost, localAddress.getPort)
       log.info("Listening on {}", localAddress)
       log.info(
         "Node address: enode://{}@{}:{}",
         Hex.toHexString(nodeStatus.nodeId),
-        getHostName(localAddress.getAddress),
-        localAddress.getPort
+        getHostName(advertisedHost),
+        advertisedAddress.getPort
       )
-      nodeStatusHolder.getAndUpdate(_.copy(serverStatus = ServerStatus.Listening(localAddress)))
+      nodeStatusHolder.getAndUpdate(_.copy(serverStatus = ServerStatus.Listening(advertisedAddress)))
       context.become(listening)
 
     case CommandFailed(b: Bind) =>
@@ -59,5 +71,5 @@ object ServerActor {
   def props(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: ActorRef): Props =
     Props(new ServerActor(nodeStatusHolder, peerManager))
 
-  case class StartServer(address: InetSocketAddress)
+  case class StartServer(address: InetSocketAddress, advertisedAddress: Option[InetAddress] = None)
 }

--- a/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
@@ -38,9 +38,6 @@ class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: Ac
   def waitingForBindingResult: Receive = {
     case Bound(localAddress) =>
       val nodeStatus = nodeStatusHolder.get()
-      // Resolve the address to advertise in enode URL and to peers.
-      // When bound to an unspecified address (:: or 0.0.0.0), peers cannot dial back using
-      // that address — fall back to the configured advertised-address or InetAddress.getLocalHost.
       val advertisedHost: InetAddress = advertisedAddressOverride.getOrElse {
         if (localAddress.getAddress.isAnyLocalAddress) InetAddress.getLocalHost
         else localAddress.getAddress

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -107,8 +107,11 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
     val nodeStatus = nodeStatusHolder.get()
     val listenPort = nodeStatus.serverStatus match {
       case ServerStatus.Listening(address) => address.getPort
-      case ServerStatus.NotListening       =>
-        log.debug("Server not yet listening when constructing Hello — using configured port {}", Config.Network.Server.port)
+      case ServerStatus.NotListening =>
+        log.debug(
+          "Server not yet listening when constructing Hello — using configured port {}",
+          Config.Network.Server.port
+        )
         Config.Network.Server.port
     }
     Hello(

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -107,7 +107,9 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
     val nodeStatus = nodeStatusHolder.get()
     val listenPort = nodeStatus.serverStatus match {
       case ServerStatus.Listening(address) => address.getPort
-      case ServerStatus.NotListening       => 0
+      case ServerStatus.NotListening       =>
+        log.warn("Server not yet listening when constructing Hello — using configured port {}", Config.Network.Server.port)
+        Config.Network.Server.port
     }
     Hello(
       p2pVersion = EtcHelloExchangeState.P2pVersion,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -108,7 +108,7 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
     val listenPort = nodeStatus.serverStatus match {
       case ServerStatus.Listening(address) => address.getPort
       case ServerStatus.NotListening       =>
-        log.warn("Server not yet listening when constructing Hello — using configured port {}", Config.Network.Server.port)
+        log.debug("Server not yet listening when constructing Hello — using configured port {}", Config.Network.Server.port)
         Config.Network.Server.port
     }
     Hello(

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -50,8 +50,6 @@ case class EthNodeStatus64ExchangeState(
       localForkId
     )
 
-    // ETH/64+ handshaker was missing networkId check — nodes with wrong networkId (e.g. PulseChain=369)
-    // but matching genesis hash were accepted, polluting the SNAP peer pool.
     if (status.networkId != peerConfiguration.networkId) {
       log.warn(
         "STATUS_EXCHANGE: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -50,7 +50,16 @@ case class EthNodeStatus64ExchangeState(
       localForkId
     )
 
-    if (status.genesisHash != localGenesisHash) {
+    // ETH/64+ handshaker was missing networkId check — nodes with wrong networkId (e.g. PulseChain=369)
+    // but matching genesis hash were accepted, polluting the SNAP peer pool.
+    if (status.networkId != peerConfiguration.networkId) {
+      log.warn(
+        "STATUS_EXCHANGE: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
+        peerConfiguration.networkId,
+        status.networkId
+      )
+      DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
+    } else if (status.genesisHash != localGenesisHash) {
       log.warn(
         "STATUS_EXCHANGE: Peer genesis hash mismatch! Local: {}, Remote: {} - disconnecting peer",
         localGenesisHash,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -46,7 +46,14 @@ case class EthNodeStatus69ExchangeState(
 
     val localGenesisHash = blockchainReader.genesisHeader.hash
 
-    if (status.genesisHash != localGenesisHash) {
+    if (status.networkId != peerConfiguration.networkId) {
+      log.warn(
+        "ETH69_STATUS: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
+        peerConfiguration.networkId,
+        status.networkId
+      )
+      DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
+    } else if (status.genesisHash != localGenesisHash) {
       log.warn(
         "ETH69_STATUS: Genesis hash mismatch! Local: {}, Remote: {} - disconnecting",
         localGenesisHash,

--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/Capability.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/Capability.scala
@@ -126,9 +126,9 @@ object Capability {
 
   implicit class CapabilityRLPEncodableDec(val rLPEncodeable: RLPEncodeable) extends AnyVal {
     def toCapability: Option[Capability] = rLPEncodeable match {
-      case RLPList(RLPValue(nameBytes), RLPValue(versionBytes)) if versionBytes.nonEmpty =>
+      case RLPList(RLPValue(nameBytes), RLPValue(versionBytes), _*) if versionBytes.nonEmpty =>
         parse(s"${new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)}/${versionBytes(0)}")
-      case _ => throw new RLPException("Cannot decode Capability")
+      case _ => None // Silently ignore unknown/malformed capability structures (EIP-8 lenience)
     }
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/SNAP.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/SNAP.scala
@@ -18,17 +18,15 @@ import com.chipprbots.ethereum.utils.ByteUtils
   *
   * See: https://github.com/ethereum/devp2p/blob/master/caps/snap.md
   *
-  * Message codes: SNAP defines relative codes 0x00-0x07 per the spec. On the wire, each
-  * capability occupies a contiguous block allocated by Hello capability order. For ETH+SNAP
-  * peers, SNAP starts right after ETH's code range. Wire offsets therefore depend on the
-  * negotiated ETH version: ETH/66-68 reserve 17 codes (0x10-0x20), ETH/69 reserves 18
-  * (0x10-0x21 including BlockRangeUpdate at rel 0x11). Peer SNAP wire base is computed in
-  * RLPxConnectionHandler based on negotiated eth cap.
+  * Message codes: SNAP defines relative codes 0x00-0x07 per the spec. On the wire, each capability occupies a
+  * contiguous block allocated by Hello capability order. For ETH+SNAP peers, SNAP starts right after ETH's code range.
+  * Wire offsets therefore depend on the negotiated ETH version: ETH/66-68 reserve 17 codes (0x10-0x20), ETH/69 reserves
+  * 18 (0x10-0x21 including BlockRangeUpdate at rel 0x11). Peer SNAP wire base is computed in RLPxConnectionHandler
+  * based on negotiated eth cap.
   *
-  * Canonical codes (internal to this codebase) live at 0x30-0x37. The 0x30 offset leaves
-  * room for ETH/69's full range AND avoids a historical collision with ETH/69's
-  * BlockRangeUpdate (canonical 0x10+0x11 = 0x21), which would have aliased onto the old
-  * SnapProtocolOffset=0x21 and caused SNAP's GetAccountRange to decode as BlockRangeUpdate.
+  * Canonical codes (internal to this codebase) live at 0x30-0x37. The 0x30 offset leaves room for ETH/69's full range
+  * AND avoids a historical collision with ETH/69's BlockRangeUpdate (canonical 0x10+0x11 = 0x21), which would have
+  * aliased onto the old SnapProtocolOffset=0x21 and caused SNAP's GetAccountRange to decode as BlockRangeUpdate.
   */
 object SNAP {
 

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -518,8 +518,12 @@ class RLPxConnectionHandler(
         cancellableAckTimeout: Option[CancellableAckTimeout] = None,
         seqNumber: Int = 0
     ): Unit =
-      extractor.readHello(data) match {
-        case Some((hello, restFrames)) =>
+      Try(extractor.readHello(data)) match {
+        case Failure(err) =>
+          log.warning("[RLPx] Malformed Hello from peer {}: {} — disconnecting", peerId, err.getMessage)
+          context.parent ! ConnectionFailed
+          gracefulStop()
+        case Success(Some((hello, restFrames))) =>
           log.debug(
             "[RLPx] Extracted Hello message from peer {}, protocol version: {}, capabilities: {}",
             peerId,
@@ -555,8 +559,8 @@ class RLPxConnectionHandler(
               context.parent ! ConnectionFailed
               gracefulStop()
           }
-        case None =>
-          log.warning("[RLPx] Did not find 'Hello' in message from peer {}, continuing to await", peerId)
+        case Success(None) =>
+          log.debug("[RLPx] Did not find 'Hello' in message from peer {}, continuing to await", peerId)
           context.become(awaitInitialHello(extractor, cancellableAckTimeout, seqNumber))
       }
 

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -126,10 +126,10 @@ class RLPxConnectionHandler(
     private val CanonicalSnapBase = 0x30
     private val CanonicalSnapSize = 0x08
 
-    /** Wire-space size of the peer's ETH protocol — varies by version. ETH/66-68 have 17
-      * codes (0x00..0x10). ETH/69 adds BlockRangeUpdate at 0x11, for 18 codes. Getting this
-      * wrong shifts the peer's SNAP base by one and every subsequent SNAP message decodes
-      * against the adjacent canonical code (e.g. GetStorageRanges mis-decoded as StorageRanges).
+    /** Wire-space size of the peer's ETH protocol — varies by version. ETH/66-68 have 17 codes (0x00..0x10). ETH/69
+      * adds BlockRangeUpdate at 0x11, for 18 codes. Getting this wrong shifts the peer's SNAP base by one and every
+      * subsequent SNAP message decodes against the adjacent canonical code (e.g. GetStorageRanges mis-decoded as
+      * StorageRanges).
       */
     private def ethWireSizeFor(cap: Capability): Int = cap match {
       case Capability.ETH69 => 0x12

--- a/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
@@ -14,20 +14,17 @@ import com.chipprbots.ethereum.rlp.RLPValue
 import com.chipprbots.ethereum.utils.ByteUtils
 import com.chipprbots.ethereum.utils.Logger
 
-/** Server-side SNAP/1 helpers — Merkle Patricia Trie range traversal and Merkle proof
-  * generation for incoming `GetAccountRange`, `GetStorageRanges`, and `GetTrieNodes`
-  * requests from peers.
+/** Server-side SNAP/1 helpers — Merkle Patricia Trie range traversal and Merkle proof generation for incoming
+  * `GetAccountRange`, `GetStorageRanges`, and `GetTrieNodes` requests from peers.
   *
-  * The traversal walks the trie in nibble (key) order and yields `(keyHash, valueRLP)`
-  * pairs strictly between the requested `[origin, limit]` bounds, stopping once the
-  * accumulated response size exceeds `responseBytes` (per SNAP/1 spec, the server may
-  * truncate the response prefix early — but must always emit at least one item if any
-  * exists in the range).
+  * The traversal walks the trie in nibble (key) order and yields `(keyHash, valueRLP)` pairs strictly between the
+  * requested `[origin, limit]` bounds, stopping once the accumulated response size exceeds `responseBytes` (per SNAP/1
+  * spec, the server may truncate the response prefix early — but must always emit at least one item if any exists in
+  * the range).
   *
-  * For each non-empty range we also emit a proof: the path from the root to the first
-  * returned key, and (if more than one item is emitted) the path from the root to the
-  * last returned key. These let the requester rebuild a partial trie and verify the
-  * range is contiguous against the claimed root hash.
+  * For each non-empty range we also emit a proof: the path from the root to the first returned key, and (if more than
+  * one item is emitted) the path from the root to the last returned key. These let the requester rebuild a partial trie
+  * and verify the range is contiguous against the claimed root hash.
   */
 object SnapServer extends Logger {
 
@@ -45,7 +42,7 @@ object SnapServer extends Logger {
   }
 
   /** Convert a 64-nibble key path back to a 32-byte hash. Returns None if length is odd. */
-  def nibblesToHash(nibbles: Array[Byte]): Option[ByteString] = {
+  def nibblesToHash(nibbles: Array[Byte]): Option[ByteString] =
     if (nibbles.length % 2 != 0) None
     else {
       val out = new Array[Byte](nibbles.length / 2)
@@ -56,7 +53,6 @@ object SnapServer extends Logger {
       }
       Some(ByteString(out))
     }
-  }
 
   /** Compare two nibble arrays lexicographically (treating each nibble as a digit 0..15). */
   private def cmpNibbles(a: Array[Byte], b: Array[Byte]): Int = {
@@ -86,17 +82,15 @@ object SnapServer extends Logger {
     try storage.get(rootHash.toArray)
     catch { case _: Throwable => NullNode }
 
-  /** Slim-account RLP element per geth's snap protocol convention: the storageRoot and
-    * codeHash fields are encoded as empty bytes when they equal the canonical empty-trie
-    * root and empty-code hash respectively. Saves ~64 bytes per EOA — critical for the
-    * SNAP byte-budget which counts the leaf body length toward the soft response limit.
+  /** Slim-account RLP element per geth's snap protocol convention: the storageRoot and codeHash fields are encoded as
+    * empty bytes when they equal the canonical empty-trie root and empty-code hash respectively. Saves ~64 bytes per
+    * EOA — critical for the SNAP byte-budget which counts the leaf body length toward the soft response limit.
     *
-    * Our `AccountImplicits.toAccount` decoder already normalises empty bytes back to the
-    * canonical defaults, so round-trips are lossless across our own and geth's clients.
+    * Our `AccountImplicits.toAccount` decoder already normalises empty bytes back to the canonical defaults, so
+    * round-trips are lossless across our own and geth's clients.
     *
-    * Returns the parsed RLP element so callers can either embed it (in `AccountRange`'s
-    * RLP envelope) or serialise it (`rlp.encode(toSlimAccountRlp(...))`) for byte-budget
-    * accounting.
+    * Returns the parsed RLP element so callers can either embed it (in `AccountRange`'s RLP envelope) or serialise it
+    * (`rlp.encode(toSlimAccountRlp(...))`) for byte-budget accounting.
     */
   def toSlimAccountRlp(account: Account): RLPList = {
     val nonceRlp: RLPEncodeable = RLPValue(ByteUtils.bigIntToUnsignedByteArray(account.nonce))
@@ -110,9 +104,8 @@ object SnapServer extends Logger {
     RLPList(nonceRlp, balanceRlp, srRlp, chRlp)
   }
 
-  /** RLP-encode a node and emit its keccak256 hash + encoded bytes. Used when collecting
-    * proof nodes — peers verify by re-hashing each proof node and matching against
-    * parent references.
+  /** RLP-encode a node and emit its keccak256 hash + encoded bytes. Used when collecting proof nodes — peers verify by
+    * re-hashing each proof node and matching against parent references.
     */
   private def encodeNodeWithHash(node: MptNode): (ByteString, ByteString) = {
     val encoded = MptTraversals.encodeNode(node)
@@ -120,14 +113,12 @@ object SnapServer extends Logger {
     (hash, ByteString(encoded))
   }
 
-  /** Range walker — yields (keyHash, leafValue) pairs whose key falls in
-    * [originNibbles, limitNibbles] (inclusive on both ends), traversing the trie in key
-    * order. Caller stops consuming when their byte budget is exceeded.
+  /** Range walker — yields (keyHash, leafValue) pairs whose key falls in [originNibbles, limitNibbles] (inclusive on
+    * both ends), traversing the trie in key order. Caller stops consuming when their byte budget is exceeded.
     *
-    * Pruning: for a partial nibble prefix `p` of length L, the minimum reachable full key
-    * is `p ++ 0×(N-L)` and the maximum is `p ++ F×(N-L)` (where N is the full key length
-    * in nibbles, 64 for an account hash). We skip a subtree only when its max < origin
-    * OR its min > limit.
+    * Pruning: for a partial nibble prefix `p` of length L, the minimum reachable full key is `p ++ 0×(N-L)` and the
+    * maximum is `p ++ F×(N-L)` (where N is the full key length in nibbles, 64 for an account hash). We skip a subtree
+    * only when its max < origin OR its min > limit.
     */
   private val FullKeyNibbles = 64
 
@@ -137,12 +128,11 @@ object SnapServer extends Logger {
   private def minKeyWith(prefix: Array[Byte]): Array[Byte] =
     prefix ++ Array.fill(math.max(0, FullKeyNibbles - prefix.length))(0.toByte)
 
-  /** Subtree-prune predicate. We only skip subtrees that lie strictly BELOW `origin`
-    * (i.e. their max key is < origin). Subtrees ABOVE `limit` are intentionally not
-    * pruned — the visitor's stop-on-`>=limit` rule needs to see the first leaf past the
-    * limit (geth's serveAccountRange does the same: it iterates past the limit,
-    * `break`s after emitting one). Limit-side pruning would cut off that extra leaf
-    * and undercount in any range whose first available key extends past `limit`.
+  /** Subtree-prune predicate. We only skip subtrees that lie strictly BELOW `origin` (i.e. their max key is < origin).
+    * Subtrees ABOVE `limit` are intentionally not pruned — the visitor's stop-on-`>=limit` rule needs to see the first
+    * leaf past the limit (geth's serveAccountRange does the same: it iterates past the limit, `break`s after emitting
+    * one). Limit-side pruning would cut off that extra leaf and undercount in any range whose first available key
+    * extends past `limit`.
     */
   private def subtreeIntersectsRange(
       prefix: Array[Byte],
@@ -151,12 +141,12 @@ object SnapServer extends Logger {
   ): Boolean =
     cmpNibbles(maxKeyWith(prefix), originNibbles) >= 0
 
-  /** Visit-style range walker — calls `visit(keyHash, valueRLP)` for every leaf whose key
-    * falls in `[origin, limit]`, traversing the trie in key order. The visitor returns
-    * `true` to continue or `false` to stop the walk early (used by the byte-budget gate).
+  /** Visit-style range walker — calls `visit(keyHash, valueRLP)` for every leaf whose key falls in `[origin, limit]`,
+    * traversing the trie in key order. The visitor returns `true` to continue or `false` to stop the walk early (used
+    * by the byte-budget gate).
     *
-    * Iterative-style traversal via direct recursion (no Iterator.flatMap chain) — much
-    * cheaper than the previous lazy iterator construction when the chain depth is 64.
+    * Iterative-style traversal via direct recursion (no Iterator.flatMap chain) — much cheaper than the previous lazy
+    * iterator construction when the chain depth is 64.
     */
   private def walkRangeVisit(
       root: MptNode,
@@ -170,7 +160,7 @@ object SnapServer extends Logger {
       if (stop) return
       if (!subtreeIntersectsRange(prefix, originNibbles, limitNibbles)) return
       resolve(node, storage) match {
-        case NullNode => ()
+        case NullNode                      => ()
         case LeafNode(key, value, _, _, _) =>
           // Geth semantics (eth/protocols/snap/handler.go:304-322): emit any leaf
           // whose key is `>= origin`, then `break` after emitting one with key
@@ -210,8 +200,8 @@ object SnapServer extends Logger {
     descend(root, Array.emptyByteArray)
   }
 
-  /** Compatibility wrapper retained for callers that want an Iterator. Internally uses
-    * the visit-style walker but materialises results into a buffer first.
+  /** Compatibility wrapper retained for callers that want an Iterator. Internally uses the visit-style walker but
+    * materialises results into a buffer first.
     */
   private def walkRange(
       root: MptNode,
@@ -226,10 +216,9 @@ object SnapServer extends Logger {
     buf.iterator
   }
 
-  /** Collect the proof path for a given key — the nodes traversed from root to the leaf
-    * (or the deepest reachable node along the path if the key is absent). The proof is
-    * returned as a sequence of RLP-encoded MPT nodes (with each node's keccak hash
-    * available to the caller for de-duplication).
+  /** Collect the proof path for a given key — the nodes traversed from root to the leaf (or the deepest reachable node
+    * along the path if the key is absent). The proof is returned as a sequence of RLP-encoded MPT nodes (with each
+    * node's keccak hash available to the caller for de-duplication).
     */
   private def proofFor(
       root: MptNode,
@@ -266,10 +255,9 @@ object SnapServer extends Logger {
     acc.toSeq
   }
 
-  /** Build an `AccountRange` response by walking the state trie at `rootHash` between
-    * `startingHash` and `limitHash`, emitting accounts whose RLP totals up to (but
-    * generally not exceeding) `responseBytes`. Always emits at least one account if any
-    * fall in the range.
+  /** Build an `AccountRange` response by walking the state trie at `rootHash` between `startingHash` and `limitHash`,
+    * emitting accounts whose RLP totals up to (but generally not exceeding) `responseBytes`. Always emits at least one
+    * account if any fall in the range.
     */
   def serveAccountRange(
       requestId: BigInt,
@@ -342,9 +330,9 @@ object SnapServer extends Logger {
     AccountRange(requestId, collected.toSeq, dedupedProof)
   }
 
-  /** Build a `StorageRanges` response — for each account, walk the per-account storage
-    * trie between `startingHash` and `limitHash`. Only the first account's range is
-    * proved (per SNAP/1 spec — subsequent accounts are returned in full, no proof).
+  /** Build a `StorageRanges` response — for each account, walk the per-account storage trie between `startingHash` and
+    * `limitHash`. Only the first account's range is proved (per SNAP/1 spec — subsequent accounts are returned in full,
+    * no proof).
     */
   def serveStorageRanges(
       requestId: BigInt,
@@ -413,9 +401,8 @@ object SnapServer extends Logger {
     StorageRanges(requestId, perAccount.toSeq, firstProof)
   }
 
-  /** Build a `TrieNodes` response — look up each requested HP-encoded path from `rootHash`
-    * and return the raw RLP-encoded node found at that path. Missing nodes yield empty
-    * bytes per SNAP/1 spec.
+  /** Build a `TrieNodes` response — look up each requested HP-encoded path from `rootHash` and return the raw
+    * RLP-encoded node found at that path. Missing nodes yield empty bytes per SNAP/1 spec.
     */
   def serveTrieNodes(
       requestId: BigInt,
@@ -494,9 +481,8 @@ object SnapServer extends Logger {
     TrieNodes(requestId, collected.toSeq)
   }
 
-  /** Walk the state trie following `nibbles` to a leaf and decode that leaf's value as
-    * an `Account`. Returns None if the path doesn't terminate at a leaf or the leaf
-    * isn't a valid account RLP.
+  /** Walk the state trie following `nibbles` to a leaf and decode that leaf's value as an `Account`. Returns None if
+    * the path doesn't terminate at a leaf or the leaf isn't a valid account RLP.
     */
   private def resolveLeafAccount(
       root: MptNode,
@@ -539,8 +525,8 @@ object SnapServer extends Logger {
     descend(root, nibbles)
   }
 
-  /** Decode an HP-encoded (Hex Prefix, EIP-2 / yellow-paper) path back to its nibble
-    * representation. Drops the leaf/extension flag bit.
+  /** Decode an HP-encoded (Hex Prefix, EIP-2 / yellow-paper) path back to its nibble representation. Drops the
+    * leaf/extension flag bit.
     */
   private def decodeHpPath(bytes: Array[Byte]): Array[Byte] = {
     if (bytes.isEmpty) return Array.emptyByteArray
@@ -554,8 +540,8 @@ object SnapServer extends Logger {
     firstNibble ++ rest.drop(skipFirst - 1).take(rest.length - (skipFirst - 1))
   }
 
-  /** Walk the trie following `nibbles` and return the encoded node found at that exact
-    * path (as a raw MPT node), or None if the path doesn't terminate cleanly at a node.
+  /** Walk the trie following `nibbles` and return the encoded node found at that exact path (as a raw MPT node), or
+    * None if the path doesn't terminate cleanly at a node.
     */
   private def collectNodeAtPath(
       root: MptNode,

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -142,7 +142,10 @@ abstract class BaseNode extends Node {
     }
   }
 
-  private[this] def startServer(): Unit = server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
+  private[this] def startServer(): Unit = server ! ServerActor.StartServer(
+    networkConfig.Server.listenAddress,
+    networkConfig.Server.advertisedAddress.map(java.net.InetAddress.getByName)
+  )
 
   private[this] def startSyncController(): Unit = syncController ! SyncProtocol.Start
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -52,10 +52,10 @@ abstract class BaseNode extends Node {
     startEngineApiServer()
 
     // Phase 3: P2P networking
-    startPeerManager()
+    startServer()
     loadStaticNodes()
     startPortForwarding()
-    startServer()
+    startPeerManager()
     startDiscoveryManager()
 
     // Phase 5: Background work

--- a/src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala
@@ -64,6 +64,10 @@ class InstanceConfig(val config: TypesafeConfig, val instanceId: String = "defau
       val interface: String = serverConfig.getString("interface")
       val port: Int = serverConfig.getInt("port")
       val listenAddress = new InetSocketAddress(interface, port)
+      val advertisedAddress: Option[String] =
+        if (serverConfig.hasPath("advertised-address") && !serverConfig.getIsNull("advertised-address"))
+          Some(serverConfig.getString("advertised-address"))
+        else None
     }
 
     val peer: PeerConfiguration = new PeerConfiguration {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -399,9 +399,8 @@ class BlockFetcherSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfter
       sender ! PeersClient.Response(fakePeer, ETH66BlockBodies(0, firstBlocksBatch.map(_.body)))
     }
 
-    /** Synchronise on BlockFetcher having finished processing the bodies response.
-      * 1s is well above observed CI latency for a single message hop; short sleep
-      * keeps local runs fast.
+    /** Synchronise on BlockFetcher having finished processing the bodies response. 1s is well above observed CI latency
+      * for a single message hop; short sleep keeps local runs fast.
       */
     def awaitBodiesProcessed(): Unit = Thread.sleep(1000L)
 

--- a/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/BlockExecutionSpec.scala
@@ -708,6 +708,7 @@ class BlockExecutionSpec
   }
 
   trait BlockExecutionTestSetup extends BlockchainSetup {
+
     /** Read-only view of the account trie rooted at the parent block's stateRoot. */
     def readOnceAtParent: InMemoryWorldStateProxy =
       InMemoryWorldStateProxy(
@@ -719,7 +720,6 @@ class BlockExecutionSpec
         noEmptyAccounts = false,
         ethCompatibleStorage = true
       )
-
 
     override lazy val blockValidation =
       new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))

--- a/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -524,7 +524,7 @@ class NetworkHandshakerSpec extends AnyFlatSpec with Matchers {
       p2pVersion = EtcHelloExchangeState.P2pVersion,
       clientId = Config.clientId,
       capabilities = Config.supportedCapabilities, // Use actual supported capabilities from Config
-      listenPort = 0, // Local node not listening
+      listenPort = Config.Network.Server.port, // Falls back to configured port when NotListening (BUG-NET1 fix)
       nodeId = ByteString(nodeStatus.nodeId)
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -523,8 +523,8 @@ class NetworkHandshakerSpec extends AnyFlatSpec with Matchers {
     val localHello: Hello = Hello(
       p2pVersion = EtcHelloExchangeState.P2pVersion,
       clientId = Config.clientId,
-      capabilities = Config.supportedCapabilities, // Use actual supported capabilities from Config
-      listenPort = Config.Network.Server.port, // Falls back to configured port when NotListening (BUG-NET1 fix)
+      capabilities = Config.supportedCapabilities,
+      listenPort = Config.Network.Server.port,
       nodeId = ByteString(nodeStatus.nodeId)
     )
 


### PR DESCRIPTION
## Summary

Four independent P2P/network correctness fixes found during ETC mainnet testing:

- **RLP decoder crash** — `Capability` decoder threw on unknown peer capabilities (e.g. from non-ETC clients) instead of skipping gracefully per EIP-8
- **listenPort=0 in Hello** — `EtcHelloExchangeState` advertised the ephemeral port `0` to peers when the server hadn't bound yet; peers would record an unreachable endpoint
- **Real IP in Hello** — `ServerActor` advertised `[::]` (unspecified) instead of resolving the actual bound interface address
- **networkId check in ETH/64+ handshaker** — `EthNodeStatus64ExchangeState` / `EthNodeStatus69ExchangeState` accepted peers with mismatched `networkId`; nodes on foreign networks (wrong networkId) but matching genesis hash were accepted, polluting the peer pool

## Changes

| File | Change |
|------|--------|
| `network/p2p/messages/Capability.scala` | Skip unknown capabilities in RLP decode (EIP-8 lenience) |
| `network/rlpx/RLPxConnectionHandler.scala` | Guard against unknown capability crash |
| `network/handshaker/EtcHelloExchangeState.scala` | Use resolved listen port, not 0 |
| `network/handshaker/EthNodeStatus64ExchangeState.scala` | Reject mismatched networkId before genesis check |
| `network/handshaker/EthNodeStatus69ExchangeState.scala` | Reject mismatched networkId before genesis check |
| `network/ServerActor.scala` | Resolve real IP from bound address; support `advertised-address` override |
| `nodebuilder/StdNode.scala` | Pass resolved address to ServerActor |
| `utils/InstanceConfig.scala` | Expose `advertised-address` config key |
| `conf/base/network.conf` | Config support for `advertised-address` |
| `network/handshaker/EtcHandshakerSpec.scala` | Test update |

## Test plan

- [ ] `sbt test` passes
- [ ] Connect to ETC mainnet peers — no RLP decoder crashes on unknown capabilities
- [ ] Verify `admin_nodeInfo` returns correct IP and port (not `[::]` / `0`)
- [ ] Verify peers with wrong networkId are disconnected at handshake

🤖 Generated with [Claude Code](https://claude.com/claude-code)