### PR TITLE
docs: fix mkdocs strict-mode warnings (broken links + missing nav)

### DIFF
--- a/docs/api/INSOMNIA_WORKSPACE_GUIDE.md
+++ b/docs/api/INSOMNIA_WORKSPACE_GUIDE.md
@@ -4,7 +4,7 @@ This guide explains how to use the Fukuii Insomnia workspace to test and interac
 
 ## Overview
 
-The `insomnia_workspace.json` file contains a complete collection of all 77 JSON-RPC endpoints implemented in Fukuii, organized into 10 namespaces for easy navigation and testing. See the [RPC Endpoint Inventory](./RPC_ENDPOINT_INVENTORY.md) for the complete 97-endpoint catalog including the MCP namespace.
+The `insomnia_workspace.json` file contains a complete collection of all 77 JSON-RPC endpoints implemented in Fukuii, organized into 10 namespaces for easy navigation and testing. See the [JSON-RPC API Reference](./JSON_RPC_API_REFERENCE.md) for the full endpoint catalog.
 
 ## Installation
 

--- a/docs/api/JSON_RPC_COVERAGE_ANALYSIS.md
+++ b/docs/api/JSON_RPC_COVERAGE_ANALYSIS.md
@@ -2,7 +2,7 @@
 
 This document provides a comprehensive analysis of fukuii's JSON-RPC implementation compared to the Ethereum JSON-RPC specification.
 
-> **Note:** This analysis was written before the MCP namespace was added (Nov 2025). See [RPC Endpoint Inventory](./RPC_ENDPOINT_INVENTORY.md) for the current 97-endpoint catalog.
+> **Note:** This analysis was written before the MCP namespace was added (Nov 2025). See [JSON-RPC API Reference](./JSON_RPC_API_REFERENCE.md) for the current endpoint catalog.
 
 **Date**: 2025-11-24
 **Purpose**: Identify gaps in JSON-RPC endpoint coverage and plan for MCP server integration

--- a/docs/api/MCP_ANALYSIS_SUMMARY.md
+++ b/docs/api/MCP_ANALYSIS_SUMMARY.md
@@ -469,8 +469,6 @@ This analysis demonstrates that Fukuii has a solid foundation for MCP integratio
 
 ## Related Documents
 
-- **[RPC_ENDPOINT_INVENTORY.md](./RPC_ENDPOINT_INVENTORY.md)** - Complete catalog of all RPC endpoints
-- **[MCP_ENHANCEMENT_PLAN.md](./MCP_ENHANCEMENT_PLAN.md)** - Detailed implementation roadmap
 - **[MCP_INTEGRATION_GUIDE.md](./MCP_INTEGRATION_GUIDE.md)** - Existing MCP integration documentation
 - **[JSON_RPC_API_REFERENCE.md](./JSON_RPC_API_REFERENCE.md)** - Complete RPC API reference
 - **[MCP.md](../MCP.md)** - MCP overview and usage

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -21,14 +21,6 @@ Welcome to the Fukuii JSON-RPC API documentation. This directory contains compre
    - Best practices for API usage
    - **Use this for**: Learning the API, integrating clients, reference lookup
 
-3. **[RPC Endpoint Inventory](./RPC_ENDPOINT_INVENTORY.md)** 🆕
-   - Comprehensive catalog of all 97 RPC endpoints
-   - Organized by namespace with safety classifications
-   - MCP coverage analysis
-   - Production readiness indicators
-   - Priority gaps for agent control
-   - **Use this for**: Complete RPC endpoint reference, MCP planning
-
 3. **[JSON-RPC Coverage Analysis](./JSON_RPC_COVERAGE_ANALYSIS.md)**
    - Comprehensive gap analysis vs Ethereum specification
    - Implementation status by namespace
@@ -46,15 +38,7 @@ Welcome to the Fukuii JSON-RPC API documentation. This directory contains compre
    - Implementation timeline and success metrics
    - **Use this for**: Understanding MCP strategy, stakeholder communication
 
-5. **[MCP Enhancement Plan](./MCP_ENHANCEMENT_PLAN.md)** 🆕
-   - Complete roadmap for agent-controlled node management
-   - 6-phase implementation plan (12-16 weeks)
-   - 45+ new tools, 20+ resources, 15+ prompts
-   - Security considerations and acceptance criteria
-   - Testing strategy and documentation requirements
-   - **Use this for**: Implementing complete agent control, detailed planning
-
-6. **[MCP Integration Guide](./MCP_INTEGRATION_GUIDE.md)**
+5. **[MCP Integration Guide](./MCP_INTEGRATION_GUIDE.md)**
    - Architecture for Model Context Protocol server
    - Resource and tool definitions
    - Security considerations and authentication

--- a/docs/api/interactive-api-reference.md
+++ b/docs/api/interactive-api-reference.md
@@ -54,7 +54,6 @@ curl -X POST http://localhost:8546 \
 ## Additional Resources
 
 - **[JSON-RPC API Reference (Text)](./JSON_RPC_API_REFERENCE.md)**: Detailed text documentation
-- **[RPC Endpoint Inventory](./RPC_ENDPOINT_INVENTORY.md)**: Complete catalog with safety classifications
 - **[Insomnia Workspace Guide](./INSOMNIA_WORKSPACE_GUIDE.md)**: How to use the Insomnia collection
 - **[API Overview](./README.md)**: Getting started with the API
 

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -549,7 +549,7 @@ The Engine API is the standardized interface between an execution layer (EL) and
 - **Post-Merge validation**: PoS headers are validated for `difficulty = 0`, `nonce = 0`, empty ommers, presence of `withdrawalsRoot` (EIP-4895), `blobGasUsed` / `excessBlobGas` (EIP-4844), and `requestsHash` (EIP-7685)
 - **EIP support**: EIP-3651 (warm COINBASE), EIP-4895 (withdrawals), EIP-4844 (blob transactions), EIP-4788 (beacon root contract), EIP-7685 (execution requests), EIP-6122 (timestamp ForkID), EIP-1153 (transient storage), EIP-5656 (MCOPY)
 
-The feature-level summary of Engine API capabilities, along with `ops/barad-dur/sepolia/` deployment instructions for pairing with Lighthouse, is maintained in the project [`README.md`](../../README.md).
+The feature-level summary of Engine API capabilities, along with `ops/barad-dur/sepolia/` deployment instructions for pairing with Lighthouse, is maintained in the project [`README.md`](https://github.com/chippr-robotics/fukuii/blob/develop/README.md).
 
 ### 10. Database System
 

--- a/docs/for-developers/index.md
+++ b/docs/for-developers/index.md
@@ -28,7 +28,7 @@ sbt test
 |----------|-------------|
 | [JSON-RPC Reference](../api/JSON_RPC_API_REFERENCE.md) | 77 documented methods |
 | [Coverage Analysis](../api/JSON_RPC_COVERAGE_ANALYSIS.md) | Gap analysis vs specification |
-| [MCP Integration](../../MCP.md) | Model Context Protocol tools and resources |
+| [MCP Integration](../MCP.md) | Model Context Protocol tools and resources |
 
 ## Development Commands
 

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -24,7 +24,6 @@ This directory contains test reports, implementation summaries, and analysis doc
 ## Related Documentation
 
 - [Testing Documentation](../testing/README.md) - Testing guides and strategies
-- [Investigation Reports](../investigation/README.md) - Detailed failure analysis
 
 ## Report Organization
 

--- a/docs/runbooks/log-triage.md
+++ b/docs/runbooks/log-triage.md
@@ -685,7 +685,6 @@ When investigating an issue:
 - [Peering](peering.md) - Network and peer-related logs
 - [Disk Management](disk-management.md) - Database and storage logs
 - [Known Issues](known-issues.md) - Common log patterns and solutions
-- [Investigation Reports](../investigation/README.md) - Detailed analysis of production incidents and operational issues
 
 ### Example Analysis Reports
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -21,13 +21,11 @@ Welcome to the Fukuii troubleshooting guides! This directory contains step-by-st
 - [Operations Runbooks](../runbooks/README.md) — Day-to-day operational guides
 - [Known Issues & Solutions](../runbooks/known-issues.md) — Common scenarios with solutions
 - [Log Analysis](../runbooks/log-triage.md) — Understanding log messages
-- [Investigation Reports](../investigation/README.md) — Historical issue investigations
 
 ## Getting Help
 
 If you can't find what you're looking for:
 
 1. Check the [Known Issues](../runbooks/known-issues.md) list
-2. Review relevant [Investigation Reports](../investigation/README.md)
-3. Search [GitHub Issues](https://github.com/chippr-robotics/fukuii/issues)
-4. Open a new issue with detailed information — we're happy to help!
+2. Search [GitHub Issues](https://github.com/chippr-robotics/fukuii/issues)
+3. Open a new issue with detailed information — we're happy to help!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,10 +252,6 @@ nav:
       - historical/README.md
       - Migration History: historical/MIGRATION_HISTORY.md
       - Ethereum Tests Migration: historical/ETHEREUM_TESTS_MIGRATION.md
-    - Investigation:
-      - FastSync Timeout: investigation/FASTSYNC_TIMEOUT_INVESTIGATION.md
-      - Contract Test Failure: investigation/CONTRACT_TEST_FAILURE_ANALYSIS.md
-      - Integration Tests: investigation/INTEGRATION_TEST_CLASSIFICATION.md
     - Analysis:
       - EIP-2124 Implementation: analysis/EIP-2124_IMPLEMENTATION_ANALYSIS.md
       - RLPx Handshake Analysis: analysis/RLPX_HANDSHAKE_AND_MESSAGE_ENCODING_ANALYSIS.md
@@ -269,8 +265,6 @@ nav:
       - reports/README.md
       - Network Test Report: reports/NETWORK_TEST_REPORT.md
       - Implementation Complete: reports/IMPLEMENTATION_COMPLETE.md
-    - Announcements:
-      - Gorgoroth Trials: announcements/gorgoroth-trials-announcement.md
     - Tools:
       - tools/README.md
       - Configuration Wizard: tools/configuration-wizard.md


### PR DESCRIPTION
## Summary

- 17 mkdocs strict-mode warnings have been failing the Deploy Documentation workflow on every merge into develop since at least PR #1041
- Removed 4 nav entries pointing at files that don't exist
- Replaced / removed 7 broken markdown links to files that were never created (\`RPC_ENDPOINT_INVENTORY.md\`, \`MCP_ENHANCEMENT_PLAN.md\`)
- Fixed up-and-out paths that escape the docs tree
- Removed 4 links to non-existent \`../investigation/README.md\`

## Test plan
- [x] \`mkdocs build --strict\` exits 0 locally
- [ ] CI: Deploy Documentation workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)