### PR TITLE
fix(snap): Besu state machine alignment — remove experimental behaviors

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -112,10 +112,8 @@ sync {
     # Keep very low to avoid starving SNAP sync and PivotHeaderBootstrap of peers.
     # With ~10 peers, 2 concurrent chain requests leaves 8 peers for SNAP sync.
     chain-download-max-concurrent-requests = 2
-    # Boosted concurrency after SNAP state sync completes. At this point all peers are free
-    # for chain download — no need to reserve slots for SNAP protocol requests.
-    # With 50 bodies/request, 16 concurrent = 800 bodies in-flight ≈ 4-5x speedup.
-    chain-download-boosted-concurrent-requests = 16
+    # Besu-aligned D14: chain-download-boosted-concurrent-requests removed.
+    # Single concurrency throughout (no boost after state sync). Simpler = fewer divergences.
     # Timeout for chain download ETH protocol requests (seconds).
     # Much shorter than SNAP sync timeout (45s) to avoid holding peers "busy" for too long.
     # If a peer can't respond in 10s it's likely overloaded — release it quickly.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -215,6 +215,8 @@
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap" level="ERROR" />
     <!-- SNAP sync actors (AccountRangeCoordinator, workers) — INFO for optimization visibility -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.actors" level="INFO" />
+    <!-- Chain download progress — must be explicit, not inherited from snap (ERROR) -->
+    <logger name="com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.AccountRangeDownloader" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.StorageRangeDownloader" level="ERROR" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.TrieNodeHealer" level="ERROR" />

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -7,6 +7,7 @@ import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Scheduler
 import org.apache.pekko.util.ByteString
 
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -70,8 +71,8 @@ class ChainDownloader(
   private var paused = false
 
   // Queues of block hashes needing bodies/receipts
-  private var bodiesQueue: Vector[ByteString] = Vector.empty
-  private var receiptsQueue: Vector[ByteString] = Vector.empty
+  private val bodiesQueue: mutable.ArrayDeque[ByteString] = mutable.ArrayDeque.empty
+  private val receiptsQueue: mutable.ArrayDeque[ByteString] = mutable.ArrayDeque.empty
 
   // Track in-flight requests to limit concurrency
   private var headerRequestPeers: Set[PeerId] = Set.empty
@@ -84,7 +85,7 @@ class ChainDownloader(
   private var receiptsDownloaded: BigInt = 0
   private var lastLogTime: Long = 0
 
-  // Concurrency — starts conservative during SNAP state sync, boosted after state completes
+  // Besu-aligned D14: single concurrency throughout (no boost mode after state sync).
   private var maxConcurrentRequests: Int = initialMaxConcurrentRequests
 
   // Dispatch timer
@@ -118,9 +119,6 @@ class ChainDownloader(
         scheduleDispatch()
         context.become(downloading)
       }
-
-    case BoostConcurrency(n) =>
-      boostConcurrency(n)
 
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
@@ -158,10 +156,6 @@ class ChainDownloader(
       )
       dispatchTask.foreach(_.cancel())
       context.become(idle)
-
-    case BoostConcurrency(n) =>
-      boostConcurrency(n)
-      dispatchRequests() // Immediately use the new slots
 
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
@@ -309,10 +303,10 @@ class ChainDownloader(
   }
 
   private def requestBodies(peer: Peer): Unit = {
-    val batch = bodiesQueue.take(syncConfig.blockBodiesPerRequest)
+    val batch = bodiesQueue.take(syncConfig.blockBodiesPerRequest).toVector
     if (batch.isEmpty) return
 
-    bodiesQueue = bodiesQueue.drop(batch.size)
+    bodiesQueue.dropInPlace(batch.size)
 
     val requestMsg = ETH66.GetBlockBodies(ETH66.nextRequestId, batch)
 
@@ -333,10 +327,10 @@ class ChainDownloader(
   }
 
   private def requestReceipts(peer: Peer): Unit = {
-    val batch = receiptsQueue.take(syncConfig.receiptsPerRequest)
+    val batch = receiptsQueue.take(syncConfig.receiptsPerRequest).toVector
     if (batch.isEmpty) return
 
-    receiptsQueue = receiptsQueue.drop(batch.size)
+    receiptsQueue.dropInPlace(batch.size)
 
     val requestMsg = ETH66.GetReceipts(ETH66.nextRequestId, batch)
 
@@ -410,8 +404,8 @@ class ChainDownloader(
           .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
           .commit()
 
-        bodiesQueue :+= header.hash
-        receiptsQueue :+= header.hash
+        bodiesQueue += header.hash
+        receiptsQueue += header.hash
         prevHash = Some(header.hash)
         validCount += 1
       } else {
@@ -436,7 +430,7 @@ class ChainDownloader(
   private def handleBodies(peer: Peer, requestedHashes: Seq[ByteString], bodies: Seq[BlockBody]): Unit = {
     if (bodies.isEmpty) {
       // Re-queue the hashes
-      bodiesQueue = requestedHashes.toVector ++ bodiesQueue
+      bodiesQueue.prependAll(requestedHashes)
       blacklist.add(
         peer.id,
         syncConfig.blacklistDuration,
@@ -457,7 +451,7 @@ class ChainDownloader(
     // Re-queue any remaining hashes that weren't served
     val remaining = requestedHashes.drop(bodies.size)
     if (remaining.nonEmpty) {
-      bodiesQueue = remaining.toVector ++ bodiesQueue
+      bodiesQueue.prependAll(remaining)
     }
   }
 
@@ -471,7 +465,7 @@ class ChainDownloader(
     val hashStrings = requestedHashes.map(h => s"0x${h.toArray.map("%02x".format(_)).mkString}")
     val receiptsRlp = eth66Receipts.receiptsForBlocks
     if (receiptsRlp.items.isEmpty) {
-      receiptsQueue = requestedHashes.toVector ++ receiptsQueue
+      receiptsQueue.prependAll(requestedHashes)
       blacklist.add(peer.id, syncConfig.blacklistDuration, EmptyReceipts(hashStrings))
       return
     }
@@ -503,12 +497,12 @@ class ChainDownloader(
       // Re-queue remaining
       val remaining = requestedHashes.drop(receiptsByBlock.size)
       if (remaining.nonEmpty) {
-        receiptsQueue = remaining.toVector ++ receiptsQueue
+        receiptsQueue.prependAll(remaining)
       }
     } catch {
       case ex: Exception =>
         log.warning("Chain download: failed to decode receipts from peer {}: {}", peer.id, ex.getMessage)
-        receiptsQueue = requestedHashes.toVector ++ receiptsQueue
+        receiptsQueue.prependAll(requestedHashes)
         blacklist.add(
           peer.id,
           syncConfig.blacklistDuration,
@@ -563,10 +557,10 @@ class ChainDownloader(
       blockchainReader.getBlockHeaderByNumber(i) match {
         case Some(header) =>
           if (blockchainReader.getBlockBodyByHash(header.hash).isEmpty) {
-            bodiesQueue :+= header.hash
+            bodiesQueue += header.hash
           }
           if (blockchainReader.getReceiptsByHash(header.hash).isEmpty) {
-            receiptsQueue :+= header.hash
+            receiptsQueue += header.hash
           }
         case None => // shouldn't happen
       }
@@ -576,13 +570,7 @@ class ChainDownloader(
     best
   }
 
-  private def boostConcurrency(n: Int): Unit = {
-    val prev = maxConcurrentRequests
-    maxConcurrentRequests = n
-    log.info("Chain download concurrency boosted: {} -> {} (state sync complete, all peers available)", prev, n)
-    // Reschedule dispatch at faster interval — 2s was conservative to avoid SNAP contention
-    scheduleDispatch(200.millis)
-  }
+  // boostConcurrency() removed: Besu-aligned D14 (no boost mode).
 
   private def scheduleDispatch(interval: FiniteDuration = 2.seconds): Unit = {
     dispatchTask.foreach(_.cancel())
@@ -604,7 +592,7 @@ object ChainDownloader {
   case object Resume
   case object Stop
   case object Done
-  case class BoostConcurrency(maxConcurrent: Int)
+  // BoostConcurrency removed: Besu-aligned D14 (no boost mode, single concurrency throughout).
   case object GetProgress
   case class Progress(
       headersDownloaded: BigInt,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -89,9 +89,6 @@ class SNAPSyncController(
 
   private val progressMonitor = new SyncProgressMonitor(scheduler)
 
-  // Failure tracking for fallback to fast sync
-  private var criticalFailureCount: Int = 0
-
   // Retry counter for validation failures to prevent infinite loops
   private var validationRetryCount: Int = 0
   private val MaxValidationRetries = 3
@@ -140,8 +137,14 @@ class SNAPSyncController(
   private case object CheckSnapCapability
   private case object TuneRateTracker
   private case object EvictNonSnapPeers
+  private case object CheckPivotStaleness
   private var snapCapabilityCheckTask: Option[Cancellable] = None
   private var snapPeerEvictionTask: Option[Cancellable] = None
+  private var pivotStalenessCheckTask: Option[Cancellable] = None
+
+  // Besu DynamicPivotBlockSelector.java constants
+  private val PivotWindowValidity: Int = 126  // blocks behind chain tip before pivot switch
+  private val PivotCheckInterval: FiniteDuration = 60.seconds
 
   /** Like handlePeerListMessagesWithRateTracking, but also reactively triggers a bootstrap retry when new SNAP-capable
     * peers arrive during the bootstrapping state. Without this, the node waits for the full exponential backoff timer
@@ -225,6 +228,7 @@ class SNAPSyncController(
     accountStagnationCheckTask.foreach(_.cancel())
     storageStagnationCheckTask.foreach(_.cancel())
     healingRequestTask.foreach(_.cancel())
+    pivotStalenessCheckTask.foreach(_.cancel())
     bootstrapCheckTask.foreach(_.cancel())
     pivotBootstrapRetryTask.foreach(_.cancel())
     snapCapabilityCheckTask.foreach(_.cancel())
@@ -255,7 +259,8 @@ class SNAPSyncController(
     case EvictNonSnapPeers =>
       evictNonSnapPeers()
 
-    // Snap capability grace period check: if still no snap/1 peers, fall back to fast sync
+    // Snap capability grace period check: reschedule if no snap/1 peers found yet.
+    // Besu-aligned: never fall back to fast sync. Keep waiting indefinitely for SNAP peers.
     case CheckSnapCapability =>
       val snapPeerCount = peersToDownloadFrom.count { case (_, p) =>
         p.peerInfo.remoteStatus.supportsSnap
@@ -267,8 +272,13 @@ class SNAPSyncController(
         )
         stateRoot.foreach(launchAccountRangeWorkers(_, effectiveConcurrency))
       } else {
-        log.warning("No snap-capable peers found after grace period. Falling back to fast sync.")
-        fallbackToFastSync()
+        // Besu-aligned: no fallback to fast sync. Reschedule and keep waiting for SNAP peers.
+        val gracePeriod = snapSyncConfig.snapCapabilityGracePeriod
+        log.warning(
+          s"No snap-capable peers found after grace period. " +
+          s"Rescheduling check in ${gracePeriod.toSeconds}s (Besu-aligned: no fallback)."
+        )
+        snapCapabilityCheckTask = Some(scheduler.scheduleOnce(gracePeriod, self, CheckSnapCapability)(ec))
       }
 
     // Periodic request triggers
@@ -406,17 +416,14 @@ class SNAPSyncController(
             consecutivePivotRefreshes = 0 // Reset — accounts completing IS progress
             refreshPivotInPlace(reason)
           } else {
-            // Accounts still in progress — full restart is acceptable
-            // but preserve range progress (existing preservedRangeProgress mechanism)
+            // Accounts still in progress — Besu-aligned: no fallback, no critical failure tracking.
+            // Besu persists indefinitely. Reset counter and refresh pivot.
             log.warning(
-              s"$consecutivePivotRefreshes consecutive pivot refreshes without progress. " +
-                "Peers likely lack snapshot databases."
+              s"$consecutivePivotRefreshes consecutive stateless pivot refreshes during account sync. " +
+                "Besu-aligned: resetting counter and refreshing pivot (no fallback to fast sync)."
             )
-            if (recordCriticalFailure(s"$consecutivePivotRefreshes consecutive stateless pivot refreshes")) {
-              fallbackToFastSync()
-            } else {
-              restartSnapSync(s"consecutive stateless pivots ($consecutivePivotRefreshes): $reason")
-            }
+            consecutivePivotRefreshes = 0
+            refreshPivotInPlace(reason)
           }
         } else {
           refreshPivotInPlace(reason)
@@ -437,9 +444,17 @@ class SNAPSyncController(
           completePivotRefreshWithStateRoot(pendingPivot, header, reason)
         case None =>
           log.warning(
-            s"Pivot header bootstrap for block $pendingPivot returned no header. Falling back to full restart."
+            s"Pivot header bootstrap for block $pendingPivot returned no header. " +
+              s"Scheduling retry in 60s (preserving sync state)."
           )
-          restartSnapSync(s"pivot refresh bootstrap returned no header for $pendingPivot: $reason")
+          // Besu: switchToNewPivotBlock() never destroys state on header fetch failure — it simply
+          // retries. PivotBootstrapFailed (below) already schedules a 60s retry via RetryPivotRefresh;
+          // BootstrapComplete(None) must do the same. restartSnapSync() here destroys 5+ days of
+          // downloaded account/storage data on a transient header unavailability.
+          pivotBootstrapRetryTask.foreach(_.cancel())
+          pivotBootstrapRetryTask = Some(
+            scheduler.scheduleOnce(60.seconds, self, RetryPivotRefresh)(context.dispatcher)
+          )
       }
 
     // Handle pivot header bootstrap failure. The bootstrap exhausted all retries (with exponential
@@ -458,9 +473,9 @@ class SNAPSyncController(
 
     case RetryPivotRefresh =>
       pivotBootstrapRetryTask = None
-      if (currentPhase == AccountRangeSync || currentPhase == ByteCodeAndStorageSync) {
-        log.info("Retrying pivot refresh after bootstrap failure...")
-        refreshPivotInPlace("retry after bootstrap failure")
+      if (currentPhase == AccountRangeSync || currentPhase == ByteCodeAndStorageSync || currentPhase == StateHealing) {
+        log.info(s"Retrying pivot refresh (phase=$currentPhase)...")
+        refreshPivotInPlace("retry pivot refresh")
       } else {
         log.info(s"Skipping pivot refresh retry — phase=$currentPhase no longer needs it")
       }
@@ -517,10 +532,9 @@ class SNAPSyncController(
         currentPhase = ByteCodeAndStorageSync
         progressMonitor.startPhase(ByteCodeAndStorageSync)
 
-        // Redistribute per-peer budget: accounts done, give storage+bytecode more bandwidth.
-        // Global budget remains 5 per peer: storage=3, bytecode=2.
-        storageRangeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(3))
-        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(2))
+        // Besu-aligned D11: 1 request per peer for all coordinators.
+        storageRangeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
+        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
 
         // Cancel account stagnation checks (no longer relevant)
         accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
@@ -539,13 +553,12 @@ class SNAPSyncController(
       log.info(
         s"ByteCode sync complete ($downloaded bytecodes). Storage: $storagePhaseComplete, Accounts: $accountsComplete"
       )
-      // Bytecode done — give storage the full per-peer budget (was 3/5, now 5/5).
-      // On peer-limited networks (Mordor: ~10 peers), this nearly doubles storage throughput.
+      // Besu-aligned D11: keep 1 req/peer even after bytecode completes.
       if (!storagePhaseComplete) {
         storageRangeCoordinator.foreach { coord =>
-          coord ! actors.Messages.UpdateMaxInFlightPerPeer(snapSyncConfig.maxInFlightPerPeer)
+          coord ! actors.Messages.UpdateMaxInFlightPerPeer(1)
           log.info(
-            s"Storage per-peer budget boosted to ${snapSyncConfig.maxInFlightPerPeer} (bytecode complete, full budget)"
+            "Storage per-peer budget remains 1 (Besu-aligned D11: no pipelining)"
           )
         }
       }
@@ -556,25 +569,60 @@ class SNAPSyncController(
       log.info(s"Storage range sync complete. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete")
       checkAllDownloadsComplete()
 
-    case HealingAllPeersStateless if currentPhase == StateHealing =>
+    // Sender-guards on all healing coordinator messages: Pekko context.stop is async — old
+    // coordinator instances continue processing their mailbox after context.stop() is called.
+    // Only the CURRENT coordinator (trieNodeHealingCoordinator.contains(sender())) may trigger
+    // state transitions. Stale messages from stopped coordinators are logged and dropped.
+    case HealingAllPeersStateless
+        if currentPhase == StateHealing && trieNodeHealingCoordinator.contains(sender()) =>
       log.warning("All healing peers stateless — refreshing pivot in-place for healing")
       refreshPivotInPlace("all healing peers stateless")
 
-    case StateHealingComplete =>
-      log.info("Healing coordinator idle (no pending tasks, no active requests).")
-      if (trieWalkInProgress) {
+    case HealingAllPeersStateless if currentPhase == StateHealing =>
+      log.debug(s"Ignoring HealingAllPeersStateless from non-current coordinator (${sender().path.name})")
+
+    // HealingStagnated is no longer sent (Besu-aligned: no stagnation watchdog in TrieNodeHealingCoordinator).
+    // Handler removed in april-besu-alignment D7.
+
+    case PersistHealingQueue(pending, _) =>
+      log.debug(s"[HEAL-PERSIST] ${pending.size} pending nodes (persistence not implemented on this branch — discarding)")
+
+    case StateHealingComplete(abandonedNodes, totalHealed)
+        if trieNodeHealingCoordinator.contains(sender()) =>
+      log.info(s"State healing complete [abandonedNodes=$abandonedNodes, healed=$totalHealed].")
+      // D17 (Besu alignment): Besu finalizes SNAP sync immediately after healing with no
+      // post-healing validation trie walk. SnapWorldDownloadState.onSnapServerDown() /
+      // TrieNodeHealingStep just calls worldStateDownloadState.checkCompletion() which
+      // calls onAllTrieNodeHealingRequestsComplete() → triggers finalization directly.
+      // fukuii's 3-pass validation (findMissingNodesWithPaths + validateAccountTrie +
+      // validateAllStorageTries) has no Besu counterpart and takes 30+ minutes on mainnet.
+      // When abandonedNodes==0, every referenced trie node is in storage — skip all validation.
+      if (abandonedNodes == 0) {
+        log.info(
+          s"[D17] Healing complete with 0 abandoned nodes (healed=$totalHealed) — " +
+            "skipping validation walk, finalizing SNAP sync directly (Besu-aligned)"
+        )
+        pivotStalenessCheckTask.foreach(_.cancel())
+        pivotStalenessCheckTask = None
+        pivotBlock.foreach(finalizeSnapSync)
+      } else if (trieWalkInProgress) {
         // A trie walk is already running — its result will determine next step
         log.info("Trie walk in progress, waiting for result...")
       } else {
-        // No walk in progress — start one to check for deeper missing nodes
+        // abandonedNodes > 0: some nodes couldn't be healed — run the walk to find stragglers
         startTrieWalk()
       }
+
+    case StateHealingComplete(_, _) =>
+      log.debug(s"Ignoring StateHealingComplete from non-current coordinator (${sender().path.name})")
 
     case TrieWalkResult(missingNodes) if currentPhase == StateHealing =>
       trieWalkInProgress = false
       if (missingNodes.isEmpty) {
         log.info("Trie walk found no missing nodes — healing complete!")
         consecutiveUnproductiveHealingRounds = 0
+        pivotStalenessCheckTask.foreach(_.cancel())
+        pivotStalenessCheckTask = None
         progressMonitor.startPhase(StateValidation)
         currentPhase = StateValidation
         validateState()
@@ -587,6 +635,8 @@ class SNAPSyncController(
               s"Proceeding to validation — regular sync will recover missing nodes on-demand."
           )
           consecutiveUnproductiveHealingRounds = 0
+          pivotStalenessCheckTask.foreach(_.cancel())
+          pivotStalenessCheckTask = None
           progressMonitor.startPhase(StateValidation)
           currentPhase = StateValidation
           validateState()
@@ -614,6 +664,20 @@ class SNAPSyncController(
       scheduler.scheduleOnce(5.seconds) {
         self ! ScheduledTrieWalk
       }(ec)
+
+    // Besu DynamicPivotBlockSelector: every 60s check if pivot drifted >126 blocks behind chain tip.
+    case CheckPivotStaleness if currentPhase == StateHealing =>
+      val currentPivot = pivotBlock.getOrElse(BigInt(0))
+      currentNetworkBestFromSnapPeers().foreach { networkBest =>
+        val pivotAge = networkBest - currentPivot
+        if (pivotAge > PivotWindowValidity) {
+          log.info(
+            s"[PIVOT-STALENESS] Pivot $currentPivot is $pivotAge blocks behind network head $networkBest " +
+              s"(threshold: $PivotWindowValidity). Refreshing pivot."
+          )
+          refreshPivotInPlace("pivot-staleness-check")
+        }
+      }
 
     case StateValidationComplete =>
       log.info("State validation complete. SNAP sync finished!")
@@ -729,25 +793,33 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
+      // Besu alignment: healing is always required before SNAP sync is considered complete.
+      // The deferred-merkleization path (which skipped healing) has been removed — it caused
+      // SnapSyncDone to be persisted before trie nodes were present, breaking regular sync.
       if (snapSyncConfig.deferredMerkleization) {
-        // With deferred merkleization, trie nodes were never constructed during download —
-        // only flat storage was written. A trie walk would find the entire internal trie "missing",
-        // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).
-        //
-        // Skip healing/validation entirely. Regular sync's BlockImporter will fetch missing trie
-        // nodes on-demand via GetTrieNodes (SNAP protocol) when block execution encounters them.
-        // This is the "lazy healing" pattern used by geth's path-based storage.
-        log.info(
-          "All state downloads complete (accounts + bytecodes + storage). " +
-            "Deferred merkleization enabled — skipping healing/validation phase. " +
-            "Missing trie nodes will be fetched on-demand during block execution."
+        log.warning(
+          "All state downloads complete. deferred-merkleization=true is set but healing is " +
+            "required for correctness — forcing healing phase (Besu-aligned)."
         )
-        completeSnapSync()
       } else {
         log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
-        currentPhase = StateHealing
-        startStateHealing()
       }
+      currentPhase = StateHealing
+
+      // Besu alignment: startTrieHeal() calls pivotBlockSelector.switchToNewPivotBlock()
+      // UNCONDITIONALLY before seeding healing. No staleness check — always refresh.
+      // The pivot from refreshPivotInPlace() comes from the NETWORK (networkBest - offset),
+      // not from local chain download progress. This ensures healing always starts from a
+      // root within the SNAP serve window (~64 blocks from head).
+      val currentPivot = pivotBlock.getOrElse(BigInt(0))
+      log.info(
+        s"Pre-healing pivot switch: refreshing from pivot $currentPivot to network head " +
+          s"before seeding healing coordinator " +
+          s"(mirrors Besu startTrieHeal → switchToNewPivotBlock unconditionally)."
+      )
+      refreshPivotInPlace("pre-healing pivot switch")
+      // startStateHealing() called from completePivotRefreshWithStateRoot()
+      // when currentPhase == StateHealing && trieNodeHealingCoordinator.isEmpty
     }
 
   def bootstrapping: Receive = handlePeerListMessagesWithBootstrapReactivity.orElse {
@@ -931,16 +1003,13 @@ class SNAPSyncController(
     case PivotBootstrapFailed(reason) =>
       log.warning(s"Pivot header bootstrap failed during initial startup: $reason")
       bootstrapRetryCount += 1
-      if (checkBootstrapRetryTimeout(s"bootstrap failed: $reason")) {
-        // checkBootstrapRetryTimeout already called fallbackToFastSync()
-      } else {
-        val delay = bootstrapRetryDelay
-        log.info(s"Retrying SNAP sync start in $delay (attempt $bootstrapRetryCount)")
-        bootstrapCheckTask.foreach(_.cancel())
-        bootstrapCheckTask = Some(
-          scheduler.scheduleOnce(delay)(self ! RetrySnapSyncStart)(ec)
-        )
-      }
+      checkBootstrapRetryTimeout(s"bootstrap failed: $reason")
+      val delay = bootstrapRetryDelay
+      log.info(s"Retrying SNAP sync start in $delay (attempt $bootstrapRetryCount)")
+      bootstrapCheckTask.foreach(_.cancel())
+      bootstrapCheckTask = Some(
+        scheduler.scheduleOnce(delay)(self ! RetrySnapSyncStart)(ec)
+      )
 
     // SNAP peer eviction runs during bootstrap to free slots for SNAP-capable peers
     case EvictNonSnapPeers =>
@@ -972,7 +1041,7 @@ class SNAPSyncController(
     if (appStateStorage.isSnapSyncAccountsComplete()) {
       val savedPivot = appStateStorage.getSnapSyncPivotBlock()
       val savedRootOpt = appStateStorage.getSnapSyncStateRoot()
-      val savedStoragePath = appStateStorage.getSnapSyncStorageFilePath()
+      val savedStoragePath = appStateStorage.getSnapSyncStorageFilePath().filter(_.nonEmpty)
 
       (savedPivot, savedRootOpt) match {
         case (Some(pivot), Some(rootBs)) if pivot > 0 =>
@@ -1034,7 +1103,7 @@ class SNAPSyncController(
                     maxInFlightRequests = snapSyncConfig.storageConcurrency,
                     requestTimeout = snapSyncConfig.timeout,
                     snapSyncController = self,
-                    initialMaxInFlightPerPeer = 3, // Recovery: accounts done, storage gets 3 of 5 per-peer budget
+                    initialMaxInFlightPerPeer = 1, // Besu-aligned D11: 1 request per peer, no pipelining
                     initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
                     minResponseBytes = snapSyncConfig.storageMinResponseBytes,
                     deferredMerkleization = snapSyncConfig.deferredMerkleization
@@ -1048,8 +1117,8 @@ class SNAPSyncController(
               scheduler.scheduleWithFixedDelay(0.seconds, 1.second, self, RequestStorageRanges)(ec)
             )
 
-            // Recovery budget: accounts done, bytecode=2, storage=3 (total 5 per peer)
-            bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(2))
+            // Besu-aligned D11: 1 request per peer, no pipelining.
+            bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
 
             // Stream storage tasks from persisted file if available
             savedStoragePath.foreach { pathStr =>
@@ -1085,8 +1154,15 @@ class SNAPSyncController(
                     } finally raf.close()
                     totalTasks
                   }
+                  .recover { case ex: Exception =>
+                    log.warning(s"Recovery: failed to stream storage tasks from $filePath: ${ex.getMessage}")
+                    -1
+                  }
                   .foreach { count =>
-                    log.info(s"Recovery: streamed $count storage tasks from ${filePath}")
+                    if (count >= 0)
+                      log.info(s"Recovery: streamed $count storage tasks from ${filePath}")
+                    else
+                      log.warning(s"Recovery: storage file read failed, proceeding without storage tasks from $filePath")
                     // Signal no more tasks — sentinel allows completion
                     coordinator ! actors.Messages.NoMoreStorageTasks
                   }
@@ -1268,8 +1344,9 @@ class SNAPSyncController(
           context.become(syncing)
 
         case None =>
-          log.error("Genesis block header not available - cannot start SNAP sync")
-          context.parent ! FallbackToFastSync
+          // Besu-aligned: genesis not available is a transient startup error; retry instead of falling back.
+          log.error("Genesis block header not available — retrying SNAP sync start in 5s (Besu-aligned: no fallback)")
+          scheduler.scheduleOnce(5.seconds, self, Start)(ec)
       }
       return
     }
@@ -1419,79 +1496,18 @@ class SNAPSyncController(
     math.min(delaySeconds, BootstrapRetryMaxDelay.toSeconds).seconds
   }
 
-  /** Check if bootstrap retry has exceeded the maximum count. If so, falls back to fast sync. */
-  private def checkBootstrapRetryTimeout(context: String): Boolean =
+  /** Check if bootstrap retry has exceeded the maximum count.
+    * Besu-aligned: never fall back to fast sync. Reset counter and keep retrying indefinitely.
+    */
+  private def checkBootstrapRetryTimeout(context: String): Boolean = {
     if (bootstrapRetryCount >= MaxBootstrapRetries) {
       log.warning(
-        s"No peers found after $bootstrapRetryCount bootstrap retries ($context). Falling back to fast sync."
+        s"Reached max bootstrap retries ($bootstrapRetryCount, $context) — " +
+        "Besu-aligned: resetting counter and continuing to retry (no fallback to fast sync)."
       )
-      fallbackToFastSync()
-      true
-    } else {
-      if (bootstrapRetryCount > 0 && bootstrapRetryCount % 5 == 0) {
-        log.info(
-          s"Bootstrap retry diagnostics ($context): " +
-            s"attempt=$bootstrapRetryCount/$MaxBootstrapRetries, " +
-            s"handshakedPeers=${handshakedPeers.size}, " +
-            s"snapCapable=${handshakedPeers.values.count(_.peerInfo.remoteStatus.supportsSnap)}"
-        )
-      }
-      false
+      bootstrapRetryCount = 0
     }
-
-  /** Record a critical failure and check if we should fallback to fast sync. Critical failures are those that indicate
-    * SNAP sync cannot proceed.
-    *
-    * @param reason
-    *   Description of the failure
-    * @return
-    *   true if we should fallback to fast sync
-    */
-  private def recordCriticalFailure(reason: String): Boolean = {
-    criticalFailureCount += 1
-    log.warning(s"Critical SNAP sync failure ($criticalFailureCount/${snapSyncConfig.maxSnapSyncFailures}): $reason")
-
-    if (criticalFailureCount >= snapSyncConfig.maxSnapSyncFailures) {
-      log.error(s"SNAP sync failed ${criticalFailureCount} times, falling back to fast sync")
-      true
-    } else {
-      false
-    }
-  }
-
-  /** Trigger fallback to fast sync due to repeated SNAP sync failures */
-  private def fallbackToFastSync(): Unit = {
-    // Set phase to Completed FIRST to prevent aroundReceive guards (which check currentPhase)
-    // from re-triggering stagnation checks while we're tearing down.
-    currentPhase = Completed
-
-    log.warning("Triggering fallback to fast sync due to repeated SNAP sync failures")
-
-    // Cancel all scheduled tasks
-    accountRangeRequestTask.foreach(_.cancel())
-    bytecodeRequestTask.foreach(_.cancel())
-    storageRangeRequestTask.foreach(_.cancel())
-    healingRequestTask.foreach(_.cancel())
-    snapCapabilityCheckTask.foreach(_.cancel())
-    snapPeerEvictionTask.foreach(_.cancel())
-
-    // Stop progress monitoring
-    progressMonitor.stopPeriodicLogging()
-
-    // Clear persisted SNAP progress — fast sync will start fresh
-    appStateStorage.putSnapSyncProgress("").commit()
-    appStateStorage.putSnapSyncAccountsComplete(false).commit()
-    appStateStorage.putSnapSyncStorageFilePath("").commit()
-    preservedRangeProgress = Map.empty
-    preservedAtPivotBlock = None
-
-    // Stop chain downloader
-    chainDownloader.foreach(context.stop)
-    chainDownloader = None
-
-    // Notify parent controller to switch to fast sync
-    context.parent ! FallbackToFastSync
-    context.become(completed)
+    false // never signal fallback
   }
 
   /** Evict non-SNAP outgoing peers when SNAP peer count is below threshold.
@@ -1662,7 +1678,7 @@ class SNAPSyncController(
             snapSyncController = self,
             resumeProgress = resumeProgress,
             initialMaxInFlightPerPeer =
-              5, // Full per-peer budget during AccountRangeSync (storage+bytecode deferred to 0)
+              1, // Besu-aligned D11: 1 request per peer, no pipelining
             trieFlushThreshold = snapSyncConfig.accountTrieFlushThreshold,
             initialResponseBytes = snapSyncConfig.accountInitialResponseBytes,
             minResponseBytes = snapSyncConfig.accountMinResponseBytes
@@ -1950,10 +1966,10 @@ class SNAPSyncController(
         )
       )
 
-      // Start the coordinator — give healing full per-peer budget (accounts/storage/bytecode done)
+      // Start the coordinator — Besu-aligned D11: 1 request per peer, no pipelining.
       trieNodeHealingCoordinator.foreach { coordinator =>
         coordinator ! actors.Messages.StartTrieNodeHealing(root)
-        coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(5)
+        coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(1)
       }
 
       // Periodically send peer availability notifications
@@ -1963,6 +1979,18 @@ class SNAPSyncController(
           1.second,
           self,
           RequestTrieNodeHealing
+        )(ec)
+      )
+
+      // Besu DynamicPivotBlockSelector: 60s periodic staleness check during healing.
+      // If pivot drifts >126 blocks behind chain tip, refresh pivot in-place.
+      pivotStalenessCheckTask.foreach(_.cancel())
+      pivotStalenessCheckTask = Some(
+        scheduler.scheduleWithFixedDelay(
+          PivotCheckInterval,
+          PivotCheckInterval,
+          self,
+          CheckPivotStaleness
         )(ec)
       )
 
@@ -2060,11 +2088,12 @@ class SNAPSyncController(
                   s"Root node missing after $validationRetryCount validation attempts. " +
                     s"Proceeding to regular sync — missing nodes will be fetched on-demand during block execution."
                 )
-                // Skip validation and proceed: mark SNAP done, start regular sync.
-                // With deferred merkleization, the root node was never built from flat data.
-                // Regular sync's StateNodeFetcher will retrieve it via GetTrieNodes when needed.
-                appStateStorage.snapSyncDone().commit()
-                context.parent ! Done
+                // Finalize SNAP sync properly so regular sync has a valid best block anchor.
+                // The bare snapSyncDone().commit() path was missing the pivot block body, chain
+                // weight, and BestBlockInfo hash — causing ConsensusAdapter.getBestBlock() to
+                // return None on every block import attempt. finalizeSnapSync() stores all of
+                // them atomically (H-013) before sending Done to SyncController.
+                finalizeSnapSync(pivot)
               } else {
                 log.error(s"Root node is missing (retry attempt $validationRetryCount of $MaxValidationRetries)")
                 log.info("Retrying validation after brief delay...")
@@ -2189,8 +2218,18 @@ class SNAPSyncController(
     val newRoot = newStateRoot.take(4).toHex
 
     if (stateRoot.contains(newStateRoot)) {
-      log.warning(s"Pivot refresh: new root $newRoot is same as old. Falling back to full restart.")
-      restartSnapSync(s"pivot refresh produced same root ($newRoot): $reason")
+      log.info(
+        s"Pivot refresh: new root $newRoot same as current — proceeding with healing " +
+          s"(Besu: switchToNewPivotBlock fires callback even when newPivotBlockFound=false)"
+      )
+      // Stop coordinator if running; restart from same (confirmed-current) stateRoot.
+      // DO NOT call restartSnapSync() — that destroys 5+ days of downloaded account data.
+      if (currentPhase == StateHealing) {
+        trieNodeHealingCoordinator.foreach(context.stop)
+        trieNodeHealingCoordinator = None
+        trieWalkInProgress = false
+        startStateHealing()
+      }
       return
     }
 
@@ -2215,13 +2254,15 @@ class SNAPSyncController(
     // Bytecodes are content-addressed (hash-keyed) so pivot changes don't invalidate them,
     // but the coordinator should clear stale peer tracking.
     bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePivotRefreshed)
-    // Healing coordinator: update root, clear pending tasks and stateless peers.
-    // Then re-walk the trie with the new root to discover missing nodes.
-    trieNodeHealingCoordinator.foreach { coordinator =>
-      coordinator ! actors.Messages.HealingPivotRefreshed(newStateRoot)
-      // Re-walk trie with new root to populate fresh healing tasks
-      trieWalkInProgress = false // Reset so startTrieWalk() can proceed
-      startTrieWalk()
+    // Besu alignment: reloadTrieHeal() clears ALL pending requests and restarts healing
+    // from scratch with the fresh stateRoot. In-place update (HealingPivotRefreshed) leaves
+    // stale in-flight requests against the old root outstanding — peers respond with
+    // empty/error because the old root is outside their 64-block serve window, locking up workers.
+    // Stop coordinator if running; Change 2 guard below restarts with fresh stateRoot.
+    if (currentPhase == StateHealing) {
+      trieNodeHealingCoordinator.foreach(context.stop)
+      trieNodeHealingCoordinator = None
+      trieWalkInProgress = false
     }
     // Chain download target extends to the new pivot (chain data is canonical, never invalidated)
     if (chainDownloader.isDefined) {
@@ -2239,60 +2280,29 @@ class SNAPSyncController(
     // This ensures that repeated stateless-peer pivot cycles don't prevent the
     // stagnation watchdog from eventually triggering a full restart.
     lastAccountProgressMs = System.currentTimeMillis()
+
+    // Besu alignment: after any pivot refresh during the healing phase, restart the healing
+    // coordinator with the fresh stateRoot if it is not already running. This covers:
+    //
+    //   (a) Pre-healing pivot switch (Gap 1): coordinator was never created because
+    //       checkAllDownloadsComplete() deferred startStateHealing() above.
+    //
+    //   (b) Post-pivot restart (Gap 2): coordinator was stopped, pivot refreshed,
+    //       healing must restart with the fresh stateRoot.
+    //
+    //   (c) This case no longer exists: coordinator is always hard-restarted (Besu D10 alignment)
+    //       via the stop at L2249-2253 above, so trieNodeHealingCoordinator is always None here.
+    if (currentPhase == StateHealing && trieNodeHealingCoordinator.isEmpty) {
+      log.info(
+        s"Restarting healing coordinator with fresh pivot=$newPivotBlock " +
+          s"stateRoot=$newRoot (Besu startTrieHeal → switchToNewPivotBlock alignment)"
+      )
+      startStateHealing()
+    }
   }
 
-  private def restartSnapSync(reason: String): Unit = {
-    log.warning(s"Restarting SNAP sync with a fresher pivot: $reason")
-
-    // Clear any pending pivot refresh (we're doing a full restart instead)
-    pendingPivotRefresh = None
-
-    // NOTE: do NOT reset consecutivePivotRefreshes here. restartSnapSync is often called
-    // from refreshPivotInPlace when no new pivot is available, which means the counter would
-    // reset on every failed cycle and never reach the threshold. The counter only resets on
-    // actual account download progress (ProgressAccountsSynced) or at startSnapSync().
-
-    // Cancel periodic phase request ticks
-    accountRangeRequestTask.foreach(_.cancel()); accountRangeRequestTask = None
-    bytecodeRequestTask.foreach(_.cancel()); bytecodeRequestTask = None
-    storageRangeRequestTask.foreach(_.cancel()); storageRangeRequestTask = None
-    accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
-    storageStagnationCheckTask.foreach(_.cancel()); storageStagnationCheckTask = None
-    healingRequestTask.foreach(_.cancel()); healingRequestTask = None
-    bootstrapCheckTask.foreach(_.cancel()); bootstrapCheckTask = None
-    pivotBootstrapRetryTask.foreach(_.cancel()); pivotBootstrapRetryTask = None
-    rateTrackerTuneTask.foreach(_.cancel()); rateTrackerTuneTask = None
-
-    // Stop coordinators so we don't double-run phases
-    accountRangeCoordinator.foreach(context.stop); accountRangeCoordinator = None
-    bytecodeCoordinator.foreach(context.stop); bytecodeCoordinator = None
-    storageRangeCoordinator.foreach(context.stop); storageRangeCoordinator = None
-    trieNodeHealingCoordinator.foreach(context.stop); trieNodeHealingCoordinator = None
-
-    // Clear inflight request timeouts and internal phase state
-    requestTracker.clear()
-
-    // Clear concurrent download state and recovery data
-    accountsComplete = false
-    bytecodePhaseComplete = false
-    storagePhaseComplete = false
-    appStateStorage.putSnapSyncAccountsComplete(false).commit()
-    appStateStorage.putSnapSyncStorageFilePath("").commit()
-
-    // Reset pivot/state root and storage so a new selection is committed
-    pivotBlock = None
-    stateRoot = None
-    mptStorage = None
-    currentPhase = Idle
-    coordinatorGeneration += 1
-
-    // Reset progress counters so logs/ETA reflect the new attempt
-    progressMonitor.reset()
-
-    // Re-run pivot selection/bootstrap with the latest visible peer set
-    context.become(idle)
-    startSnapSync()
-  }
+  // restartSnapSync() removed: Besu-aligned (D7). Besu never does a full restart from stagnation.
+  // All pivot updates use refreshPivotInPlace() instead.
 
   /** Trigger healing by re-running the trie walk with path tracking. Called from validateState() when missing nodes are
     * discovered. The passed hashes are just an indicator — we re-walk to get proper paths for GetTrieNodes.
@@ -2468,14 +2478,10 @@ class SNAPSyncController(
         chainDownloader = None
         finalizeSnapSync(pivot)
       } else {
-        // If chain download is still running, boost its concurrency and wait
+        // If chain download is still running, wait for it
+        // Besu-aligned D14: no concurrency boost — single concurrency throughout.
         if (!chainDownloadComplete && chainDownloader.isDefined) {
-          log.info("SNAP state sync complete, boosting chain download concurrency and waiting for completion...")
-          chainDownloader.foreach(
-            _ ! ChainDownloader.BoostConcurrency(
-              snapSyncConfig.chainDownloadBoostedConcurrentRequests
-            )
-          )
+          log.info("SNAP state sync complete, waiting for chain download to finish...")
           currentPhase = ChainDownloadCompletion
           progressMonitor.startPhase(ChainDownloadCompletion)
           context.become(waitingForChainDownload)
@@ -2488,8 +2494,6 @@ class SNAPSyncController(
 
   /** Final SNAP sync completion — called when both state sync and chain download are done. */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
-    appStateStorage.snapSyncDone().commit()
-
     // Look up the pivot header so we can store a complete "best block" anchor.
     // RegularSync's BranchResolution needs: header, body, number→hash mapping,
     // ChainWeight, and BestBlockInfo (hash + number) to accept blocks that chain
@@ -2497,31 +2501,22 @@ class SNAPSyncController(
     blockchainReader.getBlockHeaderByNumber(pivot) match {
       case Some(pivotHeader) =>
         val pivotHash = pivotHeader.hash
-
-        // Store the full block (header + empty body) so getBlockByHash(pivotHash) returns
-        // a Block AND the number→hash mapping is written. PivotHeaderBootstrap already stored
-        // the header, but storeBlock ensures the mapping is present even if the header was
-        // stored by a different code path during pivot refresh.
-        blockchainWriter.storeBlock(Block(pivotHeader, BlockBody.empty)).commit()
-
-        // Store a ChainWeight so compareBranch() can evaluate new blocks.
-        // We estimate totalDifficulty ≈ difficulty × blockNumber. This doesn't need
-        // to be exact — it just needs to exist so branch resolution doesn't error,
-        // and subsequent blocks will accumulate from this baseline.
         val estimatedTotalDifficulty = pivotHeader.difficulty * pivot
-        blockchainWriter
-          .storeChainWeight(
+
+        // H-013: Atomic finalization — commit SnapSyncDone marker together with
+        // pivot block, chain weight, and best block info in a single batch.
+        // If any of these are missing when SnapSyncDone=true, regular sync fails
+        // on startup (branch resolution finds no chain weight, no best block hash).
+        // go-ethereum writes pivot + state atomically; we do the same.
+        appStateStorage.snapSyncDone()
+          .and(blockchainWriter.storeBlock(Block(pivotHeader, BlockBody.empty)))
+          .and(blockchainWriter.storeChainWeight(
             pivotHash,
             ChainWeight.totalDifficultyOnly(estimatedTotalDifficulty)
-          )
-          .commit()
-
-        // Set best block info with BOTH hash and number (putBestBlockNumber only
-        // sets the number, leaving getBestBlockInfo().hash empty).
-        appStateStorage
-          .putBestBlockInfo(
+          ))
+          .and(appStateStorage.putBestBlockInfo(
             com.chipprbots.ethereum.domain.appstate.BlockInfo(pivotHash, pivot)
-          )
+          ))
           .commit()
 
         log.info(s"SNAP sync completed successfully at block $pivot (hash=${pivotHash.take(8).toHex})")
@@ -2529,7 +2524,9 @@ class SNAPSyncController(
       case None =>
         // Fallback: shouldn't happen since PivotHeaderBootstrap stored the header
         log.warning(s"Pivot header for block $pivot not found in storage — setting best block number only")
-        appStateStorage.putBestBlockNumber(pivot).commit()
+        appStateStorage.snapSyncDone()
+          .and(appStateStorage.putBestBlockNumber(pivot))
+          .commit()
     }
 
     // Stop chain downloader if still running
@@ -2681,8 +2678,9 @@ object SNAPSyncController {
       codeHashes: Seq[ByteString],
       storageTasks: Seq[StorageTask]
   )
-  case object StateHealingComplete
+  case class StateHealingComplete(abandonedNodes: Int, totalHealed: Int)
   case object HealingAllPeersStateless
+  case class PersistHealingQueue(pending: Seq[(Seq[ByteString], ByteString)], force: Boolean = false)
   case object StateValidationComplete
   case object GetProgress
 
@@ -2746,29 +2744,27 @@ case class SNAPSyncConfig(
     maxPivotStalenessBlocks: Long = 4096,
     accountConcurrency: Int = 16,
     storageConcurrency: Int = 16,
-    storageBatchSize: Int = 128,
+    storageBatchSize: Int = 384,
     storageInitialResponseBytes: Int = 1048576,
     storageMinResponseBytes: Int = 131072,
-    healingBatchSize: Int = 16,
+    healingBatchSize: Int = 384,
     healingConcurrency: Int = 16,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,
-    timeout: FiniteDuration = 30.seconds,
-    maxSnapSyncFailures: Int = 5, // Max failures before fallback to fast sync
-    // Grace period after bootstrap to wait for snap/1-capable peers before falling back.
-    // If no connected peer advertises snap/1 within this window, fall back to fast sync.
+    timeout: FiniteDuration = 10.seconds,
+    // Grace period after bootstrap to wait for snap/1-capable peers before rescheduling.
+    // Besu-aligned: no fallback to fast sync — reschedule indefinitely until snap peers appear.
     snapCapabilityGracePeriod: FiniteDuration = 30.seconds,
     // Account stagnation timeout: if no account range tasks complete within this window,
-    // record a critical failure (may trigger fallback). Reduced from 15 minutes to catch
-    // non-snap peers faster.
+    // Besu-aligned: stall triggers in-place pivot refresh only, never fallback.
     accountStagnationTimeout: FiniteDuration = 10.minutes,
-    maxInFlightPerPeer: Int = 5,
+    maxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
     accountTrieFlushThreshold: Int = 50000,
     accountInitialResponseBytes: Int = 524288,
     accountMinResponseBytes: Int = 102400,
     chainDownloadEnabled: Boolean = true,
     chainDownloadMaxConcurrentRequests: Int = 2,
-    chainDownloadBoostedConcurrentRequests: Int = 16,
+    // Besu-aligned D14: no boosted concurrency mode. Single concurrency throughout.
     chainDownloadTimeout: FiniteDuration = 10.seconds,
     minSnapPeers: Int = 3,
     snapPeerEvictionInterval: FiniteDuration = 15.seconds,
@@ -2810,10 +2806,6 @@ object SNAPSyncConfig {
       stateValidationEnabled = snapConfig.getBoolean("state-validation-enabled"),
       maxRetries = snapConfig.getInt("max-retries"),
       timeout = snapConfig.getDuration("timeout").toMillis.millis,
-      maxSnapSyncFailures =
-        if (snapConfig.hasPath("max-snap-sync-failures"))
-          snapConfig.getInt("max-snap-sync-failures")
-        else 5,
       snapCapabilityGracePeriod =
         if (snapConfig.hasPath("snap-capability-grace-period"))
           snapConfig.getDuration("snap-capability-grace-period").toMillis.millis
@@ -2846,10 +2838,7 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("chain-download-max-concurrent-requests"))
           snapConfig.getInt("chain-download-max-concurrent-requests")
         else 2,
-      chainDownloadBoostedConcurrentRequests =
-        if (snapConfig.hasPath("chain-download-boosted-concurrent-requests"))
-          snapConfig.getInt("chain-download-boosted-concurrent-requests")
-        else 16,
+      // Besu-aligned D14: chainDownloadBoostedConcurrentRequests removed.
       chainDownloadTimeout =
         if (snapConfig.hasPath("chain-download-timeout"))
           snapConfig.getDuration("chain-download-timeout").toMillis.millis

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -56,7 +56,7 @@ class AccountRangeCoordinator(
     concurrency: Int,
     snapSyncController: ActorRef,
     resumeProgress: Map[ByteString, ByteString] = Map.empty,
-    initialMaxInFlightPerPeer: Int = 5,
+    initialMaxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
     trieFlushThreshold: Int = 50000,
     initialResponseBytesConfig: Int = 524288,
     minResponseBytesConfig: Int = 102400
@@ -248,37 +248,9 @@ class AccountRangeCoordinator(
   private def activePeerCount: Int =
     knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerCoolingDown(p)).max(1)
 
-  // Per-peer adaptive byte budgeting (ported from StorageRangeCoordinator).
-  // Geth's snap handler supports up to 2MB responses. Starting at 512KB and probing upward
-  // on responsive peers, scaling down on failures.
-  private val minResponseBytes: BigInt = BigInt(minResponseBytesConfig)
-  private val maxResponseBytes: BigInt = 2 * 1024 * 1024 // 2MB ceiling (Geth handler limit)
-  private val initialResponseBytes: BigInt = BigInt(initialResponseBytesConfig)
-  private val increaseFactor: Double = 1.25 // Scale up when 90%+ fill
-  private val decreaseFactor: Double = 0.5 // Scale down on failure/empty
-
-  private val peerResponseBytesTarget = mutable.Map.empty[String, BigInt]
-
-  private def responseBytesTargetFor(peer: Peer): BigInt =
-    peerResponseBytesTarget
-      .getOrElseUpdate(peer.id.value, initialResponseBytes)
-      .max(minResponseBytes)
-      .min(maxResponseBytes)
-
-  private def adjustResponseBytesOnSuccess(peer: Peer, requested: BigInt, received: BigInt): Unit =
-    if (requested > 0 && received * 10 >= requested * 9 && requested < maxResponseBytes) {
-      val next = (requested.toDouble * increaseFactor).toLong
-      peerResponseBytesTarget.update(peer.id.value, BigInt(next).min(maxResponseBytes))
-    }
-
-  private def adjustResponseBytesOnFailure(peer: Peer, reason: String): Unit = {
-    val cur = responseBytesTargetFor(peer)
-    val next = (cur.toDouble * decreaseFactor).toLong
-    peerResponseBytesTarget.update(peer.id.value, BigInt(next).max(minResponseBytes))
-    log.debug(
-      s"Reducing account responseBytes target for peer ${peer.id.value}: $cur -> ${peerResponseBytesTarget(peer.id.value)} ($reason)"
-    )
-  }
+  // Besu-aligned D12: fixed request size, no per-peer adaptive ratcheting.
+  // Use the config value directly as a fixed request size.
+  private val requestResponseBytes: BigInt = BigInt(initialResponseBytesConfig)
 
   // Track consecutive timeouts per peer. When a peer hits the threshold, it's marked stateless.
   // This handles the case where ETC mainnet peers silently stop responding (timeout) when
@@ -410,8 +382,7 @@ class AccountRangeCoordinator(
       statelessPeers.clear()
       pivotRefreshRequested = false
 
-      // Clear per-peer adaptive state (new root = new response characteristics)
-      peerResponseBytesTarget.clear()
+      // Besu-aligned D12: no per-peer adaptive state to clear (fixed request size).
       peerCooldownUntilMs.clear()
       peerConsecutiveTimeouts.clear()
       // Note: do NOT reset consecutiveUnproductiveRefreshes here.
@@ -625,7 +596,7 @@ class AccountRangeCoordinator(
 
     val requestId = requestTracker.generateRequestId()
     activeTasks.put(requestId, (task, worker, peer))
-    val responseBytes = responseBytesTargetFor(peer)
+    val responseBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
 
     worker ! FetchAccountRange(task, peer, requestId, responseBytes)
   }
@@ -649,12 +620,10 @@ class AccountRangeCoordinator(
       result match {
         case Right((accountCount, accounts, _)) =>
           log.info(
-            s"Task completed successfully: $accountCount accounts (responseBytes=${responseBytesTargetFor(peer)})"
+            s"Task completed successfully: $accountCount accounts (responseBytes=$requestResponseBytes)"
           )
 
-          // Adjust adaptive byte budget — estimate received bytes from account count
-          val estimatedBytes = BigInt(accountCount * 100) // ~100 bytes per account (hash + RLP)
-          adjustResponseBytesOnSuccess(peer, responseBytesTargetFor(peer), estimatedBytes)
+          // Besu-aligned D12: no adaptive byte budget ratcheting.
 
           // Reset consecutive timeout counter — peer is responsive
           peerConsecutiveTimeouts.remove(peer.id.value)
@@ -778,7 +747,7 @@ class AccountRangeCoordinator(
       // which already blocks them from dispatch)
       if (!reason.contains("Missing proof for empty account range")) {
         recordPeerCooldown(peer, reason)
-        adjustResponseBytesOnFailure(peer, reason)
+        // Besu-aligned D12: no adaptive byte budget ratcheting.
       }
     }
     // Re-dispatch re-queued tasks to any known available peer that isn't stateless.
@@ -1112,7 +1081,7 @@ object AccountRangeCoordinator {
       concurrency: Int,
       snapSyncController: ActorRef,
       resumeProgress: Map[ByteString, ByteString] = Map.empty,
-      initialMaxInFlightPerPeer: Int = 5,
+      initialMaxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
       trieFlushThreshold: Int = 50000,
       initialResponseBytes: Int = 524288,
       minResponseBytes: Int = 102400

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -111,35 +111,8 @@ class ByteCodeCoordinator(
   private var bytecodesDownloaded: Long = 0
   private var bytesDownloaded: Long = 0
 
-  // ByteCodes request tuning (Nethermind-style): use a per-peer dynamic byte budget, clamped hard to 2 MiB.
-  // We send many hashes and rely on the peer-side `responseBytes` soft limit to bound work.
-  private val minResponseBytes: BigInt = 50 * 1024
-  private val maxResponseBytes: BigInt = 2 * 1024 * 1024
-  private val initialResponseBytes: BigInt = 512 * 1024
-  private val increaseFactor: Double = 1.25
-  private val decreaseFactor: Double = 0.5
-
-  private val peerResponseBytesTarget = mutable.Map.empty[com.chipprbots.ethereum.network.PeerId, BigInt]
-
-  private def responseBytesTargetFor(peer: Peer): BigInt =
-    peerResponseBytesTarget.getOrElseUpdate(peer.id, initialResponseBytes).max(minResponseBytes).min(maxResponseBytes)
-
-  private def adjustResponseBytesTargetOnSuccess(peer: Peer, requested: BigInt, received: BigInt): Unit =
-    // If we appear to be filling the current budget, try increasing (up to clamp).
-    // This mimics Nethermind's approach of probing larger budgets on responsive peers.
-    if (requested > 0 && received * 10 >= requested * 9 && requested < maxResponseBytes) {
-      val next = (requested.toDouble * increaseFactor).toLong
-      peerResponseBytesTarget.update(peer.id, BigInt(next).min(maxResponseBytes).max(minResponseBytes))
-    }
-
-  private def adjustResponseBytesTargetOnFailure(peer: Peer, reason: String): Unit = {
-    val cur = responseBytesTargetFor(peer)
-    val next = (cur.toDouble * decreaseFactor).toLong
-    peerResponseBytesTarget.update(peer.id, BigInt(next).max(minResponseBytes))
-    log.debug(
-      s"Reducing ByteCodes responseBytes target for peer ${peer.id.value}: $cur -> ${peerResponseBytesTarget(peer.id)} ($reason)"
-    )
-  }
+  // Besu-aligned D12: fixed request size, no per-peer adaptive ratcheting.
+  private val requestResponseBytes: BigInt = 512 * 1024
 
   private def inFlightForPeer(peer: Peer): Int =
     activeTasks.values.count(_.peer.id == peer.id)
@@ -184,7 +157,7 @@ class ByteCodeCoordinator(
       log.info("Pivot refreshed — clearing bytecode peer cooldowns")
       peerFailureCounts.clear()
       peerCooldownUntilMillis.clear()
-      peerResponseBytesTarget.clear()
+      // Besu-aligned D12: no peerResponseBytesTarget to clear.
 
     case PeerAvailable(peer) =>
       if (isPeerCoolingDown(peer)) {
@@ -236,7 +209,7 @@ class ByteCodeCoordinator(
         task.pending = false
         pendingTasks.enqueue(task)
         recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"request failed: $error")
-        adjustResponseBytesTargetOnFailure(peer, s"request failed: $error")
+        // Besu-aligned D12: no adaptive byte budget ratcheting.
         markWorkerIdle(worker)
       }
       checkCompletion()
@@ -259,7 +232,7 @@ class ByteCodeCoordinator(
     val task = pendingTasks.dequeue()
     val requestId = requestTracker.generateRequestId()
 
-    val requestedBytes = responseBytesTargetFor(peer)
+    val requestedBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
 
     task.pending = true
     activeTasks.put(
@@ -328,7 +301,7 @@ class ByteCodeCoordinator(
 
             // Spec violation or malicious peer - back off harder than empty responses.
             recordPeerCooldown(peer, cooldownConfig.baseInvalid, s"invalid ByteCodes: $error")
-            adjustResponseBytesTargetOnFailure(peer, s"invalid response: $error")
+            // Besu-aligned D12: no adaptive byte budget ratcheting.
             markWorkerIdle(worker)
             checkCompletion()
 
@@ -344,7 +317,7 @@ class ByteCodeCoordinator(
                 // Storage failure isn't necessarily the peer's fault, but to be a good neighbor
                 // (and avoid tight loops), briefly cool down this peer.
                 recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"local store failed: $error")
-                adjustResponseBytesTargetOnFailure(peer, s"local store failed: $error")
+                // Besu-aligned D12: no adaptive byte budget ratcheting.
                 markWorkerIdle(worker)
                 checkCompletion()
 
@@ -352,11 +325,9 @@ class ByteCodeCoordinator(
                 val remainingHashes = task.codeHashes.filterNot(validated.matchedHashes.contains)
 
                 val receivedBytes: BigInt = BigInt(response.codes.map(_.size.toLong).sum)
-                // Update per-peer budget based on observed response size.
-                adjustResponseBytesTargetOnSuccess(peer, requested = requestedBytes, received = receivedBytes)
+                // Besu-aligned D12: fixed request size, no adaptive ratcheting.
                 log.debug(
-                  s"ByteCodes tuning: peer=${peer.id.value} requestedBytes=$requestedBytes receivedBytes=$receivedBytes " +
-                    s"elapsedMs=$elapsedMillis newTarget=${responseBytesTargetFor(peer)}"
+                  s"ByteCodes response: peer=${peer.id.value} requestedBytes=$requestedBytes receivedBytes=$receivedBytes elapsedMs=$elapsedMillis"
                 )
 
                 // Backoff behavior:
@@ -563,8 +534,8 @@ object ByteCodeCoordinator {
       baseEmpty = 2.seconds,
       baseTimeout = 10.seconds,
       baseInvalid = 15.seconds,
-      // Increase per-peer concurrency (Besu caps peer-wide outstanding at 5; this keeps us competitive).
-      maxInFlightPerPeer = 5,
+      // Besu-aligned D11: 1 request per peer, no pipelining.
+      maxInFlightPerPeer = 1,
       max = 2.minutes,
       exponentCap = 10
     )

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -50,7 +50,7 @@ class StorageRangeCoordinator(
     maxInFlightRequests: Int,
     requestTimeout: FiniteDuration,
     snapSyncController: ActorRef,
-    initialMaxInFlightPerPeer: Int = 5,
+    initialMaxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
     configInitialResponseBytes: Int = 1048576,
     configMinResponseBytes: Int = 131072,
     deferredMerkleization: Boolean = true
@@ -102,13 +102,6 @@ class StorageRangeCoordinator(
   private val minRefreshIntervalMs: Long = 60000L // 1 minute minimum between refreshes
   private val maxRefreshIntervalMs: Long = 300000L // 5 minutes maximum backoff
 
-  // No-activity timeout: detects stalls caused by "ghost" peers in knownAvailablePeers
-  // that disconnected without being removed and thus never get marked stateless.
-  // When tasks are pending, nothing is in-flight, and no dispatch/response has occurred
-  // for this duration, we treat it as all-stateless and request a pivot refresh.
-  private var lastDispatchOrResponseMs: Long = System.currentTimeMillis()
-  private val noActivityTimeoutMs: Long = 120000L // 2 minutes
-
   // Post-pivot-refresh cooldown: after a pivot refresh, peers need time to sync to the new root.
   // Dispatching immediately causes all peers to return empty → marked stateless → another pivot
   // refresh → infinite tight loop. This cooldown prevents ALL dispatch paths (tryRedispatchPendingTasks,
@@ -132,43 +125,14 @@ class StorageRangeCoordinator(
   }
 
   private def maybeRequestPivotRefresh(): Unit = {
+    // Besu-aligned: only trigger pivot refresh when ALL known peers are stateless.
+    // No time-based stagnation trigger — Besu has no equivalent stagnation watchdog.
     if (pivotRefreshRequested) return
     val allStateless = knownAvailablePeers.nonEmpty &&
       knownAvailablePeers.forall(p => statelessPeers.contains(p.id.value))
 
-    // Secondary trigger: tasks pending but no dispatch/response activity for 2 minutes.
-    // Catches "ghost" peers that remain in knownAvailablePeers after disconnecting
-    // without being marked stateless (preventing allStateless from ever being true).
-    // Note: activeTasks may be non-empty if requests to ghost peers never time out
-    // (SNAPRequestTracker timeouts are poll-based, not scheduled), so we check
-    // activity time regardless of in-flight count.
-    val now = System.currentTimeMillis()
-    val dispatchStalled = !allStateless && tasks.nonEmpty &&
-      (now - lastDispatchOrResponseMs) > noActivityTimeoutMs
-
-    if (dispatchStalled) {
-      log.warning(
-        s"Storage dispatch stalled: ${tasks.size} pending, ${activeTasks.size} active, " +
-          s"no activity for ${(now - lastDispatchOrResponseMs) / 1000}s. " +
-          s"Peers: ${knownAvailablePeers.size} known, ${statelessPeers.size} stateless. " +
-          s"Marking remaining peers as stateless (likely disconnected)."
-      )
-      knownAvailablePeers.foreach(p => statelessPeers.add(p.id.value))
-      // Re-queue any stale in-flight tasks from ghost peers
-      if (activeTasks.nonEmpty) {
-        val staleCount = activeTasks.size
-        activeTasks.values.foreach { case (_, batchTasks, _) =>
-          batchTasks.foreach { task =>
-            task.pending = false
-            tasks.enqueue(task)
-          }
-        }
-        activeTasks.clear()
-        log.info(s"Re-queued $staleCount stale in-flight requests from ghost peers")
-      }
-    }
-
-    if (allStateless || dispatchStalled) {
+    if (allStateless) {
+      val now = System.currentTimeMillis()
       val backoffMs = math.min(
         maxRefreshIntervalMs,
         minRefreshIntervalMs * (1L << math.min(consecutiveUnproductiveRefreshes, 3))
@@ -204,42 +168,7 @@ class StorageRangeCoordinator(
     }
   }
 
-  // Per-peer adaptive batch size: tracks which peers support multi-account batching.
-  // Starts at maxAccountsPerBatch, ratchets down on empty batched responses, scales back up
-  // on successful packed responses. This allows recovery from transient issues rather than
-  // permanently degrading to batch=1 for the lifetime of the sync.
-  private val peerBatchSize = mutable.Map.empty[String, Int]
-  private val peerBatchSuccessStreak = mutable.Map.empty[String, Int]
-  private val batchRecoveryStreak = 3 // Consecutive successes before scaling up
-
-  private def batchSizeFor(peer: Peer): Int =
-    peerBatchSize.getOrElseUpdate(peer.id.value, maxAccountsPerBatch)
-
-  private def reduceBatchSize(peer: Peer): Unit = {
-    peerBatchSize.update(peer.id.value, 1)
-    peerBatchSuccessStreak.remove(peer.id.value)
-  }
-
-  /** Scale batch size back up after consecutive successful packed responses. Doubles the batch size per peer, capped at
-    * maxAccountsPerBatch.
-    */
-  private def maybeIncreaseBatchSize(peer: Peer, servedCount: Int, requestedCount: Int): Unit =
-    // Only count as "packed" if the response served most of the requested accounts
-    if (requestedCount > 1 && servedCount >= requestedCount / 2) {
-      val streak = peerBatchSuccessStreak.getOrElse(peer.id.value, 0) + 1
-      peerBatchSuccessStreak.update(peer.id.value, streak)
-      if (streak >= batchRecoveryStreak) {
-        val current = batchSizeFor(peer)
-        val next = math.min(current * 2, maxAccountsPerBatch)
-        if (next > current) {
-          peerBatchSize.update(peer.id.value, next)
-          peerBatchSuccessStreak.update(peer.id.value, 0)
-          log.info(
-            s"Peer ${peer.id.value} batch size increased: $current -> $next (after $streak consecutive successes)"
-          )
-        }
-      }
-    }
+  // Besu-aligned D12: fixed batch size (maxAccountsPerBatch from config), no per-peer adaptation.
 
   // Track last known available peers so we can re-dispatch after task failures
   // without waiting for the next StoragePeerAvailable message.
@@ -267,37 +196,8 @@ class StorageRangeCoordinator(
   private var bytesDownloaded: Long = 0
   private val startTime = System.currentTimeMillis()
 
-  // Per-peer adaptive byte budgeting (ported from ByteCodeCoordinator).
-  // Geth's snap handler supports up to 2MB responses. Starting at 512KB and probing upward
-  // on responsive peers, scaling down on failures.
-  private val minResponseBytes: BigInt = configMinResponseBytes // Configurable floor (avoid excessive small requests)
-  private val maxResponseBytes: BigInt = 2 * 1024 * 1024 // 2MB ceiling (Geth handler limit)
-  private val initialResponseBytes: BigInt = configInitialResponseBytes // Configurable starting point
-  private val increaseFactor: Double = 1.25 // Scale up when 90%+ fill
-  private val decreaseFactor: Double = 0.5 // Scale down on failure/empty
-
-  private val peerResponseBytesTarget = mutable.Map.empty[String, BigInt]
-
-  private def responseBytesTargetFor(peer: Peer): BigInt =
-    peerResponseBytesTarget
-      .getOrElseUpdate(peer.id.value, initialResponseBytes)
-      .max(minResponseBytes)
-      .min(maxResponseBytes)
-
-  private def adjustResponseBytesOnSuccess(peer: Peer, requested: BigInt, received: BigInt): Unit =
-    if (requested > 0 && received * 10 >= requested * 9 && requested < maxResponseBytes) {
-      val next = (requested.toDouble * increaseFactor).toLong
-      peerResponseBytesTarget.update(peer.id.value, BigInt(next).min(maxResponseBytes))
-    }
-
-  private def adjustResponseBytesOnFailure(peer: Peer, reason: String): Unit = {
-    val cur = responseBytesTargetFor(peer)
-    val next = (cur.toDouble * decreaseFactor).toLong
-    peerResponseBytesTarget.update(peer.id.value, BigInt(next).max(minResponseBytes))
-    log.debug(
-      s"Reducing storage responseBytes target for peer ${peer.id.value}: $cur -> ${peerResponseBytesTarget(peer.id.value)} ($reason)"
-    )
-  }
+  // Besu-aligned D12: fixed request size from config, no per-peer adaptive ratcheting.
+  private val requestResponseBytes: BigInt = BigInt(configInitialResponseBytes)
 
   // ========================================
   // Two-phase storage: raw slot buffering + deferred trie construction
@@ -645,15 +545,12 @@ class StorageRangeCoordinator(
         log.info(s"Cancelled $cancelledCount in-flight storage requests (stale root)")
       }
 
-      // Clear all per-peer adaptive state — fresh start with new root
+      // Clear per-peer state — fresh start with new root
       statelessPeers.clear()
       pivotRefreshRequested = false
-      lastDispatchOrResponseMs = System.currentTimeMillis()
       peerCooldownUntilMs.clear()
       peerConsecutiveTimeouts.clear()
-      peerBatchSize.clear()
-      peerBatchSuccessStreak.clear()
-      peerResponseBytesTarget.clear()
+      // Besu-aligned D12: no per-peer batch size or response byte maps to clear.
       emptyResponsesByTask.clear()
       proofVerifiers.clear()
 
@@ -752,7 +649,8 @@ class StorageRangeCoordinator(
     val max = ByteString(Array.fill(32)(0xff.toByte))
     def isInitialRange(t: StorageTask): Boolean = t.next == min && t.last == max
 
-    val peerBatch = batchSizeFor(peer)
+    // Besu-aligned D12: fixed batch size (maxAccountsPerBatch from config), no per-peer adaptation.
+    val peerBatch = maxAccountsPerBatch
 
     // snap/1 origin/limit semantics apply to the first account only. To avoid incorrect continuation
     // behavior, only batch tasks that request the initial full range.
@@ -771,7 +669,7 @@ class StorageRangeCoordinator(
       return None
     }
 
-    val requestedBytes = responseBytesTargetFor(peer)
+    val requestedBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
     val requestId = requestTracker.generateRequestId()
     val accountHashes = batchTasks.map(_.accountHash)
     val firstTask = batchTasks.head
@@ -811,8 +709,6 @@ class StorageRangeCoordinator(
     import com.chipprbots.ethereum.network.p2p.messages.SNAP.GetStorageRanges.GetStorageRangesEnc
     val messageSerializable: MessageSerializable = new GetStorageRangesEnc(request)
     networkPeerManager ! NetworkPeerManagerActor.SendMessage(messageSerializable, peer.id)
-    lastDispatchOrResponseMs = System.currentTimeMillis()
-
     Some(requestId)
   }
 
@@ -859,16 +755,7 @@ class StorageRangeCoordinator(
     )
 
     if (servedCount == 0) {
-      // Per-peer batch reduction: only reduce for the specific peer that failed
-      if (tasks.size > 1 && batchSizeFor(peer) > 1) {
-        log.info(
-          s"Received empty StorageRanges for a batched request from peer ${peer.id.value} (accounts=${tasks.size}); " +
-            s"falling back to single-account requests for this peer"
-        )
-        reduceBatchSize(peer)
-      }
-
-      adjustResponseBytesOnFailure(peer, "empty response")
+      // Besu-aligned D12: no per-peer batch size or response byte ratcheting.
 
       // Track empties per task to avoid re-queueing forever.
       // If the same task yields empty responses repeatedly, skip it with a loud warning.
@@ -915,10 +802,8 @@ class StorageRangeCoordinator(
     statelessPeers.remove(peer.id.value)
     peerConsecutiveTimeouts.remove(peer.id.value)
     consecutiveUnproductiveRefreshes = 0
-    lastDispatchOrResponseMs = System.currentTimeMillis()
 
-    // Adaptive batch scaling: track successes for this peer, scale up after consecutive packed responses
-    maybeIncreaseBatchSize(peer, servedCount, tasks.size)
+    // Besu-aligned D12: no adaptive batch scaling.
 
     // Clear empty-response counters for tasks that are now being served.
     tasks.foreach { task =>
@@ -936,7 +821,6 @@ class StorageRangeCoordinator(
       }
     }
 
-    // Track total received bytes across all served tasks for adaptive byte budgeting
     var totalReceivedBytes: Long = 0
 
     servedTasks.zipWithIndex.foreach { case (task, idx) =>
@@ -955,7 +839,7 @@ class StorageRangeCoordinator(
         case Left(error) =>
           log.warning(s"Storage proof verification failed for account ${task.accountString}: $error")
           recordPeerCooldown(peer, s"verification failed: $error")
-          adjustResponseBytesOnFailure(peer, s"verification failed: $error")
+          // Besu-aligned D12: no adaptive byte budget ratcheting.
           task.pending = false
           this.tasks.enqueue(task)
 
@@ -1027,10 +911,7 @@ class StorageRangeCoordinator(
       }
     }
 
-    // Adjust per-peer byte budget based on total received bytes
-    if (totalReceivedBytes > 0) {
-      adjustResponseBytesOnSuccess(peer, requestedBytes, BigInt(totalReceivedBytes))
-    }
+    // Besu-aligned D12: no adaptive byte budget adjustment.
 
     // Check completion after processing all served tasks
     self ! StorageCheckCompletion
@@ -1046,7 +927,7 @@ class StorageRangeCoordinator(
     activeTasks.remove(requestId).foreach { case (peer, batchTasks, _) =>
       log.warning(s"Storage range request timeout for ${batchTasks.size} accounts from peer ${peer.id.value}")
       recordPeerCooldown(peer, "request timeout")
-      adjustResponseBytesOnFailure(peer, "request timeout")
+      // Besu-aligned D12: no adaptive byte budget ratcheting.
 
       // Track consecutive timeouts — on ETC mainnet, peers silently stop responding when
       // the snap serve window expires. After N consecutive timeouts, treat as stateless.
@@ -1136,7 +1017,7 @@ object StorageRangeCoordinator {
       maxInFlightRequests: Int,
       requestTimeout: FiniteDuration,
       snapSyncController: ActorRef,
-      initialMaxInFlightPerPeer: Int = 5,
+      initialMaxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
       initialResponseBytes: Int = 1048576,
       minResponseBytes: Int = 131072,
       deferredMerkleization: Boolean = true

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -38,20 +38,24 @@ class TrieNodeHealingCoordinator(
   import Messages._
 
   // Task management — each task has a pathset (for GetTrieNodes) and a hash (for verification)
-  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0)
-  private var pendingTasks: Seq[HealingEntry] = Seq.empty
+  // depth + priority enable DFS traversal: priority = parentPriority * 16 + childIndex (Besu InMemoryTasksPriorityQueues)
+  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0, depth: Int = 0, priority: Long = 0L)
+  // DFS priority queue: min-priority first (root=0, leftmost child first), depth DESC breaks ties.
+  // Besu uses a min-heap over (priority, -depth). This keeps the working set O(depth×16) ≈ 1K entries vs BFS O(N).
+  private val pendingTasks: mutable.PriorityQueue[HealingEntry] =
+    mutable.PriorityQueue.empty[HealingEntry](Ordering.by(e => (-e.priority, e.depth)))
   private var completedTaskCount: Int = 0
   private var abandonedTaskCount: Int = 0
 
   // Per-task retry limit: after this many timeouts/failures, skip the task.
-  // At ~6s per timeout cycle, 20 retries = ~2 minutes of trying per node.
-  private val maxRetriesPerTask: Int = 20
+  // Aligned with Besu MAX_RETRIES=4 (RetryingGetTrieNodeFromPeerTask.java).
+  // 4 retries × 60s timeout = 4 min max per node before abandonment.
+  // Prior value of 20 locked all workers for 20 min on unserviceable nodes (BUG-HEAL-11).
+  private val maxRetriesPerTask: Int = 4
 
   // Global stagnation detection: if no nodes healed for this duration, declare
   // healing complete with a warning. Prevents infinite loops when all peers lack
   // GetTrieNodes support (ETH68 networks). Regular sync fetches missing nodes on-demand.
-  private var lastHealedAtMs: Long = System.currentTimeMillis()
-  private val healingStagnationTimeoutMs: Long = 5 * 60 * 1000 // 5 minutes
 
   // Active request tracking: maps requestId -> (tasks, peer, requestedBytes, sentAtMs)
   private case class ActiveRequest(
@@ -64,12 +68,18 @@ class TrieNodeHealingCoordinator(
 
   // Concurrency: per-peer limit (like StorageRangeCoordinator) + global safety cap
   private val maxConcurrentRequests = concurrency
-  private var maxInFlightPerPeer: Int = 5
+  private var maxInFlightPerPeer: Int = 1 // Besu-aligned D11: 1 request per peer, no pipelining
 
   // Statistics
   private var totalNodesHealed: Int = 0
   private var totalBytesReceived: Long = 0
   private val startTime = System.currentTimeMillis()
+  private var lastProgressLogAt: Long = 0   // for 500-node interval progress log
+  private val ProgressLogInterval: Long = 500
+  private var lastPulseHealedCount: Int = 0 // for 2-min HEAL-PULSE velocity logging
+  // Rolling 60s window for recent throughput (matches controller's SyncProgressMonitor pattern)
+  private val recentHistory: mutable.Queue[(Long, Long)] = mutable.Queue.empty
+  private val RecentWindowMs: Long = 60_000
 
   // Adaptive healing throttle (geth p2p/msgrate alignment)
   // When pending nodes exceed 2× the processing rate, throttle increases (slow down requests).
@@ -93,37 +103,21 @@ class TrieNodeHealingCoordinator(
 
   // Stateless peer tracking (geth-aligned: peers that return empty TrieNodes for current root)
   private val statelessPeers = mutable.Set[String]()
+  // Persistent stateless tracking by remote address — survives peer reconnect with new session ID.
+  // Non-static peers that return empty GetTrieNodes are blocked even after reconnection.
+  private val statelessRemoteAddresses = mutable.Set[String]()
   private var pivotRefreshRequested: Boolean = false
+  // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
+  // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
+  private var postRefreshCooldownUntilMs: Long = 0L
+  private val postRefreshCooldownMs: Long = 10_000L // 10s (matches StorageRangeCoordinator)
 
-  // Per-peer adaptive byte budgeting
-  private val minResponseBytes: BigInt = 50 * 1024
-  private val maxResponseBytes: BigInt = 2 * 1024 * 1024
-  private val initialResponseBytes: BigInt = 512 * 1024
-  private val increaseFactor: Double = 1.25
-  private val decreaseFactor: Double = 0.5
+  // Besu-aligned D12: fixed request size, no per-peer adaptive ratcheting.
+  // Besu uses a fixed REQUEST_SIZE in RequestDataStep.java with no per-peer tracking.
+  private val requestResponseBytes: BigInt = 512 * 1024
 
-  private val peerResponseBytesTarget = mutable.Map.empty[String, BigInt]
-
-  private def responseBytesTargetFor(peer: Peer): BigInt =
-    peerResponseBytesTarget
-      .getOrElseUpdate(peer.id.value, initialResponseBytes)
-      .max(minResponseBytes)
-      .min(maxResponseBytes)
-
-  private def adjustResponseBytesOnSuccess(peer: Peer, requested: BigInt, received: BigInt): Unit =
-    if (requested > 0 && received * 10 >= requested * 9 && requested < maxResponseBytes) {
-      val next = (requested.toDouble * increaseFactor).toLong
-      peerResponseBytesTarget.update(peer.id.value, BigInt(next).min(maxResponseBytes))
-    }
-
-  private def adjustResponseBytesOnFailure(peer: Peer, reason: String): Unit = {
-    val cur = responseBytesTargetFor(peer)
-    val next = (cur.toDouble * decreaseFactor).toLong
-    peerResponseBytesTarget.update(peer.id.value, BigInt(next).max(minResponseBytes))
-    log.debug(
-      s"Reducing healing responseBytes target for peer ${peer.id.value}: $cur -> ${peerResponseBytesTarget(peer.id.value)} ($reason)"
-    )
-  }
+  // HW1 self-feeding: tracks total missing trie children discovered across all healed nodes
+  private var childrenDiscoveredTotal: Int = 0
 
   // Peer cooldown
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
@@ -133,9 +127,12 @@ class TrieNodeHealingCoordinator(
     peerCooldownUntilMs.get(peer.id.value).exists(_ > System.currentTimeMillis())
 
   private def recordPeerCooldown(peer: Peer, reason: String): Unit = {
-    val until = System.currentTimeMillis() + peerCooldownDefault.toMillis
+    // OPT-P5: Static peers (core-geth, Besu configured as static) get a shorter cooldown —
+    // trusted infrastructure should be re-tried sooner after transient failures.
+    val cooldown = if (peer.isStatic) 5.seconds else peerCooldownDefault
+    val until = System.currentTimeMillis() + cooldown.toMillis
     peerCooldownUntilMs.put(peer.id.value, until)
-    log.debug(s"Cooling down peer ${peer.id.value} for ${peerCooldownDefault.toSeconds}s: $reason")
+    log.debug(s"Cooling down peer ${peer.id.value} for ${cooldown.toSeconds}s (static=${peer.isStatic}): $reason")
   }
 
   /** Count in-flight requests for a given peer (pipelining support). */
@@ -145,14 +142,20 @@ class TrieNodeHealingCoordinator(
   /** Dispatch up to maxInFlightPerPeer requests to a single peer (pipelining). */
   private def dispatchIfPossible(peer: Peer): Unit = {
     if (pivotRefreshRequested) return
+    val nowMs = System.currentTimeMillis()
+    if (nowMs < postRefreshCooldownUntilMs) {
+      log.debug(s"[HEAL] Dispatch to ${peer.id.value} deferred — post-refresh cooldown (${(postRefreshCooldownUntilMs - nowMs) / 1000}s remaining)")
+      return
+    }
     if (statelessPeers.contains(peer.id.value)) return
     if (isPeerCoolingDown(peer)) return
     var inflight = inFlightForPeer(peer)
-    while (pendingTasks.nonEmpty && inflight < maxInFlightPerPeer && activeRequests.size < maxConcurrentRequests)
+    while (pendingTasks.nonEmpty && inflight < maxInFlightPerPeer && activeRequests.size < maxConcurrentRequests) {
       requestNextBatch(peer) match {
         case Some(_) => inflight += 1
         case None    => return
       }
+    }
   }
 
   // Batched raw node storage: accumulate nodes and flush asynchronously
@@ -162,6 +165,8 @@ class TrieNodeHealingCoordinator(
 
   // Internal message for async flush completion
   private case class FlushComplete(count: Int)
+  // Periodic stagnation and no-activity check (every 2 minutes)
+  private case object HealingStagnationCheck
 
   /** Synchronous flush — used only for final completion flush (small buffer, safe to block). */
   private def flushRawNodesSync(): Unit =
@@ -190,8 +195,11 @@ class TrieNodeHealingCoordinator(
       }(context.dispatcher).foreach(n => selfRef ! FlushComplete(n))(context.dispatcher)
     }
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     log.info(s"TrieNodeHealingCoordinator starting (concurrency=$concurrency)")
+    import context.dispatcher
+    context.system.scheduler.scheduleWithFixedDelay(2.minutes, 2.minutes, self, HealingStagnationCheck)
+  }
 
   override val supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1.minute) { case _: Exception =>
@@ -202,42 +210,119 @@ class TrieNodeHealingCoordinator(
   override def receive: Receive = {
     case StartTrieNodeHealing(root) =>
       log.info(s"Starting trie node healing for state root ${Hex.toHexString(root.take(8).toArray)}")
+      // ARCH-ROOT-SEED: Seed immediately with root node (Besu-style top-down discovery).
+      // Prior: waited 50+ min for walk results. Now: healing starts instantly.
+      // When root is healed, discoverMissingChildren() discovers all children inline.
+      // Walk becomes validation-only — its results remain additive (dedup prevents duplicates).
+      val emptyPath = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+      queueNodes(Seq((Seq(emptyPath), root)))
+      log.info(
+        s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} seeded with empty path — " +
+        s"inline child discovery will populate the work queue top-down (Besu-aligned)"
+      )
 
     case QueueMissingNodes(nodes) =>
-      log.info(s"Queuing ${nodes.size} missing nodes for healing")
+      log.info(s"[HEAL-RESUME] Received ${nodes.size} persisted missing nodes from prior session")
       queueNodes(nodes)
       // Immediately dispatch to any known available peers
       tryRedispatchPendingTasks()
+      if (pendingTasks.isEmpty)
+        log.info(
+          s"[HEAL] All ${nodes.size} resumed nodes already present in trie DB — " +
+            s"no network requests needed, proceeding to trie walk"
+        )
+      self ! HealingCheckCompletion
 
     case HealingPeerAvailable(peer) =>
-      // Evict stale entry for same physical node (reconnection creates new PeerId)
-      knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
-      knownAvailablePeers += peer
-      dispatchIfPossible(peer)
+      // Skip if this remote address has been marked stateless — blocks reconnected dead peers
+      if (statelessRemoteAddresses.contains(peer.remoteAddress.toString)) {
+        log.debug(
+          s"[HEALING] Skipping ${peer.remoteAddress} — address known stateless (prior GetTrieNodes failure)"
+        )
+      } else {
+        // Evict stale entry for same physical node (reconnection creates new PeerId).
+        // Also clean up stale session-ID entries from statelessPeers and cooldown map.
+        val evicted = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
+        statelessPeers --= evicted.map(_.id.value)
+        peerCooldownUntilMs --= evicted.map(_.id.value)
+        knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
+        knownAvailablePeers += peer
+        dispatchIfPossible(peer)
+      }
 
     case UpdateMaxInFlightPerPeer(newLimit) =>
-      log.info(s"Healing per-peer budget: $maxInFlightPerPeer -> $newLimit")
-      maxInFlightPerPeer = newLimit
-      if (newLimit > 0) tryRedispatchPendingTasks()
+      if (newLimit != maxInFlightPerPeer) {
+        val wasLimit = maxInFlightPerPeer
+        log.info(s"Healing per-peer budget: $maxInFlightPerPeer -> $newLimit")
+        maxInFlightPerPeer = newLimit
+        // LOG-BUDGET-ZERO: Warn when budget drops to 1 — indicates high timeout rate
+        if (newLimit <= 1 && wasLimit > 1) {
+          log.warning(
+            s"[HEAL-BUDGET] In-flight budget dropped to $newLimit/peer — high timeout rate detected. " +
+            s"healed=$totalNodesHealed pending=${pendingTasks.size}"
+          )
+        }
+        if (newLimit > 0) tryRedispatchPendingTasks()
+      }
 
     case HealingPivotRefreshed(newStateRoot) =>
       val oldRoot = Hex.toHexString(stateRoot.take(4).toArray)
       val newRootHex = Hex.toHexString(newStateRoot.take(4).toArray)
       log.info(
         s"Healing pivot refreshed: $oldRoot -> $newRootHex. " +
-          s"Clearing ${pendingTasks.size} pending tasks, ${statelessPeers.size} stateless peers."
+          s"Clearing ${pendingTasks.size} pending tasks + ${pendingHashSet.size} hashes " +
+          s"(aligned to Besu reloadTrieHeal: clear all, reseed from new root). " +
+          s"Clearing ${statelessPeers.size} stateless peers."
       )
       stateRoot = newStateRoot
-      flushRawNodesSync() // Flush any buffered nodes before clearing state
-      pendingTasks = Seq.empty // Will be re-populated by trie walk from controller
+      flushRawNodesSync() // Flush any buffered nodes before pivot switch
+      // Besu SnapWorldDownloadState.reloadTrieHeal(): pendingTrieNodeRequests.clear() + startTrieHeal()
+      // ARCH-ROOT-SEED (already committed) immediately re-seeds the new root, so there is no
+      // empty-queue window — BUG-H3's original concern no longer applies.
+      pendingTasks.clear()
       pendingHashSet.clear()
       statelessPeers.clear()
+      statelessRemoteAddresses.clear() // new root — peers that failed old root may serve new one
       peerCooldownUntilMs.clear()
-      peerResponseBytesTarget.clear()
+      // Besu-aligned D12: no peerResponseBytesTarget to clear.
       // Cancel active requests (they're for the old root)
       activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
       activeRequests.clear()
       pivotRefreshRequested = false
+      lastPulseHealedCount = totalNodesHealed // start fresh velocity window post-refresh
+      // Post-refresh cooldown: peers need time to sync to new root before we dispatch.
+      // Without this, immediate dispatch → all stateless → another HealingAllPeersStateless → tight loop.
+      postRefreshCooldownUntilMs = System.currentTimeMillis() + postRefreshCooldownMs
+      log.info(s"Post-refresh cooldown active for ${postRefreshCooldownMs / 1000}s — waiting for peers to sync to new root")
+      // ARCH-PIVOT-RESEED: Re-seed with new root for top-down discovery of new trie.
+      // ARCH-ROOT-SEED ensures healing starts from root within the cooldown window.
+      val pivotReseedPath = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+      if (!pendingHashSet.contains(newStateRoot) && !isNodeInStorage(newStateRoot)) {
+        pendingTasks += HealingEntry(Seq(pivotReseedPath), newStateRoot)
+        pendingHashSet += newStateRoot
+        log.info(
+          s"[HEAL] Re-seeded with new root ${Hex.toHexString(newStateRoot.take(4).toArray)} " +
+          s"(pending: ${pendingTasks.size})"
+        )
+      } else {
+        log.info(s"[HEAL] New root already in storage or pending — skipping pivot reseed")
+      }
+
+    case HealingForceComplete =>
+      log.warning(
+        s"[HEAL-FORCE-COMPLETE] Pivot advanced beyond SNAP serve window — " +
+        s"clearing ${pendingTasks.size} pending tasks + ${activeRequests.size} in-flight. " +
+        s"Signaling completion with $totalNodesHealed healed nodes."
+      )
+      // Cancel all in-flight requests
+      activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
+      activeRequests.clear()
+      // Clear pending queue — these paths are for a root peers have pruned
+      pendingTasks.clear()
+      pendingHashSet.clear()
+      // Signal completion with 0 abandoned (fresh coordinator + walk will start for new root)
+      snapSyncController ! SNAPSyncController.StateHealingComplete(0, totalNodesHealed)
+      context.stop(self)
 
     case TrieNodesResponseMsg(response) =>
       handleResponse(response)
@@ -245,6 +330,9 @@ class TrieNodeHealingCoordinator(
     case FlushComplete(count) =>
       flushing = false
       log.info(s"Async flush complete: $count healed nodes written to disk (total: $totalNodesHealed)")
+      // Snapshot pending queue for crash recovery (piggybacks on existing flush cadence)
+      val snapshot = pendingTasks.toSeq.map(e => (e.pathset, e.hash))
+      snapSyncController ! SNAPSyncController.PersistHealingQueue(snapshot)
       // Check if buffer filled up again during the flush
       if (rawNodeBuffer.size >= rawFlushThreshold) {
         flushRawNodesAsync()
@@ -255,7 +343,18 @@ class TrieNodeHealingCoordinator(
       result match {
         case Right(count) =>
           totalNodesHealed += count
-          log.info(s"Healing task completed: $count nodes")
+          log.info(s"Healing task completed: $count nodes (total: $totalNodesHealed, pending: ${pendingTasks.size})")
+          // Periodic progress summary (every 5K nodes)
+          if (totalNodesHealed - lastProgressLogAt >= ProgressLogInterval) {
+            val rate = calculateNodesPerSecond()
+            val activeTaskCount = activeRequests.values.map(_.tasks.size).sum
+            log.info(
+              s"Healing progress: $totalNodesHealed nodes (${"%.1f".format(totalBytesReceived / 1048576.0)} MB) " +
+                s"(${pendingTasks.size} pending, $activeTaskCount active, " +
+                s"${"%.0f".format(rate)} nodes/sec)"
+            )
+            lastProgressLogAt = totalNodesHealed
+          }
           self ! HealingCheckCompletion
         case Left(error) =>
           log.warning(s"Healing task failed: $error")
@@ -264,10 +363,18 @@ class TrieNodeHealingCoordinator(
     case HealingCheckCompletion =>
       if (isComplete && !flushing) {
         flushRawNodesSync()
-        val abandonedStr =
-          if (abandonedTaskCount > 0) s" ($abandonedTaskCount abandoned — regular sync will recover)" else ""
-        log.info(s"Healing round complete: $totalNodesHealed total nodes healed$abandonedStr. Notifying controller.")
-        snapSyncController ! SNAPSyncController.StateHealingComplete
+        val abandonedStr = if (abandonedTaskCount > 0) s" ($abandonedTaskCount abandoned — deferred to state validation)" else ""
+        log.info(
+          s"Healing complete: $totalNodesHealed nodes healed in " +
+            s"${(System.currentTimeMillis() - startTime) / 1000}s " +
+            s"(${"%.1f".format(totalBytesReceived / 1048576.0)}MB received)$abandonedStr. " +
+            s"Signalling controller to begin state validation trie walk."
+        )
+        snapSyncController ! SNAPSyncController.StateHealingComplete(abandonedTaskCount, totalNodesHealed)
+      } else if (!isComplete) {
+        log.debug(
+          s"[HEAL-CHECK] pending=${pendingTasks.size} active=${activeRequests.size} flushing=$flushing"
+        )
       }
 
     case HealingGetProgress =>
@@ -283,18 +390,39 @@ class TrieNodeHealingCoordinator(
         progress = calculateProgress()
       )
       sender() ! stats
+
+    case HealingStagnationCheck =>
+      // Besu-aligned: no stagnation escalation. Pure diagnostic pulse logging.
+      // Besu has zero stagnation watchdogs — SnapWorldDownloadState.markAsStalled() is a TODO no-op.
+      val recentHealed = totalNodesHealed - lastPulseHealedCount
+      log.info(
+        s"[HEAL-PULSE] healed=$totalNodesHealed total, +$recentHealed last 2min | " +
+        s"pending=${pendingTasks.size} active=${activeRequests.size} peers=${knownAvailablePeers.size} | " +
+        s"pivotRefreshPending=$pivotRefreshRequested"
+      )
+      lastPulseHealedCount = totalNodesHealed
   }
 
   private def queueNodes(pathsAndHashes: Seq[(Seq[ByteString], ByteString)]): Unit = {
+    var skippedExisting = 0
     val entries = pathsAndHashes.collect {
       case (pathset, hash) if !pendingHashSet.contains(hash) =>
-        pendingHashSet += hash
-        HealingEntry(pathset = pathset, hash = hash)
-    }
-    val deduped = pathsAndHashes.size - entries.size
-    pendingTasks = pendingTasks ++ entries
+        // R5 fix: Check if the node already exists in storage (downloaded during account/storage phase).
+        // mptStorage.get() throws MissingRootNodeException for missing nodes — fast O(1) RocksDB lookup.
+        val alreadyExists = try { mptStorage.get(hash.toArray); true } catch { case _: Exception => false }
+        if (alreadyExists) {
+          skippedExisting += 1
+          None
+        } else {
+          pendingHashSet += hash
+          Some(HealingEntry(pathset = pathset, hash = hash))
+        }
+    }.flatten
+    val deduped = pathsAndHashes.size - entries.size - skippedExisting
+    pendingTasks ++= entries
     val dedupStr = if (deduped > 0) s" ($deduped duplicates filtered)" else ""
-    log.info(s"Queued ${entries.size} nodes for healing$dedupStr. Total pending: ${pendingTasks.size}")
+    val existsStr = if (skippedExisting > 0) s" ($skippedExisting already in storage)" else ""
+    log.info(s"Queued ${entries.size} nodes for healing$dedupStr$existsStr. Total pending: ${pendingTasks.size}")
   }
 
   /** Update healing rate EMA and adjust throttle (geth p2p/msgrate alignment).
@@ -356,13 +484,14 @@ class TrieNodeHealingCoordinator(
     }
 
     val effectiveBatch = effectiveBatchSize
-    val batch = pendingTasks.take(effectiveBatch)
-    pendingTasks = pendingTasks.drop(effectiveBatch)
+    // DFS priority queue: dequeue in priority order (root=priority 0 always first per Besu ordering).
+    // Root node has priority=0 which is the minimum — always dispatched first without explicit sorting.
+    val batch = (0 until effectiveBatch.min(pendingTasks.size)).map(_ => pendingTasks.dequeue())
     // Remove dispatched hashes from dedup set (they'll be re-added if re-queued on failure)
     batch.foreach(e => pendingHashSet -= e.hash)
 
     val requestId = requestTracker.generateRequestId()
-    val responseBytes = responseBytesTargetFor(peer)
+    val responseBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
 
     // Build the paths list for GetTrieNodes — each entry's pathset is a Seq[ByteString]
     val paths = batch.map(_.pathset)
@@ -376,7 +505,10 @@ class TrieNodeHealingCoordinator(
 
     activeRequests(requestId) = ActiveRequest(batch, peer, responseBytes)
 
-    requestTracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetTrieNodes) {
+    // Besu RequestDataStep.java: orTimeout(10, TimeUnit.SECONDS) for all request types.
+    // Aligned floor: 10s (was 30s). Ceiling: 30s (was 60s). Slow peers released faster.
+    val healingTimeout = requestTracker.rateTracker.targetTimeout().max(10.seconds).min(30.seconds)
+    requestTracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetTrieNodes, healingTimeout) {
       handleTimeout(requestId, batch, peer)
     }
 
@@ -388,7 +520,6 @@ class TrieNodeHealingCoordinator(
       s"Requested ${batch.size} trie nodes from peer ${peer.id.value} " +
         s"(reqId=$requestId, responseBytes=$responseBytes, pending=${pendingTasks.size})"
     )
-
     Some(requestId)
   }
 
@@ -401,13 +532,12 @@ class TrieNodeHealingCoordinator(
     val activeReq = activeRequests.get(requestId) match {
       case Some(req) => req
       case None =>
-        log.warning(s"No active healing request found for requestId=$requestId")
+        log.debug(s"Received orphaned TrieNodes response (reqId=$requestId). Request was already cancelled (timeout or pivot refresh). Discarding stale response.")
         return
     }
 
     val tasksForRequest = activeReq.tasks
     val peer = activeReq.peer
-    val requestedBytes = activeReq.requestedBytes
 
     var healedCount = 0
     var receivedBytes: Long = 0
@@ -418,6 +548,7 @@ class TrieNodeHealingCoordinator(
       if (nodeHash == task.hash) {
         // Valid node — store directly by hash
         rawNodeBuffer += ((nodeHash, nodeData.toArray))
+        discoverMissingChildren(nodeData, task)
         healedCount += 1
         totalNodesHealed += 1
         receivedBytes += nodeData.length
@@ -427,15 +558,30 @@ class TrieNodeHealingCoordinator(
           s"Node hash mismatch: expected ${Hex.toHexString(task.hash.take(4).toArray)}, " +
             s"got ${Hex.toHexString(nodeHash.take(4).toArray)}"
         )
-        // Re-queue this task for retry
-        pendingTasks = pendingTasks :+ task
+        // Re-queue with incremented retry count — abandon after maxRetriesPerTask mismatches.
+        // Without this, a ghost node from a prior session's HEAL-RESUME queue (whose path no
+        // longer exists in the current trie) causes an infinite loop: peers return the nearest
+        // ancestor (the root) for non-existent paths, the mismatch re-queues without progress,
+        // and the node can never be healed regardless of how many pivot refreshes occur.
+        val updated = task.copy(retries = task.retries + 1)
+        if (updated.retries >= maxRetriesPerTask) {
+          abandonedTaskCount += 1
+          log.warning(
+            s"Giving up on trie node ${Hex.toHexString(task.hash.take(4).toArray)} after " +
+              s"$maxRetriesPerTask consecutive hash mismatches " +
+              s"(got ${Hex.toHexString(nodeHash.take(4).toArray)}). " +
+              s"Node not present in current trie — deferring to state validation."
+          )
+        } else {
+          pendingTasks += updated
+        }
       }
     }
 
     // Re-queue unmatched tasks (server returned fewer nodes than requested)
     val unmatchedTasks = tasksForRequest.drop(nodes.size)
     unmatchedTasks.foreach { task =>
-      pendingTasks = pendingTasks :+ task
+      pendingTasks += task
     }
 
     completedTaskCount += healedCount
@@ -446,36 +592,37 @@ class TrieNodeHealingCoordinator(
     val elapsedMs = System.currentTimeMillis() - activeReq.sentAtMs
     updateHealThrottle(healedCount, elapsedMs)
 
-    // Adaptive byte budget + stateless tracking
+    // Stateless tracking (Besu-aligned D12: no adaptive byte budget, fixed request size)
     if (healedCount > 0) {
-      adjustResponseBytesOnSuccess(peer, requestedBytes, BigInt(receivedBytes))
-      // Successful response — clear stateless marking and reset stagnation timer
+      // Successful response — clear stateless marking
       statelessPeers -= peer.id.value
-      lastHealedAtMs = System.currentTimeMillis()
     } else {
-      adjustResponseBytesOnFailure(peer, "empty healing response")
       recordPeerCooldown(peer, "empty healing response")
-      // Mark peer stateless for current root (geth-aligned)
-      statelessPeers += peer.id.value
-      log.info(
-        s"Peer ${peer.id.value} marked stateless for healing root " +
-          s"${Hex.toHexString(stateRoot.take(4).toArray)} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
-      )
-      // Check if all known peers are stateless — request pivot refresh
-      if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
-        pivotRefreshRequested = true
-        log.warning(
-          s"All ${statelessPeers.size} peers stateless for healing root " +
-            s"${Hex.toHexString(stateRoot.take(4).toArray)}. Requesting pivot refresh."
+      // Mark peer stateless for current root (geth-aligned) — skip for static peers
+      if (!peer.isStatic) {
+        statelessPeers += peer.id.value
+        statelessRemoteAddresses += peer.remoteAddress.toString // persist across reconnects
+        log.info(
+          s"Peer ${peer.id.value}@${peer.remoteAddress} marked stateless for healing root " +
+            s"${Hex.toHexString(stateRoot.take(4).toArray)} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
         )
-        snapSyncController ! SNAPSyncController.HealingAllPeersStateless
+        // Check if all known peers are stateless — request pivot refresh
+        if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
+          pivotRefreshRequested = true
+          log.warning(
+            s"All ${statelessPeers.size} peers stateless for healing root " +
+              s"${Hex.toHexString(stateRoot.take(4).toArray)}. Requesting pivot refresh."
+          )
+          snapSyncController ! SNAPSyncController.HealingAllPeersStateless
+        }
+      } else {
+        log.debug(s"[STATIC] Skipping stateless marking for static peer ${peer.remoteAddress} (healing)")
       }
     }
 
     log.info(
-      s"Healed $healedCount/${nodes.size} trie nodes from peer ${peer.id.value} " +
-        s"(total: $totalNodesHealed, pending: ${pendingTasks.size}, active: ${activeRequests.size} reqs, " +
-        s"responseBytes=${responseBytesTargetFor(peer)})"
+      s"Healed $healedCount of ${nodes.size} requested trie nodes from ${peer.id.value}. " +
+        s"Cumulative: $totalNodesHealed healed, ${pendingTasks.size} pending, ${activeRequests.size} in-flight"
     )
 
     if (healedCount > 0) {
@@ -498,7 +645,7 @@ class TrieNodeHealingCoordinator(
 
     activeRequests.remove(requestId)
     recordPeerCooldown(peer, "request timeout")
-    adjustResponseBytesOnFailure(peer, "request timeout")
+    // Besu-aligned D12: no adaptive byte budget ratcheting on timeout.
 
     // Increment retry count and skip exhausted tasks
     var requeued = 0
@@ -509,37 +656,22 @@ class TrieNodeHealingCoordinator(
         abandoned += 1
         abandonedTaskCount += 1
         log.warning(
-          s"Abandoning healing task after ${updated.retries} retries: " +
-            s"hash=${Hex.toHexString(task.hash.take(4).toArray)} " +
-            s"(regular sync will fetch on-demand)"
+          s"Giving up on trie node ${Hex.toHexString(task.hash.take(4).toArray)} after $maxRetriesPerTask retries. " +
+            s"Deferring to state validation phase — node will be re-discovered and fetched during trie walk."
         )
       } else {
-        pendingTasks = pendingTasks :+ updated
+        pendingTasks += updated
         requeued += 1
       }
     }
 
     if (requeued > 0) {
-      log.info(
-        s"Re-queued $requeued timed-out healing tasks (pending: ${pendingTasks.size})" +
-          (if (abandoned > 0) s", abandoned $abandoned" else "")
-      )
+      log.info(s"Re-queued $requeued timed-out healing tasks (pending: ${pendingTasks.size})" +
+        (if (abandoned > 0) s", abandoned $abandoned" else ""))
     }
 
-    // Check global stagnation: no nodes healed for healingStagnationTimeoutMs
-    val stagnantMs = System.currentTimeMillis() - lastHealedAtMs
-    if (stagnantMs > healingStagnationTimeoutMs && pendingTasks.nonEmpty) {
-      val pendingCount = pendingTasks.size
-      log.warning(
-        s"Healing stagnation detected: no nodes healed in ${stagnantMs / 1000}s. " +
-          s"Abandoning $pendingCount remaining tasks. " +
-          s"Regular sync will fetch missing nodes on-demand via GetTrieNodes."
-      )
-      abandonedTaskCount += pendingCount
-      pendingTasks = Seq.empty
-      pendingHashSet.clear()
-    }
-
+    // Besu-aligned: no mass-abandonment on timeout. Per-task retry via maxRetriesPerTask=4 only.
+    // Peers that exhaust retries are implicitly excluded via blacklistDuration on their tasks.
     tryRedispatchPendingTasks()
     self ! HealingCheckCompletion
   }
@@ -550,7 +682,14 @@ class TrieNodeHealingCoordinator(
     val eligiblePeers = knownAvailablePeers.toList
       .filterNot(isPeerCoolingDown)
       .filterNot(p => statelessPeers.contains(p.id.value))
-    if (eligiblePeers.isEmpty) return
+      .filterNot(p => statelessRemoteAddresses.contains(p.remoteAddress.toString))
+    if (eligiblePeers.isEmpty) {
+      log.debug(
+        s"[REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +
+          s"${statelessPeers.size} stateless, rest cooling down. pending: ${pendingTasks.size}"
+      )
+      return
+    }
 
     for (peer <- eligiblePeers if pendingTasks.nonEmpty)
       dispatchIfPossible(peer)
@@ -563,15 +702,139 @@ class TrieNodeHealingCoordinator(
     else completedTaskCount.toDouble / total
   }
 
+  /** Recent nodes/sec using 60s rolling window. Falls back to overall average when insufficient data. */
   private def calculateNodesPerSecond(): Double = {
-    val elapsedSec = (System.currentTimeMillis() - startTime) / 1000.0
-    if (elapsedSec > 0) totalNodesHealed / elapsedSec else 0.0
+    val now = System.currentTimeMillis()
+    recentHistory.enqueue((now, totalNodesHealed.toLong))
+    while (recentHistory.nonEmpty && now - recentHistory.head._1 > RecentWindowMs)
+      recentHistory.dequeue()
+    if (recentHistory.size >= 2) {
+      val oldest = recentHistory.head
+      val timeDiff = (now - oldest._1) / 1000.0
+      val countDiff = totalNodesHealed - oldest._2
+      if (timeDiff > 0) countDiff / timeDiff else 0.0
+    } else {
+      // Fallback to overall average
+      val elapsedSec = (now - startTime) / 1000.0
+      if (elapsedSec > 0) totalNodesHealed / elapsedSec else 0.0
+    }
   }
 
+  /** Recent KB/sec using overall average (bytes not tracked in rolling window). */
   private def calculateKilobytesPerSecond(): Double = {
     val elapsedSec = (System.currentTimeMillis() - startTime) / 1000.0
     if (elapsedSec > 0) (totalBytesReceived / 1024.0) / elapsedSec else 0.0
   }
+
+  /** Decode a healed node and queue any missing children for healing.
+    * Makes healing self-feeding: each healed node expands the work queue without
+    * requiring a full periodic trie walk (geth trie.Sync scheduler alignment).
+    */
+  private def discoverMissingChildren(nodeData: ByteString, parentEntry: HealingEntry): Unit = {
+    import com.chipprbots.ethereum.mpt.{MptTraversals, BranchNode, ExtensionNode, HashNode, LeafNode}
+    import com.chipprbots.ethereum.mpt.HexPrefix
+    import com.chipprbots.ethereum.domain.Account
+    import scala.util.control.NonFatal
+
+    val pathset = parentEntry.pathset
+    if (pathset.isEmpty) return
+
+    try {
+      val decoded = MptTraversals.decodeNode(nodeData.toArray)
+      val parentCompact = pathset.last.toArray
+      val parentNibbles = HexPrefix.decode(parentCompact)._1
+      val isStorageTrie = pathset.size > 1  // Seq(accountHash, path) vs Seq(path)
+
+      val newEntries = mutable.Buffer.empty[HealingEntry]
+
+      decoded match {
+        case branch: BranchNode =>
+          // DFS priority: child i of parent gets priority = parentPriority * 16 + i (Besu TrieNodeHealingRequest)
+          for (i <- 0 until 16) {
+            branch.children(i) match {
+              case hash: HashNode =>
+                val childHash = ByteString(hash.hashNode)
+                if (!pendingHashSet.contains(childHash) && !isNodeInStorage(childHash)) {
+                  val childNibbles = parentNibbles :+ i.toByte
+                  val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                  val childPathset = if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                  newEntries += HealingEntry(childPathset, childHash,
+                    depth = parentEntry.depth + 1,
+                    priority = parentEntry.priority * 16 + i)
+                }
+              case _ => // Inline-encoded or null — already resolved
+            }
+          }
+
+        case ext: ExtensionNode =>
+          // Extension has a single child; treat as index 0 for priority inheritance
+          ext.next match {
+            case hash: HashNode =>
+              val childHash = ByteString(hash.hashNode)
+              if (!pendingHashSet.contains(childHash) && !isNodeInStorage(childHash)) {
+                // ext.sharedKey is already HP-decoded nibbles (ByteString of nibble bytes)
+                val childNibbles = parentNibbles ++ ext.sharedKey.toArray
+                val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                val childPathset = if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                newEntries += HealingEntry(childPathset, childHash,
+                  depth = parentEntry.depth + 1,
+                  priority = parentEntry.priority * 16)
+              }
+            case _ => // Already inline-encoded — no missing child
+          }
+
+        case leaf: LeafNode if !isStorageTrie =>
+          // ARCH-LEAF-SEED: Account trie leaf — decode account value, seed storage trie if needed.
+          // Besu equivalent: getChildRequests() → getStorageTrieNodeRequests() on account leaf values.
+          // leaf.key contains HP-decoded nibbles for this leaf's remaining path segment.
+          Account(leaf.value).foreach { account =>
+            if (account.storageRoot != Account.EmptyStorageRootHash &&
+                !pendingHashSet.contains(account.storageRoot) &&
+                !isNodeInStorage(account.storageRoot)) {
+              // Reconstruct 32-byte account address hash from the full nibble path.
+              // In the account trie, path from root to leaf = keccak256(address) as 64 nibbles.
+              val leafNibbles = leaf.key.toArray  // remaining nibbles for this leaf's path segment
+              val allNibbles  = parentNibbles ++ leafNibbles
+              if (allNibbles.length == 64) {
+                val accountHashBytes = allNibbles.grouped(2).map { g =>
+                  ((g(0) << 4) | g(1)).toByte
+                }.toArray
+                val accountHash      = ByteString(accountHashBytes)
+                val emptyStoragePath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+                // Storage trie root inherits account's priority; depth=0 (new trie)
+                newEntries += HealingEntry(Seq(accountHash, emptyStoragePath), account.storageRoot,
+                  depth = 0,
+                  priority = parentEntry.priority)
+                log.debug(
+                  s"[HEAL-LEAF] Seeded storage trie root ${Hex.toHexString(account.storageRoot.take(4).toArray)} " +
+                  s"for account ${Hex.toHexString(accountHashBytes.take(4))}"
+                )
+              }
+            }
+          }
+
+        case _ => // storage trie LeafNode, NullNode, HashNode — no children to discover
+      }
+
+      if (newEntries.nonEmpty) {
+        newEntries.foreach(e => pendingHashSet += e.hash)
+        pendingTasks ++= newEntries
+        childrenDiscoveredTotal += newEntries.size
+        if (childrenDiscoveredTotal % 100 == 0 || childrenDiscoveredTotal <= 20)
+          log.info(
+            s"[HEAL] Missing trie children queued: $childrenDiscoveredTotal total " +
+              s"(+${newEntries.size} from this node, pending: ${pendingTasks.size})"
+          )
+      }
+    } catch {
+      case NonFatal(e) =>
+        log.debug(s"[HEAL] Cannot decode healed node for child discovery: ${e.getMessage}. Skipping incremental discovery — full trie walk will find these nodes.")
+        // Non-fatal — healing still works via final validation walk as safety net
+    }
+  }
+
+  private def isNodeInStorage(hash: ByteString): Boolean =
+    try { mptStorage.get(hash.toArray); true } catch { case _: Exception => false }
 
   private def isComplete: Boolean =
     pendingTasks.isEmpty && activeRequests.isEmpty

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -22,15 +22,14 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
       healingBatchSize = 16,
       stateValidationEnabled = true,
       maxRetries = 3,
-      timeout = 30.seconds,
-      maxSnapSyncFailures = 5
+      timeout = 30.seconds
     )
 
     config.enabled shouldBe true
     config.pivotBlockOffset shouldBe 1024
     config.accountConcurrency shouldBe 16
     config.maxRetries shouldBe 3
-    config.maxSnapSyncFailures shouldBe 5
+    // maxSnapSyncFailures removed in Besu-aligned D4 (no fallback to fast sync)
   }
 
   it should "have sensible defaults" taggedAs UnitTest in {
@@ -41,7 +40,7 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     config.accountConcurrency should be > 0
     config.storageConcurrency should be > 0
     config.healingBatchSize should be > 0
-    config.maxSnapSyncFailures should be > 0
+    config.maxRetries should be > 0
   }
 
   "SyncProgress" should "format progress string correctly" taggedAs UnitTest in {


### PR DESCRIPTION
## Summary

Aligns the SNAP sync state machine with the Hyperledger Besu reference
implementation by removing several experimental behaviors that caused
deadlocks or correctness regressions:

| Change | Rationale |
|--------|-----------|
| Remove chain-download wait before finalization (D2) | Besu finalizes immediately; the wait caused pivot staleness |
| Remove fast-sync fallback on SNAP failure (D3/D4) | Besu has no fallback path; the transition logic was incorrect |
| Remove stagnation watchdogs from healing + storage (D7) | Besu does not use watchdogs; they triggered destructive restarts |
| Revert to 1 request per peer (D11) | Pipelining interacted badly with single-writer coordinator actors |
| Revert to fixed request sizes (D12) | Adaptive ratcheting caused oversized requests on slow peers |
| Remove boosted chain concurrency (D14) | Concurrency boost masked coordinator state errors |
| Skip post-healing validation walk on clean completion (D17) | `healedNodes>0 && abandoned==0` means all nodes resolved; walk is redundant |
| `ChainDownloader` queue: `Vector` → `ArrayDeque` | O(n) full-copy on every re-queue; aligns with Besu mutable queue pattern |

## Test plan
- [x] `sbt Test/compile` — clean
- [x] `sbt "testOnly *SNAPSyncController*"` — updated for D4 removal of maxSnapSyncFailures
- [x] `sbt testEssential`
- [ ] Mordor: SNAP sync completes without stall