### PR TITLE
fix(mpt): return walked-path proof of non-inclusion (EIP-1186)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
@@ -109,25 +109,76 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
       case _ => None
     }.flatten
 
-  /** Get the proof associated with the key passed, if there exists one.
+  /** Get the Merkle proof for `key`, supporting both inclusion and non-inclusion proofs.
     *
-    * @param key
-    * @return
-    *   Option object with proof if there exists one.
+    * Inclusion (`key` is present): returns every node on the path from the root down to (and including) the `LeafNode`
+    * carrying the value. A verifier can re-hash the sequence to confirm the value against the trie root.
+    *
+    * Non-inclusion (`key` is absent): returns every node visited on the walk before termination — the last node proves
+    * why the lookup stopped (a LeafNode with a different key, an ExtensionNode with an incompatible shared prefix, or a
+    * BranchNode whose relevant child slot is NullNode). Per EIP-1186 this is the "walked-path proof of absence" that
+    * proof-of-state-at-block RPC clients expect.
+    *
+    * Returns `None` only when the trie has no root at all (empty trie). A present-but-absent key on a non-empty trie
+    * always returns `Some(nonEmptyPath)`.
+    *
     * @throws com.chipprbots.ethereum.mpt.MerklePatriciaTrie.MPTException
-    *   if there is any inconsistency in how the trie is build.
+    *   if there is any inconsistency in how the trie is built.
     */
   def getProof(key: K): Option[Vector[MptNode]] =
-    pathTraverse[Vector[MptNode]](Vector.empty, mkKeyNibbles(key)) { case (acc, node) =>
-      node match {
-        case Some(hash: HashNode) =>
-          // Resolve hash references to actual nodes for the proof
-          acc :+ getFromHash(hash.hashNode, nodeStorage)
-        case Some(nextNode @ (_: BranchNode | _: ExtensionNode | _: LeafNode)) =>
-          acc :+ nextNode
-        case _ => acc
-      }
+    rootNode.map { root =>
+      collectProof(Vector.empty, resolveIfHash(root), mkKeyNibbles(key))
     }
+
+  @tailrec
+  private def collectProof(
+      acc: Vector[MptNode],
+      node: MptNode,
+      searchKey: Array[Byte]
+  ): Vector[MptNode] =
+    node match {
+      case leaf: LeafNode =>
+        // Always include the leaf: either it's a match (inclusion proof) or it's the divergent
+        // leaf found at this position (proof of absence on a trie shaped like {k1 -> v}).
+        acc :+ leaf
+
+      case ext @ ExtensionNode(sharedKey, _, _, _, _) =>
+        val withExt = acc :+ ext
+        if (
+          searchKey.length >= sharedKey.length && sharedKey.toArray[Byte].sameElements(searchKey.take(sharedKey.length))
+        ) {
+          collectProof(withExt, resolveIfHash(ext.next), searchKey.drop(sharedKey.length))
+        } else {
+          // Shared prefix mismatch: extension itself is the proof of non-inclusion.
+          withExt
+        }
+
+      case branch: BranchNode =>
+        val withBranch = acc :+ branch
+        if (searchKey.isEmpty) {
+          // Key bottomed out at a branch: the branch terminator (or lack thereof) is the answer.
+          withBranch
+        } else {
+          branch.children(searchKey(0)) match {
+            case NullNode =>
+              // Relevant child slot is null — branch is the proof of non-inclusion.
+              withBranch
+            case child =>
+              collectProof(withBranch, resolveIfHash(child), searchKey.drop(1))
+          }
+        }
+
+      case HashNode(bytes) =>
+        collectProof(acc, getFromHash(bytes, nodeStorage), searchKey)
+
+      case NullNode =>
+        acc
+    }
+
+  private def resolveIfHash(node: MptNode): MptNode = node match {
+    case HashNode(bytes) => getFromHash(bytes, nodeStorage)
+    case other           => other
+  }
 
   /** Traverse given path from the root to value and accumulate data. Only nodes which are significant for searching for
     * value are taken into account.

--- a/src/test/scala/com/chipprbots/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/domain/BlockchainSpec.scala
@@ -15,13 +15,11 @@ import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import com.chipprbots.ethereum.db.dataSource.EphemDataSource
 import com.chipprbots.ethereum.db.storage.StateStorage
 import com.chipprbots.ethereum.domain.Account.accountSerializer
-import com.chipprbots.ethereum.mpt.HashNode
 import com.chipprbots.ethereum.mpt.LeafNode
 import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
+import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.proof.MptProofVerifier
 import com.chipprbots.ethereum.proof.ProofVerifyResult.ValidProof
-import com.chipprbots.ethereum.mpt.MptNode
-import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.testing.Tags._
 
@@ -176,7 +174,10 @@ class BlockchainSpec
     // non-empty walk — every node visited on the way to the divergence. In this trie the
     // sole entry is `Address(42)`, so the root resolves directly to a LeafNode whose key
     // doesn't match our wrongAddress; that leaf is the termination point and the proof.
-    val proof = retrievedAccountProofWrong.getOrElse(Vector.empty)
+    // Assert the Option is defined explicitly so a regression back to `None` fails with a
+    // clear message rather than an empty-vector assertion further down.
+    retrievedAccountProofWrong shouldBe defined
+    val proof = retrievedAccountProofWrong.get
     proof should not be empty
     proof.last match {
       case _: LeafNode => succeed

--- a/src/test/scala/com/chipprbots/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/domain/BlockchainSpec.scala
@@ -16,6 +16,7 @@ import com.chipprbots.ethereum.db.dataSource.EphemDataSource
 import com.chipprbots.ethereum.db.storage.StateStorage
 import com.chipprbots.ethereum.domain.Account.accountSerializer
 import com.chipprbots.ethereum.mpt.HashNode
+import com.chipprbots.ethereum.mpt.LeafNode
 import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.proof.MptProofVerifier
 import com.chipprbots.ethereum.proof.ProofVerifyResult.ValidProof
@@ -154,8 +155,7 @@ class BlockchainSpec
   it should "return proof for non-existent account" taggedAs (
     UnitTest,
     StateTest,
-    MPTTest,
-    DisabledTest
+    MPTTest
   ) in new EphemBlockchainTestSetup {
     val emptyMpt: MerklePatriciaTrie[Address, Account] = MerklePatriciaTrie[Address, Account](
       storagesInstance.storages.stateStorage.getBackingStorage(0)
@@ -171,11 +171,17 @@ class BlockchainSpec
     val wrongAddress: Address = Address(666)
     val retrievedAccountProofWrong: Option[Vector[MptNode]] =
       blockchainReader.getAccountProof(blockchainReader.getBestBranch(), wrongAddress, headerWithAcc.number)
-    // the account doesn't exist, so we can't retrieve it, but we do receive a proof of non-existence with a full path of nodes(root node) that we iterated
-    (retrievedAccountProofWrong.getOrElse(Vector.empty).toList match {
-      case _ @HashNode(_) :: Nil => true
-      case _                     => false
-    }) shouldBe true
+
+    // EIP-1186 proof of non-inclusion: the account doesn't exist, but we still receive a
+    // non-empty walk — every node visited on the way to the divergence. In this trie the
+    // sole entry is `Address(42)`, so the root resolves directly to a LeafNode whose key
+    // doesn't match our wrongAddress; that leaf is the termination point and the proof.
+    val proof = retrievedAccountProofWrong.getOrElse(Vector.empty)
+    proof should not be empty
+    proof.last match {
+      case _: LeafNode => succeed
+      case other       => fail(s"Expected terminal LeafNode in proof-of-absence, got $other")
+    }
     mptWithAcc.get(wrongAddress) shouldBe None
   }
 


### PR DESCRIPTION
## Summary

`MerklePatriciaTrie.getProof(absentKey)` previously returned an **empty** `Vector` for keys not present in the trie. Discovered while un-silencing `BlockchainSpec:154` "return proof for non-existent account" in PR #1059 — the test fails `Vector() was empty` on what should be a valid proof-of-absence.

EIP-1186 and the `eth_getProof` RPC contract that flows from it require the proof of non-inclusion to include **every node visited on the walk before termination**. The last node proves why the lookup stopped:
- a `LeafNode` whose key doesn't match the search key
- an `ExtensionNode` whose shared prefix diverges from the search key
- a `BranchNode` whose relevant child slot is `NullNode`

## Root cause

`getProof` delegated to `pathTraverse`, whose visitor emits `None` for leaf/extension/branch mismatch. The `getProof` match arm `case _ => acc` dropped those silently without appending anything. Proof-of-absence was structurally unprovable: zero nodes to hash-verify against the root.

## Changes

- Rewrote `getProof` as a dedicated `collectProof` helper that walks the trie explicitly and always appends the current node before deciding whether to recurse.
- `HashNode` references are resolved before being added, so the returned sequence is a pure `LeafNode` / `ExtensionNode` / `BranchNode` list — the exact shape an RPC client's verifier expects.

**Semantic changes callers will notice:**
| Input | Before | After |
|---|---|---|
| Absent key on non-empty trie | `Some(Vector.empty)` | `Some(Vector(...nonEmptyPath))` |
| Empty trie | `None` | `None` (unchanged) |
| Present key | `Some(path)` | `Some(path)` (unchanged) |

## Testing

- [x] `sbt Test/compile` — clean
- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt "testOnly *MerklePatriciaTrieSpec *BlockchainSpec *MptProofVerifierSpec"` — **9/9 green**
- [x] `sbt "testOnly *MerklePatriciaTrieSuite *ProofServiceSpec *EthProofServiceSpec"` — **47/47 green**
- [x] Happy-path proof verification (`BlockchainSpec:120`) unchanged — existing `MptProofVerifier.verifyProof` still accepts the inclusion proof.
- [x] No fukuii nodes running while tests ran (per standing rule).

## Un-silenced test

`BlockchainSpec:154` "return proof for non-existent account" — **Bucket C** from `memory/test_inventory_silenced.md`. Original assertion `HashNode(_) :: Nil` was checking an intermediate walk artifact that the refactor no longer produces (hashes are resolved inline); updated to the structural invariant: proof is non-empty and terminates in the leaf that diverges from the search key.

## Progress

Closes Bucket C. **Only 7 of 17** silenced tests remain, all actor-choreography flakes (Bucket B + late BlockFetcher) in scope for a separate ADR-017 rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)