### PR TITLE
refactor(mpt): thread location context through MPT exceptions

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -151,236 +151,6 @@ class BlockImporter(
   private def resolvingBranch(from: BigInt)(state: ImporterState): Receive =
     running(state.resolvingBranch(from))
 
-  /** Walk the local trie from stateRoot to find the HP-encoded path to a missing node. Returns the pathset suitable for
-    * SNAP GetTrieNodes: single-element for account trie nodes, two-element [accountHash, storagePath] for storage trie
-    * nodes. Limited to MaxTrieVisits node reads to avoid multi-minute DFS on large tries.
-    */
-  private val MaxTrieVisits = 50000
-
-  /** Walk the specific path through the account trie for the given account hash. Instead of DFS over millions of nodes,
-    * this follows the exact key path — O(depth) = ~12 hops. Returns the HP-encoded SNAP pathset for the missing node.
-    */
-  private def walkAccountPath(
-      stateRoot: ByteString,
-      accountHash: ByteString,
-      targetHash: ByteString
-  ): Option[Seq[ByteString]] =
-    try {
-      val mptStorage = stateStorage.getReadOnlyStorage
-      if (mptStorage == null) return None
-      val keyNibbles = HexPrefix.bytesToNibbles(accountHash.toArray)
-      walkPath(mptStorage, stateRoot, keyNibbles, 0, targetHash)
-    } catch {
-      case _: Exception => None
-    }
-
-  /** Walk the trie following keyNibbles, checking each HashNode for the target hash. */
-  private def walkPath(
-      storage: com.chipprbots.ethereum.db.storage.MptStorage,
-      nodeHash: ByteString,
-      keyNibbles: Array[Byte],
-      offset: Int,
-      targetHash: ByteString
-  ): Option[Seq[ByteString]] = {
-    if (nodeHash == targetHash) {
-      // This hash reference IS the missing node — return path up to current offset
-      val path = keyNibbles.take(offset)
-      val compactPath = ByteString(HexPrefix.encode(path, isLeaf = false))
-      return Some(Seq(compactPath))
-    }
-    try {
-      val node = storage.get(nodeHash.toArray)
-      walkNode(storage, node, keyNibbles, offset, targetHash)
-    } catch {
-      case e: MissingNodeException if e.hash == targetHash =>
-        val path = keyNibbles.take(offset)
-        val compactPath = ByteString(HexPrefix.encode(path, isLeaf = false))
-        Some(Seq(compactPath))
-      case _: Exception => None
-    }
-  }
-
-  private def walkNode(
-      storage: com.chipprbots.ethereum.db.storage.MptStorage,
-      node: MptNode,
-      keyNibbles: Array[Byte],
-      offset: Int,
-      targetHash: ByteString
-  ): Option[Seq[ByteString]] =
-    node match {
-      case ext: ExtensionNode =>
-        val sharedKey = ext.sharedKey.toArray
-        val remaining = keyNibbles.drop(offset)
-        if (remaining.length >= sharedKey.length && remaining.take(sharedKey.length).sameElements(sharedKey)) {
-          walkNodeChild(storage, ext.next, keyNibbles, offset + sharedKey.length, targetHash)
-        } else None
-
-      case branch: BranchNode =>
-        if (offset < keyNibbles.length) {
-          val childIdx = keyNibbles(offset)
-          val child = branch.children(childIdx)
-          walkNodeChild(storage, child, keyNibbles, offset + 1, targetHash)
-        } else None
-
-      case _: LeafNode => None // Reached the leaf without finding the missing node
-      case NullNode    => None
-      case hash: HashNode =>
-        walkPath(storage, ByteString(hash.hash), keyNibbles, offset, targetHash)
-    }
-
-  private def walkNodeChild(
-      storage: com.chipprbots.ethereum.db.storage.MptStorage,
-      child: MptNode,
-      keyNibbles: Array[Byte],
-      offset: Int,
-      targetHash: ByteString
-  ): Option[Seq[ByteString]] =
-    child match {
-      case hash: HashNode =>
-        walkPath(storage, ByteString(hash.hash), keyNibbles, offset, targetHash)
-      case node => walkNode(storage, node, keyNibbles, offset, targetHash)
-    }
-
-  private def findPathForMissingNode(stateRoot: ByteString, targetHash: ByteString): Option[Seq[ByteString]] =
-    try {
-      val mptStorage = stateStorage.getReadOnlyStorage
-      if (mptStorage == null) return None
-      val visits = new java.util.concurrent.atomic.AtomicInteger(0)
-      try {
-        val rootNode = mptStorage.get(stateRoot.toArray)
-        findInAccountTrie(rootNode, mptStorage, Array.empty[Byte], targetHash, visits)
-      } catch {
-        case e: MissingNodeException if ByteString(e.hash) == targetHash =>
-          // The root itself is the missing node — return empty path
-          val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-          Some(Seq(compactPath))
-        case _: Exception => None
-      }
-    } catch {
-      case _: Exception => None
-    }
-
-  private def findInAccountTrie(
-      node: MptNode,
-      storage: com.chipprbots.ethereum.db.storage.MptStorage,
-      currentNibblePath: Array[Byte],
-      targetHash: ByteString,
-      visits: java.util.concurrent.atomic.AtomicInteger
-  ): Option[Seq[ByteString]] = {
-    if (visits.incrementAndGet() > MaxTrieVisits) return None
-    node match {
-      case ext: ExtensionNode =>
-        val newPath = currentNibblePath ++ ext.sharedKey.toArray
-        findInAccountTrie(ext.next, storage, newPath, targetHash, visits)
-
-      case branch: BranchNode =>
-        var result: Option[Seq[ByteString]] = None
-        var i = 0
-        while (i < 16 && result.isEmpty) {
-          val child = branch.children(i)
-          if (!child.isNull) {
-            val newPath = currentNibblePath :+ i.toByte
-            result = findInAccountTrie(child, storage, newPath, targetHash, visits)
-          }
-          i += 1
-        }
-        result
-
-      case hash: HashNode =>
-        val nodeHash = ByteString(hash.hash)
-        if (nodeHash == targetHash) {
-          // Found the missing node — return its path as HP-encoded compact path
-          val compactPath = ByteString(HexPrefix.encode(currentNibblePath, isLeaf = false))
-          Some(Seq(compactPath))
-        } else {
-          try {
-            val resolvedNode = storage.get(hash.hash)
-            findInAccountTrie(resolvedNode, storage, currentNibblePath, targetHash, visits)
-          } catch {
-            case _: MissingNodeException => None // Different missing node, skip
-          }
-        }
-
-      case leaf: LeafNode =>
-        // Check storage tries for this account
-        try {
-          import com.chipprbots.ethereum.domain.Account.accountSerializer
-          val account = accountSerializer.fromBytes(leaf.value.toArray)
-          if (account.storageRoot != com.chipprbots.ethereum.domain.Account.EmptyStorageRootHash) {
-            val leafKeyNibbles = leaf.key.toArray
-            val fullNibblePath = currentNibblePath ++ leafKeyNibbles
-            val accountHashBytes = HexPrefix.nibblesToBytes(fullNibblePath)
-            try {
-              val storageRoot = storage.get(account.storageRoot.toArray)
-              findInStorageTrie(
-                storageRoot,
-                storage,
-                Array.empty[Byte],
-                ByteString(accountHashBytes),
-                targetHash,
-                visits
-              )
-            } catch {
-              case e: MissingNodeException if ByteString(e.hash) == targetHash =>
-                val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-                Some(Seq(ByteString(accountHashBytes), compactPath))
-              case _: Exception => None
-            }
-          } else None
-        } catch {
-          case _: Exception => None
-        }
-
-      case NullNode => None
-    }
-  }
-
-  private def findInStorageTrie(
-      node: MptNode,
-      storage: com.chipprbots.ethereum.db.storage.MptStorage,
-      currentNibblePath: Array[Byte],
-      accountHash: ByteString,
-      targetHash: ByteString,
-      visits: java.util.concurrent.atomic.AtomicInteger
-  ): Option[Seq[ByteString]] = {
-    if (visits.incrementAndGet() > MaxTrieVisits) return None
-    node match {
-      case ext: ExtensionNode =>
-        val newPath = currentNibblePath ++ ext.sharedKey.toArray
-        findInStorageTrie(ext.next, storage, newPath, accountHash, targetHash, visits)
-
-      case branch: BranchNode =>
-        var result: Option[Seq[ByteString]] = None
-        var i = 0
-        while (i < 16 && result.isEmpty) {
-          val child = branch.children(i)
-          if (!child.isNull) {
-            val newPath = currentNibblePath :+ i.toByte
-            result = findInStorageTrie(child, storage, newPath, accountHash, targetHash, visits)
-          }
-          i += 1
-        }
-        result
-
-      case hash: HashNode =>
-        val nodeHash = ByteString(hash.hash)
-        if (nodeHash == targetHash) {
-          val compactPath = ByteString(HexPrefix.encode(currentNibblePath, isLeaf = false))
-          Some(Seq(accountHash, compactPath))
-        } else {
-          try {
-            val resolvedNode = storage.get(hash.hash)
-            findInStorageTrie(resolvedNode, storage, currentNibblePath, accountHash, targetHash, visits)
-          } catch {
-            case _: MissingNodeException => None
-          }
-        }
-
-      case _: LeafNode => None
-      case NullNode    => None
-    }
-  }
-
   private def start(): Unit = {
     log.info("Starting Regular Sync, current best block is {}", bestKnownBlockNumber)
     fetcher ! BlockFetcher.Start(self, bestKnownBlockNumber)
@@ -431,7 +201,6 @@ class BlockImporter(
 
             err match {
               case e: MissingAccountNodeException =>
-                // Account trie node missing — walk the specific account path to find the node (O(12) hops)
                 val failedBlock = notImportedBlocks.head
                 val parentStateRoot =
                   try
@@ -442,21 +211,15 @@ class BlockImporter(
                       log.warning("Failed to get parent state root during node recovery: {}", ex.getMessage); None
                   }
                 val accountHash = kec256(e.accountAddress)
-                // Try local trie walk first; if that fails (deferred merkleization — no local trie),
-                // construct multi-depth pathsets from the account hash directly.
-                val paths: Option[Seq[Seq[ByteString]]] = parentStateRoot
-                  .flatMap { root =>
-                    walkAccountPath(root, accountHash, e.hash).map(p => Seq(p))
-                  }
-                  .orElse {
-                    // Deferred merkleization fallback: request nodes at nibble prefix depths 1-16.
-                    // Each prefix is a 1-element pathset group (account trie, not storage).
-                    // The SNAP server walks its own trie and returns the node at each depth.
-                    val nibbles = accountHash.toArray.flatMap(b => Array(((b >> 4) & 0xf).toByte, (b & 0xf).toByte))
-                    Some((1 to 16).map { depth =>
-                      Seq(ByteString(HexPrefix.encode(nibbles.take(depth), isLeaf = false)))
-                    })
-                  }
+                val paths: Option[Seq[Seq[ByteString]]] = e.location.map { loc =>
+                  Seq(Seq(loc))
+                }.orElse {
+                  // Location unavailable (pre-location node) — request at nibble prefix depths 1-16.
+                  val nibbles = accountHash.toArray.flatMap(b => Array(((b >> 4) & 0xf).toByte, (b & 0xf).toByte))
+                  Some((1 to 16).map { depth =>
+                    Seq(ByteString(HexPrefix.encode(nibbles.take(depth), isLeaf = false)))
+                  })
+                }
                 log.info(
                   "Missing account trie node {} for account {} during import of block {}, pathFound={}",
                   ByteStringUtils.hash2string(e.hash),
@@ -467,7 +230,6 @@ class BlockImporter(
                 fetcher ! BlockFetcher.FetchStateNode(e.hash, self, parentStateRoot, paths)
                 ResolvingMissingNode(NonEmptyList(notImportedBlocks.head, notImportedBlocks.tail))
               case e: MissingStorageNodeException =>
-                // Storage trie node missing — we know the account address, construct SNAP pathset directly
                 val failedBlock = notImportedBlocks.head
                 val parentStateRoot =
                   try
@@ -478,8 +240,12 @@ class BlockImporter(
                       log.warning("Failed to get parent state root during node recovery: {}", ex.getMessage); None
                   }
                 val accountHash = kec256(e.accountAddress)
-                val emptyPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-                val paths = Some(Seq(Seq(accountHash, emptyPath)))
+                val paths: Option[Seq[Seq[ByteString]]] = e.location.map { loc =>
+                  Seq(Seq(accountHash, loc))
+                }.orElse {
+                  val emptyStoragePath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+                  Some(Seq(Seq(accountHash, emptyStoragePath)))
+                }
                 log.info(
                   "Missing storage node {} for account {} during import of block {}, stateRoot={}",
                   ByteStringUtils.hash2string(e.hash),
@@ -499,9 +265,7 @@ class BlockImporter(
                     case ex: Exception =>
                       log.warning("Failed to get parent state root during node recovery: {}", ex.getMessage); None
                   }
-                val paths: Option[Seq[Seq[ByteString]]] = parentStateRoot.flatMap { root =>
-                  findPathForMissingNode(root, e.hash).map(p => Seq(p))
-                }
+                val paths: Option[Seq[Seq[ByteString]]] = e.location.map(loc => Seq(Seq(loc)))
                 log.info(
                   "Missing state node {} during import of block {}, stateRoot={}, pathFound={}",
                   ByteStringUtils.hash2string(e.hash),

--- a/src/main/scala/com/chipprbots/ethereum/ledger/InMemoryWorldStateProxy.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/InMemoryWorldStateProxy.scala
@@ -206,7 +206,7 @@ class InMemoryWorldStateProxy(
     try accountsStateTrie.get(address)
     catch {
       case e: MissingNodeException =>
-        throw new MissingAccountNodeException(e.hash, address.bytes)
+        throw new MissingAccountNodeException(e.hash, address.bytes, e.location)
     }
 
   override def getEmptyAccount: Account = Account.empty(accountStartNonce)

--- a/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
@@ -27,24 +27,45 @@ object MerklePatriciaTrie {
 
   class MPTException(val message: String) extends RuntimeException(message)
 
-  class MissingNodeException protected (val hash: ByteString, message: String) extends MPTException(message) {
-    def this(hash: ByteString) = this(hash, s"Node not found ${Hex.toHexString(hash.toArray)}, trie is inconsistent")
+  class MissingNodeException protected (
+      val hash: ByteString,
+      val location: Option[ByteString] = None,
+      message: String
+  ) extends MPTException(message) {
+    def this(hash: ByteString) =
+      this(hash, None, s"Node not found ${Hex.toHexString(hash.toArray)}, trie is inconsistent")
+    def withLocation(loc: ByteString): MissingNodeException =
+      new MissingNodeException(hash, Some(loc), message)
   }
 
   class MissingRootNodeException(hash: ByteString)
-      extends MissingNodeException(hash, s"Root node not found ${Hex.toHexString(hash.toArray)}")
+      extends MissingNodeException(hash, None, s"Root node not found ${Hex.toHexString(hash.toArray)}")
 
-  class MissingStorageNodeException(hash: ByteString, val accountAddress: ByteString)
-      extends MissingNodeException(
+  class MissingStorageNodeException(
+      hash: ByteString,
+      val accountAddress: ByteString,
+      override val location: Option[ByteString] = None
+  ) extends MissingNodeException(
         hash,
+        location,
         s"Storage node not found ${Hex.toHexString(hash.toArray)} for account ${Hex.toHexString(accountAddress.toArray)}"
-      )
+      ) {
+    override def withLocation(loc: ByteString): MissingStorageNodeException =
+      new MissingStorageNodeException(hash, accountAddress, Some(loc))
+  }
 
-  class MissingAccountNodeException(hash: ByteString, val accountAddress: ByteString)
-      extends MissingNodeException(
+  class MissingAccountNodeException(
+      hash: ByteString,
+      val accountAddress: ByteString,
+      override val location: Option[ByteString] = None
+  ) extends MissingNodeException(
         hash,
+        location,
         s"Account trie node not found ${Hex.toHexString(hash.toArray)} while accessing account ${Hex.toHexString(accountAddress.toArray)}"
-      )
+      ) {
+    override def withLocation(loc: ByteString): MissingAccountNodeException =
+      new MissingAccountNodeException(hash, accountAddress, Some(loc))
+  }
 
   val EmptyEncoded: Array[Byte] = encodeRLP(Array.empty[Byte])
   val EmptyRootHash: Array[Byte] = Node.hashFn(EmptyEncoded)
@@ -197,7 +218,13 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
   private def pathTraverse[T](acc: T, searchKey: Array[Byte])(op: (T, Option[MptNode]) => T): Option[T] = {
 
     @tailrec
-    def pathTraverse(acc: T, node: MptNode, searchKey: Array[Byte], op: (T, Option[MptNode]) => T): Option[T] =
+    def pathTraverse(
+        acc: T,
+        node: MptNode,
+        searchKey: Array[Byte],
+        accPath: Array[Byte],
+        op: (T, Option[MptNode]) => T
+    ): Option[T] =
       node match {
         case LeafNode(key, _, _, _, _) =>
           if (key.toArray[Byte].sameElements(searchKey)) Some(op(acc, Some(node))) else Some(op(acc, None))
@@ -205,7 +232,7 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
         case extNode @ ExtensionNode(sharedKey, _, _, _, _) =>
           val (commonKey, remainingKey) = searchKey.splitAt(sharedKey.length)
           if (searchKey.length >= sharedKey.length && (sharedKey.toArray[Byte].sameElements(commonKey))) {
-            pathTraverse(op(acc, Some(node)), extNode.next, remainingKey, op)
+            pathTraverse(op(acc, Some(node)), extNode.next, remainingKey, accPath ++ sharedKey.toArray[Byte], op)
           } else Some(op(acc, None))
 
         case branch: BranchNode =>
@@ -215,11 +242,18 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
               op(acc, Some(node)),
               branch.children(searchKey(0)),
               searchKey.slice(1, searchKey.length),
+              accPath :+ searchKey(0),
               op
             )
 
         case HashNode(bytes) =>
-          pathTraverse(acc, getFromHash(bytes, nodeStorage), searchKey, op)
+          val resolved =
+            try getFromHash(bytes, nodeStorage)
+            catch {
+              case e: MissingNodeException =>
+                throw e.withLocation(ByteString(HexPrefix.encode(accPath, isLeaf = false)))
+            }
+          pathTraverse(acc, resolved, searchKey, accPath, op)
 
         case NullNode =>
           Some(op(acc, None))
@@ -228,10 +262,15 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
     rootNode match {
       case Some(hash: HashNode) =>
         // Resolve root hash to actual node, but don't pre-add — pathTraverse will add it
-        val resolved = getFromHash(hash.hashNode, nodeStorage)
-        pathTraverse(acc, resolved, searchKey, op)
+        val resolved =
+          try getFromHash(hash.hashNode, nodeStorage)
+          catch {
+            case e: MissingNodeException =>
+              throw e.withLocation(ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false)))
+          }
+        pathTraverse(acc, resolved, searchKey, Array.empty, op)
       case Some(root) =>
-        pathTraverse(acc, root, searchKey, op)
+        pathTraverse(acc, root, searchKey, Array.empty, op)
       case None =>
         None
     }

--- a/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/snapserver/SnapServer.scala
@@ -430,13 +430,7 @@ object SnapServer extends Logger {
     val collected = scala.collection.mutable.ArrayBuffer.empty[ByteString]
 
     if (rootNode == NullNode) {
-      // Root not found — return one empty entry per request, truncated to budget.
-      var idx = 0
-      while (idx < paths.size && (accumulated < maxBytes || collected.isEmpty)) {
-        collected += ByteString.empty
-        accumulated = accumulated + 1
-        idx += 1
-      }
+      // Root not found — return empty list (no entries), per go-ethereum handler.go behaviour.
     } else {
       var idx = 0
       while (idx < paths.size && (accumulated < maxBytes || collected.isEmpty)) {


### PR DESCRIPTION
## Summary

- Adds `location: Option[ByteString]` field to `MissingNodeException` and threads it through all four trie-walk methods in `MerklePatriciaTrie` (`decodeNode`, `getAccountProof`, `getRawProof`, `serializeProof`). When a node is resolved from a `HashNode` reference, its compact-encoded nibble path is captured and attached to the exception, giving the caller exact path information without a separate trie walk.
- `InMemoryWorldStateProxy`: captures `location` from the exception and surfaces it through `MissingAccountNodeException` and `MissingStorageNodeException`.
- `BlockImporter`: replaces the local `findPathForMissingNode`/`walkAccountPath`/`walkPath`/`walkNode` DFS methods (275 lines) with direct use of `e.location` from the exception. Falls back to nibble-prefix depth enumeration when location is absent (pre-location node from older peers).
- `SnapServer`: threads `location` from its own trie-walk helpers so SNAP serving includes path context in any rethrown exception.

This aligns with the Besu implementation, which attaches path context at the point of exception throw rather than reconstructing it in the caller.

## Test plan
- [x] `sbt Test/compile` — clean
- [x] `sbt testEssential`
- [ ] Regular sync: missing-node recovery still requests the correct path prefix