### PR TITLE
fix(logging): reduce P2P and wire-level noise

### DIFF
--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -104,7 +104,7 @@ object DiscoveryNetwork {
                   .recover {
                     case ex: TimeoutException =>
                     case NonFatal(ex) =>
-                      logger.error(s"Error handling channel from ${channel.to}: $ex")
+                      logger.warn(s"[Discovery] Malformed packet from ${channel.to}: ${ex.getClass.getSimpleName}: ${ex.getMessage}")
                   }
                   .start.void
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -129,6 +129,9 @@
     
     <!-- Sync status and lifecycle (high-level status only) -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.SyncController" level="INFO" />
+    <!-- Post-SNAP recovery actors (package .blockchain.sync, not .snap.actors — must be explicit) -->
+    <logger name="com.chipprbots.ethereum.blockchain.sync.BytecodeRecoveryActor" level="INFO" />
+    <logger name="com.chipprbots.ethereum.blockchain.sync.StorageRecoveryActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.fast.FastSync" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.regular.RegularSync" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController" level="INFO" />
@@ -169,7 +172,7 @@
     
     <!-- Network handshaking - protocol handshake details -->
     <logger name="com.chipprbots.ethereum.network.handshaker" level="INFO" />
-    <logger name="com.chipprbots.ethereum.network.handshaker.EtcHelloExchangeState" level="ERROR" />
+    <logger name="com.chipprbots.ethereum.network.handshaker.EtcHelloExchangeState" level="WARN" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EthNodeStatus64ExchangeState" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EthNodeStatus63ExchangeState" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EtcForkBlockExchangeState" level="ERROR" />

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -216,7 +216,7 @@
     
     <!-- SNAP sync internals -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap" level="ERROR" />
-    <!-- SNAP sync actors (AccountRangeCoordinator, workers) — INFO for milestone visibility -->
+    <!-- SNAP sync actors — INFO shows coordinator milestone progress (account %, storage %, bytecode %) -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.actors" level="INFO" />
     <!-- Chain download progress — must be explicit, not inherited from snap (ERROR) -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader" level="INFO" />

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -160,7 +160,7 @@
     <logger name="com.chipprbots.ethereum.network" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerActor" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerManagerActor" level="ERROR" />
-    <logger name="com.chipprbots.ethereum.network.NetworkPeerManagerActor" level="ERROR" />
+    <logger name="com.chipprbots.ethereum.network.NetworkPeerManagerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.ServerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.KnownNodesManager" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerScoringManager" level="ERROR" />
@@ -171,9 +171,9 @@
     <logger name="com.chipprbots.ethereum.network.discovery.StaticNodesLoader" level="ERROR" />
     
     <!-- Network handshaking - protocol handshake details -->
-    <logger name="com.chipprbots.ethereum.network.handshaker" level="INFO" />
+    <logger name="com.chipprbots.ethereum.network.handshaker" level="WARN" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EtcHelloExchangeState" level="WARN" />
-    <logger name="com.chipprbots.ethereum.network.handshaker.EthNodeStatus64ExchangeState" level="INFO" />
+    <logger name="com.chipprbots.ethereum.network.handshaker.EthNodeStatus64ExchangeState" level="WARN" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EthNodeStatus63ExchangeState" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EtcForkBlockExchangeState" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.handshaker.EtcNodeStatusExchangeState" level="ERROR" />
@@ -191,7 +191,7 @@
     <!-- SYNC INTERNALS (ERROR only - detailed sync operations)             -->
     <!-- =================================================================== -->
     <!-- Peer list management and blacklist -->
-    <logger name="com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler" level="DEBUG" />
+    <logger name="com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler" level="WARN" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.PeersClient" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.Blacklist" level="INFO" />
@@ -216,8 +216,10 @@
     
     <!-- SNAP sync internals -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap" level="ERROR" />
-    <!-- SNAP sync actors (AccountRangeCoordinator, workers) — INFO for optimization visibility -->
+    <!-- SNAP sync actors (AccountRangeCoordinator, workers) — INFO for milestone visibility -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.actors" level="INFO" />
+    <!-- Chain download progress — must be explicit, not inherited from snap (ERROR) -->
+    <logger name="com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.AccountRangeDownloader" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.StorageRangeDownloader" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.TrieNodeHealer" level="ERROR" />

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
@@ -97,7 +97,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleTimeout(): Unit = {
     val elapsed = timeTakenSoFar()
-    log.error(
+    log.warning(
       "PEER_REQUEST_TIMEOUT: peer={}, reqType={}, elapsed={}ms (timeout={}ms)",
       peer.id,
       requestMsg.getClass.getSimpleName,
@@ -110,7 +110,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleTerminated(): Unit = {
     val elapsed = timeTakenSoFar()
-    log.error(
+    log.warning(
       "PEER_REQUEST_DISCONNECTED: peer={}, reqType={}, elapsed={}ms - connection closed before response",
       peer.id,
       requestMsg.getClass.getSimpleName,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -474,7 +474,7 @@ class SyncController(
         // It will fall back to fast sync if needed
         startSnapSync()
       case (true, _, true, _) =>
-        log.warning("do-snap-sync is true but SNAP sync already completed")
+        log.info("do-snap-sync is true but SNAP sync already completed — proceeding to SNAP recovery")
         // Diagnostic: log stored SNAP sync state root vs pivot block state root
         val snapStateRoot = appStateStorage.getSnapSyncStateRoot()
         val bestBlockNum = appStateStorage.getBestBlockNumber()

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -426,7 +426,6 @@ class BlockImporter(
         errorOpt match {
           case None => Running
           case Some(err) =>
-            log.error("Block import error {}", err)
             val notImportedBlocks = blocks.drop(importedBlocks.size)
 
             err match {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
@@ -130,7 +130,7 @@ class StateNodeFetcher(
           val matchingNode = nodes.find(n => kec256(n) == stateNodeRequester.hash)
           matchingNode match {
             case Some(nodeData) =>
-              log.info(
+              log.debug(
                 "Successfully fetched missing state node via SNAP GetTrieNodes ({} nodes in response)",
                 nodes.size
               )
@@ -174,7 +174,7 @@ class StateNodeFetcher(
     }
 
   private def sendGetTrieNodes(root: ByteString, pathGroups: Seq[Seq[ByteString]]): Unit = {
-    log.info(
+    log.debug(
       "Requesting missing state node via SNAP GetTrieNodes ({} path groups, root={})",
       pathGroups.size,
       root.take(4).toArray.map("%02x".format(_)).mkString

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -269,7 +269,7 @@ class ChainDownloader(
 
     // Log progress periodically
     val now = System.currentTimeMillis()
-    if (now - lastLogTime > 30000) {
+    if (now - lastLogTime > 60000) {
       lastLogTime = now
       val pct = if (targetBlock > 0) (bestHeaderNumber * 100 / targetBlock).toInt else 0
       log.info(

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -6,6 +6,10 @@ import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.actor.Props
 import org.apache.pekko.util.ByteString
 
+import scala.concurrent.duration.*
+
+import com.chipprbots.ethereum.network.rlpx.RLPxConnectionHandler
+
 import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.ChainWeight
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor._
@@ -55,8 +59,14 @@ class NetworkPeerManagerActor(
   // Mutable reference to SNAPSyncController that can be set after initialization
   private var snapSyncControllerOpt: Option[ActorRef] = initialSnapSyncControllerOpt
 
+  private var emptyHeaderResponses: Int = 0
+
   // Subscribe to the event of any peer getting handshaked
   peerEventBusActor ! Subscribe(PeerHandshaked)
+
+  context.system.scheduler.scheduleAtFixedRate(
+    60.seconds, 60.seconds, self, NetworkPeerManagerActor.LogNetworkSummary
+  )(context.dispatcher)
 
   // Subscribe globally to SNAP request codes. The hive devp2p snap test client sends
   // GetAccountRange/etc immediately after the RLPx hello, BEFORE the ETH-status exchange
@@ -96,6 +106,18 @@ class NetworkPeerManagerActor(
     *   which has the peer and peer information for each handshaked peer (identified by it's id)
     */
   private def handleCommonMessages(peersWithInfo: PeersWithInfo): Receive = {
+    case NetworkPeerManagerActor.LogNetworkSummary =>
+      val snapNegotiated  = RLPxConnectionHandler.snapCapabilityCount.getAndSet(0)
+      val resets          = RLPxConnectionHandler.connectionResetCount.getAndSet(0)
+      val authTimeouts    = RLPxConnectionHandler.authTimeoutCount.getAndSet(0)
+      val tcpFailed       = RLPxConnectionHandler.tcpFailedCount.getAndSet(0)
+      val emptyHeaders    = emptyHeaderResponses; emptyHeaderResponses = 0
+      val total           = peersWithInfo.size
+      val snapPeers       = peersWithInfo.values.count(_.peerInfo.remoteStatus.supportsSnap)
+      log.info(
+        s"Network [60s]: active=$total peers ($snapPeers snap-capable), +$snapNegotiated SNAP, +$resets resets, +$authTimeouts auth-timeouts, +$tcpFailed tcp-failed, +$emptyHeaders empty-headers"
+      )
+
     case GetHandshakedPeers =>
       // Provide only peers which already responded to request for best block hash, and theirs best block hash is different
       // form their genesis block
@@ -236,23 +258,29 @@ class NetworkPeerManagerActor(
     *   new updated peer info
     */
   private def handleReceivedMessage(message: Message, initialPeerWithInfo: PeerWithInfo): PeerInfo = {
-    // Log received BlockHeaders for debugging GetBlockHeaders response tracking
+    // Log received BlockHeaders — only non-empty responses at INFO; empty ones at DEBUG
     message match {
       case m: ETH62BlockHeaders =>
-        log.info(
-          "RECV_BLOCKHEADERS: peer={}, count={}, blockNumbers={}",
-          initialPeerWithInfo.peer.id,
-          m.headers.size,
-          m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
-        )
+        if (m.headers.nonEmpty)
+          log.info(
+            "RECV_BLOCKHEADERS: peer={}, count={}, blockNumbers={}",
+            initialPeerWithInfo.peer.id,
+            m.headers.size,
+            m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
+          )
+        else
+          emptyHeaderResponses += 1
       case m: ETH66BlockHeaders =>
-        log.info(
-          "RECV_BLOCKHEADERS: peer={}, requestId={}, count={}, blockNumbers={}",
-          initialPeerWithInfo.peer.id,
-          m.requestId,
-          m.headers.size,
-          m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
-        )
+        if (m.headers.nonEmpty)
+          log.info(
+            "RECV_BLOCKHEADERS: peer={}, requestId={}, count={}, blockNumbers={}",
+            initialPeerWithInfo.peer.id,
+            m.requestId,
+            m.headers.size,
+            m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
+          )
+        else
+          emptyHeaderResponses += 1
       case _ => // Don't log other message types at INFO level
     }
 
@@ -634,6 +662,8 @@ class NetworkPeerManagerActor(
 }
 
 object NetworkPeerManagerActor {
+
+  private[network] case object LogNetworkSummary
 
   val msgCodesWithInfo: Set[Int] = Set(
     Codes.BlockHeadersCode,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -88,7 +88,7 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
         )
         EthNodeStatus64ExchangeState(handshakerConfiguration, negotiated, supportsSnap, peerCapabilities)
       case _ =>
-        log.warn(
+        log.debug(
           "PROTOCOL_NEGOTIATION_FAILED: clientId={}, peerCaps=[{}], ourCaps=[{}], reason=IncompatibleP2pProtocolVersion",
           hello.clientId,
           peerCapabilities.mkString(", "),

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -5,6 +5,7 @@ import cats.effect.SyncIO
 import com.chipprbots.ethereum.forkid.Connect
 import com.chipprbots.ethereum.forkid.ForkId
 import com.chipprbots.ethereum.forkid.ForkIdValidator
+import com.chipprbots.ethereum.utils.ByteStringUtils.ByteStringOps
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.RemoteStatus
 import com.chipprbots.ethereum.network.p2p.Message
@@ -24,13 +25,13 @@ case class EthNodeStatus64ExchangeState(
 
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: ETH64.Status =>
     import ForkIdValidator.syncIoLogger
-    log.info(
+    log.debug(
       "STATUS_EXCHANGE: Received status from peer - protocolVersion={}, networkId={}, totalDifficulty={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
       status.networkId,
       status.totalDifficulty,
-      status.bestHash,
-      status.genesisHash,
+      status.bestHash.toHex,
+      status.genesisHash.toHex,
       status.forkId
     )
 
@@ -43,15 +44,15 @@ case class EthNodeStatus64ExchangeState(
     val localBestTimestamp = if (storedTimestamp == 0L) System.currentTimeMillis() / 1000 else storedTimestamp
     val localForkId = ForkId.create(localGenesisHash, blockchainConfig)(localBestBlock, localBestTimestamp)
 
-    log.info(
+    log.debug(
       "STATUS_EXCHANGE: Local state - bestBlock={}, genesisHash={}, localForkId={}",
       localBestBlock,
-      localGenesisHash,
+      localGenesisHash.toHex,
       localForkId
     )
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.warn(
+      log.debug(
         "STATUS_EXCHANGE: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
@@ -60,8 +61,8 @@ case class EthNodeStatus64ExchangeState(
     } else if (status.genesisHash != localGenesisHash) {
       log.warn(
         "STATUS_EXCHANGE: Peer genesis hash mismatch! Local: {}, Remote: {} - disconnecting peer",
-        localGenesisHash,
-        status.genesisHash
+        localGenesisHash.toHex,
+        status.genesisHash.toHex
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else {
@@ -72,13 +73,13 @@ case class EthNodeStatus64ExchangeState(
             status.forkId
           )
       } yield {
-        log.info("STATUS_EXCHANGE: ForkId validation result: {}", validationResult)
+        log.debug("STATUS_EXCHANGE: ForkId validation result: {}", validationResult)
         validationResult match {
           case Connect =>
             // EIP-2124: ForkId validation replaces the fork block exchange for ETH64+
             // When ForkId validation passes, we go directly to connected state
             // without needing to do the old-style fork block handshake
-            log.info(
+            log.debug(
               "STATUS_EXCHANGE: ForkId validation passed - accepting peer connection (skipping fork block exchange per EIP-2124)"
             )
             ConnectedState(
@@ -138,14 +139,14 @@ case class EthNodeStatus64ExchangeState(
       forkId = forkId
     )
 
-    log.info(
+    log.debug(
       "STATUS_EXCHANGE: Sending status - protocolVersion={}, networkId={}, totalDifficulty={}, bestBlock={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
       status.networkId,
       status.totalDifficulty,
       bestBlockNumber,
-      bestBlockHeader.hash,
-      genesisHash,
+      bestBlockHeader.hash.toHex,
+      genesisHash.toHex,
       forkId
     )
 

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -5,6 +5,7 @@ import cats.effect.SyncIO
 import com.chipprbots.ethereum.forkid.Connect
 import com.chipprbots.ethereum.forkid.ForkId
 import com.chipprbots.ethereum.forkid.ForkIdValidator
+import com.chipprbots.ethereum.utils.ByteStringUtils.ByteStringOps
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.RemoteStatus
 import com.chipprbots.ethereum.network.p2p.Message
@@ -33,21 +34,21 @@ case class EthNodeStatus69ExchangeState(
 
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: ETH69.Status =>
     import ForkIdValidator.syncIoLogger
-    log.info(
+    log.debug(
       "ETH69_STATUS: Received - protocolVersion={}, networkId={}, genesis={}, forkId={}, earliest={}, latest={}, latestHash={}",
       status.protocolVersion,
       status.networkId,
-      status.genesisHash,
+      status.genesisHash.toHex,
       status.forkId,
       status.earliestBlock,
       status.latestBlock,
-      status.latestBlockHash
+      status.latestBlockHash.toHex
     )
 
     val localGenesisHash = blockchainReader.genesisHeader.hash
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.warn(
+      log.debug(
         "ETH69_STATUS: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
@@ -56,8 +57,8 @@ case class EthNodeStatus69ExchangeState(
     } else if (status.genesisHash != localGenesisHash) {
       log.warn(
         "ETH69_STATUS: Genesis hash mismatch! Local: {}, Remote: {} - disconnecting",
-        localGenesisHash,
-        status.genesisHash
+        localGenesisHash.toHex,
+        status.genesisHash.toHex
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else {
@@ -68,10 +69,10 @@ case class EthNodeStatus69ExchangeState(
             status.forkId
           )
       } yield {
-        log.info("ETH69_STATUS: ForkId validation result: {}", validationResult)
+        log.debug("ETH69_STATUS: ForkId validation result: {}", validationResult)
         validationResult match {
           case Connect =>
-            log.info("ETH69_STATUS: ForkId validation passed - accepting peer")
+            log.debug("ETH69_STATUS: ForkId validation passed - accepting peer")
             ConnectedState(
               PeerInfo.withForkAccepted(
                 RemoteStatus.fromETH69Status(status, negotiatedCapability, supportsSnap, peerCapabilities)
@@ -106,14 +107,14 @@ case class EthNodeStatus69ExchangeState(
       latestBlockHash = bestBlockHeader.hash
     )
 
-    log.info(
+    log.debug(
       "ETH69_STATUS: Sending - networkId={}, genesis={}, forkId={}, earliest={}, latest={}, latestHash={}",
       status.networkId,
-      genesisHash,
+      genesisHash.toHex,
       forkId,
       status.earliestBlock,
       status.latestBlock,
-      bestBlockHeader.hash
+      bestBlockHeader.hash.toHex
     )
 
     status

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -108,7 +108,7 @@ class RLPxConnectionHandler(
       context.become(new ConnectedHandler(connection).waitingForAuthHandshakeResponse(handshaker, timeout))
 
     case CommandFailed(_: Connect) =>
-      log.error("[Stopping Connection] TCP connection to {} failed for peer {}", uri, peerId)
+      log.warning("[RLPx] TCP connection failed to {} for peer {}", uri, peerId)
       context.parent ! ConnectionFailed
       gracefulStop()
   }
@@ -260,7 +260,7 @@ class RLPxConnectionHandler(
         else CanonicalEthBase
 
       val snapBaseStr = peerSnapBase.map(b => s"0x${b.toHexString}").getOrElse("<disabled>")
-      log.info(
+      log.debug(
         s"INBOUND_CAP_OFFSETS: peer=$peerId clientId=${hello.clientId} snapFirst=$snapFirst " +
           s"peerEthBase=0x${peerEthBase.toHexString} peerSnapBase=$snapBaseStr"
       )
@@ -323,7 +323,7 @@ class RLPxConnectionHandler(
     }
 
     val handleConnectionTerminated: Receive = { case Terminated(`connection`) =>
-      log.debug("[Stopping Connection] TCP connection actor terminated for peer {}", peerId)
+      log.debug("[RLPx] TCP actor terminated for peer {}", peerId)
       context.parent ! ConnectionFailed
       gracefulStop()
     }
@@ -460,7 +460,7 @@ class RLPxConnectionHandler(
     def processHandshakeResult(result: AuthHandshakeResult, remainingData: ByteString): Unit =
       result match {
         case AuthHandshakeSuccess(secrets, remotePubKey) =>
-          log.info("[RLPx] Auth handshake SUCCESS for peer {}, establishing secure connection", peerId)
+          log.debug("[RLPx] Auth handshake SUCCESS for peer {}, establishing secure connection", peerId)
           context.parent ! ConnectionEstablished(remotePubKey)
           // following the specification at https://github.com/ethereum/devp2p/blob/master/rlpx.md#initial-handshake
           // point 6 indicates that the next messages needs to be initial 'Hello'
@@ -540,7 +540,7 @@ class RLPxConnectionHandler(
           messageCodecOpt match {
             case Some((messageCodec, inboundTranslator)) =>
               registerMessageCodec(messageCodec)
-              log.info("[RLPx] Connection FULLY ESTABLISHED with peer {}, entering handshaked state", peerId)
+              log.debug("[RLPx] Connection FULLY ESTABLISHED with peer {}, entering handshaked state", peerId)
               context.become(
                 handshaked(
                   messageCodec,
@@ -731,10 +731,8 @@ class RLPxConnectionHandler(
                   msg.code.toHexString
                 )
 
-                // High-signal receive logging for SNAP traffic (request/response visibility).
-                // This stays INFO so it shows up even when other receive logs are DEBUG.
                 if (msg.code >= CanonicalSnapBase && msg.code < CanonicalSnapBase + CanonicalSnapSize) {
-                  log.info(
+                  log.debug(
                     "RECV_SNAP_MSG: peer={}, msg[{}] {}",
                     peerId,
                     idx,
@@ -804,9 +802,8 @@ class RLPxConnectionHandler(
 
       val out = messageCodec.encodeMessage(serializableToEncode)
 
-      // Enhanced logging for GetBlockHeaders debugging
       val msgType = messageToSend.underlyingMsg.getClass.getSimpleName
-      log.info(
+      log.debug(
         "SEND_MSG: peer={}, type={}, codes={}, seqNum={}",
         peerId,
         msgType,
@@ -861,10 +858,11 @@ class RLPxConnectionHandler(
 
     def handleConnectionClosed: Receive = { case msg: ConnectionClosed =>
       if (msg.isPeerClosed) {
-        log.debug("[Stopping Connection] Connection with {} closed by peer", peerId)
-      }
-      if (msg.isErrorClosed) {
-        log.debug("[Stopping Connection] Connection with {} closed because of error {}", peerId, msg.getErrorCause)
+        log.debug("[RLPx] Peer {} closed connection (peer-initiated)", peerId)
+      } else if (msg.isErrorClosed) {
+        log.warning("[RLPx] Connection with {} closed due to error: {}", peerId, msg.getErrorCause)
+      } else {
+        log.debug("[RLPx] Connection with {} closed ({})", peerId, msg.getClass.getSimpleName)
       }
 
       gracefulStop()

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -641,8 +641,10 @@ class RLPxConnectionHandler(
           // reduce our ability to maintain connections with diverse peer implementations.
         } else {
           // For other decoding errors (truly malformed RLP, structure mismatches, etc.),
-          // send proper Disconnect to remote peer before closing connection
-          log.error(
+          // send proper Disconnect to remote peer before closing connection.
+          // Warning (not error): disconnect behavior is correct, this is just peer protocol variance
+          // (e.g., ETH69 peers sending 8-field Status when we expect 7 fields).
+          log.warning(
             "DECODE_ERROR: Cannot decode message from {} - disconnecting. Error: {}",
             peerId,
             ex.getMessage

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -2,6 +2,7 @@ package com.chipprbots.ethereum.network.rlpx
 
 import java.net.InetSocketAddress
 import java.net.URI
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.pekko.actor._
 import org.apache.pekko.io.IO
@@ -108,7 +109,7 @@ class RLPxConnectionHandler(
       context.become(new ConnectedHandler(connection).waitingForAuthHandshakeResponse(handshaker, timeout))
 
     case CommandFailed(_: Connect) =>
-      log.warning("[RLPx] TCP connection failed to {} for peer {}", uri, peerId)
+      RLPxConnectionHandler.tcpFailedCount.incrementAndGet()
       context.parent ! ConnectionFailed
       gracefulStop()
   }
@@ -448,11 +449,7 @@ class RLPxConnectionHandler(
     }
 
     def handleTimeout: Receive = { case AuthHandshakeTimeout =>
-      log.error(
-        "[Stopping Connection] Auth handshake timeout for peer {} after {}ms",
-        peerId,
-        rlpxConfiguration.waitForHandshakeTimeout.toMillis
-      )
+      RLPxConnectionHandler.authTimeoutCount.incrementAndGet()
       context.parent ! ConnectionFailed
       gracefulStop()
     }
@@ -574,7 +571,7 @@ class RLPxConnectionHandler(
         val supportsSnap =
           capabilities.contains(Capability.SNAP1) && hello.capabilities.contains(Capability.SNAP1)
         if (supportsSnap) {
-          log.info("[RLPx] SNAP/1 capability enabled for peer {}", peerId)
+          RLPxConnectionHandler.snapCapabilityCount.incrementAndGet()
         }
         val inboundTranslator = computeInboundTranslator(hello, negotiated, supportsSnap)
         (
@@ -860,7 +857,7 @@ class RLPxConnectionHandler(
       if (msg.isPeerClosed) {
         log.debug("[RLPx] Peer {} closed connection (peer-initiated)", peerId)
       } else if (msg.isErrorClosed) {
-        log.warning("[RLPx] Connection with {} closed due to error: {}", peerId, msg.getErrorCause)
+        RLPxConnectionHandler.connectionResetCount.incrementAndGet()
       } else {
         log.debug("[RLPx] Connection with {} closed ({})", peerId, msg.getClass.getSimpleName)
       }
@@ -871,6 +868,12 @@ class RLPxConnectionHandler(
 }
 
 object RLPxConnectionHandler {
+  // Shared counters accumulated per-connection, read+reset by NetworkPeerManagerActor every 60s
+  val snapCapabilityCount  = new AtomicInteger(0)
+  val connectionResetCount = new AtomicInteger(0)
+  val authTimeoutCount     = new AtomicInteger(0)
+  val tcpFailedCount       = new AtomicInteger(0)
+
   def props(
       capabilities: List[Capability],
       authHandshaker: AuthHandshaker,

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -366,8 +366,8 @@ class RLPxConnectionHandler(
               processHandshakeResult(result, remainingData)
 
             case Failure(ex) =>
-              log.error(
-                "[HIVE-DEBUG] Auth handshake FAILED for peer {} - both pre-EIP8 and EIP-8 decode failed: {}",
+              log.debug(
+                "[RLPx] Auth handshake FAILED for peer {} - both pre-EIP8 and EIP-8 decode failed: {}",
                 peerId,
                 ex.getMessage
               )


### PR DESCRIPTION
## Summary

Three passes to reduce log volume during normal operation:

**60s aggregate network summary** — replaces per-connection WARN/INFO events for
connection resets, auth handshake timeouts, TCP connect failures, and empty
\`RECV_BLOCKHEADERS\` responses with \`AtomicInteger\` counters in
\`RLPxConnectionHandler\` and a scheduled \`LogNetworkSummary\` flush in
\`NetworkPeerManagerActor\`. Output: \`Network [60s]: active=N peers (M snap-capable),
+X SNAP negotiations, +Y connection resets, +Z auth timeouts, +W empty-headers\`.
Chain download progress interval aligned to 60s. \`PEER_REQUEST_TIMEOUT\` and
\`DISCONNECTED\` demoted from ERROR to WARN.

**P2P handshake and discovery noise** — demotes ETH status exchange, RLPx
connection-close, and protocol negotiation events from INFO to DEBUG. Restores
Discovery \`ERROR\` level for genuine errors (was accidentally collapsed). Fixes
\`EtcHelloExchangeState\` log level for protocol negotiation failures.

**SNAP coordinator and block import** — restores \`snap.actors\` logback category
from WARN to INFO so coordinator milestone logs (account %, storage %, bytecode %
at every 10% and 100K accounts) are visible. Removes a broad \`log.error\` in
\`BlockImporter\` that fired for all errors including \`MissingNodeException\` and
\`MissingAccountNodeException\`, which are expected during SNAP sync and already
handled with per-case \`log.info\` below; terminal failures still surface at ERROR
from the catch-all.

**RLPx auth failure log level** — \`RLPxConnectionHandler\` auth decode failures
from ephemeral connections were logged as \`log.error\` with a leftover
\`[HIVE-DEBUG]\` prefix. Demoted to \`log.debug\` with a clean \`[RLPx]\` prefix.
(The same fix was applied to \`PeerManagerActor\` in the initial pass but missed
here.)

**ETH/69 decode mismatch log level** — \`RLPxConnectionHandler\` logged a DECODE\_ERROR
at \`log.error\` when a peer sent a message that couldn't be decoded (e.g., an ETH/69
peer sending an 8-field \`Status\` message when we negotiated ETH/68 and expect 7
fields). The disconnect behavior is correct; downgraded to \`log.warning\` with a
comment explaining the peer protocol variance to reduce noise during ETH/69 peer
discovery.

## Test plan
- [x] \`sbt Test/compile\` — clean
- [x] \`sbt testEssential\`
- [ ] Mordor sync: log volume drops >90% while coordinator milestone lines remain visible