### PR TITLE
fix(sync): self-heal BlockFetcher on stale-tip header rejections (Bug 31)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/Blacklist.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/Blacklist.scala
@@ -293,6 +293,21 @@ object Blacklist {
       val reasonType: BlacklistReasonType = UnrequestedHeadersType
       val description: String = "Received unrequested headers"
     }
+    // Specific reasons that previously all folded into UnrequestedHeaders. The name there is
+    // misleading — these cases are responses we DID request, they just fail chain validation
+    // relative to our current queue state. Split out so diagnosis is possible from logs alone.
+    case object HeadersNotFormingChain extends BlacklistReason {
+      val reasonType: BlacklistReasonType = UnrequestedHeadersType
+      val description: String = "Received headers do not form an internal parent->child chain"
+    }
+    case object HeadersDontExtendReadyBlocks extends BlacklistReason {
+      val reasonType: BlacklistReasonType = UnrequestedHeadersType
+      val description: String = "Received headers do not extend our last ready block (possible stale tip)"
+    }
+    case object HeadersDontExtendWaitingQueue extends BlacklistReason {
+      val reasonType: BlacklistReasonType = UnrequestedHeadersType
+      val description: String = "Received headers do not extend our waiting-headers queue (possible reorg)"
+    }
     final case class RegularSyncRequestFailed(error: String) extends BlacklistReason {
       val reasonType: BlacklistReasonType = RegularSyncRequestFailedType
       val description: String = s"Request failed with error: $error"

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -192,34 +192,38 @@ class BlockFetcher(
                 state.lastBlock
               )
             }
-            state.appendHeaders(headers) match {
+            val afterAppend = state.appendHeaders(headers) match {
               case Left(HeadersNotFormingSeq) =>
-                log.debug("Dismissed received headers due to: {} (peer: {})", HeadersNotFormingSeq.description, peer.id)
-                log.debug(
-                  "Header validation failed: headers do not form a sequence. First: {}, Last: {}, Count: {}",
+                log.info(
+                  "Dismissed received headers: {} (peer={}, first={}, last={}, count={})",
+                  HeadersNotFormingSeq.description,
+                  peer.id,
                   headers.headOption.map(_.number),
                   headers.lastOption.map(_.number),
                   headers.size
                 )
-                peersClient ! BlacklistPeer(peer.id, BlacklistReason.UnrequestedHeaders)
-                state.withHeaderFetchReceived
+                peersClient ! BlacklistPeer(peer.id, BlacklistReason.HeadersNotFormingChain)
+                state.withHeaderFetchReceived.recordHeaderRejection()
               case Left(HeadersNotMatchingReadyBlocks) =>
-                log.debug(
-                  "Dismissed received headers due to: {} (peer: {})",
+                log.info(
+                  "Dismissed received headers: {} (peer={}, readyTip={}, respFirst={})",
                   HeadersNotMatchingReadyBlocks.description,
-                  peer.id
-                )
-                log.debug(
-                  "Header validation failed: headers do not match ready blocks. Ready blocks: {}, Headers first: {}",
+                  peer.id,
                   state.readyBlocks.lastOption.map(_.number),
                   headers.headOption.map(_.number)
                 )
-                peersClient ! BlacklistPeer(peer.id, BlacklistReason.UnrequestedHeaders)
-                state.withHeaderFetchReceived
+                peersClient ! BlacklistPeer(peer.id, BlacklistReason.HeadersDontExtendReadyBlocks)
+                state.withHeaderFetchReceived.recordHeaderRejection()
               case Left(err) =>
-                log.debug("Dismissed received headers due to: {} (peer: {})", err, peer.id)
-                log.debug("Header validation error details: {}", err.description)
-                state.withHeaderFetchReceived
+                log.info(
+                  "Dismissed received headers: {} (peer={}, waitingTip={}, respFirst={})",
+                  err.description,
+                  peer.id,
+                  state.waitingHeaders.lastOption.map(_.number),
+                  headers.headOption.map(_.number)
+                )
+                peersClient ! BlacklistPeer(peer.id, BlacklistReason.HeadersDontExtendWaitingQueue)
+                state.withHeaderFetchReceived.recordHeaderRejection()
               case Right(updatedState) =>
                 log.debug(
                   "Successfully validated and appended {} headers. New waiting headers count: {}",
@@ -234,6 +238,23 @@ class BlockFetcher(
                 } else updatedState
                 finalState.withHeaderFetchReceived
             }
+
+            // Stale-tip recovery (Bug 31): when enough independent peers reject our queue
+            // state in a row, assume the waitingHeaders/readyBlocks tip is orphaned and
+            // rewind. Without this, the fetcher loops forever on a poisoned seed state —
+            // notably observed on the fast-sync → regular-sync handoff.
+            if (afterAppend.shouldRewindOnRejections(BlockFetcher.HeaderRejectionRewindThreshold)) {
+              val rewindTarget = (afterAppend.lastBlock - BlockFetcher.HeaderRejectionRewindBlocks).max(0)
+              log.warn(
+                "Stale chain tip detected: {} consecutive header rejections across peers. " +
+                  "Rewinding from block {} to block {} to recover.",
+                afterAppend.consecutiveHeaderRejections,
+                afterAppend.lastBlock,
+                rewindTarget
+              )
+              val (_, rewoundState) = afterAppend.invalidateBlocksFrom(rewindTarget, None)
+              rewoundState.copy(consecutiveHeaderRejections = 0)
+            } else afterAppend
           }
         fetchBlocks(newState)
 
@@ -543,6 +564,18 @@ class BlockFetcher(
 }
 
 object BlockFetcher {
+
+  /** Number of consecutive header-rejection peers required before we conclude the queue state is stale and trigger an
+    * InvalidateBlocksFrom rewind (Bug 31 recovery). With 3, we avoid churning on a single buggy peer but still catch
+    * every "all peers reject" scenario well before the 60s blacklist cooldown completes on the first peer.
+    */
+  val HeaderRejectionRewindThreshold: Int = 3
+
+  /** How far back from `lastBlock` to rewind when stale-tip recovery fires. One batch of headers is enough to land us
+    * at a block that ALL peers still have cached, even in the presence of short reorgs.
+    */
+  val HeaderRejectionRewindBlocks: Int = 128
+
   def apply(
       peersClient: ClassicActorRef,
       peerEventBus: ClassicActorRef,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherState.scala
@@ -49,7 +49,13 @@ case class BlockFetcherState(
     fetchingBodiesState: FetchingBodiesState,
     lastBlock: BigInt,
     knownTop: BigInt,
-    blockProviders: Map[BigInt, PeerId]
+    blockProviders: Map[BigInt, PeerId],
+    // Count of consecutive header-fetch rejections since the last successful appendHeaders.
+    // Bumps on every peer response that fails chain-validation; resets on any successful
+    // append. Used by BlockFetcher to detect "stale tip" situations (all peers consistently
+    // reject — Bug 31) and trigger a rewind via InvalidateBlocksFrom so we can recover
+    // instead of looping on the same poisoned queue state indefinitely.
+    consecutiveHeaderRejections: Int = 0
 ) {
 
   def isFetching: Boolean = isFetchingHeaders || isFetchingBodies
@@ -85,9 +91,25 @@ case class BlockFetcherState(
       val lastNumber = HeadersSeq.lastNumber(validHeaders)
       withPossibleNewTopAt(lastNumber)
         .copy(
-          waitingHeaders = waitingHeaders ++ validHeaders
+          waitingHeaders = waitingHeaders ++ validHeaders,
+          // Any successful append clears the consecutive-rejection counter
+          consecutiveHeaderRejections = 0
         )
     }
+
+  /** Record that a header-fetch response was rejected by validation. Incremented on every rejection; reset to 0 by
+    * appendHeaders on success. The threshold at which BlockFetcher should trigger a stale-tip recovery is
+    * [[BlockFetcher.HeaderRejectionRewindThreshold]].
+    */
+  def recordHeaderRejection(): BlockFetcherState =
+    copy(consecutiveHeaderRejections = consecutiveHeaderRejections + 1)
+
+  /** True when enough independent peers have rejected the current queue state to conclude our waitingHeaders /
+    * readyBlocks tip is stale (e.g. orphaned after a tip reorg, or seeded wrong at the fast-sync → regular-sync
+    * handoff). Caller should rewind with [[InvalidateBlocksFrom]] and refresh from storage.
+    */
+  def shouldRewindOnRejections(threshold: Int): Boolean =
+    consecutiveHeaderRejections >= threshold
 
   /** Validates received headers consistency and their compatibility with the state
     */

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -225,7 +225,7 @@ class BlockFetcherSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfter
       shutdownActorSystem()
     }
 
-    "should ensure blocks passed to importer are always forming chain" taggedAs DisabledTest in new TestSetup {
+    "should ensure blocks passed to importer are always forming chain" in new TestSetup {
       startFetcher()
 
       triggerFetching()

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
@@ -80,5 +80,47 @@ class BlockFetcherStateSpec
         assert(result.map(_.waitingHeaders) === Left(HeadersNotMatchingReadyBlocks))
       }
     }
+
+    // Bug 31: stale-tip recovery — fast-sync→regular-sync handoff left the fetcher's
+    // queue state unable to chain onto any peer's response. The fetcher blacklisted
+    // every peer forever with zero self-heal. The counter below is the signal used by
+    // BlockFetcher to trigger a rewind via InvalidateBlocksFrom.
+    "tracking consecutive header rejections for stale-tip recovery (Bug 31)" should {
+      "start the counter at zero on initial state" in {
+        BlockFetcherState.initial(importer, validators.blockValidator, 100).consecutiveHeaderRejections shouldBe 0
+      }
+
+      "increment the counter via recordHeaderRejection" in {
+        val initial = BlockFetcherState.initial(importer, validators.blockValidator, 100)
+        initial
+          .recordHeaderRejection()
+          .recordHeaderRejection()
+          .recordHeaderRejection()
+          .consecutiveHeaderRejections shouldBe 3
+      }
+
+      "reset the counter to zero after a successful appendHeaders" in {
+        val stale = BlockFetcherState
+          .initial(importer, validators.blockValidator, 0)
+          .recordHeaderRejection()
+          .recordHeaderRejection()
+        stale.consecutiveHeaderRejections shouldBe 2
+
+        val Right(recovered) = stale.appendHeaders(blocks.map(_.header))
+        recovered.consecutiveHeaderRejections shouldBe 0
+      }
+
+      "cross the rewind threshold when consecutive rejections reach the limit" in {
+        val state = BlockFetcherState.initial(importer, validators.blockValidator, 100)
+        state.shouldRewindOnRejections(3) shouldBe false
+        state.recordHeaderRejection().shouldRewindOnRejections(3) shouldBe false
+        state.recordHeaderRejection().recordHeaderRejection().shouldRewindOnRejections(3) shouldBe false
+        state
+          .recordHeaderRejection()
+          .recordHeaderRejection()
+          .recordHeaderRejection()
+          .shouldRewindOnRejections(3) shouldBe true
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

**Bug 31**: ETC mainnet fast sync finishes cleanly at 99.96% state, transitions to regular sync — and stalls 1,550 blocks behind chain tip **indefinitely**. Observed 2026-04-24 on Barad-dûr: fast sync done 05:39 UTC, zero blocks imported for 5.5 hours.

Every peer's GetBlockHeaders response was being rejected by `BlockFetcher.scala:204/217` with reason `UnrequestedHeaders` — 768 rejections across 4 peers in a 5-minute sample. Peers returned exactly what we asked for; the fetcher's state machine just couldn't chain them onto its queue.

Two separable bugs:

1. **Misleading blacklist reason**. `UnrequestedHeaders` fires on `HeadersNotFormingSeq` and `HeadersNotMatchingReadyBlocks` validation errors. The third validation error (`HeadersNotMatchingWaitingHeaders`) was silently debug-logged with no blacklist at all.

2. **No self-heal**. When every peer consistently rejects the queue state, the fetcher loops forever on the poisoned seed. Only recovery is a node restart + fresh fast sync.

## Changes

- `Blacklist.scala`: three new specific reasons (`HeadersNotFormingChain`, `HeadersDontExtendReadyBlocks`, `HeadersDontExtendWaitingQueue`) whose descriptions name the real failure. Kept under the same `UnrequestedHeadersType` so existing tallies don't shift.
- `BlockFetcher.scala`: each rejection branch now blacklists with the specific reason and promotes the diagnostic from DEBUG to INFO with `readyTip`/`waitingTip`/`respFirst` context. The previously-silent third-branch path now also blacklists + logs. Added `HeaderRejectionRewindThreshold=3` + `HeaderRejectionRewindBlocks=128` constants. After each rejection, the fetcher checks `state.shouldRewindOnRejections(threshold)`; when reached, it calls `invalidateBlocksFrom(lastBlock - 128)` to drop the poisoned queue and re-anchor. Counter resets, fetch resumes.
- `BlockFetcherState.scala`: new `consecutiveHeaderRejections: Int = 0` field + `recordHeaderRejection()` + `shouldRewindOnRejections(threshold)` helpers. `appendHeaders` resets the counter on success.

## Testing

- [x] `sbt Test/compile` — clean
- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt "testOnly *BlockFetcherSpec *BlockFetcherStateSpec"` — 15/15 green (4 new + 11 existing)
- [x] No fukuii nodes running while tests ran (per standing rule)
- [x] Un-silenced `BlockFetcherSpec:228` — "should ensure blocks passed to importer are always forming chain" (was tagged `DisabledTest` 2026-04-23 in b02e732f8). Passes without modification.

## Related

- Stacks on top of #1054 (Bug 27 sanitizer) — both are self-contained so merge order doesn't matter.
- Two remaining Bucket B `DisabledTest` entries in `RegularSyncSpec` were un-silenced during investigation but fail on pre-existing actor-timing races unrelated to Bug 31. Re-silenced. Covered in the next PR in the sequence per `memory/hive_remediation_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)