### PR TITLE
style: scalafmtAll — format drift from recent GraphQL + snap PRs

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
@@ -192,11 +192,12 @@ class EthTxService(
         // through `tx.gasPrice` as ~10^9, which drags the arithmetic mean into the tens of
         // millions and fails hive's graphql test 07 (accepts 0x10 or 0x1 — both low). geth
         // and besu both use the median of the recent-blocks sample for the same reason.
-        val sorted   = gasPrice.sorted
+        val sorted = gasPrice.sorted
         val midIndex = sorted.length / 2
-        val median   = if (sorted.length % 2 == 0 && sorted.length >= 2)
-          (sorted(midIndex - 1) + sorted(midIndex)) / 2
-        else sorted(midIndex)
+        val median =
+          if (sorted.length % 2 == 0 && sorted.length >= 2)
+            (sorted(midIndex - 1) + sorted(midIndex)) / 2
+          else sorted(midIndex)
         Right(GetGasPriceResponse(median))
       } else {
         Right(GetGasPriceResponse(0))

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLContext.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLContext.scala
@@ -4,7 +4,15 @@ import org.apache.pekko.util.ByteString
 
 import com.chipprbots.ethereum.consensus.mining.Mining
 import com.chipprbots.ethereum.db.storage.EvmCodeStorage
-import com.chipprbots.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader, Receipt, SignedTransaction, TxLogEntry}
+import com.chipprbots.ethereum.domain.{
+  Block,
+  BlockHeader,
+  Blockchain,
+  BlockchainReader,
+  Receipt,
+  SignedTransaction,
+  TxLogEntry
+}
 import com.chipprbots.ethereum.jsonrpc.EthBlocksService
 import com.chipprbots.ethereum.jsonrpc.EthFilterService
 import com.chipprbots.ethereum.jsonrpc.EthInfoService
@@ -29,9 +37,9 @@ case class GraphQLContext(
     ethFilterService: EthFilterService
 )
 
-/** GraphQL wrappers that carry a bit more context than the bare domain type — for example a
-  * transaction needs to know its own block to resolve `block`/`status`/`gasUsed`, and a log needs to
-  * know its parent transaction plus its ordinal position.
+/** GraphQL wrappers that carry a bit more context than the bare domain type — for example a transaction needs to know
+  * its own block to resolve `block`/`status`/`gasUsed`, and a log needs to know its parent transaction plus its ordinal
+  * position.
   */
 object GraphQLTypes {
 

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLScalars.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLScalars.scala
@@ -37,10 +37,12 @@ object GraphQLScalars {
   def toHexBigInt(n: BigInt): String = {
     // EIP-1767 canonical: no leading zeroes, with "0x0" for zero.
     val raw = n.toString(16)
-    "0x" + (if (raw == "0") "0" else raw.dropWhile(_ == '0') match {
-      case ""    => "0"
-      case other => other
-    })
+    "0x" + (if (raw == "0") "0"
+            else
+              raw.dropWhile(_ == '0') match {
+                case ""    => "0"
+                case other => other
+              })
   }
 
   def toHexLong(n: Long): String = toHexBigInt(BigInt(n))

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLSchema.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLSchema.scala
@@ -65,12 +65,12 @@ object GraphQLSchema {
   // Guard: query depth limit (matches geth/graphql/service.go:33).
   val MaxQueryDepth: Int = 20
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   // SignedTransaction.getSender needs an implicit BlockchainConfig (for EIP-155 chainId
   // extraction from the v signature field). We inherit from the global Config — same pattern
   // as EthTxService and TransactionResponse.
-  private implicit val blockchainConfigImplicit: com.chipprbots.ethereum.utils.BlockchainConfig =
+  implicit private val blockchainConfigImplicit: com.chipprbots.ethereum.utils.BlockchainConfig =
     com.chipprbots.ethereum.utils.Config.blockchains.blockchainConfig
 
   // ---------------------------------------------------------------------------
@@ -109,11 +109,11 @@ object GraphQLSchema {
   }
 
   private def txType(tx: Transaction): Long = tx match {
-    case _: LegacyTransaction          => 0L
-    case _: TransactionWithAccessList  => 1L
-    case _: TransactionWithDynamicFee  => 2L
-    case _: BlobTransaction            => 3L
-    case _: SetCodeTransaction         => 4L
+    case _: LegacyTransaction         => 0L
+    case _: TransactionWithAccessList => 1L
+    case _: TransactionWithDynamicFee => 2L
+    case _: BlobTransaction           => 3L
+    case _: SetCodeTransaction        => 4L
   }
 
   private def txAccessList(tx: Transaction): Option[List[AccessListItem]] = tx match {
@@ -162,8 +162,9 @@ object GraphQLSchema {
       case other => other.gasPrice - baseFee.getOrElse(BigInt(0))
     }
 
-  /** `null` for pre-Byzantium receipts (which store a state root instead of a status byte —
-    * see EIP-658). Hive test 30 expects `status: null` for a Frontier-era transaction. */
+  /** `null` for pre-Byzantium receipts (which store a state root instead of a status byte — see EIP-658). Hive test 30
+    * expects `status: null` for a Frontier-era transaction.
+    */
   private def txStatus(r: Receipt): Option[Long] =
     r.postTransactionStateHash match {
       case SuccessOutcome => Some(1L)
@@ -197,11 +198,10 @@ object GraphQLSchema {
       )
     }
 
-  /** For `Pending.transactions` / `Pending.transactionCount`, surface only the lowest-nonce tx
-    * per sender — the one that is "next in line" to be included. The mempool stores every
-    * queued tx (including future-nonce ones), but hive's graphql test 35 expects the geth-style
-    * view where each sender contributes at most one "pending" entry. Mirrors
-    * `eth_pendingTransactions` behaviour in geth / besu.
+  /** For `Pending.transactions` / `Pending.transactionCount`, surface only the lowest-nonce tx per sender — the one
+    * that is "next in line" to be included. The mempool stores every queued tx (including future-nonce ones), but
+    * hive's graphql test 35 expects the geth-style view where each sender contributes at most one "pending" entry.
+    * Mirrors `eth_pendingTransactions` behaviour in geth / besu.
     */
   private def readyPendingTxs(
       all: Seq[com.chipprbots.ethereum.transactions.PendingTransactionsManager.PendingTransaction]
@@ -270,29 +270,29 @@ object GraphQLSchema {
   )
 
   // Common arguments — explicit result types needed for Scala 3 FromInput derivation.
-  private val BlockNumberArg: Argument[Option[Long]]       = Argument("block", OptionInputType(LongType))
-  private val NumberArg: Argument[Option[Long]]            = Argument("number", OptionInputType(LongType))
-  private val HashArg: Argument[Option[ByteString]]        = Argument("hash", OptionInputType(Bytes32Type))
-  private val AddressArg: Argument[ByteString]             = Argument("address", AddressType)
-  private val SlotArg: Argument[ByteString]                = Argument("slot", Bytes32Type)
-  private val IndexArg: Argument[Long]                     = Argument("index", LongType)
-  private val FromArg: Argument[Option[Long]]              = Argument("from", OptionInputType(LongType))
-  private val ToArg: Argument[Option[Long]]                = Argument("to", OptionInputType(LongType))
-  private val CallDataArg: Argument[Map[String, Any]]      = Argument("data", CallDataInputType)
-  private val BlockFilterArg: Argument[Map[String, Any]]   = Argument("filter", BlockFilterCriteriaInputType)
-  private val FilterArg: Argument[Map[String, Any]]        = Argument("filter", FilterCriteriaInputType)
-  private val TxHashArg: Argument[ByteString]              = Argument("hash", Bytes32Type)
-  private val RawDataArg: Argument[ByteString]             = Argument("data", BytesType)
+  private val BlockNumberArg: Argument[Option[Long]] = Argument("block", OptionInputType(LongType))
+  private val NumberArg: Argument[Option[Long]] = Argument("number", OptionInputType(LongType))
+  private val HashArg: Argument[Option[ByteString]] = Argument("hash", OptionInputType(Bytes32Type))
+  private val AddressArg: Argument[ByteString] = Argument("address", AddressType)
+  private val SlotArg: Argument[ByteString] = Argument("slot", Bytes32Type)
+  private val IndexArg: Argument[Long] = Argument("index", LongType)
+  private val FromArg: Argument[Option[Long]] = Argument("from", OptionInputType(LongType))
+  private val ToArg: Argument[Option[Long]] = Argument("to", OptionInputType(LongType))
+  private val CallDataArg: Argument[Map[String, Any]] = Argument("data", CallDataInputType)
+  private val BlockFilterArg: Argument[Map[String, Any]] = Argument("filter", BlockFilterCriteriaInputType)
+  private val FilterArg: Argument[Map[String, Any]] = Argument("filter", FilterCriteriaInputType)
+  private val TxHashArg: Argument[ByteString] = Argument("hash", Bytes32Type)
+  private val RawDataArg: Argument[ByteString] = Argument("data", BytesType)
 
   // Convert a CallData input map to EthInfoService.CallTx.
   private def toCallTx(m: Map[String, Any]): EthInfoService.CallTx = {
-    val from     = m.get("from").flatMap(asOption[ByteString])
-    val toRaw    = m.get("to").flatMap(asOption[ByteString])
-    val gas      = m.get("gas").flatMap(asOption[Long]).map(BigInt(_))
+    val from = m.get("from").flatMap(asOption[ByteString])
+    val toRaw = m.get("to").flatMap(asOption[ByteString])
+    val gas = m.get("gas").flatMap(asOption[Long]).map(BigInt(_))
     val gasPrice = m.get("gasPrice").flatMap(asOption[BigInt]).getOrElse(BigInt(0))
-    val maxFee   = m.get("maxFeePerGas").flatMap(asOption[BigInt])
-    val value    = m.get("value").flatMap(asOption[BigInt]).getOrElse(BigInt(0))
-    val data     = m.get("data").flatMap(asOption[ByteString]).getOrElse(ByteString.empty)
+    val maxFee = m.get("maxFeePerGas").flatMap(asOption[BigInt])
+    val value = m.get("value").flatMap(asOption[BigInt]).getOrElse(BigInt(0))
+    val data = m.get("data").flatMap(asOption[ByteString]).getOrElse(ByteString.empty)
     // When the caller omits `to` AND provides no payload, treat the call as a zero-value
     // no-op transfer to the zero address — that's what geth returns for hive's
     // `pending.estimateGas(data: {})` test (expected 0x5208 = 21000, the plain-transfer
@@ -303,7 +303,8 @@ object GraphQLSchema {
       else toRaw
     // If dynamic fee fields are present but no legacy gasPrice, synthesise the legacy field to
     // maxFeePerGas so the existing stxLedger.simulateTransaction path can run unchanged.
-    val effectiveGasPrice = if (m.get("gasPrice").flatMap(asOption[BigInt]).isDefined) gasPrice else maxFee.getOrElse(gasPrice)
+    val effectiveGasPrice =
+      if (m.get("gasPrice").flatMap(asOption[BigInt]).isDefined) gasPrice else maxFee.getOrElse(gasPrice)
     EthInfoService.CallTx(
       from = from,
       to = to,
@@ -316,10 +317,10 @@ object GraphQLSchema {
   }
 
   private def asOption[A](v: Any): Option[A] = v match {
-    case null       => None
-    case None       => None
-    case Some(x)    => Some(x.asInstanceOf[A])
-    case other      => Some(other.asInstanceOf[A])
+    case null    => None
+    case None    => None
+    case Some(x) => Some(x.asInstanceOf[A])
+    case other   => Some(other.asInstanceOf[A])
   }
 
   // ---------------------------------------------------------------------------
@@ -462,7 +463,9 @@ object GraphQLSchema {
             val blockNum = c.arg(BlockNumberArg) match {
               case Some(n) => BigInt(n)
               case None =>
-                c.value.parent.blockInfo.map(_.block.header.number).getOrElse(c.ctx.blockchainReader.getBestBlockNumber())
+                c.value.parent.blockInfo
+                  .map(_.block.header.number)
+                  .getOrElse(c.ctx.blockchainReader.getBestBlockNumber())
             }
             GAccount(c.value.log.loggerAddress.bytes, blockNum)
           }
@@ -546,8 +549,8 @@ object GraphQLSchema {
         Field(
           "effectiveGasPrice",
           OptionType(BigIntType),
-          resolve = c =>
-            c.value.blockInfo.map(bi => Transaction.effectiveGasPrice(c.value.stx.tx, bi.block.header.baseFee))
+          resolve =
+            c => c.value.blockInfo.map(bi => Transaction.effectiveGasPrice(c.value.stx.tx, bi.block.header.baseFee))
         ),
         Field(
           "blobGasUsed",
@@ -564,7 +567,7 @@ object GraphQLSchema {
           OptionType(BigIntType),
           resolve = c =>
             for {
-              bi  <- c.value.blockInfo
+              bi <- c.value.blockInfo
               ebg <- bi.block.header.excessBlobGas
             } yield BlobGasUtils.getBlobGasPrice(ebg, bi.block.header.unixTimestamp, c.ctx.blockchainConfig)
         ),
@@ -604,7 +607,8 @@ object GraphQLSchema {
         Field(
           "rawReceipt",
           BytesType,
-          resolve = c => receiptBundle(c.ctx, c.value).map(rb => rlpEncodeReceipt(rb.receipt)).getOrElse(ByteString.empty)
+          resolve =
+            c => receiptBundle(c.ctx, c.value).map(rb => rlpEncodeReceipt(rb.receipt)).getOrElse(ByteString.empty)
         ),
         Field(
           "blobVersionedHashes",
@@ -627,19 +631,24 @@ object GraphQLSchema {
         Field(
           "parent",
           OptionType(BlockType),
-          resolve = c =>
-            c.ctx.blockchainReader.getBlockByHash(c.value.header.parentHash).map(b => buildGBlock(c.ctx, b))
+          resolve =
+            c => c.ctx.blockchainReader.getBlockByHash(c.value.header.parentHash).map(b => buildGBlock(c.ctx, b))
         ),
         Field("nonce", BytesType, resolve = _.value.header.nonce),
         Field("transactionsRoot", Bytes32Type, resolve = _.value.header.transactionsRoot),
-        Field("transactionCount", OptionType(LongType), resolve = c => Some(c.value.block.body.transactionList.size.toLong)),
+        Field(
+          "transactionCount",
+          OptionType(LongType),
+          resolve = c => Some(c.value.block.body.transactionList.size.toLong)
+        ),
         Field("stateRoot", Bytes32Type, resolve = _.value.header.stateRoot),
         Field("receiptsRoot", Bytes32Type, resolve = _.value.header.receiptsRoot),
         Field(
           "miner",
           AccountType,
           arguments = List(BlockNumberArg),
-          resolve = c => GAccount(c.value.header.beneficiary, c.arg(BlockNumberArg).map(BigInt(_)).getOrElse(c.value.number))
+          resolve =
+            c => GAccount(c.value.header.beneficiary, c.arg(BlockNumberArg).map(BigInt(_)).getOrElse(c.value.number))
         ),
         Field("extraData", BytesType, resolve = _.value.header.extraData),
         Field("gasLimit", LongType, resolve = _.value.header.gasLimit.toLong),
@@ -663,7 +672,11 @@ object GraphQLSchema {
         Field("logsBloom", BytesType, resolve = _.value.header.logsBloom),
         Field("mixHash", Bytes32Type, resolve = _.value.header.mixHash),
         Field("difficulty", BigIntType, resolve = _.value.header.difficulty),
-        Field("totalDifficulty", BigIntType, resolve = c => c.value.totalDifficulty.getOrElse(c.value.header.difficulty)),
+        Field(
+          "totalDifficulty",
+          BigIntType,
+          resolve = c => c.value.totalDifficulty.getOrElse(c.value.header.difficulty)
+        ),
         Field(
           "ommerCount",
           OptionType(LongType),
@@ -767,18 +780,16 @@ object GraphQLSchema {
             val io = c.ctx.ethInfoService.call(req)
             val estGasIo = c.ctx.ethInfoService.estimateGas(req)
             val fut: Future[Option[GCallResult]] = (for {
-              callE   <- io
-              gasE    <- estGasIo
-            } yield {
-              (callE, gasE) match {
-                case (Right(resp), Right(gasResp)) =>
-                  Some(GCallResult(resp.returnData, gasResp.gas.toLong, 1L))
-                case (Right(resp), Left(_)) =>
-                  Some(GCallResult(resp.returnData, 0L, 1L))
-                case (Left(err), _) if err.code == 3 => // execution reverted
-                  Some(GCallResult(ByteString.empty, 0L, 0L))
-                case _ => None
-              }
+              callE <- io
+              gasE <- estGasIo
+            } yield (callE, gasE) match {
+              case (Right(resp), Right(gasResp)) =>
+                Some(GCallResult(resp.returnData, gasResp.gas.toLong, 1L))
+              case (Right(resp), Left(_)) =>
+                Some(GCallResult(resp.returnData, 0L, 1L))
+              case (Left(err), _) if err.code == 3 => // execution reverted
+                Some(GCallResult(ByteString.empty, 0L, 0L))
+              case _ => None
             }).unsafeToFuture()
             fut
           }
@@ -857,15 +868,15 @@ object GraphQLSchema {
           arguments = List(CallDataArg),
           resolve = { c =>
             val callTx = toCallTx(c.arg(CallDataArg))
-            val req    = EthInfoService.CallRequest(callTx, BlockParam.Pending)
+            val req = EthInfoService.CallRequest(callTx, BlockParam.Pending)
             val fut = (for {
               callE <- c.ctx.ethInfoService.call(req)
-              gasE  <- c.ctx.ethInfoService.estimateGas(req)
+              gasE <- c.ctx.ethInfoService.estimateGas(req)
             } yield (callE, gasE) match {
-              case (Right(resp), Right(gasResp)) => Some(GCallResult(resp.returnData, gasResp.gas.toLong, 1L))
-              case (Right(resp), Left(_))        => Some(GCallResult(resp.returnData, 0L, 1L))
+              case (Right(resp), Right(gasResp))   => Some(GCallResult(resp.returnData, gasResp.gas.toLong, 1L))
+              case (Right(resp), Left(_))          => Some(GCallResult(resp.returnData, 0L, 1L))
               case (Left(err), _) if err.code == 3 => Some(GCallResult(ByteString.empty, 0L, 0L))
-              case _                             => None
+              case _                               => None
             }).unsafeToFuture()
             fut
           }
@@ -876,7 +887,7 @@ object GraphQLSchema {
           arguments = List(CallDataArg),
           resolve = { c =>
             val callTx = toCallTx(c.arg(CallDataArg))
-            val req    = EthInfoService.CallRequest(callTx, BlockParam.Pending)
+            val req = EthInfoService.CallRequest(callTx, BlockParam.Pending)
             c.ctx.ethInfoService
               .estimateGas(req)
               .map {
@@ -917,7 +928,7 @@ object GraphQLSchema {
                 .orElse {
                   for {
                     header <- reader.getBlockHeaderByNumber(bn)
-                    body   <- reader.getBlockBodyByHash(header.hash)
+                    body <- reader.getBlockBodyByHash(header.hash)
                   } yield Block(header, body)
                 }
               blockOpt match {
@@ -929,7 +940,7 @@ object GraphQLSchema {
             case (None, Some(h)) =>
               reader.getBlockByHash(h) match {
                 case Some(b) => Some(buildGBlock(c.ctx, b))
-                case None    =>
+                case None =>
                   val hex = "0x" + h.toArray.map("%02x".format(_)).mkString
                   throw GraphQLDataFetchingError.notFound("block", s"Block hash $hex was not found")
               }
@@ -946,7 +957,7 @@ object GraphQLSchema {
           val reader = c.ctx.blockchainReader
           val best = reader.getBestBlockNumber()
           val from = c.arg(FromArg).map(BigInt(_)).getOrElse(BigInt(0))
-          val to   = c.arg(ToArg).map(BigInt(_)).getOrElse(best)
+          val to = c.arg(ToArg).map(BigInt(_)).getOrElse(best)
           // Hive test 43 (byWrongRange): `to < from` is Invalid params, not an empty list.
           if (to < from) throw GraphQLDataFetchingError.invalidParams("blocks")
           val count = (to - from + 1).min(MaxBlocksPerRange).toInt
@@ -1003,7 +1014,7 @@ object GraphQLSchema {
         resolve = { c =>
           val m = c.arg(FilterArg)
           val fromBlock = m.get("fromBlock").flatMap(asOption[Long]).map(BigInt(_))
-          val toBlock   = m.get("toBlock").flatMap(asOption[Long]).map(BigInt(_))
+          val toBlock = m.get("toBlock").flatMap(asOption[Long]).map(BigInt(_))
           val addrs: Seq[ByteString] =
             m.get("addresses").flatMap(asOption[Vector[ByteString]]).getOrElse(Vector.empty)
           val topics: Seq[Seq[ByteString]] =
@@ -1076,7 +1087,9 @@ object GraphQLSchema {
             .syncing(com.chipprbots.ethereum.jsonrpc.EthInfoService.SyncingRequest())
             .map {
               case Right(resp) =>
-                resp.syncStatus.map(s => GSyncState(s.startingBlock.toLong, s.currentBlock.toLong, s.highestBlock.toLong))
+                resp.syncStatus.map(s =>
+                  GSyncState(s.startingBlock.toLong, s.currentBlock.toLong, s.highestBlock.toLong)
+                )
               case Left(_) => None
             }
             .unsafeToFuture()
@@ -1191,16 +1204,16 @@ object GraphQLSchema {
   )
 }
 
-/** User-facing error thrown from resolvers. Sangria renders these without the stack trace and
-  * exposes the message to the GraphQL client. */
+/** User-facing error thrown from resolvers. Sangria renders these without the stack trace and exposes the message to
+  * the GraphQL client.
+  */
 final case class GraphQLUserError(msg: String) extends Exception(msg) with sangria.execution.UserFacingError
 
 /** DataFetchingException emitted in the geth-compatible format hive testcases expect.
   *
-  * The constructed `message` matches graphql-java's format: `Exception while fetching data
-  * (/<path>) : <reason>`. The `errorCode` and `errorMessage` optional fields map to
-  * `extensions.errorCode` / `extensions.errorMessage` per the JSON-RPC error convention. See
-  * `src/test/resources/graphql-errors.md` for the expected shapes.
+  * The constructed `message` matches graphql-java's format: `Exception while fetching data (/<path>) : <reason>`. The
+  * `errorCode` and `errorMessage` optional fields map to `extensions.errorCode` / `extensions.errorMessage` per the
+  * JSON-RPC error convention. See `src/test/resources/graphql-errors.md` for the expected shapes.
   */
 final case class GraphQLDataFetchingError(
     fieldPath: String,
@@ -1218,12 +1231,13 @@ object GraphQLDataFetchingError {
 
   /** JSON-RPC error codes that hive testcases expect to flow through `extensions.errorCode`. */
   object Codes {
-    val InvalidParams: Int  = -32602
-    val NonceTooLow: Int    = -32001
+    val InvalidParams: Int = -32602
+    val NonceTooLow: Int = -32001
   }
 
-  /** "Invalid params" — EIP-1474 / JSON-RPC -32602. Used when the query mixes incompatible args
-    * (e.g. both `number` and `hash` on `block`) or when a numeric arg is out of range. */
+  /** "Invalid params" — EIP-1474 / JSON-RPC -32602. Used when the query mixes incompatible args (e.g. both `number` and
+    * `hash` on `block`) or when a numeric arg is out of range.
+    */
   def invalidParams(fieldPath: String): GraphQLDataFetchingError =
     GraphQLDataFetchingError(
       fieldPath,
@@ -1232,13 +1246,14 @@ object GraphQLDataFetchingError {
       errorMessage = Some("Invalid params")
     )
 
-  /** Object not found — plain DataFetchingException (no `errorCode`). Hive's test 15
-    * (byHashInvalid) expects exactly this shape for unknown block hashes. */
+  /** Object not found — plain DataFetchingException (no `errorCode`). Hive's test 15 (byHashInvalid) expects exactly
+    * this shape for unknown block hashes.
+    */
   def notFound(fieldPath: String, reason: String): GraphQLDataFetchingError =
     GraphQLDataFetchingError(fieldPath, reason, errorCode = None, errorMessage = None)
 
-  /** "Nonce too low" — EIP-1474 -32001. Used by `sendRawTransaction` when the account nonce has
-    * already been consumed. */
+  /** "Nonce too low" — EIP-1474 -32001. Used by `sendRawTransaction` when the account nonce has already been consumed.
+    */
   def nonceTooLow(fieldPath: String): GraphQLDataFetchingError =
     GraphQLDataFetchingError(
       fieldPath,

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLService.scala
@@ -20,9 +20,9 @@ import com.chipprbots.ethereum.utils.Logger
 
 /** Executes GraphQL queries against the Fukuii `GraphQLSchema`.
   *
-  * Bridges Sangria's `Future`-based executor into cats-effect `IO` so call sites match the
-  * JSON-RPC handlers. Returns `(statusCode, jsonBody)` — geth returns 400 when the response has
-  * any errors, 200 otherwise. Hive testcases rely on this.
+  * Bridges Sangria's `Future`-based executor into cats-effect `IO` so call sites match the JSON-RPC handlers. Returns
+  * `(statusCode, jsonBody)` — geth returns 400 when the response has any errors, 200 otherwise. Hive testcases rely on
+  * this.
   */
 class GraphQLService(
     graphQLContext: GraphQLContext,
@@ -35,8 +35,8 @@ class GraphQLService(
 
   private val depthReducer = QueryReducer.rejectMaxDepth[GraphQLContext](maxQueryDepth)
 
-  /** Parse + validate + execute a GraphQL request, returning the JSON response body and a
-    * preferred HTTP status code (200 for success, 400 for query errors).
+  /** Parse + validate + execute a GraphQL request, returning the JSON response body and a preferred HTTP status code
+    * (200 for success, 400 for query errors).
     */
   def execute(query: String, variables: Option[Json], operationName: Option[String]): IO[(Int, Json)] = {
     val parsed: Either[Json, Document] = QueryParser.parse(query) match {
@@ -75,8 +75,9 @@ class GraphQLService(
     }
   }
 
-  /** Geth returns 400 whenever a GraphQL response has a non-empty `errors` array, regardless of
-    * whether the query parsed successfully. Hive testcases rely on this. */
+  /** Geth returns 400 whenever a GraphQL response has a non-empty `errors` array, regardless of whether the query
+    * parsed successfully. Hive testcases rely on this.
+    */
   private def statusForResult(json: Json): Int =
     json.hcursor.downField("errors").focus.flatMap(_.asArray) match {
       case Some(arr) if arr.nonEmpty => 400
@@ -99,9 +100,9 @@ class GraphQLService(
     *     }
     *   }]
     * }}}
-    * Resolvers throw [[GraphQLDataFetchingError]] to control the `errorCode` / `errorMessage`
-    * extensions. Any other throwable gets wrapped as a generic DataFetchingException so hive
-    * testcases matching on the `extensions.classification` string still pass.
+    * Resolvers throw [[GraphQLDataFetchingError]] to control the `errorCode` / `errorMessage` extensions. Any other
+    * throwable gets wrapped as a generic DataFetchingException so hive testcases matching on the
+    * `extensions.classification` string still pass.
     */
   private val graphQLExceptionHandler: sangria.execution.ExceptionHandler =
     sangria.execution.ExceptionHandler {
@@ -121,9 +122,9 @@ class GraphQLService(
       errorMessage: Option[String]
   ): HandledException = {
     val classificationField = Vector("classification" -> m.scalarNode("DataFetchingException", "String", Set.empty))
-    val codeField           = errorCode.map(c => "errorCode" -> m.scalarNode(c, "Int", Set.empty)).toVector
-    val msgField            = errorMessage.map(em => "errorMessage" -> m.scalarNode(em, "String", Set.empty)).toVector
-    val fields              = classificationField ++ codeField ++ msgField
+    val codeField = errorCode.map(c => "errorCode" -> m.scalarNode(c, "Int", Set.empty)).toVector
+    val msgField = errorMessage.map(em => "errorMessage" -> m.scalarNode(em, "String", Set.empty)).toVector
+    val fields = classificationField ++ codeField ++ msgField
     HandledException(
       reason,
       additionalFields = fields.toMap,
@@ -150,7 +151,7 @@ object GraphQLService {
           case Left(e) => Left(s"missing 'query' field: ${e.message}")
           case Right(q) =>
             val variables = cursor.downField("variables").focus.filterNot(_.isNull)
-            val opName    = cursor.get[String]("operationName").toOption.filter(_.nonEmpty)
+            val opName = cursor.get[String]("operationName").toOption.filter(_.nonEmpty)
             Right(GraphQLRequest(q, variables, opName))
         }
     }

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
@@ -191,7 +191,7 @@ trait JsonRpcHttpServer extends Json4sSupport with Logger {
     complete(httpResponseF.unsafeToFuture()(runtime))
   }
 
-  private def handleGraphQL(svc: GraphQLService, body: String): StandardRoute = {
+  private def handleGraphQL(svc: GraphQLService, body: String): StandardRoute =
     GraphQLService.parseJsonBody(body) match {
       case Left(msg) =>
         val escaped = msg.replace("\\", "\\\\").replace("\"", "\\\"")
@@ -212,7 +212,6 @@ trait JsonRpcHttpServer extends Json4sSupport with Logger {
           .unsafeToFuture()
         complete(fut)
     }
-  }
 
   private def handleBuildInfo(): StandardRoute = {
     val buildInfo = Serialization.writePretty(BuildInfo.toMap)(DefaultFormats)

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -385,25 +385,28 @@ class NetworkPeerManagerActor(
     // Route reply via peerManagerActor.SendMessage so it works whether or not the peer is
     // already in PeersWithInfo (early SNAP requests can arrive before ETH-status exchange).
     val _ = peerWithInfo
-    val response: AccountRange = try {
-      mptStorageOpt match {
-        case Some(storage) if isStateRootFresh(msg.rootHash) =>
-          com.chipprbots.ethereum.network.snapserver.SnapServer.serveAccountRange(
-            requestId = msg.requestId,
-            rootHash = msg.rootHash,
-            startingHash = msg.startingHash,
-            limitHash = msg.limitHash,
-            responseBytes = msg.responseBytes,
-            storage = storage
+    val response: AccountRange =
+      try
+        mptStorageOpt match {
+          case Some(storage) if isStateRootFresh(msg.rootHash) =>
+            com.chipprbots.ethereum.network.snapserver.SnapServer.serveAccountRange(
+              requestId = msg.requestId,
+              rootHash = msg.rootHash,
+              startingHash = msg.startingHash,
+              limitHash = msg.limitHash,
+              responseBytes = msg.responseBytes,
+              storage = storage
+            )
+          case _ =>
+            AccountRange(msg.requestId, Seq.empty, Seq.empty)
+        }
+      catch {
+        case t: Throwable =>
+          log.error(
+            s"serveAccountRange threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
           )
-        case _ =>
           AccountRange(msg.requestId, Seq.empty, Seq.empty)
       }
-    } catch {
-      case t: Throwable =>
-        log.error(s"serveAccountRange threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-        AccountRange(msg.requestId, Seq.empty, Seq.empty)
-    }
     peerManagerActor ! PeerManagerActor.SendMessage(response, peerId)
   }
 
@@ -430,9 +433,9 @@ class NetworkPeerManagerActor(
     }
   }
 
-  /** Per SNAP/1: nodes only need to serve state for "recent" roots — geth uses a 128-block
-    * window. Looks up the requested rootHash in a cached set of recent canonical state
-    * roots. Returns true (serve) if blockchainReader isn't injected.
+  /** Per SNAP/1: nodes only need to serve state for "recent" roots — geth uses a 128-block window. Looks up the
+    * requested rootHash in a cached set of recent canonical state roots. Returns true (serve) if blockchainReader isn't
+    * injected.
     */
   private def isStateRootFresh(rootHash: ByteString): Boolean = blockchainReader match {
     case None => true
@@ -461,78 +464,78 @@ class NetworkPeerManagerActor(
 
     val _ = peerWithInfo
     val response = mptStorageOpt match {
-        case Some(storage) =>
-          // Per-account storage roots come from looking up each account in the state trie.
-          // Here we resolve via blockchainReader's ability to fetch the account at the
-          // canonical state root — but the SNAP request specifies an arbitrary state root.
-          // Approximation: walk the account trie at msg.rootHash to find each account's
-          // storageRoot. Since this is only on the server-serve path, simple fallback:
-          // look up each account via SnapServer using msg.rootHash.
-          import com.chipprbots.ethereum.network.snapserver.SnapServer
-          import com.chipprbots.ethereum.mpt.{MerklePatriciaTrie, NullNode}
-          // Resolve the state-trie root ONCE per request. The per-account closure
-          // reuses this resolved node instead of re-fetching on every call.
-          val stateRootNodeOpt: Option[com.chipprbots.ethereum.mpt.MptNode] =
-            try {
-              if (msg.rootHash.toArray.sameElements(MerklePatriciaTrie.EmptyRootHash)) None
-              else {
-                val node = storage.get(msg.rootHash.toArray)
-                if (node == NullNode) None else Some(node)
-              }
-            } catch { case _: Throwable => None }
-          val accountRoot: ByteString => Option[ByteString] = { accountHash =>
-            val nibbles = SnapServer.hashToNibbles(accountHash)
-            try
-              stateRootNodeOpt.flatMap { rootNode =>
-                def find(node: com.chipprbots.ethereum.mpt.MptNode, rem: Array[Byte]): Option[ByteString] = {
-                  val resolved = node match {
-                    case h: com.chipprbots.ethereum.mpt.HashNode => storage.get(h.hashNode)
-                    case other                                   => other
-                  }
-                  resolved match {
-                    case com.chipprbots.ethereum.mpt.LeafNode(key, value, _, _, _) =>
-                      if (rem.sameElements(key.toArray)) {
-                        import com.chipprbots.ethereum.network.p2p.messages.ETH63.AccountImplicits._
-                        val acct = value.toArray.toAccount
-                        Some(acct.storageRoot)
-                      } else None
-                    case com.chipprbots.ethereum.mpt.ExtensionNode(sk, next, _, _, _) =>
-                      if (rem.length >= sk.length && rem.take(sk.length).sameElements(sk.toArray))
-                        find(next, rem.drop(sk.length))
-                      else None
-                    case com.chipprbots.ethereum.mpt.BranchNode(children, _, _, _, _) =>
-                      if (rem.isEmpty) None
-                      else {
-                        val ch = children(rem(0) & 0x0f)
-                        if (ch == NullNode) None else find(ch, rem.drop(1))
-                      }
-                    case _ => None
-                  }
-                }
-                find(rootNode, nibbles)
-              }
-            catch { case _: Throwable => None }
-          }
+      case Some(storage) =>
+        // Per-account storage roots come from looking up each account in the state trie.
+        // Here we resolve via blockchainReader's ability to fetch the account at the
+        // canonical state root — but the SNAP request specifies an arbitrary state root.
+        // Approximation: walk the account trie at msg.rootHash to find each account's
+        // storageRoot. Since this is only on the server-serve path, simple fallback:
+        // look up each account via SnapServer using msg.rootHash.
+        import com.chipprbots.ethereum.network.snapserver.SnapServer
+        import com.chipprbots.ethereum.mpt.{MerklePatriciaTrie, NullNode}
+        // Resolve the state-trie root ONCE per request. The per-account closure
+        // reuses this resolved node instead of re-fetching on every call.
+        val stateRootNodeOpt: Option[com.chipprbots.ethereum.mpt.MptNode] =
           try
-            SnapServer.serveStorageRanges(
-              requestId = msg.requestId,
-              rootHash = msg.rootHash,
-              accountHashes = msg.accountHashes,
-              startingHash = msg.startingHash,
-              limitHash = msg.limitHash,
-              responseBytes = msg.responseBytes,
-              storage = storage,
-              accountRoot = accountRoot
+            if (msg.rootHash.toArray.sameElements(MerklePatriciaTrie.EmptyRootHash)) None
+            else {
+              val node = storage.get(msg.rootHash.toArray)
+              if (node == NullNode) None else Some(node)
+            }
+          catch { case _: Throwable => None }
+        val accountRoot: ByteString => Option[ByteString] = { accountHash =>
+          val nibbles = SnapServer.hashToNibbles(accountHash)
+          try
+            stateRootNodeOpt.flatMap { rootNode =>
+              def find(node: com.chipprbots.ethereum.mpt.MptNode, rem: Array[Byte]): Option[ByteString] = {
+                val resolved = node match {
+                  case h: com.chipprbots.ethereum.mpt.HashNode => storage.get(h.hashNode)
+                  case other                                   => other
+                }
+                resolved match {
+                  case com.chipprbots.ethereum.mpt.LeafNode(key, value, _, _, _) =>
+                    if (rem.sameElements(key.toArray)) {
+                      import com.chipprbots.ethereum.network.p2p.messages.ETH63.AccountImplicits._
+                      val acct = value.toArray.toAccount
+                      Some(acct.storageRoot)
+                    } else None
+                  case com.chipprbots.ethereum.mpt.ExtensionNode(sk, next, _, _, _) =>
+                    if (rem.length >= sk.length && rem.take(sk.length).sameElements(sk.toArray))
+                      find(next, rem.drop(sk.length))
+                    else None
+                  case com.chipprbots.ethereum.mpt.BranchNode(children, _, _, _, _) =>
+                    if (rem.isEmpty) None
+                    else {
+                      val ch = children(rem(0) & 0x0f)
+                      if (ch == NullNode) None else find(ch, rem.drop(1))
+                    }
+                  case _ => None
+                }
+              }
+              find(rootNode, nibbles)
+            }
+          catch { case _: Throwable => None }
+        }
+        try
+          SnapServer.serveStorageRanges(
+            requestId = msg.requestId,
+            rootHash = msg.rootHash,
+            accountHashes = msg.accountHashes,
+            startingHash = msg.startingHash,
+            limitHash = msg.limitHash,
+            responseBytes = msg.responseBytes,
+            storage = storage,
+            accountRoot = accountRoot
+          )
+        catch {
+          case t: Throwable =>
+            log.error(
+              s"serveStorageRanges threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
             )
-          catch {
-            case t: Throwable =>
-              log.error(
-                s"serveStorageRanges threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
-              )
-              StorageRanges(msg.requestId, Seq.empty, Seq.empty)
-          }
-        case None =>
-          StorageRanges(msg.requestId, Seq.empty, Seq.empty)
+            StorageRanges(msg.requestId, Seq.empty, Seq.empty)
+        }
+      case None =>
+        StorageRanges(msg.requestId, Seq.empty, Seq.empty)
     }
     peerManagerActor ! PeerManagerActor.SendMessage(response, peerId)
   }
@@ -556,24 +559,27 @@ class NetworkPeerManagerActor(
     )
 
     val _ = peerWithInfo
-    val response: TrieNodes = try {
-      mptStorageOpt match {
-        case Some(storage) =>
-          com.chipprbots.ethereum.network.snapserver.SnapServer.serveTrieNodes(
-            requestId = msg.requestId,
-            rootHash = msg.rootHash,
-            paths = msg.paths,
-            responseBytes = msg.responseBytes,
-            storage = storage
+    val response: TrieNodes =
+      try
+        mptStorageOpt match {
+          case Some(storage) =>
+            com.chipprbots.ethereum.network.snapserver.SnapServer.serveTrieNodes(
+              requestId = msg.requestId,
+              rootHash = msg.rootHash,
+              paths = msg.paths,
+              responseBytes = msg.responseBytes,
+              storage = storage
+            )
+          case None =>
+            TrieNodes(msg.requestId, Seq.empty)
+        }
+      catch {
+        case t: Throwable =>
+          log.error(
+            s"serveTrieNodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
           )
-        case None =>
           TrieNodes(msg.requestId, Seq.empty)
       }
-    } catch {
-      case t: Throwable =>
-        log.error(s"serveTrieNodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-        TrieNodes(msg.requestId, Seq.empty)
-    }
     peerManagerActor ! PeerManagerActor.SendMessage(response, peerId)
   }
 
@@ -596,29 +602,32 @@ class NetworkPeerManagerActor(
     )
 
     val _ = peerWithInfo
-    val response: ByteCodes = try {
-      val maxBytes = msg.responseBytes.toInt.max(0)
-      val codes: Seq[ByteString] = evmCodeStorage match {
-        case Some(storage) =>
-          val collected = scala.collection.mutable.ListBuffer.empty[ByteString]
-          var totalBytes = 0
-          val it = msg.hashes.iterator
-          while (it.hasNext && (totalBytes < maxBytes || collected.isEmpty)) {
-            val codeHash = it.next()
-            storage.get(codeHash).foreach { code =>
-              collected += code
-              totalBytes += code.size
+    val response: ByteCodes =
+      try {
+        val maxBytes = msg.responseBytes.toInt.max(0)
+        val codes: Seq[ByteString] = evmCodeStorage match {
+          case Some(storage) =>
+            val collected = scala.collection.mutable.ListBuffer.empty[ByteString]
+            var totalBytes = 0
+            val it = msg.hashes.iterator
+            while (it.hasNext && (totalBytes < maxBytes || collected.isEmpty)) {
+              val codeHash = it.next()
+              storage.get(codeHash).foreach { code =>
+                collected += code
+                totalBytes += code.size
+              }
             }
-          }
-          collected.toList
-        case None => Seq.empty
+            collected.toList
+          case None => Seq.empty
+        }
+        ByteCodes(requestId = msg.requestId, codes = codes)
+      } catch {
+        case t: Throwable =>
+          log.error(
+            s"serveByteCodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}"
+          )
+          ByteCodes(msg.requestId, Seq.empty)
       }
-      ByteCodes(requestId = msg.requestId, codes = codes)
-    } catch {
-      case t: Throwable =>
-        log.error(s"serveByteCodes threw for peer $peerId (requestId=${msg.requestId}): ${t.getClass.getName}: ${t.getMessage}")
-        ByteCodes(msg.requestId, Seq.empty)
-    }
     peerManagerActor ! PeerManagerActor.SendMessage(response, peerId)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
@@ -14,20 +14,17 @@ import com.chipprbots.ethereum.rlp.RLPValue
 import com.chipprbots.ethereum.utils.ByteUtils
 import com.chipprbots.ethereum.utils.Logger
 
-/** Server-side SNAP/1 helpers — Merkle Patricia Trie range traversal and Merkle proof
-  * generation for incoming `GetAccountRange`, `GetStorageRanges`, and `GetTrieNodes`
-  * requests from peers.
+/** Server-side SNAP/1 helpers — Merkle Patricia Trie range traversal and Merkle proof generation for incoming
+  * `GetAccountRange`, `GetStorageRanges`, and `GetTrieNodes` requests from peers.
   *
-  * The traversal walks the trie in nibble (key) order and yields `(keyHash, valueRLP)`
-  * pairs strictly between the requested `[origin, limit]` bounds, stopping once the
-  * accumulated response size exceeds `responseBytes` (per SNAP/1 spec, the server may
-  * truncate the response prefix early — but must always emit at least one item if any
-  * exists in the range).
+  * The traversal walks the trie in nibble (key) order and yields `(keyHash, valueRLP)` pairs strictly between the
+  * requested `[origin, limit]` bounds, stopping once the accumulated response size exceeds `responseBytes` (per SNAP/1
+  * spec, the server may truncate the response prefix early — but must always emit at least one item if any exists in
+  * the range).
   *
-  * For each non-empty range we also emit a proof: the path from the root to the first
-  * returned key, and (if more than one item is emitted) the path from the root to the
-  * last returned key. These let the requester rebuild a partial trie and verify the
-  * range is contiguous against the claimed root hash.
+  * For each non-empty range we also emit a proof: the path from the root to the first returned key, and (if more than
+  * one item is emitted) the path from the root to the last returned key. These let the requester rebuild a partial trie
+  * and verify the range is contiguous against the claimed root hash.
   */
 object SnapServer extends Logger {
 
@@ -45,7 +42,7 @@ object SnapServer extends Logger {
   }
 
   /** Convert a 64-nibble key path back to a 32-byte hash. Returns None if length is odd. */
-  def nibblesToHash(nibbles: Array[Byte]): Option[ByteString] = {
+  def nibblesToHash(nibbles: Array[Byte]): Option[ByteString] =
     if (nibbles.length % 2 != 0) None
     else {
       val out = new Array[Byte](nibbles.length / 2)
@@ -56,7 +53,6 @@ object SnapServer extends Logger {
       }
       Some(ByteString(out))
     }
-  }
 
   /** Compare two nibble arrays lexicographically (treating each nibble as a digit 0..15). */
   private def cmpNibbles(a: Array[Byte], b: Array[Byte]): Int = {
@@ -86,17 +82,15 @@ object SnapServer extends Logger {
     try storage.get(rootHash.toArray)
     catch { case _: Throwable => NullNode }
 
-  /** Slim-account RLP element per geth's snap protocol convention: the storageRoot and
-    * codeHash fields are encoded as empty bytes when they equal the canonical empty-trie
-    * root and empty-code hash respectively. Saves ~64 bytes per EOA — critical for the
-    * SNAP byte-budget which counts the leaf body length toward the soft response limit.
+  /** Slim-account RLP element per geth's snap protocol convention: the storageRoot and codeHash fields are encoded as
+    * empty bytes when they equal the canonical empty-trie root and empty-code hash respectively. Saves ~64 bytes per
+    * EOA — critical for the SNAP byte-budget which counts the leaf body length toward the soft response limit.
     *
-    * Our `AccountImplicits.toAccount` decoder already normalises empty bytes back to the
-    * canonical defaults, so round-trips are lossless across our own and geth's clients.
+    * Our `AccountImplicits.toAccount` decoder already normalises empty bytes back to the canonical defaults, so
+    * round-trips are lossless across our own and geth's clients.
     *
-    * Returns the parsed RLP element so callers can either embed it (in `AccountRange`'s
-    * RLP envelope) or serialise it (`rlp.encode(toSlimAccountRlp(...))`) for byte-budget
-    * accounting.
+    * Returns the parsed RLP element so callers can either embed it (in `AccountRange`'s RLP envelope) or serialise it
+    * (`rlp.encode(toSlimAccountRlp(...))`) for byte-budget accounting.
     */
   def toSlimAccountRlp(account: Account): RLPList = {
     val nonceRlp: RLPEncodeable = RLPValue(ByteUtils.bigIntToUnsignedByteArray(account.nonce))
@@ -110,9 +104,8 @@ object SnapServer extends Logger {
     RLPList(nonceRlp, balanceRlp, srRlp, chRlp)
   }
 
-  /** RLP-encode a node and emit its keccak256 hash + encoded bytes. Used when collecting
-    * proof nodes — peers verify by re-hashing each proof node and matching against
-    * parent references.
+  /** RLP-encode a node and emit its keccak256 hash + encoded bytes. Used when collecting proof nodes — peers verify by
+    * re-hashing each proof node and matching against parent references.
     */
   private def encodeNodeWithHash(node: MptNode): (ByteString, ByteString) = {
     val encoded = MptTraversals.encodeNode(node)
@@ -120,14 +113,12 @@ object SnapServer extends Logger {
     (hash, ByteString(encoded))
   }
 
-  /** Range walker — yields (keyHash, leafValue) pairs whose key falls in
-    * [originNibbles, limitNibbles] (inclusive on both ends), traversing the trie in key
-    * order. Caller stops consuming when their byte budget is exceeded.
+  /** Range walker — yields (keyHash, leafValue) pairs whose key falls in [originNibbles, limitNibbles] (inclusive on
+    * both ends), traversing the trie in key order. Caller stops consuming when their byte budget is exceeded.
     *
-    * Pruning: for a partial nibble prefix `p` of length L, the minimum reachable full key
-    * is `p ++ 0×(N-L)` and the maximum is `p ++ F×(N-L)` (where N is the full key length
-    * in nibbles, 64 for an account hash). We skip a subtree only when its max < origin
-    * OR its min > limit.
+    * Pruning: for a partial nibble prefix `p` of length L, the minimum reachable full key is `p ++ 0×(N-L)` and the
+    * maximum is `p ++ F×(N-L)` (where N is the full key length in nibbles, 64 for an account hash). We skip a subtree
+    * only when its max < origin OR its min > limit.
     */
   private val FullKeyNibbles = 64
 
@@ -137,12 +128,11 @@ object SnapServer extends Logger {
   private def minKeyWith(prefix: Array[Byte]): Array[Byte] =
     prefix ++ Array.fill(math.max(0, FullKeyNibbles - prefix.length))(0.toByte)
 
-  /** Subtree-prune predicate. We only skip subtrees that lie strictly BELOW `origin`
-    * (i.e. their max key is < origin). Subtrees ABOVE `limit` are intentionally not
-    * pruned — the visitor's stop-on-`>=limit` rule needs to see the first leaf past the
-    * limit (geth's serveAccountRange does the same: it iterates past the limit,
-    * `break`s after emitting one). Limit-side pruning would cut off that extra leaf
-    * and undercount in any range whose first available key extends past `limit`.
+  /** Subtree-prune predicate. We only skip subtrees that lie strictly BELOW `origin` (i.e. their max key is < origin).
+    * Subtrees ABOVE `limit` are intentionally not pruned — the visitor's stop-on-`>=limit` rule needs to see the first
+    * leaf past the limit (geth's serveAccountRange does the same: it iterates past the limit, `break`s after emitting
+    * one). Limit-side pruning would cut off that extra leaf and undercount in any range whose first available key
+    * extends past `limit`.
     */
   private def subtreeIntersectsRange(
       prefix: Array[Byte],
@@ -151,12 +141,12 @@ object SnapServer extends Logger {
   ): Boolean =
     cmpNibbles(maxKeyWith(prefix), originNibbles) >= 0
 
-  /** Visit-style range walker — calls `visit(keyHash, valueRLP)` for every leaf whose key
-    * falls in `[origin, limit]`, traversing the trie in key order. The visitor returns
-    * `true` to continue or `false` to stop the walk early (used by the byte-budget gate).
+  /** Visit-style range walker — calls `visit(keyHash, valueRLP)` for every leaf whose key falls in `[origin, limit]`,
+    * traversing the trie in key order. The visitor returns `true` to continue or `false` to stop the walk early (used
+    * by the byte-budget gate).
     *
-    * Iterative-style traversal via direct recursion (no Iterator.flatMap chain) — much
-    * cheaper than the previous lazy iterator construction when the chain depth is 64.
+    * Iterative-style traversal via direct recursion (no Iterator.flatMap chain) — much cheaper than the previous lazy
+    * iterator construction when the chain depth is 64.
     */
   private def walkRangeVisit(
       root: MptNode,
@@ -170,7 +160,7 @@ object SnapServer extends Logger {
       if (stop) return
       if (!subtreeIntersectsRange(prefix, originNibbles, limitNibbles)) return
       resolve(node, storage) match {
-        case NullNode => ()
+        case NullNode                      => ()
         case LeafNode(key, value, _, _, _) =>
           // Geth semantics (eth/protocols/snap/handler.go:304-322): emit any leaf
           // whose key is `>= origin`, then `break` after emitting one with key
@@ -210,10 +200,9 @@ object SnapServer extends Logger {
     descend(root, Array.emptyByteArray)
   }
 
-  /** Collect the proof path for a given key — the nodes traversed from root to the leaf
-    * (or the deepest reachable node along the path if the key is absent). The proof is
-    * returned as a sequence of RLP-encoded MPT nodes (with each node's keccak hash
-    * available to the caller for de-duplication).
+  /** Collect the proof path for a given key — the nodes traversed from root to the leaf (or the deepest reachable node
+    * along the path if the key is absent). The proof is returned as a sequence of RLP-encoded MPT nodes (with each
+    * node's keccak hash available to the caller for de-duplication).
     */
   private def proofFor(
       root: MptNode,
@@ -250,10 +239,9 @@ object SnapServer extends Logger {
     acc.toSeq
   }
 
-  /** Build an `AccountRange` response by walking the state trie at `rootHash` between
-    * `startingHash` and `limitHash`, emitting accounts whose RLP totals up to (but
-    * generally not exceeding) `responseBytes`. Always emits at least one account if any
-    * fall in the range.
+  /** Build an `AccountRange` response by walking the state trie at `rootHash` between `startingHash` and `limitHash`,
+    * emitting accounts whose RLP totals up to (but generally not exceeding) `responseBytes`. Always emits at least one
+    * account if any fall in the range.
     */
   def serveAccountRange(
       requestId: BigInt,
@@ -335,9 +323,9 @@ object SnapServer extends Logger {
     AccountRange(requestId, collected.toSeq, dedupedProof)
   }
 
-  /** Build a `StorageRanges` response — for each account, walk the per-account storage
-    * trie between `startingHash` and `limitHash`. Only the first account's range is
-    * proved (per SNAP/1 spec — subsequent accounts are returned in full, no proof).
+  /** Build a `StorageRanges` response — for each account, walk the per-account storage trie between `startingHash` and
+    * `limitHash`. Only the first account's range is proved (per SNAP/1 spec — subsequent accounts are returned in full,
+    * no proof).
     */
   def serveStorageRanges(
       requestId: BigInt,
@@ -421,9 +409,8 @@ object SnapServer extends Logger {
     StorageRanges(requestId, perAccount.toSeq, firstProof)
   }
 
-  /** Build a `TrieNodes` response — look up each requested HP-encoded path from `rootHash`
-    * and return the raw RLP-encoded node found at that path. Missing nodes yield empty
-    * bytes per SNAP/1 spec.
+  /** Build a `TrieNodes` response — look up each requested HP-encoded path from `rootHash` and return the raw
+    * RLP-encoded node found at that path. Missing nodes yield empty bytes per SNAP/1 spec.
     */
   def serveTrieNodes(
       requestId: BigInt,
@@ -500,9 +487,8 @@ object SnapServer extends Logger {
     TrieNodes(requestId, collected.toSeq)
   }
 
-  /** Walk the state trie following `nibbles` to a leaf and decode that leaf's value as
-    * an `Account`. Returns None if the path doesn't terminate at a leaf or the leaf
-    * isn't a valid account RLP.
+  /** Walk the state trie following `nibbles` to a leaf and decode that leaf's value as an `Account`. Returns None if
+    * the path doesn't terminate at a leaf or the leaf isn't a valid account RLP.
     */
   private def resolveLeafAccount(
       root: MptNode,
@@ -545,8 +531,8 @@ object SnapServer extends Logger {
     descend(root, nibbles)
   }
 
-  /** Decode an HP-encoded (Hex Prefix, EIP-2 / yellow-paper) path back to its nibble
-    * representation. Drops the leaf/extension flag bit.
+  /** Decode an HP-encoded (Hex Prefix, EIP-2 / yellow-paper) path back to its nibble representation. Drops the
+    * leaf/extension flag bit.
     */
   private def decodeHpPath(bytes: Array[Byte]): Array[Byte] = {
     if (bytes.isEmpty) return Array.emptyByteArray
@@ -560,8 +546,8 @@ object SnapServer extends Logger {
     firstNibble ++ rest.drop(skipFirst - 1).take(rest.length - (skipFirst - 1))
   }
 
-  /** Walk the trie following `nibbles` and return the encoded node found at that exact
-    * path (as a raw MPT node), or None if the path doesn't terminate cleanly at a node.
+  /** Walk the trie following `nibbles` and return the encoded node found at that exact path (as a raw MPT node), or
+    * None if the path doesn't terminate cleanly at a node.
     */
   private def collectNodeAtPath(
       root: MptNode,

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -886,7 +886,7 @@ trait GraphQLServiceBuilder {
     if (!graphQLConfig.enabled) None
     else {
       implicit val ec: scala.concurrent.ExecutionContext = system.dispatcher
-      implicit val runtime: cats.effect.unsafe.IORuntime  = cats.effect.unsafe.IORuntime.global
+      implicit val runtime: cats.effect.unsafe.IORuntime = cats.effect.unsafe.IORuntime.global
       val ctx = com.chipprbots.ethereum.jsonrpc.graphql.GraphQLContext(
         blockchain = blockchain,
         blockchainReader = blockchainReader,

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLHttpRouteSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLHttpRouteSpec.scala
@@ -60,7 +60,10 @@ class GraphQLHttpRouteSpec extends AnyFlatSpec with Matchers with ScalatestRoute
   implicit val routeTestTimeout: org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout =
     org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout(30.seconds)
 
-  it should "respond with 200 and JSON body to a well-formed POST /graphql" taggedAs (UnitTest, RPCTest) in new TestSetup {
+  it should "respond with 200 and JSON body to a well-formed POST /graphql" taggedAs (
+    UnitTest,
+    RPCTest
+  ) in new TestSetup {
     val body =
       """{"query":"{ chainID }"}"""
     val req = HttpRequest(
@@ -99,7 +102,9 @@ class GraphQLHttpRouteSpec extends AnyFlatSpec with Matchers with ScalatestRoute
     }
   }
 
-  it should "return 404 when GraphQL is disabled" taggedAs (UnitTest, RPCTest) in new TestSetup(graphQLEnabled = false) {
+  it should "return 404 when GraphQL is disabled" taggedAs (UnitTest, RPCTest) in new TestSetup(graphQLEnabled =
+    false
+  ) {
     val body = """{"query":"{ chainID }"}"""
     val req = HttpRequest(
       method = HttpMethods.POST,
@@ -120,7 +125,8 @@ class GraphQLHttpRouteSpec extends AnyFlatSpec with Matchers with ScalatestRoute
     override lazy val mining: TestMining = buildTestMining().withBlockGenerator(blockGenerator)
     override lazy val miningConfig = MiningConfigs.miningConfig
 
-    @annotation.unused val appStateStorage: AppStateStorage = mock[AppStateStorage]
+    @annotation.unused
+    val appStateStorage: AppStateStorage = mock[AppStateStorage]
     override lazy val stxLedger: StxLedger = mock[StxLedger]
     val keyStore: KeyStore = mock[KeyStore]
     val syncProbe = TestProbe()

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/graphql/GraphQLServiceSpec.scala
@@ -122,8 +122,7 @@ class GraphQLServiceSpec
   }
 
   // -------------------------------------------------------------------------
-  abstract class GraphQLTestSetup(val maxDepth: Int = GraphQLSchema.MaxQueryDepth)
-      extends EphemBlockchainTestSetup {
+  abstract class GraphQLTestSetup(val maxDepth: Int = GraphQLSchema.MaxQueryDepth) extends EphemBlockchainTestSetup {
 
     // Mining — needed by resolveBlock(Pending) path. The tests here don't exercise the
     // Pending branch, so the mock's default return is sufficient.


### PR DESCRIPTION
## Summary

- 11 files failed \`sbt scalafmtCheckAll\` on develop tip (blocked PR #1047 develop→main)
- No logical changes; \`sbt scalafmtAll\` only
- \`sbt compile\` + \`sbt Test/compile\` clean

## Test plan
- [x] sbt scalafmtCheckAll passes locally after this patch
- [x] sbt compile + Test/compile clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)