### PR TITLE
docs(metrics): surface Bug 29 multi-instance shared-registry limitation

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.prometheus.client.exporter.HTTPServer
 import io.prometheus.client.hotspot.DefaultExports
 import kamon.Kamon
+import org.slf4j.LoggerFactory
 
 case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: Int = 0) {
 
@@ -68,6 +69,8 @@ case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: I
 }
 
 object Metrics {
+  private val log = LoggerFactory.getLogger(getClass)
+
   final val MetricsPrefix = "app"
 
   // Multi-instance registry: maps instanceId → Metrics
@@ -84,7 +87,20 @@ object Metrics {
   def forInstance(instanceId: String): Metrics =
     Option(instances.get(instanceId)).getOrElse(get())
 
-  /** Configure metrics for a specific instance. Thread-safe, supports multiple calls. */
+  /** Configure metrics for a specific instance. Thread-safe, supports multiple calls.
+    *
+    * **Multi-instance limitation (Bug 29)**: every `MetricsContainer`-mixed-in singleton (`SNAPSyncMetrics`,
+    * `RegularSyncMetrics`, etc.) reads from `Metrics.get()` — the static `defaultRef`. The first instance to configure
+    * wins the default; all subsequent instances write their samples into the SAME registry, so per-network dashboards
+    * can't distinguish chains. Worse, the Prometheus HTTP exporter used here (`io.prometheus.client.HTTPServer`) serves
+    * the shared Prometheus default registry, so both `/metrics` endpoints return byte-identical content regardless of
+    * which instance they belong to.
+    *
+    * We emit a WARN at second-configure time so operators see the limitation loudly rather than silently. Workaround
+    * for full per-chain observability: run one fukuii container per chain. Proper fix is out of scope here — it
+    * requires either (a) refactoring the `object` metric holders to classes parameterised on a registry, or (b)
+    * attaching per-network tags at write time and ensuring the exporter serves the correct Micrometer registry.
+    */
   def configure(config: MetricsConfig, instanceId: String = "default"): Try[Unit] =
     Try {
       if (config.enabled) {
@@ -94,7 +110,24 @@ object Metrics {
         if (existing == null) {
           metrics.start()
           // First instance also becomes the default
-          defaultRef.compareAndSet(defaultMetrics, metrics)
+          val becameDefault = defaultRef.compareAndSet(defaultMetrics, metrics)
+          if (!becameDefault && instances.size() > 1) {
+            val otherId = scala.jdk.CollectionConverters
+              .MapHasAsScala(instances)
+              .asScala
+              .collectFirst { case (id, _) if id != instanceId => id }
+              .getOrElse("<unknown>")
+            log.warn(
+              "Metrics registered for instance '{}' on port {}, but samples are written to the " +
+                "shared static registry wired to instance '{}' (Bug 29). This /metrics endpoint will " +
+                "serve the same data as the first-registered instance's endpoint. For per-chain " +
+                "observability, run a separate fukuii container per chain until the metrics " +
+                "refactor lands.",
+              instanceId,
+              config.port.toString,
+              otherId
+            )
+          }
         } else {
           metrics.close()
           // Already configured for this instance — not an error in multi-instance mode

--- a/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
@@ -3,6 +3,7 @@ package com.chipprbots.ethereum.metrics
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 import io.micrometer.core.instrument._
@@ -111,11 +112,13 @@ object Metrics {
           metrics.start()
           // First instance also becomes the default
           val becameDefault = defaultRef.compareAndSet(defaultMetrics, metrics)
-          if (!becameDefault && instances.size() > 1) {
-            val otherId = scala.jdk.CollectionConverters
-              .MapHasAsScala(instances)
-              .asScala
-              .collectFirst { case (id, _) if id != instanceId => id }
+          if (!becameDefault) {
+            // Identify the owner of `defaultRef` — that's the instance whose writes the shared
+            // registry actually reflects. `instances` may have other entries too (3+-way
+            // multi-instance), but the default-owner is the one operators need to know about.
+            val activeDefault = defaultRef.get()
+            val ownerId = instances.asScala
+              .collectFirst { case (id, m) if m eq activeDefault => id }
               .getOrElse("<unknown>")
             log.warn(
               "Metrics registered for instance '{}' on port {}, but samples are written to the " +
@@ -125,7 +128,7 @@ object Metrics {
                 "refactor lands.",
               instanceId,
               config.port.toString,
-              otherId
+              ownerId
             )
           }
         } else {

--- a/src/main/scala/com/chipprbots/ethereum/metrics/MetricsContainer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/MetricsContainer.scala
@@ -2,6 +2,13 @@ package com.chipprbots.ethereum.metrics
 
 /** An object that contains metrics, typically owned by an application component. We also use it as a marker trait, so
   * that subclasses can easily give us an idea of what metrics we implement across the application.
+  *
+  * **Multi-instance caveat (Bug 29)**: `metrics` resolves to `Metrics.get()`, which is the static `defaultRef` —
+  * effectively the first-registered `Metrics` instance. Every `MetricsContainer` subclass across every running chain
+  * instance therefore writes to the SAME registry. In a single-instance deployment this is fine; in `fukuii-runtime`
+  * multi-instance deployments it means per-chain `/metrics` endpoints cannot be distinguished. Run one fukuii container
+  * per chain for per-chain observability until the registry-per-instance refactor lands. See `Metrics.configure` for
+  * the WARN that fires when a second instance is registered.
   */
 trait MetricsContainer {
   final lazy val metrics: Metrics = Metrics.get()

--- a/src/test/scala/com/chipprbots/ethereum/metrics/MetricsMultiInstanceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/metrics/MetricsMultiInstanceSpec.scala
@@ -1,0 +1,37 @@
+package com.chipprbots.ethereum.metrics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Locks the behavior documented in [[Metrics.configure]] for multi-instance registration (Bug 29).
+  *
+  * These tests don't fix the shared-registry semantics — that requires an architectural refactor of the `object`-level
+  * `MetricsContainer` singletons. What they DO is guarantee that the fallback contract (`Metrics.forInstance(unknownId)
+  * \== Metrics.get()`) remains the observable API, so any change to the multi-instance wiring at least surfaces in this
+  * test first.
+  *
+  * Avoids real port binding — we don't go through `configure` because it calls `Metrics.start()` which binds a real
+  * Prometheus HTTP server. Port-binding tests belong in an integration suite with explicit lifecycle control; the Bug
+  * 29 *semantic* we want to lock is the lookup fallback, which doesn't require binding.
+  */
+class MetricsMultiInstanceSpec extends AnyFlatSpec with Matchers {
+
+  "Metrics.forInstance" should "fall back to Metrics.get() for unknown instance ids" in {
+    val any = Metrics.forInstance("definitely-not-registered-12345")
+    any shouldBe Metrics.get()
+  }
+
+  it should "return the same reference for repeated lookups of the default" in {
+    val a = Metrics.get()
+    val b = Metrics.get()
+    a shouldBe b
+  }
+
+  "MetricsContainer.metrics" should "resolve to Metrics.get() (Bug 29 — shared registry semantic)" in {
+    // The whole point of Bug 29 is that `MetricsContainer` singletons write to the static default
+    // instead of to a per-instance registry. Assert that explicitly so a future refactor that
+    // changes the wiring has to update this test along with the production change.
+    object Probe extends MetricsContainer
+    Probe.metrics shouldBe Metrics.get()
+  }
+}


### PR DESCRIPTION
## Summary

**Bug 29**: `fukuii-runtime` multi-instance deployments silently share a single static metrics registry across all chain instances. Every `MetricsContainer` subclass (`SNAPSyncMetrics`, `RegularSyncMetrics`, etc.) resolves `metrics` to `Metrics.get()` — the static `defaultRef`. Subsequent instances configure their own Micrometer registries but no writes go there. The Prometheus HTTP exporter (`io.prometheus.client.HTTPServer`) also serves the shared Prometheus default registry, so both `/metrics` endpoints return byte-identical content.

## What this PR does NOT ship

A proper fix of the wiring. That requires refactoring ~10 `object`-level metric holders to either (a) classes parameterised on a registry, or (b) tagged-at-write-time samples with the exporter serving a specific Micrometer registry. Both are large surface-area changes.

## What this PR DOES ship

- **Scaladoc on `Metrics.configure`** explaining the limitation and the operator workaround (run one container per chain).
- **Parallel scaladoc on `MetricsContainer`** so developers reading a `MetricsContainer` subclass see the caveat at the `metrics` field they're about to use.
- **A WARN logged at second-configure time** naming the current instance's port and the instance whose writes it's actually shadowing. Previously a second configure call succeeded silently.
- **`MetricsMultiInstanceSpec`** locks the observable contract (`forInstance(unknownId) == get()`, `MetricsContainer.metrics == get()`). Any future refactor that changes the wiring must update this test along with the production change — no silent behavior drift.

## Not included

Port-binding integration tests. Triggering `Metrics.start()` from a unit test binds a real HTTP server on a user-chosen port, which conflicts with any concurrent service using the same port. Those belong in an integration suite with explicit lifecycle control.

## Testing

- [x] `sbt Test/compile` — clean
- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt "testOnly *MetricsMultiInstanceSpec"` — **3/3 green**
- [x] No fukuii nodes running while tests ran.

## Closes

Bug 29. `memory/bug29_multi_instance_metrics_shared.md` slated for removal in the session cleanup sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)