### PR TITLE
fix(sync): abandon storage recovery gracefully on stale pivot (Bug 30b)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
@@ -1,10 +1,11 @@
 package com.chipprbots.ethereum.blockchain.sync
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import scala.util.{Success, Failure}
 
@@ -109,20 +110,82 @@ class StorageRecoveryActor(
       }
   }
 
+  /** Seconds without any storage-slot progress after which we declare the recovery dead-in-the-water and abandon to
+    * regular sync. The SNAP serve window is ~128 blocks (~28 min on ETC / ~25 min on ETH); once exceeded, every peer
+    * rejects our saved pivot root and `PivotStateUnservable` fires in a loop. Pivot-refresh isn't wired into the
+    * recovery path (unlike SNAP), so the only way out is to stop trying and let regular sync's on-demand `GetTrieNodes`
+    * fetch the missing subtrees.
+    */
+  private val RecoveryAbandonAfter: FiniteDuration = 10.minutes
+
   private def downloading(coordinator: ActorRef, expectedCount: Int): Receive = {
-    case actors.Messages.StoragePeerAvailable(peer) =>
-      coordinator ! actors.Messages.StoragePeerAvailable(peer)
+    var lastProgressMs = System.currentTimeMillis()
+    var unservableCount = 0
+    var abandonTimer: Option[Cancellable] = None
 
-    case SNAPSyncController.StorageRangeSyncComplete =>
-      log.info(s"Storage recovery complete: downloaded storage for $expectedCount contracts")
-      appStateStorage.storageRecoveryDone().commit()
-      syncController ! RecoveryComplete
-      context.stop(self)
+    def recordProgress(): Unit = {
+      lastProgressMs = System.currentTimeMillis()
+      unservableCount = 0
+      abandonTimer.foreach(_.cancel())
+      abandonTimer = None
+    }
 
-    case SNAPSyncController.ProgressStorageSlotsSynced(_) =>
-    // Ignore progress updates
+    def scheduleAbandonCheck(): Unit = {
+      abandonTimer.foreach(_.cancel())
+      abandonTimer = Some(
+        context.system.scheduler.scheduleOnce(RecoveryAbandonAfter, self, CheckAbandon(lastProgressMs))
+      )
+    }
 
-    case msg => coordinator.forward(msg) // Forward SNAP protocol responses to coordinator
+    {
+      case actors.Messages.StoragePeerAvailable(peer) =>
+        coordinator ! actors.Messages.StoragePeerAvailable(peer)
+
+      case SNAPSyncController.StorageRangeSyncComplete =>
+        log.info(s"Storage recovery complete: downloaded storage for $expectedCount contracts")
+        abandonTimer.foreach(_.cancel())
+        appStateStorage.storageRecoveryDone().commit()
+        syncController ! RecoveryComplete
+        context.stop(self)
+
+      case SNAPSyncController.ProgressStorageSlotsSynced(_) =>
+        recordProgress()
+
+      // Bug 30b: coordinator reports every peer stateless for the stored pivot root. In SNAP
+      // sync this would trigger `refreshPivotInPlace` on the controller; the recovery path has
+      // no equivalent. Instead of looping forever, count the events and bail out after
+      // `RecoveryAbandonAfter` of zero slot progress. Regular sync will subsequently fetch
+      // missing trie subtrees on-demand via GetTrieNodes when block execution reaches them.
+      case _: SNAPSyncController.PivotStateUnservable =>
+        unservableCount += 1
+        log.info(
+          "Storage recovery: coordinator reports stored pivot root unservable ({} events, " +
+            "no progress for {}s). Will abandon after {}s if this persists.",
+          unservableCount,
+          (System.currentTimeMillis() - lastProgressMs) / 1000,
+          RecoveryAbandonAfter.toSeconds
+        )
+        if (abandonTimer.isEmpty) scheduleAbandonCheck()
+
+      case CheckAbandon(progressAtSchedule) =>
+        if (progressAtSchedule == lastProgressMs) {
+          log.warning(
+            "Storage recovery abandoned: no slot progress for {}s against stored pivot root after {} " +
+              "unservable events. Regular sync will fetch remaining contract storage on-demand via " +
+              "GetTrieNodes when block execution needs it.",
+            RecoveryAbandonAfter.toSeconds,
+            unservableCount
+          )
+          appStateStorage.storageRecoveryDone().commit()
+          syncController ! RecoveryComplete
+          context.stop(self)
+        } else {
+          // Progress happened between scheduling and firing — reset.
+          abandonTimer = None
+        }
+
+      case msg => coordinator.forward(msg) // Forward SNAP protocol responses to coordinator
+    }
   }
 
   /** Walk the state trie and collect (accountHash, storageRoot) for contracts whose storage tries are missing from
@@ -190,6 +253,10 @@ class StorageRecoveryActor(
 object StorageRecoveryActor {
   private case object StartScan
   private case class ScanResult(missingStorage: Seq[(ByteString, ByteString)])
+  // Delayed self-ping used by Bug 30b abandon path. Carries the progress timestamp that was
+  // current when the timer was armed; if the actor's current lastProgressMs still matches on
+  // fire, nothing has moved in the interim and we give up.
+  private case class CheckAbandon(progressAtSchedule: Long)
 
   /** Sent to SyncController when recovery is complete (or skipped) */
   case object RecoveryComplete

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
@@ -37,19 +37,30 @@ class StorageRecoveryActor(
     networkPeerManager: ActorRef,
     syncController: ActorRef,
     pivotBlockNumber: BigInt,
-    snapSyncConfig: SNAPSyncConfig
+    snapSyncConfig: SNAPSyncConfig,
+    // Test hook: when set, the actor skips the real scan and enters `downloading` with
+    // the supplied missing list directly. Production callers always leave this as None
+    // and the factory method doesn't expose it.
+    preloadedMissingForTesting: Option[Seq[(ByteString, ByteString)]] = None,
+    // Test hook: when set, the downloading state uses this ref instead of spawning a
+    // real StorageRangeCoordinator (which needs network wiring / StateStorage /
+    // FlatSlotStorage that a pure unit test doesn't want to simulate).
+    coordinatorForTesting: Option[ActorRef] = None
 ) extends Actor
     with ActorLogging {
 
   import StorageRecoveryActor._
   import context.dispatcher
 
-  override def preStart(): Unit = {
-    log.info(
-      s"StorageRecoveryActor starting: scanning state trie for missing contract storage " +
-        s"(stateRoot=${stateRoot.take(4).toArray.map("%02x".format(_)).mkString}...)"
-    )
-    self ! StartScan
+  override def preStart(): Unit = preloadedMissingForTesting match {
+    case Some(missing) =>
+      self ! ScanResult(missing)
+    case None =>
+      log.info(
+        s"StorageRecoveryActor starting: scanning state trie for missing contract storage " +
+          s"(stateRoot=${stateRoot.take(4).toArray.map("%02x".format(_)).mkString}...)"
+      )
+      self ! StartScan
   }
 
   override def receive: Receive = {
@@ -72,27 +83,29 @@ class StorageRecoveryActor(
       } else {
         log.warning(s"Storage recovery: found ${missing.size} contracts with missing storage. Starting download...")
         implicit val scheduler: org.apache.pekko.actor.Scheduler = context.system.scheduler
-        val requestTracker = new snap.SNAPRequestTracker()
-        val mptStorage = stateStorage.getBackingStorage(pivotBlockNumber)
 
-        val coordinator = context.actorOf(
-          actors.StorageRangeCoordinator
-            .props(
-              stateRoot = stateRoot,
-              networkPeerManager = networkPeerManager,
-              requestTracker = requestTracker,
-              mptStorage = mptStorage,
-              flatSlotStorage = flatSlotStorage,
-              maxAccountsPerBatch = snapSyncConfig.storageBatchSize,
-              maxInFlightRequests = snapSyncConfig.storageConcurrency,
-              requestTimeout = snapSyncConfig.timeout,
-              snapSyncController = self,
-              initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
-              minResponseBytes = snapSyncConfig.storageMinResponseBytes
-            )
-            .withDispatcher("sync-dispatcher"),
-          "storage-recovery-coordinator"
-        )
+        val coordinator = coordinatorForTesting.getOrElse {
+          val requestTracker = new snap.SNAPRequestTracker()
+          val mptStorage = stateStorage.getBackingStorage(pivotBlockNumber)
+          context.actorOf(
+            actors.StorageRangeCoordinator
+              .props(
+                stateRoot = stateRoot,
+                networkPeerManager = networkPeerManager,
+                requestTracker = requestTracker,
+                mptStorage = mptStorage,
+                flatSlotStorage = flatSlotStorage,
+                maxAccountsPerBatch = snapSyncConfig.storageBatchSize,
+                maxInFlightRequests = snapSyncConfig.storageConcurrency,
+                requestTimeout = snapSyncConfig.timeout,
+                snapSyncController = self,
+                initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
+                minResponseBytes = snapSyncConfig.storageMinResponseBytes
+              )
+              .withDispatcher("sync-dispatcher"),
+            "storage-recovery-coordinator"
+          )
+        }
 
         // Send tasks in batches of 10K (same as SNAPSyncController)
         val batchSize = 10000
@@ -110,21 +123,20 @@ class StorageRecoveryActor(
       }
   }
 
-  /** Seconds without any storage-slot progress after which we declare the recovery dead-in-the-water and abandon to
-    * regular sync. The SNAP serve window is ~128 blocks (~28 min on ETC / ~25 min on ETH); once exceeded, every peer
-    * rejects our saved pivot root and `PivotStateUnservable` fires in a loop. Pivot-refresh isn't wired into the
-    * recovery path (unlike SNAP), so the only way out is to stop trying and let regular sync's on-demand `GetTrieNodes`
-    * fetch the missing subtrees.
-    */
-  private val RecoveryAbandonAfter: FiniteDuration = 10.minutes
-
   private def downloading(coordinator: ActorRef, expectedCount: Int): Receive = {
-    var lastProgressMs = System.currentTimeMillis()
+    // A strictly-increasing counter is more robust than a wall-clock timestamp:
+    // System.currentTimeMillis() can collide if two progress updates land in the same
+    // ms (then the CheckAbandon equality check would false-fire), and wall-clock jumps
+    // would make stalledForSeconds misleading. Counter + nanoTime covers both axes.
+    var progressSeq = 0L
+    var lastProgressNanos = System.nanoTime()
     var unservableCount = 0
     var abandonTimer: Option[Cancellable] = None
+    val abandonAfter: FiniteDuration = snapSyncConfig.storageRecoveryAbandonTimeout
 
     def recordProgress(): Unit = {
-      lastProgressMs = System.currentTimeMillis()
+      progressSeq += 1
+      lastProgressNanos = System.nanoTime()
       unservableCount = 0
       abandonTimer.foreach(_.cancel())
       abandonTimer = None
@@ -133,7 +145,7 @@ class StorageRecoveryActor(
     def scheduleAbandonCheck(): Unit = {
       abandonTimer.foreach(_.cancel())
       abandonTimer = Some(
-        context.system.scheduler.scheduleOnce(RecoveryAbandonAfter, self, CheckAbandon(lastProgressMs))
+        context.system.scheduler.scheduleOnce(abandonAfter, self, CheckAbandon(progressSeq))
       )
     }
 
@@ -154,26 +166,30 @@ class StorageRecoveryActor(
       // Bug 30b: coordinator reports every peer stateless for the stored pivot root. In SNAP
       // sync this would trigger `refreshPivotInPlace` on the controller; the recovery path has
       // no equivalent. Instead of looping forever, count the events and bail out after
-      // `RecoveryAbandonAfter` of zero slot progress. Regular sync will subsequently fetch
-      // missing trie subtrees on-demand via GetTrieNodes when block execution reaches them.
+      // `abandonAfter` of zero slot progress. Regular sync will subsequently fetch missing
+      // trie subtrees on-demand via GetTrieNodes when block execution reaches them.
       case _: SNAPSyncController.PivotStateUnservable =>
         unservableCount += 1
-        log.info(
-          "Storage recovery: coordinator reports stored pivot root unservable ({} events, " +
-            "no progress for {}s). Will abandon after {}s if this persists.",
-          unservableCount,
-          (System.currentTimeMillis() - lastProgressMs) / 1000,
-          RecoveryAbandonAfter.toSeconds
-        )
+        // Rate-limit: log first 3 events, then every 100th. Avoids flooding logs when
+        // the coordinator is hammered with unservable responses in the failure mode.
+        if (unservableCount <= 3 || unservableCount % 100 == 0) {
+          log.info(
+            "Storage recovery: coordinator reports stored pivot root unservable ({} events, " +
+              "no progress for {}s). Will abandon after {}s if this persists.",
+            unservableCount,
+            (System.nanoTime() - lastProgressNanos) / 1_000_000_000L,
+            abandonAfter.toSeconds
+          )
+        }
         if (abandonTimer.isEmpty) scheduleAbandonCheck()
 
       case CheckAbandon(progressAtSchedule) =>
-        if (progressAtSchedule == lastProgressMs) {
+        if (progressAtSchedule == progressSeq) {
           log.warning(
             "Storage recovery abandoned: no slot progress for {}s against stored pivot root after {} " +
               "unservable events. Regular sync will fetch remaining contract storage on-demand via " +
               "GetTrieNodes when block execution needs it.",
-            RecoveryAbandonAfter.toSeconds,
+            abandonAfter.toSeconds,
             unservableCount
           )
           appStateStorage.storageRecoveryDone().commit()
@@ -253,10 +269,11 @@ class StorageRecoveryActor(
 object StorageRecoveryActor {
   private case object StartScan
   private case class ScanResult(missingStorage: Seq[(ByteString, ByteString)])
-  // Delayed self-ping used by Bug 30b abandon path. Carries the progress timestamp that was
-  // current when the timer was armed; if the actor's current lastProgressMs still matches on
-  // fire, nothing has moved in the interim and we give up.
-  private case class CheckAbandon(progressAtSchedule: Long)
+  // Delayed self-ping used by Bug 30b abandon path. Carries the progress counter that was
+  // current when the timer was armed; if the actor's current progressSeq still matches on
+  // fire, nothing has moved in the interim and we give up. Package-private so the spec
+  // can construct it directly and assert the fire/cancel logic.
+  private[sync] case class CheckAbandon(progressAtSchedule: Long)
 
   /** Sent to SyncController when recovery is complete (or skipped) */
   case object RecoveryComplete

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2773,7 +2773,11 @@ case class SNAPSyncConfig(
     minSnapPeers: Int = 3,
     snapPeerEvictionInterval: FiniteDuration = 15.seconds,
     maxEvictionsPerCycle: Int = 3,
-    deferredMerkleization: Boolean = true
+    deferredMerkleization: Boolean = true,
+    // Bug 30b: post-SNAP storage recovery can't refresh the pivot root. If every peer
+    // rejects the saved root for this long with no slot progress, abandon recovery and
+    // let regular sync's on-demand GetTrieNodes pick up missing subtrees.
+    storageRecoveryAbandonTimeout: FiniteDuration = 10.minutes
 )
 
 object SNAPSyncConfig {
@@ -2865,7 +2869,11 @@ object SNAPSyncConfig {
       deferredMerkleization =
         if (snapConfig.hasPath("deferred-merkleization"))
           snapConfig.getBoolean("deferred-merkleization")
-        else true
+        else true,
+      storageRecoveryAbandonTimeout =
+        if (snapConfig.hasPath("storage-recovery-abandon-timeout"))
+          snapConfig.getDuration("storage-recovery-abandon-timeout").toMillis.millis
+        else 10.minutes
     )
   }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -238,3 +238,12 @@ pekko {
   log-dead-letters = off
 
 }
+
+# Sync actors reference `sync-dispatcher` via `.withDispatcher("sync-dispatcher")`. Provide a
+# minimal config here so tests that exercise sync actors don't fail with
+# `ConfigurationException: Dispatcher [sync-dispatcher] not configured`.
+sync-dispatcher {
+  type = Dispatcher
+  executor = "default-executor"
+  throughput = 5
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActorSpec.scala
@@ -1,0 +1,160 @@
+package com.chipprbots.ethereum.blockchain.sync
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncConfig
+import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController
+import com.chipprbots.ethereum.db.cache.LruCache
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.db.storage.AppStateStorage
+import com.chipprbots.ethereum.db.storage.CachedReferenceCountedStorage
+import com.chipprbots.ethereum.db.storage.FlatSlotStorage
+import com.chipprbots.ethereum.db.storage.HeapEntry
+import com.chipprbots.ethereum.db.storage.NodeStorage
+import com.chipprbots.ethereum.db.storage.NodeStorage.NodeHash
+import com.chipprbots.ethereum.db.storage.StateStorage
+import com.chipprbots.ethereum.db.storage.pruning.ArchivePruning
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.Config
+
+/** Focused coverage for the Bug 30b abandon path. Drives the actor through its `downloading` state via the
+  * `preloadedMissingForTesting` + `coordinatorForTesting` hooks and asserts:
+  *
+  *   - Repeated `PivotStateUnservable` with no progress eventually triggers `RecoveryComplete`.
+  *   - A `ProgressStorageSlotsSynced` between unservable events resets the counter so the abandon timer does NOT fire
+  *     within the first window.
+  */
+class StorageRecoveryActorSpec
+    extends TestKit(ActorSystem("StorageRecoveryActorSpec_System"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with Eventually {
+
+  private val fakeStateRoot: ByteString = ByteString(Array.fill[Byte](32)(0x11))
+  private val fakeAccountHash: ByteString = ByteString(Array.fill[Byte](32)(0x22))
+  private val fakeStorageRoot: ByteString = ByteString(Array.fill[Byte](32)(0x33))
+  private val missingOne: Seq[(ByteString, ByteString)] = Seq((fakeAccountHash, fakeStorageRoot))
+
+  private def newConfig(abandonAfter: FiniteDuration): SNAPSyncConfig =
+    SNAPSyncConfig(storageRecoveryAbandonTimeout = abandonAfter)
+
+  private def pivotUnservable(): SNAPSyncController.PivotStateUnservable =
+    SNAPSyncController.PivotStateUnservable(fakeStateRoot, "test", 0)
+
+  private def newStorages(): (StateStorage, AppStateStorage, FlatSlotStorage) = {
+    val ds = EphemDataSource()
+    val nodeStorage = new NodeStorage(ds)
+    val appStateStorage = new AppStateStorage(ds)
+    val flatSlots = new FlatSlotStorage(ds)
+    val stateStorage = StateStorage(
+      ArchivePruning,
+      nodeStorage,
+      new LruCache[NodeHash, HeapEntry](
+        Config.inMemoryPruningNodeCacheConfig,
+        Some(CachedReferenceCountedStorage.saveOnlyNotificationHandler(nodeStorage))
+      )
+    )
+    (stateStorage, appStateStorage, flatSlots)
+  }
+
+  "StorageRecoveryActor" should
+    "abandon and commit recovery-done after repeated PivotStateUnservable with no progress" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_abandon")
+      val networkPeerManager = TestProbe("networkPeerManager_abandon")
+      val coordinatorProbe = TestProbe("coordinator_abandon")
+      val (stateStorage, appStateStorage, flatSlots) = newStorages()
+
+      // 600ms sits above the Pekko scheduler tick (~10ms) and below default ScalaTest patience.
+      val abandonAfter = 600.millis
+
+      val actor = system.actorOf(
+        Props(
+          new StorageRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            appStateStorage = appStateStorage,
+            flatSlotStorage = flatSlots,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig(abandonAfter),
+            preloadedMissingForTesting = Some(missingOne),
+            coordinatorForTesting = Some(coordinatorProbe.ref)
+          )
+        )
+      )
+
+      // Confirm the actor actually entered `downloading` — the coordinator probe should
+      // receive AddStorageTasks synchronously after ScanResult is processed.
+      coordinatorProbe.expectMsgType[com.chipprbots.ethereum.blockchain.sync.snap.actors.Messages.AddStorageTasks](
+        2.seconds
+      )
+
+      // Bump counter a handful of times — the first arms the timer, subsequent ones must
+      // NOT reset it (otherwise abandon never fires).
+      (1 to 5).foreach(_ => actor ! pivotUnservable())
+
+      syncController.expectMsg(3.seconds, StorageRecoveryActor.RecoveryComplete)
+      appStateStorage.isStorageRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+
+  it should "NOT abandon if slot progress arrives between unservable events" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in {
+    val syncController = TestProbe("syncController_noAbandon")
+    val networkPeerManager = TestProbe("networkPeerManager_noAbandon")
+    val coordinatorProbe = TestProbe("coordinator_noAbandon")
+    val (stateStorage, appStateStorage, flatSlots) = newStorages()
+
+    val abandonAfter = 500.millis
+
+    val actor = system.actorOf(
+      Props(
+        new StorageRecoveryActor(
+          stateRoot = fakeStateRoot,
+          stateStorage = stateStorage,
+          appStateStorage = appStateStorage,
+          flatSlotStorage = flatSlots,
+          networkPeerManager = networkPeerManager.ref,
+          syncController = syncController.ref,
+          pivotBlockNumber = BigInt(100),
+          snapSyncConfig = newConfig(abandonAfter),
+          preloadedMissingForTesting = Some(missingOne),
+          coordinatorForTesting = Some(coordinatorProbe.ref)
+        )
+      )
+    )
+
+    actor ! pivotUnservable()
+    // Progress resets the counter + cancels the pending abandon.
+    actor ! SNAPSyncController.ProgressStorageSlotsSynced(10)
+    actor ! pivotUnservable()
+
+    // The second PivotStateUnservable arms a fresh timer after progress reset it.
+    // Waiting 2x abandonAfter would catch a premature abandon — and by then, one
+    // `abandonAfter` after the fresh arm would have elapsed anyway. Use 1.5x so
+    // we're strictly inside the new window.
+    syncController.expectNoMessage((abandonAfter.toMillis * 3 / 2).millis)
+    appStateStorage.isStorageRecoveryDone() shouldBe false
+
+    system.stop(actor)
+  }
+}


### PR DESCRIPTION
## Summary

**Bug 30b**: after a restart past the SNAP serve window (~28 min), `StorageRecoveryActor` gets into an infinite `PivotStateUnservable` loop with the coordinator and never progresses. Node stuck forever, workaround is wipe-and-resync.

Observed 2026-04-23 on Barad-dur multi-instance — all 8 Mordor peers stateless for saved pivot root, coordinator correctly escalated to the recovery actor, but the actor's catch-all `case msg => coordinator.forward(msg)` bounced the signal right back.

## Root cause

`SNAPSyncController` has a full `refreshPivotInPlace` machinery (requests a fresh pivot header from peers via `SyncController`, updates coordinator with the new root). `StorageRecoveryActor` doesn't — re-using that machinery cleanly would require threading the pivot-bootstrap flow through two more actors.

## Fix: pragmatic abort path

When the coordinator starts reporting the stored pivot unservable, count the events. If no actual storage-slot progress happens for **10 minutes**, declare recovery abandoned:
- mark `storageRecoveryDone()` in AppStateStorage (no re-run at next restart)
- send `RecoveryComplete` to SyncController
- log a clear abandon message
- stop the actor

Regular sync's post-SNAP deferred-merkleization design already fetches any missing state node on-demand via `GetTrieNodes` during block execution, so the abandon is correct, not destructive.

## Semantic shift

| Event | Before | After |
|---|---|---|
| `PivotStateUnservable` | forwarded back to coordinator → infinite loop | counted; arms no-progress timer |
| `ProgressStorageSlotsSynced` | (no explicit handler) | resets timer + unservable count |
| No progress for 10 min + unservable events | stuck forever | graceful abandon → RecoveryComplete |

## Testing

- [x] `sbt Test/compile` — clean
- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt "testOnly *SyncControllerSpec -- -l DisabledTest -l SyncTest"` — **10/10 green**
- [x] No fukuii nodes running while tests ran.

**Unit-testing scoped to follow-up**: exercising the timer-driven abandon path against the full actor requires setting up `FlatSlotStorage` + a state trie with phantom storage roots + an `ExplicitlyTriggeredScheduler`. Significant fixture work for a bounded-timer behavior with clearly-documented semantics. Deferring to integration coverage from the next Mordor SNAP run.

## Closes

Bug 30b — `memory/bug30_storage_recovery_stale_pivot.md` slated for removal in the session cleanup sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)