### PR TITLE
test(jsonrpc): un-silence 2 of 7 DisabledTest entries in Bucket A

### DIFF
--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthFilterServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthFilterServiceSpec.scala
@@ -94,10 +94,19 @@ class EthFilterServiceSpec
     res.futureValue shouldEqual Right(GetFilterLogsResponse(logs))
   }
 
-  it should "handle getLogs request" taggedAs (UnitTest, RPCTest, DisabledTest) in new TestSetup {
+  it should "handle getLogs request" taggedAs (UnitTest, RPCTest) in new TestSetup {
+    // `getLogs` queries `blockchainReader.getBestBlockNumber()` to validate the range ceiling.
+    // The default TestSetup passes a null BlockchainReader (fine for tests that go straight to
+    // FilterManager), so this test needs its own service with a mocked reader.
+    val blockchainReaderMock: com.chipprbots.ethereum.domain.BlockchainReader =
+      mock[com.chipprbots.ethereum.domain.BlockchainReader]
+    (() => blockchainReaderMock.getBestBlockNumber()).expects().returning(BigInt(100)).anyNumberOfTimes()
+
+    val localService = new EthFilterService(filterManager.ref, filterConfig, blockchainReaderMock)
+
     val filter: Filter = Filter(None, None, None, Seq.empty)
     val res: Future[Either[JsonRpcError, GetLogsResponse]] =
-      ethFilterService.getLogs(GetLogsRequest(filter)).unsafeToFuture()
+      localService.getLogs(GetLogsRequest(filter)).unsafeToFuture()
     filterManager.expectMsg(FM.GetLogs(None, None, None, Seq.empty))
     val logs: FM.LogFilterLogs = FM.LogFilterLogs(Seq.empty)
     filterManager.reply(logs)

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -131,7 +131,7 @@ class EthServiceSpec
     response.unsafeRunSync() shouldEqual Right(CallResponse(ByteString("return_value")))
   }
 
-  it should "execute estimateGas and return a value" taggedAs (UnitTest, RPCTest, DisabledTest) in new TestSetup {
+  it should "execute estimateGas and return a value" taggedAs (UnitTest, RPCTest) in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
     blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -135,6 +135,20 @@ class EthServiceSpec
     blockchainWriter.storeBlock(blockToRequest).commit()
     blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
+    // `estimateGas` now runs a revert-check simulateTransaction FIRST, then a
+    // binarySearchGasEstimation if the tx doesn't revert. Stub both halves.
+    val worldStateProxy: InMemoryWorldStateProxy = InMemoryWorldStateProxy(
+      storagesInstance.storages.evmCodeStorage,
+      blockchain.getBackingMptStorage(-1),
+      (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
+      UInt256.Zero,
+      ByteString.empty,
+      noEmptyAccounts = false,
+      ethCompatibleStorage = true
+    )
+    val nonRevertResult: TxResult = TxResult(worldStateProxy, 123, Nil, ByteString.empty, None)
+    (stxLedger.simulateTransaction _).expects(*, *, *).returning(nonRevertResult)
+
     val estimatedGas: BigInt = BigInt(123)
     (stxLedger.binarySearchGasEstimation _).expects(*, *, *).returning(estimatedGas)
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -359,6 +359,10 @@ class EthTxServiceSpec
     )
   }
 
+  // TODO: investigate TxLog field drift — actual logIndex=1 vs expected=0, and topics container
+  // type changed from List to Vector. Unrelated to the "contract address" semantic the test
+  // title advertises; it's an assertion-shape issue inherited from a prior test refactor.
+  // Separate PR from the Bucket-A scala-mock un-silence.
   it should "calculate correct contract address for contract creating by transaction" taggedAs (
     UnitTest,
     RPCTest,

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -544,7 +544,10 @@ class JsonRpcControllerEthSpec
     response should haveStringResult("0x11")
   }
 
-  it should "return error with custom error taggedAs (UnitTest, RPCTest) in data in eth_balance" taggedAs DisabledTest in new JsonRpcControllerFixture {
+  it should "return error with custom error data in eth_balance" taggedAs (
+    UnitTest,
+    RPCTest
+  ) in new JsonRpcControllerFixture {
     val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
@@ -832,7 +835,10 @@ class JsonRpcControllerEthSpec
     )
   }
 
-  it should "return error with custom error taggedAs (UnitTest, RPCTest) in data in eth_getProof" taggedAs DisabledTest in new JsonRpcControllerFixture {
+  it should "return error with custom error data in eth_getProof" taggedAs (
+    UnitTest,
+    RPCTest
+  ) in new JsonRpcControllerFixture {
     val mockEthProofService: EthProofService & scala.reflect.Selectable = mock[EthProofService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(proofService = mockEthProofService)
 

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -544,9 +544,12 @@ class JsonRpcControllerEthSpec
     response should haveStringResult("0x11")
   }
 
+  // Re-silenced: same json4s/ScalaSig-under-testEssential issue — passes in isolation
+  // but fails when run with the full testEssential alias. See JsonRpcControllerSpec.scala.
   it should "return error with custom error data in eth_getBalance" taggedAs (
     UnitTest,
-    RPCTest
+    RPCTest,
+    DisabledTest
   ) in new JsonRpcControllerFixture {
     val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
@@ -835,9 +838,11 @@ class JsonRpcControllerEthSpec
     )
   }
 
+  // Re-silenced: same json4s/ScalaSig-under-testEssential issue as eth_getBalance above.
   it should "return error with custom error data in eth_getProof" taggedAs (
     UnitTest,
-    RPCTest
+    RPCTest,
+    DisabledTest
   ) in new JsonRpcControllerFixture {
     val mockEthProofService: EthProofService & scala.reflect.Selectable = mock[EthProofService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(proofService = mockEthProofService)

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -544,7 +544,7 @@ class JsonRpcControllerEthSpec
     response should haveStringResult("0x11")
   }
 
-  it should "return error with custom error data in eth_balance" taggedAs (
+  it should "return error with custom error data in eth_getBalance" taggedAs (
     UnitTest,
     RPCTest
   ) in new JsonRpcControllerFixture {

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -65,9 +65,15 @@ class JsonRpcControllerSpec
     response should haveStringResult("0x56570de287d73cd1cb6092bb8fdee6173974955fdef345ae579ee9f475ea7432")
   }
 
+  // Re-silenced: passes in isolation but fails under testEssential test ordering with
+  // `MappingException: Can't find ScalaSig for class ... JsonRpcError`. Root cause is
+  // a json4s reflection-cache interaction on Scala 3 (ScalaSig metadata doesn't exist
+  // in Scala 3 class files) that gets triggered by some earlier test in the alias.
+  // Separate from Bucket A's scala-mock `stub[T]` issue — needs a json4s/Scala 3 fix.
   it should "fail when invalid request is received" taggedAs (
     UnitTest,
-    RPCTest
+    RPCTest,
+    DisabledTest
   ) in new JsonRpcControllerFixture {
     val rpcRequest: JsonRpcRequest = newJsonRpcRequest("web3_sha3", JString("asdasd") :: Nil)
 
@@ -114,9 +120,11 @@ class JsonRpcControllerSpec
     response should haveStringResult(netVersion)
   }
 
+  // Re-silenced: same json4s/ScalaSig-under-testEssential issue as "fail when invalid request".
   it should "only allow to call methods of enabled apis" taggedAs (
     UnitTest,
-    RPCTest
+    RPCTest,
+    DisabledTest
   ) in new JsonRpcControllerFixture {
     override def config: JsonRpcConfig = new JsonRpcConfig {
       override val apis: Seq[String] = Seq("web3")

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -67,8 +67,7 @@ class JsonRpcControllerSpec
 
   it should "fail when invalid request is received" taggedAs (
     UnitTest,
-    RPCTest,
-    DisabledTest
+    RPCTest
   ) in new JsonRpcControllerFixture {
     val rpcRequest: JsonRpcRequest = newJsonRpcRequest("web3_sha3", JString("asdasd") :: Nil)
 
@@ -117,8 +116,7 @@ class JsonRpcControllerSpec
 
   it should "only allow to call methods of enabled apis" taggedAs (
     UnitTest,
-    RPCTest,
-    DisabledTest
+    RPCTest
   ) in new JsonRpcControllerFixture {
     override def config: JsonRpcConfig = new JsonRpcConfig {
       override val apis: Seq[String] = Seq("web3")


### PR DESCRIPTION
## Summary

Un-silence 2 of 7 DisabledTest entries in Bucket A (scala-mock `stub[T]`
null-return issues on Scala 3) where explicit mock setup or added
expectations are all that's needed.

**Un-silenced (2):**
- `EthFilterServiceSpec` — `handle getLogs request`: added a mocked
  `BlockchainReader.getBestBlockNumber()` (the default TestSetup uses a
  null reader, which crashed when the new range-validation path ran).
- `EthInfoServiceSpec` — `execute estimateGas and return a value`: the
  production code now runs a revert-check `simulateTransaction` first,
  then `binarySearchGasEstimation`. Both halves are stubbed.

**Still DisabledTest (4):**
- `JsonRpcControllerSpec` — `fail when invalid request is received`,
  `only allow to call methods of enabled apis`
- `JsonRpcControllerEthSpec` — `return error with custom error data in
  eth_getBalance`, `return error with custom error data in eth_getProof`

These four pass in isolation but fail under the `testEssential` alias
with `MappingException: Can't find ScalaSig for class JsonRpcError` —
a json4s reflection-cache issue on Scala 3 that's unrelated to Bucket A's
scala-mock problem. Re-tagged with explanatory comments so future
work can target the actual root cause (json4s + Scala 3 ScalaSig).

**Other cleanup:**
- `EthTxServiceSpec` "calculate correct contract address" — kept
  disabled with a TODO comment pointing at the TxLog field drift
  (unrelated to Bucket A).
- `JsonRpcControllerEthSpec` renamed `eth_balance` → `eth_getBalance`
  in test title (copy-paste typo).

## Test plan

- [x] `sbt "testOnly *JsonRpcControllerSpec *JsonRpcControllerEthSpec"` passes all 44 tests locally.
- [x] `sbt "testOnly *EthFilterServiceSpec *EthInfoServiceSpec"` passes.
- [ ] CI `testEssential` goes green (the 4 re-silenced tests are now skipped under that alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)