### PR TITLE
ops: grafana dashboards + multi-etc-mordor compose + cirith metrics port

### DIFF
--- a/ops/barad-dur/grafana/dashboards/fukuii-node-health.json
+++ b/ops/barad-dur/grafana/dashboards/fukuii-node-health.json
@@ -1,0 +1,310 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "At-a-glance node health: is it up, is it syncing, are peers connected, is the JVM healthy.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {"asDropdown": false, "icon": "external link", "includeVars": true, "keepTime": true, "tags": ["fukuii"], "targetBlank": false, "title": "Fukuii dashboards", "type": "dashboards"}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Node Up",
+      "id": 1,
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "up{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {"0": {"text": "DOWN", "color": "red"}, "1": {"text": "UP", "color": "green"}}}
+          ],
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Current Block",
+      "id": 2,
+      "gridPos": {"h": 4, "w": 5, "x": 4, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"} or app_sync_block_number_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "light-blue"}, "decimals": 0}},
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Best Known Block",
+      "id": 3,
+      "gridPos": {"h": 4, "w": 5, "x": 9, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "semi-dark-purple"}, "decimals": 0}},
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Blocks Behind",
+      "id": 4,
+      "gridPos": {"h": 4, "w": 5, "x": 14, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "clamp_min((app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}) - (app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}), 0)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short", "decimals": 0,
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 16},
+            {"color": "orange", "value": 128},
+            {"color": "red", "value": 1024}
+          ]}
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Handshaked Peers",
+      "id": 5,
+      "gridPos": {"h": 4, "w": 5, "x": 19, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"} + app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short", "decimals": 0,
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "red", "value": null},
+            {"color": "orange", "value": 1},
+            {"color": "yellow", "value": 3},
+            {"color": "green", "value": 5}
+          ]}
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Block height over time",
+      "id": 10,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} current (regular)"},
+        {"expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} best known"},
+        {"expr": "app_sync_block_number_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} last executed"},
+        {"expr": "app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} fast-sync best"},
+        {"expr": "app_fastsync_block_bestHeader_number_gauge{instance=~\"$instance\"}", "refId": "E", "legendFormat": "{{instance}} fast-sync headers"},
+        {"expr": "app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}", "refId": "F", "legendFormat": "{{instance}} fast-sync pivot"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "decimals": 0, "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Import rate (blocks/sec)",
+      "id": 11,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} 1m"},
+        {"expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[5m])", "refId": "B", "legendFormat": "{{instance}} 5m"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max", "mean"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Peers",
+      "id": 20,
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} outgoing"},
+        {"expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} incoming"},
+        {"expr": "app_network_peers_pending_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} pending"},
+        {"expr": "app_network_discovery_foundPeers_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} discovery"},
+        {"expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}", "refId": "E", "legendFormat": "{{instance}} blacklisted"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "decimals": 0, "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Network message rate",
+      "id": 21,
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sum by (instance) (rate(app_network_messages_sent_counter_total{instance=~\"$instance\"}[1m]))", "refId": "A", "legendFormat": "{{instance}} sent/s"},
+        {"expr": "sum by (instance) (rate(app_network_messages_received_counter_total{instance=~\"$instance\"}[1m]))", "refId": "B", "legendFormat": "{{instance}} received/s"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Block time (seconds between parent blocks)",
+      "id": 30,
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 19},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_sync_block_timeBetweenParent_seconds_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Transactions per block",
+      "id": 31,
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 19},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_sync_block_transactions_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} tx"},
+        {"expr": "app_sync_block_uncles_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} uncles"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Gas per block",
+      "id": 32,
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 19},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_sync_block_gasUsed_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} used"},
+        {"expr": "app_sync_block_gasLimit_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} limit"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM heap (bytes used vs committed)",
+      "id": 40,
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 26},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "jvm_memory_bytes_used{area=\"heap\",instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} used"},
+        {"expr": "jvm_memory_bytes_committed{area=\"heap\",instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} committed"},
+        {"expr": "jvm_memory_bytes_max{area=\"heap\",instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} max"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "GC time (s/s — fraction of CPU in GC)",
+      "id": 41,
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 26},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "rate(jvm_gc_collection_seconds_sum{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} {{gc}}"}],
+      "fieldConfig": {"defaults": {"unit": "percentunit", "max": 1, "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors / validation failures (rate/s)",
+      "id": 50,
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 33},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} snap errors"},
+        {"expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])", "refId": "B", "legendFormat": "{{instance}} snap validation"},
+        {"expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])", "refId": "C", "legendFormat": "{{instance}} snap timeouts"},
+        {"expr": "rate(app_network_peers_blacklisted_regularSyncGroup_counter_total{instance=~\"$instance\"}[1m])", "refId": "D", "legendFormat": "{{instance}} blacklist rate"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+    },
+    {
+      "type": "stat",
+      "title": "JVM threads",
+      "id": 51,
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 33},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "jvm_threads_current{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} current"},
+        {"expr": "jvm_threads_deadlocked{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} DEADLOCKED"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}
+        },
+        "overrides": [
+          {"matcher": {"id": "byFrameRefID", "options": "A"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "light-blue"}}]}
+        ]
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "SNAP phase",
+      "id": 52,
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 33},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {
+              "0": {"text": "Idle", "color": "grey"},
+              "1": {"text": "AccountRange", "color": "blue"},
+              "3": {"text": "ByteCode+Storage", "color": "purple"},
+              "5": {"text": "Healing", "color": "yellow"},
+              "6": {"text": "Validation", "color": "orange"},
+              "7": {"text": "Chain", "color": "cyan"},
+              "8": {"text": "Completed", "color": "green"}
+            }}
+          ]
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["fukuii", "health", "overview"],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(up{job=~\".*fukuii.*\"}, instance)", "refId": "Prometheus-instance-Variable-Query"},
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fukuii Node Health",
+  "uid": "fukuii-node-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/barad-dur/grafana/dashboards/fukuii-snap-sync.json
+++ b/ops/barad-dur/grafana/dashboards/fukuii-snap-sync.json
@@ -1,0 +1,308 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "enable": true,
+        "expr": "changes(app_snapsync_phase_current_gauge{instance=~\"$instance\"}[1m]) > 0",
+        "iconColor": "orange",
+        "name": "Phase Transition",
+        "step": "1m",
+        "titleFormat": "Phase change",
+        "useValueForTime": false
+      }
+    ]
+  },
+  "description": "SNAP sync phase progression and per-phase throughput.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {"asDropdown": false, "icon": "external link", "includeVars": true, "keepTime": true, "tags": ["fukuii"], "targetBlank": false, "title": "Fukuii dashboards", "type": "dashboards"}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Current Phase",
+      "id": 1,
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {
+              "0": {"text": "Idle", "color": "grey"},
+              "1": {"text": "AccountRange", "color": "blue"},
+              "3": {"text": "ByteCode + Storage", "color": "purple"},
+              "5": {"text": "Healing", "color": "yellow"},
+              "6": {"text": "Validation", "color": "orange"},
+              "7": {"text": "Chain Download", "color": "cyan"},
+              "8": {"text": "Completed", "color": "green"}
+            }}
+          ],
+          "color": {"mode": "fixed", "fixedColor": "blue"}
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Time in Phase",
+      "id": 2,
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_phase_time_seconds_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 600},
+            {"color": "orange", "value": 1800}
+          ]}
+        }
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Total Sync Time",
+      "id": 3,
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_totaltime_minutes_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "m", "color": {"mode": "fixed", "fixedColor": "light-blue"}}},
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Pivot Block",
+      "id": 4,
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_pivot_block_number_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "semi-dark-purple"}}},
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "gauge",
+      "title": "Accounts Progress",
+      "id": 10,
+      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "100 * app_snapsync_accounts_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}, {"color": "green", "value": 100}]}
+        }
+      },
+      "options": {"orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "gauge",
+      "title": "Bytecodes Progress",
+      "id": 11,
+      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "100 * app_snapsync_bytecodes_downloaded_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_bytecodes_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "purple", "value": null}, {"color": "green", "value": 100}]}
+        }
+      },
+      "options": {"orientation": "auto", "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "gauge",
+      "title": "Storage Slots Progress",
+      "id": 12,
+      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "100 * app_snapsync_storage_slots_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_storage_slots_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "orange", "value": null}, {"color": "green", "value": 100}]}
+        }
+      },
+      "options": {"orientation": "auto", "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "stat",
+      "title": "Nodes Healed",
+      "id": 13,
+      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "app_snapsync_healing_nodes_healed_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "yellow"}}},
+      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Accounts Synced (cumulative)",
+      "id": 20,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_accounts_synced_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} synced"},
+        {"expr": "app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} estimated"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Throughput — Accounts / Bytecodes / Storage / Healing (recent)",
+      "id": 21,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_accounts_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} accounts/s"},
+        {"expr": "app_snapsync_bytecodes_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} bytecodes/s"},
+        {"expr": "app_snapsync_storage_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} storage/s"},
+        {"expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} healing/s"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Recent vs Overall Throughput (Accounts)",
+      "id": 22,
+      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_accounts_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} recent"},
+        {"expr": "app_snapsync_accounts_throughput_overall_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} overall"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Recent vs Overall Throughput (Storage slots)",
+      "id": 23,
+      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_storage_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} recent"},
+        {"expr": "app_snapsync_storage_throughput_overall_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} overall"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Recent vs Overall Throughput (Healing)",
+      "id": 24,
+      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} recent"},
+        {"expr": "app_snapsync_healing_throughput_overall_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} overall"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Health — timeouts / retries / failures",
+      "id": 30,
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 27},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} timeouts"},
+        {"expr": "rate(app_snapsync_requests_retries_total{instance=~\"$instance\"}[1m])", "refId": "B", "legendFormat": "{{instance}} retries"},
+        {"expr": "rate(app_snapsync_accounts_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "C", "legendFormat": "{{instance}} account fails"},
+        {"expr": "rate(app_snapsync_bytecodes_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "D", "legendFormat": "{{instance}} bytecode fails"},
+        {"expr": "rate(app_snapsync_storage_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "E", "legendFormat": "{{instance}} storage fails"},
+        {"expr": "rate(app_snapsync_healing_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "F", "legendFormat": "{{instance}} healing fails"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Data Integrity — proofs / validation / missing nodes",
+      "id": 31,
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 27},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "rate(app_snapsync_proofs_invalid_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} invalid proofs"},
+        {"expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])", "refId": "B", "legendFormat": "{{instance}} validation fails"},
+        {"expr": "rate(app_snapsync_responses_malformed_total{instance=~\"$instance\"}[1m])", "refId": "C", "legendFormat": "{{instance}} malformed"},
+        {"expr": "app_snapsync_validation_missing_nodes_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} missing nodes"},
+        {"expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])", "refId": "E", "legendFormat": "{{instance}} errors"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Peers — SNAP-capable, handshaked, blacklisted",
+      "id": 40,
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 34},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_peers_capable_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} snap-capable"},
+        {"expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} outgoing"},
+        {"expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} incoming"},
+        {"expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} blacklisted"},
+        {"expr": "rate(app_snapsync_peers_blacklisted_total{instance=~\"$instance\"}[1m])", "refId": "E", "legendFormat": "{{instance}} snap bl rate"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Latency — max download timer (s)",
+      "id": 41,
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 34},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "app_snapsync_accounts_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} accounts"},
+        {"expr": "app_snapsync_bytecodes_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} bytecodes"},
+        {"expr": "app_snapsync_storage_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} storage"},
+        {"expr": "app_snapsync_healing_timer_seconds_max{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} healing"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["fukuii", "snap", "sync"],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(up{job=~\".*fukuii.*\"}, instance)", "refId": "Prometheus-instance-Variable-Query"},
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fukuii SNAP Sync",
+  "uid": "fukuii-snap-sync",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/barad-dur/grafana/provisioning/datasources/prometheus.yml
+++ b/ops/barad-dur/grafana/provisioning/datasources/prometheus.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/ops/barad-dur/multi-etc-mordor/conf/multi-network.conf
+++ b/ops/barad-dur/multi-etc-mordor/conf/multi-network.conf
@@ -1,0 +1,133 @@
+# Multi-instance runtime — ETC mainnet + Mordor testnet in one JVM.
+#
+# Follows the same pattern as ops/barad-dur/sepolia/fukuii-conf/multi-network.conf:
+#   - top-level fukuii.conf resolves substitutions like ${fukuii.datadir}
+#   - each instance re-includes base fukuii.conf so its own block inherits defaults
+#   - ipc { enabled = false } avoids the base ${fukuii.datadir} IPC path substitution
+
+include "conf/base/fukuii.conf"
+include "conf/base/pekko.conf"
+include "conf/base/logging.conf"
+
+logging.logs-level = "INFO"
+pekko.loglevel = "INFO"
+pekko.log-dead-letters = 0
+
+fukuii-runtime {
+  instances {
+
+    etc {
+      include "conf/base/fukuii.conf"
+      include "conf/base/pekko.conf"
+
+      fukuii {
+        datadir = "/app/data/etc"
+        client-identity = "barad-dur-multi-etc"
+
+        blockchains {
+          network = "etc"
+        }
+
+        sync {
+          do-fast-sync = true
+          do-snap-sync = false
+          peer-response-timeout = 90.seconds
+          blacklist-duration = 60.seconds
+          critical-blacklist-duration = 30.minutes
+        }
+
+        network {
+          server-address {
+            interface = "0.0.0.0"
+            port = 30303
+          }
+          discovery {
+            discovery-enabled = true
+            host = "23.122.124.251"
+            interface = "0.0.0.0"
+            port = 30303
+            scan-interval = 10.seconds
+          }
+          rpc {
+            http {
+              enabled = true
+              interface = "0.0.0.0"
+              port = 8545
+            }
+            ipc { enabled = false }
+            apis = "eth,web3,net,personal,fukuii,debug,qa"
+          }
+        }
+
+        mining {
+          mining-enabled = false
+          protocol = "pow"
+        }
+
+        metrics {
+          enabled = true
+          port = 9095
+        }
+
+        db.rocksdb.path = "/app/data/etc/rocksdb"
+      }
+    }
+
+    mordor {
+      include "conf/base/fukuii.conf"
+      include "conf/base/pekko.conf"
+
+      fukuii {
+        datadir = "/app/data/mordor"
+        client-identity = "barad-dur-multi-mordor"
+
+        blockchains {
+          network = "mordor"
+        }
+
+        sync {
+          do-fast-sync = true
+          do-snap-sync = true
+          min-peers-to-choose-pivot-block = 1
+          peers-to-choose-pivot-block-margin = 0
+        }
+
+        network {
+          server-address {
+            interface = "0.0.0.0"
+            port = 30304
+          }
+          discovery {
+            discovery-enabled = true
+            host = "23.122.124.251"
+            interface = "0.0.0.0"
+            port = 30304
+            scan-interval = 10.seconds
+          }
+          rpc {
+            http {
+              enabled = true
+              interface = "0.0.0.0"
+              port = 8547
+            }
+            ipc { enabled = false }
+            apis = "eth,web3,net,personal,fukuii,debug,qa"
+          }
+        }
+
+        mining {
+          mining-enabled = false
+          protocol = "pow"
+        }
+
+        metrics {
+          enabled = true
+          port = 9096
+        }
+
+        db.rocksdb.path = "/app/data/mordor/rocksdb"
+      }
+    }
+
+  }
+}

--- a/ops/barad-dur/multi-etc-mordor/docker-compose.yml
+++ b/ops/barad-dur/multi-etc-mordor/docker-compose.yml
@@ -1,0 +1,58 @@
+# Multi-Network Fukuii: ETC mainnet + Mordor testnet in a single process.
+#
+# Usage:
+#   docker compose -f ops/barad-dur/multi-etc-mordor/docker-compose.yml up -d
+#
+# Data mounts reuse existing directories so progress from the previous
+# single-instance runs continues without re-syncing.
+
+networks:
+  multi-etc-mordor-net:
+    driver: bridge
+
+volumes:
+  # Reuse the Mordor data volume from the cirith-ungol harness (in-place).
+  cirith-ungol_fukuii-cirith-ungol-data:
+    external: true
+
+services:
+  fukuii-multi:
+    image: ${FUKUII_IMAGE:-chipprbots/fukuii:latest}
+    container_name: fukuii-multi
+    restart: unless-stopped
+    ports:
+      # ETC mainnet
+      - "8545:8545"          # JSON-RPC HTTP
+      - "30303:30303/tcp"    # P2P TCP
+      - "30303:30303/udp"    # P2P Discovery
+      - "9095:9095"          # Metrics
+      # Mordor testnet
+      - "8547:8547"          # JSON-RPC HTTP
+      - "30304:30304/tcp"    # P2P TCP
+      - "30304:30304/udp"    # P2P Discovery
+      - "9096:9096"          # Metrics
+    volumes:
+      # ETC data carries over from fukuii-primary harness.
+      - /chipprbots/blockchain/chain-data/etc/fukuii-primary:/app/data/etc
+      # Mordor data carries over from cirith-ungol named volume.
+      - cirith-ungol_fukuii-cirith-ungol-data:/app/data/mordor
+      # Multi-instance runtime config
+      - ./conf/multi-network.conf:/app/conf/multi-network.conf:ro
+    command:
+      - "-Xmx8g"
+      - "-Xms2g"
+      - "-Xss10M"
+      - "-XX:+UseG1GC"
+      - "-XX:MaxGCPauseMillis=200"
+      - "-Dconfig.file=/app/conf/multi-network.conf"
+      - "-jar"
+      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "runtime"
+    networks:
+      - multi-etc-mordor-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8545/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 180s

--- a/ops/cirith-ungol/docker-compose.yml
+++ b/ops/cirith-ungol/docker-compose.yml
@@ -75,6 +75,8 @@ services:
       # P2P networking — TCP + UDP on same port (standard geth convention)
       - "30305:30303/tcp"
       - "30305:30303/udp"
+      # Prometheus metrics (for grafana dashboard)
+      - "9098:9095"
     volumes:
       # Configuration files
       - ./conf/etc.conf:/app/conf/etc.conf:ro
@@ -110,6 +112,9 @@ services:
       - "-XX:MaxGCPauseMillis=200"
       - "-Dconfig.file=/app/conf/etc.conf"
       - "-Dfukuii.datadir=/app/data"
+      - "-Dfukuii.network.rpc.http.port=8545"
+      - "-Dfukuii.metrics.enabled=true"
+      - "-Dfukuii.metrics.port=9095"
       - "-Dlogback.configurationFile=/app/conf/logback.xml"
       - "-Dfukuii.trace.block=${FUKUII_TRACE_BLOCK:-}"
       - "-Dfukuii.trace.tx=${FUKUII_TRACE_TX:-}"


### PR DESCRIPTION
## Summary

Three ops artifacts from the 2026-04-23/24 sync validation session. No source code changes.

### 1. Grafana dashboards (`ops/barad-dur/grafana/dashboards/`)

- **`fukuii-snap-sync.json`** — SNAP sync phase progression + throughput. Phase indicator with value mappings (Idle → AccountRange → ByteCode+Storage → Healing → Validation → Chain → Completed), per-phase progress gauges (`clamp_min` to avoid divide-by-zero), request health (timeouts, retries, per-phase failures), peer capability, request latency. Annotations mark phase transitions from `app_snapsync_phase_current_gauge` changes.
- **`fukuii-node-health.json`** — at-a-glance node health. Block-height stat falls back on `app_fastsync_block_bestFullBlock_number_gauge` when regular-sync metrics aren't populated yet (the primary case after Bug 31 recovery + fast sync). Blocks-behind stat with tiered thresholds. JVM heap + GC fraction. Deadlocked-thread alarm. SNAP phase passthrough.

Both dashboards use a Prometheus `instance=~"$instance"` template variable so they work across single-instance primary, cirith-ungol, and (when per-instance metrics isolation lands) multi-network runtimes.

The provisioned Prometheus datasource now carries an explicit `uid: prometheus` so these dashboards resolve their datasource by UID on a fresh import (previously it matched only in the running Grafana because the auto-generated UID happened to be `prometheus`).

### 2. Multi-instance runtime (`ops/barad-dur/multi-etc-mordor/`)

- **`conf/multi-network.conf`** — ETC mainnet + Mordor testnet in one JVM via the `runtime` subcommand. Follows the sepolia multi-network pattern: top-level `conf/base/fukuii.conf` for substitution resolution, per-instance `include` inside the instance block, `ipc { enabled = false }` to avoid the `${fukuii.datadir}/fukuii.ipc` substitution scoping issue that bites the shipped template.
- **`docker-compose.yml`** — single container binding host 8545/30303/9095 for ETC and 8547/30304/9096 for Mordor. Reuses existing data volumes from the single-instance harnesses in place via `external: true` on the cirith named volume.

**Known limitation**: all instances share a single static `Metrics` registry, so per-instance dashboards read identical data. Sync itself is correctly isolated (separate RPC ports return distinct state); only observability is clobbered. This is tracked in PR #1063, which adds the scaladoc + warning log + locked semantic test for the shared-registry behavior.

### 3. Cirith-ungol metrics port (`ops/cirith-ungol/docker-compose.yml`)

- Exposes container 9095 on host 9098 (avoids conflict with a primary on 9095).
- Forces `-Dfukuii.network.rpc.http.port=8545` — the compose maps host 8553 → container 8545 but the config default drifted to 8546, silently breaking host-side RPC.
- Enables metrics via JVM props; previously `fukuii.metrics.enabled` was default-false, so the Prometheus endpoint wasn't bound.

## Testing

- [x] Exercised live during the 2026-04-23 Mordor SNAP sync validation (59m full run) and the 2026-04-24 ETC mainnet fast sync.
- [x] Grafana dashboards render cleanly with the real data — node-health's fallback logic was discovered and fixed against an actual fast-sync run.
- [x] Multi-network compose brought up + confirmed both chains sync independently via `eth_blockNumber` on 8545 (ETC) and 8547 (Mordor).

No fukuii nodes were running during any `sbt test` invocation this session (ops stopped before tests, per standing rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)