### PR TITLE
fix(evm): use EIP-1559 effective gas price for GASPRICE + upfront (Trend #5)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
@@ -148,7 +148,21 @@ class BlockPreparator(
         blobGasUsed * blobBaseFee
       case _ => BigInt(0)
     }
-    val upfrontTotal = calculateUpfrontGas(stx.tx).toBigInt + blobGasCost
+    // EIP-1559 / EELS: the pre-execution balance deduction is
+    //   gasLimit * effectiveGasPrice + tx.value + blobGasCost
+    // NOT gasLimit * maxFee. The balance *check* (in validate) still requires
+    // gasLimit * maxFee to be available — that's the reservation — but the
+    // actual amount removed from the sender is only what will ever be spent
+    // at the effective gas price. See EELS prague/transactions.py
+    // `effective_gas_fee = tx.gas * effective_gas_price`.
+    //
+    // Consequence: `BALANCE(sender)` inside the VM sees the post-upfront
+    // balance computed with effectiveGasPrice, matching geth/nethermind.
+    // Surfaces on hive `bcEIP1559/burnVerify_Cancun` which reads BALANCE inside
+    // the contract to verify the burn invariant.
+    val effectiveGasPrice = Transaction.effectiveGasPrice(stx.tx, blockHeader.baseFee)
+    val executionUpfront = stx.tx.gasLimit * effectiveGasPrice
+    val upfrontTotal = executionUpfront + blobGasCost
     worldStateProxy.saveAccount(
       senderAddress,
       account.increaseBalance(UInt256(-upfrontTotal)).increaseNonce()
@@ -456,13 +470,11 @@ class BlockPreparator(
     }
     val totalGasToRefund = gasLimit - executionGasToPayToMiner
 
-    // Upfront charge was gasLimit * tx.gasPrice (= maxFeePerGas for EIP-1559).
-    // For legacy/Type-1 txs effectiveGasPrice == tx.gasPrice, so this matches
-    // (gasLimit - executionGas) * gasPrice. For EIP-1559/4844/7702 txs the
-    // refund also needs to return gasLimit * (maxFeePerGas - effectiveGasPrice)
-    // so the sender only pays executionGas * effectiveGasPrice net.
-    val maxFeeOverpay = UInt256(stx.tx.gasPrice) - gasPrice
-    val refundAmount = (totalGasToRefund * gasPrice) + (UInt256(gasLimit) * maxFeeOverpay)
+    // Upfront in `updateSenderAccountBeforeExecution` is gasLimit * effectiveGasPrice
+    // (post-EIP-1559: NOT maxFeePerGas — see comment there). So the refund only
+    // needs to return the unused portion: (gasLimit - executionGas) * effectiveGasPrice.
+    // No maxFee overpay to undo.
+    val refundAmount = totalGasToRefund * gasPrice
     val refundGasFn = pay(senderAddress, refundAmount.toUInt256, withTouch = false) _
     // EIP-1559: miner receives only the priority fee (effectiveGasPrice - baseFee).
     // The baseFee portion is burned on ETH chains, or credited to treasury on ETC (ECIP-1111).

--- a/src/main/scala/com/chipprbots/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/ProgramContext.scala
@@ -30,7 +30,14 @@ object ProgramContext {
       callerAddr = senderAddress,
       originAddr = senderAddress,
       recipientAddr = tx.receivingAddress,
-      gasPrice = UInt256(tx.gasPrice),
+      // EIP-1559: the GASPRICE opcode and the sub-call gasPrice plumbing must see
+      // the *effective* gas price (min(maxFeePerGas, baseFee + maxPriorityFeePerGas)),
+      // not the raw `tx.gasPrice` which for Type-2/3/4 returns maxFeePerGas. Surfaces
+      // on BlockchainTests/ValidBlocks/bcEIP1559/burnVerify_Cancun: the contract
+      // stores GASPRICE into a slot whose pre-existing value == baseFee, so the SSTORE
+      // should be a no-op (100 gas) but was being charged as a fresh-slot reset (2900
+      // gas) — the observed +2800 per-tx gas delta.
+      gasPrice = UInt256(Transaction.effectiveGasPrice(tx, blockHeader.baseFee)),
       startGas = gasLimit,
       inputData = tx.payload,
       value = UInt256(tx.value),

--- a/src/test/scala/com/chipprbots/ethereum/vm/ProgramContextEffectiveGasPriceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/ProgramContextEffectiveGasPriceSpec.scala
@@ -1,0 +1,82 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.{Fixtures => CommonFixtures}
+import com.chipprbots.ethereum.crypto.ECDSASignature
+import com.chipprbots.ethereum.domain.Address
+import com.chipprbots.ethereum.domain.BlockHeader
+import com.chipprbots.ethereum.domain.SignedTransaction
+import com.chipprbots.ethereum.domain.UInt256
+import com.chipprbots.ethereum.domain.TransactionWithDynamicFee
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Regression for `ProgramContext.apply` setting `gasPrice` to the EIP-1559 effective gas price (min(maxFeePerGas,
+  * baseFee + maxPriorityFeePerGas)) rather than the raw `tx.gasPrice` (which for Type-2 returns maxFeePerGas).
+  *
+  * Surfaces on the hive `bcEIP1559/burnVerify_Cancun` consensus test, whose contract stores `GASPRICE` to a slot
+  * already holding the baseFee — making it a no-op SSTORE (100 gas) only if `GASPRICE == effectiveGasPrice == baseFee`.
+  * When `GASPRICE` was leaking out as `maxFeePerGas` (1000) instead of the effective price (875 = baseFee), Fukuii
+  * treated it as a fresh-slot reset (2900 gas), yielding the observed +2800 gas delta.
+  */
+class ProgramContextEffectiveGasPriceSpec extends AnyFlatSpec with Matchers {
+
+  private val senderAddr: Address = Address(ByteString(Array.fill[Byte](20)(0x11.toByte)))
+
+  // Only the EIP-1559 fields matter for `effectiveGasPrice`. Other fields use
+  // arbitrary fixture values.
+  private def newDynamicFeeTx(maxFeePerGas: BigInt, maxPriorityFeePerGas: BigInt): SignedTransaction = {
+    val raw = TransactionWithDynamicFee(
+      nonce = 0,
+      maxPriorityFeePerGas = maxPriorityFeePerGas,
+      maxFeePerGas = maxFeePerGas,
+      gasLimit = 100000,
+      receivingAddress = Some(Address(ByteString(Array.fill[Byte](20)(0xcc.toByte)))),
+      value = 0,
+      payload = ByteString.empty,
+      accessList = Nil,
+      chainId = 1
+    )
+    SignedTransaction(raw, ECDSASignature(BigInt(0), BigInt(0), BigInt(0)))
+  }
+
+  // HefPostOlympia carries just the baseFee, which is all `Transaction.effectiveGasPrice`
+  // looks at. For Cancun-era txs the same baseFee plumbing applies through HefPostShanghai/
+  // HefPostCancun; testing the simpler branch is sufficient here.
+  private def newHeader(baseFee: BigInt): BlockHeader =
+    CommonFixtures.Blocks.ValidBlock.header.copy(
+      extraFields = BlockHeader.HeaderExtraFields.HefPostOlympia(baseFee)
+    )
+
+  // EvmConfig isn't read by ProgramContext.apply for `gasPrice`, so any config works.
+  // `Fixtures.blockchainConfig` (in this package) returns a BlockchainConfigForEvm directly.
+  private val evmConfig: EvmConfig = EvmConfig.forBlock(BigInt(1), Fixtures.blockchainConfig)
+
+  "ProgramContext" should
+    "expose the EIP-1559 effective gas price (not maxFeePerGas) for Type-2 txs" taggedAs (UnitTest) in {
+      val stx = newDynamicFeeTx(maxFeePerGas = 1000, maxPriorityFeePerGas = 0)
+      val header = newHeader(baseFee = 875)
+      val ctx = ProgramContext(stx, header, senderAddr, null, evmConfig)
+      // effective = min(maxFee=1000, baseFee+priority = 875+0 = 875) = 875
+      ctx.gasPrice shouldBe UInt256(875)
+    }
+
+  it should "cap at maxFeePerGas when baseFee + priority exceeds it" taggedAs (UnitTest) in {
+    val stx = newDynamicFeeTx(maxFeePerGas = 900, maxPriorityFeePerGas = 100)
+    val header = newHeader(baseFee = 875)
+    val ctx = ProgramContext(stx, header, senderAddr, null, evmConfig)
+    // effective = min(maxFee=900, baseFee+priority = 875+100 = 975) = 900
+    ctx.gasPrice shouldBe UInt256(900)
+  }
+
+  it should "add priority fee on top of baseFee when under maxFee" taggedAs (UnitTest) in {
+    val stx = newDynamicFeeTx(maxFeePerGas = 2000, maxPriorityFeePerGas = 100)
+    val header = newHeader(baseFee = 875)
+    val ctx = ProgramContext(stx, header, senderAddr, null, evmConfig)
+    // effective = min(maxFee=2000, baseFee+priority = 875+100 = 975) = 975
+    ctx.gasPrice shouldBe UInt256(975)
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **+2800 gas accounting gap** on hive `bcEIP1559/burnVerify_Cancun` (Trend #5 from `hive_gap_trend_analysis.md`) by fixing two coupled EIP-1559 bugs in the gas plumbing.

## Root cause

The hive consensus test imports a 2-tx block and asserts a specific block `gasUsed`. Fukuii reported 78238 vs the test's expected 75438 — exactly +2800. Local hive trace pinpointed the gap to a single SSTORE in tx0 at pc=53 inside contract `0xCCCC...CC`:

```yul
let prevBaseFee := sload(0xFFFFFF)   // pre-existing value 0x036b = baseFee = 875
sstore(0xFFFFFF, gasprice())          // expected: no-op (100 gas)
                                      // actual:   reset (2900 gas)  ← +2800
```

For the SSTORE to be a no-op, `gasprice()` must equal the slot's pre-existing value, which equals the block's baseFee. The burnVerify test was specifically crafted around `GASPRICE == baseFee` because `min(maxFee=1000, baseFee+priority=875+0) = 875 = baseFee`.

Fukuii had two coupled bugs that broke this invariant:

### Bug 1 — `ProgramContext.apply` returned `maxFeePerGas` for `GASPRICE`

```scala
gasPrice = UInt256(tx.gasPrice),   // tx.gasPrice = maxFeePerGas for Type-2
```

For EIP-1559+, `GASPRICE` (and the `gasPrice` plumbed into sub-calls) must be the **effective** price `min(maxFeePerGas, baseFee + maxPriorityFeePerGas)`, not `maxFeePerGas`. Fixed by using `Transaction.effectiveGasPrice(tx, blockHeader.baseFee)`.

### Bug 2 — Upfront deduction used `gasLimit × maxFeePerGas`

`updateSenderAccountBeforeExecution` deducted `gasLimit × tx.gasPrice` (= `gasLimit × maxFee` for Type-2) before VM execution, then the post-execution `refundAmount` added back `gasLimit × (maxFee − effectiveGasPrice)` to compensate. The ending balance was correct, but `BALANCE(sender)` *during* execution returned the wrong value (too low by the maxFee overpay).

EELS spec (`prague/transactions.py`) and geth deduct `effective_gas_price × gas` up-front; the validator's pre-check still requires `maxFee × gas + value` to be available, but the actual deduction is at the effective price. Fixed accordingly; the now-unnecessary `maxFeeOverpay` term was removed from the refund path.

The two bugs cancelled each other for the *post-block* sender balance, which is why this never surfaced in legacy/Type-0 tests — they only diverged when a contract called `BALANCE` on the sender during the same tx.

## Verification

```
$ ./hive --sim ethereum/consensus --client fukuii --sim.limit 'consensus/burnVerify'
before: block 1 gasUsed=78238 (expected 75438) → tx fails
after:  block 1 gasUsed=75438 → burnVerify_Cancun PASSES
```

## Test plan

- [x] `sbt "testOnly *ProgramContextEffectiveGasPriceSpec"` — 3/3 pass (new spec asserts `gasPrice` matches the EELS effective formula across three baseFee/maxFee/priority configurations).
- [x] `sbt "testOnly *BlockPreparator* *BlockExecution* *StxLedgerSpec*"` — 32/32 pass (regression check on the changed upfront/refund paths).
- [x] hive `consensus/burnVerify` passes locally (was failing).
- [ ] Full hive consensus rerun via CI to confirm Trend #5's other 3 `bcEIP1559` failures also close (memory note expected this single fix to recover ~4 consensus tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)