### PR TITLE
fix(snap): healing coordinator — peer exclusion, permanent-block prevention, give-up

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -83,9 +83,10 @@ sync {
     # Keeps SNAP startup fast on networks where peers don't support snap (e.g. Mordor).
     snap-capability-grace-period = 30 seconds
     # Account stagnation timeout: if no account range tasks complete within this window,
-    # record a critical failure. Reduced from 15 minutes to catch non-snap peers faster
-    # while still allowing time for large state downloads on supported networks.
-    account-stagnation-timeout = 3 minutes
+    # declare stagnation and force-complete. Besu uses 5 minutes as unified threshold.
+    # ETC mainnet has ~73M accounts across 16 parallel ranges — individual ranges on slow
+    # peers can take 3-4 minutes, so 5 minutes provides adequate headroom.
+    account-stagnation-timeout = 5 minutes
     # Maximum concurrent in-flight requests per peer for account and storage coordinators.
     # Core-geth pipelines 5+ concurrent requests per peer. Matching this eliminates idle time
     # between request send and response processing (50-200ms per response round-trip).

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -491,6 +491,10 @@ class SyncController(
         // may differ from the pivot block header's stateRoot. The trie nodes are stored under
         // the finalized root's hash, but the pivot header references the original (now orphaned) root.
         // Fix: substitute the finalized root into the pivot block header.
+        // If no valid root can be found (neither pivot nor finalized root exists in the MPT DB),
+        // the SnapSyncDone flag was written for a pivot whose state was never downloaded — clear it
+        // and restart SNAP sync so healing runs against a valid state root.
+        var snapRestartNeeded = false
         bestBlockHeader.foreach { header =>
           val mptStorage = stateStorage.getReadOnlyStorage
           val pivotRootExists =
@@ -521,22 +525,52 @@ class SyncController(
                   )
                   val updatedHeader = header.copy(stateRoot = fRoot)
                   blockchainWriter.storeBlockHeader(updatedHeader).commit()
+                } else {
+                  log.warning(
+                    "Pivot state root {} MISSING and finalized root {} also MISSING — " +
+                      "SnapSyncDone was set for a pivot whose state was never downloaded. " +
+                      "Clearing SnapSyncDone to re-run SNAP sync healing.",
+                    header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                    fRoot.take(8).toArray.map("%02x".format(_)).mkString
+                  )
+                  snapRestartNeeded = true
                 }
               case None =>
-                log.error(
-                  "Pivot state root {} MISSING and no finalized root stored! " +
-                    "Database is in an unrecoverable state — clear data and re-sync.",
+                log.warning(
+                  "Pivot state root {} MISSING and no finalized root stored — " +
+                    "SnapSyncDone was set for a pivot whose state was never downloaded " +
+                    "(likely due to pre-healing pivot switch advancing bestBlock ahead of downloaded state). " +
+                    "Clearing SnapSyncDone to re-run SNAP sync healing.",
                   header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
                 )
+                snapRestartNeeded = true
             }
           }
         }
-        val needBytecode = !appStateStorage.isBytecodeRecoveryDone()
-        val needStorage = !appStateStorage.isStorageRecoveryDone()
-        if (needBytecode || needStorage) {
-          startRecovery(needBytecode, needStorage)
+        if (snapRestartNeeded) {
+          appStateStorage.clearSnapSyncDone().commit()
+          startSnapSync()
         } else {
-          startRegularSync()
+          // Besu alignment: healing is mandatory before sync is complete.
+          // If SnapSyncDone was set by the old deferred-merkleization path (which skipped healing),
+          // clear the flag and re-enter SNAPSyncController so healing runs now.
+          val snapCfg = loadSnapSyncConfig()
+          if (!snapCfg.deferredMerkleization) {
+            log.warning(
+              "SnapSyncDone=true but deferred-merkleization=false — healing was skipped by a " +
+                "previous run. Clearing SnapSyncDone and re-entering SNAP sync for trie healing."
+            )
+            appStateStorage.clearSnapSyncDone().commit()
+            startSnapSync()
+          } else {
+            val needBytecode = !appStateStorage.isBytecodeRecoveryDone()
+            val needStorage = !appStateStorage.isStorageRecoveryDone()
+            if (needBytecode || needStorage) {
+              startRecovery(needBytecode, needStorage)
+            } else {
+              startRegularSync()
+            }
+          }
         }
       case (_, false, false, true) =>
         startFastSync()

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
@@ -242,7 +242,8 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
       return Left(s"Expected ${RequestType.GetByteCodes} but got response for ${pending.requestType}")
     }
 
-    // TODO: Validate bytecode hashes match requested hashes
+    // Content validation (keccak256 hash verification) is done in ByteCodeCoordinator.validateReturnedCodes.
+    // Tracker validates only that the response matches the tracked request type.
     Right(response)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1066,7 +1066,10 @@ class SNAPSyncController(
     // Step 7: Check for accounts-complete recovery (process crash during bytecode/storage phase).
     // If accounts were previously completed and the pivot is still fresh, skip account download
     // and only re-run bytecodes + storage from the persisted storage file.
-    if (appStateStorage.isSnapSyncAccountsComplete()) {
+    // D3 (H-017): Wrap in try-catch — corrupt checkpoint from a hard crash/power loss causes
+    // deserialization errors that would kill the actor. Explicit reset to fresh state is safer
+    // than crashing, since the next attempt will rebuild from scratch.
+    try if (appStateStorage.isSnapSyncAccountsComplete()) {
       val savedPivot = appStateStorage.getSnapSyncPivotBlock()
       val savedRootOpt = appStateStorage.getSnapSyncStateRoot()
       val savedStoragePath = appStateStorage.getSnapSyncStorageFilePath().filter(_.nonEmpty)
@@ -1224,6 +1227,15 @@ class SNAPSyncController(
           log.warning("Recovery: accounts-complete flag set but missing pivot/root. Clearing and restarting fresh.")
           appStateStorage.putSnapSyncAccountsComplete(false).commit()
       }
+    } catch {
+      case ex: Exception =>
+        log.error(
+          ex,
+          "[SNAP-RECOVERY] Exception reading checkpoint state — likely corrupt from hard shutdown. " +
+            "Clearing accounts-complete flag and starting fresh."
+        )
+        try appStateStorage.putSnapSyncAccountsComplete(false).commit()
+        catch { case _: Exception => () }
     }
 
     // Check if there's an interrupted bootstrap to resume

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -190,6 +190,7 @@ class SNAPSyncController(
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
       handlePeerListMessages(msg)
       requestTracker.rateTracker.removePeer(peerId.value)
+      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
   }
 
   /** Wrap handlePeerListMessages to also update the PeerRateTracker when peers connect/disconnect. Tracks previous peer
@@ -212,6 +213,7 @@ class SNAPSyncController(
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
       handlePeerListMessages(msg) // removes from handshakedPeers
       requestTracker.rateTracker.removePeer(peerId.value)
+      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
   }
 
   // Storage stagnation watchdog: if storage stops advancing while tasks remain, repivot/restart.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -89,9 +89,6 @@ class SNAPSyncController(
 
   private val progressMonitor = new SyncProgressMonitor(scheduler)
 
-  // Failure tracking for fallback to fast sync
-  private var criticalFailureCount: Int = 0
-
   // Retry counter for validation failures to prevent infinite loops
   private var validationRetryCount: Int = 0
   private val MaxValidationRetries = 3
@@ -114,6 +111,17 @@ class SNAPSyncController(
   // fallback to fast sync instead of cycling pivots for 75+ minutes.
   private var consecutivePivotRefreshes: Int = 0
   private val MaxConsecutivePivotRefreshes = 3
+
+  // Healing pivot refresh counter: tracks consecutive pivots where all peers fail to serve
+  // the root node during healing. After MaxHealingPivotRefreshes, fall back to the
+  // state-download pivot (whose state IS in the DB) instead of cycling indefinitely.
+  private var healingPivotRefreshes: Int = 0
+  private val MaxHealingPivotRefreshes = 6
+
+  // The pivot used for the actual state download (account/storage ranges).
+  // Saved before the pre-healing pivot switch so we can fall back to it if the
+  // new pivot's root is unservable by the current ETC SNAP peer set.
+  private var stateDownloadPivot: Option[BigInt] = None
 
   // Pending pivot refresh: when refreshPivotInPlace() needs a header from a peer,
   // it requests a bootstrap and stores the pending pivot here. When BootstrapComplete
@@ -140,8 +148,14 @@ class SNAPSyncController(
   private case object CheckSnapCapability
   private case object TuneRateTracker
   private case object EvictNonSnapPeers
+  private case object CheckPivotStaleness
   private var snapCapabilityCheckTask: Option[Cancellable] = None
   private var snapPeerEvictionTask: Option[Cancellable] = None
+  private var pivotStalenessCheckTask: Option[Cancellable] = None
+
+  // Besu DynamicPivotBlockSelector.java constants
+  private val PivotWindowValidity: Int = 126  // blocks behind chain tip before pivot switch
+  private val PivotCheckInterval: FiniteDuration = 60.seconds
 
   /** Like handlePeerListMessagesWithRateTracking, but also reactively triggers a bootstrap retry when new SNAP-capable
     * peers arrive during the bootstrapping state. Without this, the node waits for the full exponential backoff timer
@@ -225,6 +239,7 @@ class SNAPSyncController(
     accountStagnationCheckTask.foreach(_.cancel())
     storageStagnationCheckTask.foreach(_.cancel())
     healingRequestTask.foreach(_.cancel())
+    pivotStalenessCheckTask.foreach(_.cancel())
     bootstrapCheckTask.foreach(_.cancel())
     pivotBootstrapRetryTask.foreach(_.cancel())
     snapCapabilityCheckTask.foreach(_.cancel())
@@ -255,7 +270,8 @@ class SNAPSyncController(
     case EvictNonSnapPeers =>
       evictNonSnapPeers()
 
-    // Snap capability grace period check: if still no snap/1 peers, fall back to fast sync
+    // Snap capability grace period check: reschedule if no snap/1 peers found yet.
+    // Besu-aligned: never fall back to fast sync. Keep waiting indefinitely for SNAP peers.
     case CheckSnapCapability =>
       val snapPeerCount = peersToDownloadFrom.count { case (_, p) =>
         p.peerInfo.remoteStatus.supportsSnap
@@ -267,8 +283,13 @@ class SNAPSyncController(
         )
         stateRoot.foreach(launchAccountRangeWorkers(_, effectiveConcurrency))
       } else {
-        log.warning("No snap-capable peers found after grace period. Falling back to fast sync.")
-        fallbackToFastSync()
+        // Besu-aligned: no fallback to fast sync. Reschedule and keep waiting for SNAP peers.
+        val gracePeriod = snapSyncConfig.snapCapabilityGracePeriod
+        log.warning(
+          s"No snap-capable peers found after grace period. " +
+          s"Rescheduling check in ${gracePeriod.toSeconds}s (Besu-aligned: no fallback)."
+        )
+        snapCapabilityCheckTask = Some(scheduler.scheduleOnce(gracePeriod, self, CheckSnapCapability)(ec))
       }
 
     // Periodic request triggers
@@ -367,6 +388,7 @@ class SNAPSyncController(
     case ProgressNodesHealed(count) =>
       progressMonitor.incrementNodesHealed(count)
       consecutiveUnproductiveHealingRounds = 0 // Reset — healing made progress
+      if (count > 0) healingPivotRefreshes = 0  // Root was served — reset healing fallback counter
 
     case ProgressAccountEstimate(estimatedTotal) =>
       progressMonitor.updateEstimates(accounts = estimatedTotal)
@@ -406,17 +428,14 @@ class SNAPSyncController(
             consecutivePivotRefreshes = 0 // Reset — accounts completing IS progress
             refreshPivotInPlace(reason)
           } else {
-            // Accounts still in progress — full restart is acceptable
-            // but preserve range progress (existing preservedRangeProgress mechanism)
+            // Accounts still in progress — Besu-aligned: no fallback, no critical failure tracking.
+            // Besu persists indefinitely. Reset counter and refresh pivot.
             log.warning(
-              s"$consecutivePivotRefreshes consecutive pivot refreshes without progress. " +
-                "Peers likely lack snapshot databases."
+              s"$consecutivePivotRefreshes consecutive stateless pivot refreshes during account sync. " +
+                "Besu-aligned: resetting counter and refreshing pivot (no fallback to fast sync)."
             )
-            if (recordCriticalFailure(s"$consecutivePivotRefreshes consecutive stateless pivot refreshes")) {
-              fallbackToFastSync()
-            } else {
-              restartSnapSync(s"consecutive stateless pivots ($consecutivePivotRefreshes): $reason")
-            }
+            consecutivePivotRefreshes = 0
+            refreshPivotInPlace(reason)
           }
         } else {
           refreshPivotInPlace(reason)
@@ -437,9 +456,17 @@ class SNAPSyncController(
           completePivotRefreshWithStateRoot(pendingPivot, header, reason)
         case None =>
           log.warning(
-            s"Pivot header bootstrap for block $pendingPivot returned no header. Falling back to full restart."
+            s"Pivot header bootstrap for block $pendingPivot returned no header. " +
+              s"Scheduling retry in 60s (preserving sync state)."
           )
-          restartSnapSync(s"pivot refresh bootstrap returned no header for $pendingPivot: $reason")
+          // Besu: switchToNewPivotBlock() never destroys state on header fetch failure — it simply
+          // retries. PivotBootstrapFailed (below) already schedules a 60s retry via RetryPivotRefresh;
+          // BootstrapComplete(None) must do the same. restartSnapSync() here destroys 5+ days of
+          // downloaded account/storage data on a transient header unavailability.
+          pivotBootstrapRetryTask.foreach(_.cancel())
+          pivotBootstrapRetryTask = Some(
+            scheduler.scheduleOnce(60.seconds, self, RetryPivotRefresh)(context.dispatcher)
+          )
       }
 
     // Handle pivot header bootstrap failure. The bootstrap exhausted all retries (with exponential
@@ -458,9 +485,9 @@ class SNAPSyncController(
 
     case RetryPivotRefresh =>
       pivotBootstrapRetryTask = None
-      if (currentPhase == AccountRangeSync || currentPhase == ByteCodeAndStorageSync) {
-        log.info("Retrying pivot refresh after bootstrap failure...")
-        refreshPivotInPlace("retry after bootstrap failure")
+      if (currentPhase == AccountRangeSync || currentPhase == ByteCodeAndStorageSync || currentPhase == StateHealing) {
+        log.info(s"Retrying pivot refresh (phase=$currentPhase)...")
+        refreshPivotInPlace("retry pivot refresh")
       } else {
         log.info(s"Skipping pivot refresh retry — phase=$currentPhase no longer needs it")
       }
@@ -517,10 +544,9 @@ class SNAPSyncController(
         currentPhase = ByteCodeAndStorageSync
         progressMonitor.startPhase(ByteCodeAndStorageSync)
 
-        // Redistribute per-peer budget: accounts done, give storage+bytecode more bandwidth.
-        // Global budget remains 5 per peer: storage=3, bytecode=2.
-        storageRangeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(3))
-        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(2))
+        // Besu-aligned D11: 1 request per peer for all coordinators.
+        storageRangeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
+        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
 
         // Cancel account stagnation checks (no longer relevant)
         accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
@@ -539,13 +565,12 @@ class SNAPSyncController(
       log.info(
         s"ByteCode sync complete ($downloaded bytecodes). Storage: $storagePhaseComplete, Accounts: $accountsComplete"
       )
-      // Bytecode done — give storage the full per-peer budget (was 3/5, now 5/5).
-      // On peer-limited networks (Mordor: ~10 peers), this nearly doubles storage throughput.
+      // Besu-aligned D11: keep 1 req/peer even after bytecode completes.
       if (!storagePhaseComplete) {
         storageRangeCoordinator.foreach { coord =>
-          coord ! actors.Messages.UpdateMaxInFlightPerPeer(snapSyncConfig.maxInFlightPerPeer)
+          coord ! actors.Messages.UpdateMaxInFlightPerPeer(1)
           log.info(
-            s"Storage per-peer budget boosted to ${snapSyncConfig.maxInFlightPerPeer} (bytecode complete, full budget)"
+            "Storage per-peer budget remains 1 (Besu-aligned D11: no pipelining)"
           )
         }
       }
@@ -556,12 +581,34 @@ class SNAPSyncController(
       log.info(s"Storage range sync complete. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete")
       checkAllDownloadsComplete()
 
-    case HealingAllPeersStateless if currentPhase == StateHealing =>
-      log.warning("All healing peers stateless — refreshing pivot in-place for healing")
-      refreshPivotInPlace("all healing peers stateless")
+    // Sender-guards on all healing coordinator messages: Pekko context.stop is async — old
+    // coordinator instances continue processing their mailbox after context.stop() is called.
+    // Only the CURRENT coordinator (trieNodeHealingCoordinator.contains(sender())) may trigger
+    // state transitions. Stale messages from stopped coordinators are logged and dropped.
+    case HealingAllPeersStateless
+        if currentPhase == StateHealing && trieNodeHealingCoordinator.contains(sender()) =>
+      healingPivotRefreshes += 1
+      log.warning(
+        s"All healing peers stateless — pivot refresh $healingPivotRefreshes/$MaxHealingPivotRefreshes"
+      )
+      if (healingPivotRefreshes >= MaxHealingPivotRefreshes) {
+        attemptHealingFallbackToStateDownloadPivot()
+      } else {
+        refreshPivotInPlace("all healing peers stateless")
+      }
 
-    case StateHealingComplete =>
-      log.info("Healing coordinator idle (no pending tasks, no active requests).")
+    case HealingAllPeersStateless if currentPhase == StateHealing =>
+      log.debug(s"Ignoring HealingAllPeersStateless from non-current coordinator (${sender().path.name})")
+
+    // HealingStagnated is no longer sent (Besu-aligned: no stagnation watchdog in TrieNodeHealingCoordinator).
+    // Handler removed in april-besu-alignment D7.
+
+    case PersistHealingQueue(pending, _) =>
+      log.debug(s"[HEAL-PERSIST] ${pending.size} pending nodes (persistence not implemented on this branch — discarding)")
+
+    case StateHealingComplete(abandonedNodes, totalHealed)
+        if trieNodeHealingCoordinator.contains(sender()) =>
+      log.info(s"State healing complete [abandonedNodes=$abandonedNodes, healed=$totalHealed].")
       if (trieWalkInProgress) {
         // A trie walk is already running — its result will determine next step
         log.info("Trie walk in progress, waiting for result...")
@@ -570,11 +617,16 @@ class SNAPSyncController(
         startTrieWalk()
       }
 
+    case StateHealingComplete(_, _) =>
+      log.debug(s"Ignoring StateHealingComplete from non-current coordinator (${sender().path.name})")
+
     case TrieWalkResult(missingNodes) if currentPhase == StateHealing =>
       trieWalkInProgress = false
       if (missingNodes.isEmpty) {
         log.info("Trie walk found no missing nodes — healing complete!")
         consecutiveUnproductiveHealingRounds = 0
+        pivotStalenessCheckTask.foreach(_.cancel())
+        pivotStalenessCheckTask = None
         progressMonitor.startPhase(StateValidation)
         currentPhase = StateValidation
         validateState()
@@ -587,6 +639,8 @@ class SNAPSyncController(
               s"Proceeding to validation — regular sync will recover missing nodes on-demand."
           )
           consecutiveUnproductiveHealingRounds = 0
+          pivotStalenessCheckTask.foreach(_.cancel())
+          pivotStalenessCheckTask = None
           progressMonitor.startPhase(StateValidation)
           currentPhase = StateValidation
           validateState()
@@ -614,6 +668,20 @@ class SNAPSyncController(
       scheduler.scheduleOnce(5.seconds) {
         self ! ScheduledTrieWalk
       }(ec)
+
+    // Besu DynamicPivotBlockSelector: every 60s check if pivot drifted >126 blocks behind chain tip.
+    case CheckPivotStaleness if currentPhase == StateHealing =>
+      val currentPivot = pivotBlock.getOrElse(BigInt(0))
+      currentNetworkBestFromSnapPeers().foreach { networkBest =>
+        val pivotAge = networkBest - currentPivot
+        if (pivotAge > PivotWindowValidity) {
+          log.info(
+            s"[PIVOT-STALENESS] Pivot $currentPivot is $pivotAge blocks behind network head $networkBest " +
+              s"(threshold: $PivotWindowValidity). Refreshing pivot."
+          )
+          refreshPivotInPlace("pivot-staleness-check")
+        }
+      }
 
     case StateValidationComplete =>
       log.info("State validation complete. SNAP sync finished!")
@@ -729,25 +797,37 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
+      // Besu alignment: healing is always required before SNAP sync is considered complete.
+      // The deferred-merkleization path (which skipped healing) has been removed — it caused
+      // SnapSyncDone to be persisted before trie nodes were present, breaking regular sync.
       if (snapSyncConfig.deferredMerkleization) {
-        // With deferred merkleization, trie nodes were never constructed during download —
-        // only flat storage was written. A trie walk would find the entire internal trie "missing",
-        // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).
-        //
-        // Skip healing/validation entirely. Regular sync's BlockImporter will fetch missing trie
-        // nodes on-demand via GetTrieNodes (SNAP protocol) when block execution encounters them.
-        // This is the "lazy healing" pattern used by geth's path-based storage.
-        log.info(
-          "All state downloads complete (accounts + bytecodes + storage). " +
-            "Deferred merkleization enabled — skipping healing/validation phase. " +
-            "Missing trie nodes will be fetched on-demand during block execution."
+        log.warning(
+          "All state downloads complete. deferred-merkleization=true is set but healing is " +
+            "required for correctness — forcing healing phase (Besu-aligned)."
         )
-        completeSnapSync()
       } else {
         log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
-        currentPhase = StateHealing
-        startStateHealing()
       }
+      currentPhase = StateHealing
+
+      // Besu alignment: startTrieHeal() calls pivotBlockSelector.switchToNewPivotBlock()
+      // UNCONDITIONALLY before seeding healing. No staleness check — always refresh.
+      // The pivot from refreshPivotInPlace() comes from the NETWORK (networkBest - offset),
+      // not from local chain download progress. This ensures healing always starts from a
+      // root within the SNAP serve window (~64 blocks from head).
+      val currentPivot = pivotBlock.getOrElse(BigInt(0))
+      // Save the state-download pivot before switching — used as fallback if the new pivot's
+      // root is unservable by the ETC SNAP peer set after MaxHealingPivotRefreshes attempts.
+      stateDownloadPivot = pivotBlock
+      log.info(
+        s"Pre-healing pivot switch: refreshing from pivot $currentPivot to network head " +
+          s"before seeding healing coordinator " +
+          s"(mirrors Besu startTrieHeal → switchToNewPivotBlock unconditionally). " +
+          s"State-download pivot saved for fallback: $currentPivot"
+      )
+      refreshPivotInPlace("pre-healing pivot switch")
+      // startStateHealing() called from completePivotRefreshWithStateRoot()
+      // when currentPhase == StateHealing && trieNodeHealingCoordinator.isEmpty
     }
 
   def bootstrapping: Receive = handlePeerListMessagesWithBootstrapReactivity.orElse {
@@ -931,16 +1011,13 @@ class SNAPSyncController(
     case PivotBootstrapFailed(reason) =>
       log.warning(s"Pivot header bootstrap failed during initial startup: $reason")
       bootstrapRetryCount += 1
-      if (checkBootstrapRetryTimeout(s"bootstrap failed: $reason")) {
-        // checkBootstrapRetryTimeout already called fallbackToFastSync()
-      } else {
-        val delay = bootstrapRetryDelay
-        log.info(s"Retrying SNAP sync start in $delay (attempt $bootstrapRetryCount)")
-        bootstrapCheckTask.foreach(_.cancel())
-        bootstrapCheckTask = Some(
-          scheduler.scheduleOnce(delay)(self ! RetrySnapSyncStart)(ec)
-        )
-      }
+      checkBootstrapRetryTimeout(s"bootstrap failed: $reason")
+      val delay = bootstrapRetryDelay
+      log.info(s"Retrying SNAP sync start in $delay (attempt $bootstrapRetryCount)")
+      bootstrapCheckTask.foreach(_.cancel())
+      bootstrapCheckTask = Some(
+        scheduler.scheduleOnce(delay)(self ! RetrySnapSyncStart)(ec)
+      )
 
     // SNAP peer eviction runs during bootstrap to free slots for SNAP-capable peers
     case EvictNonSnapPeers =>
@@ -972,7 +1049,7 @@ class SNAPSyncController(
     if (appStateStorage.isSnapSyncAccountsComplete()) {
       val savedPivot = appStateStorage.getSnapSyncPivotBlock()
       val savedRootOpt = appStateStorage.getSnapSyncStateRoot()
-      val savedStoragePath = appStateStorage.getSnapSyncStorageFilePath()
+      val savedStoragePath = appStateStorage.getSnapSyncStorageFilePath().filter(_.nonEmpty)
 
       (savedPivot, savedRootOpt) match {
         case (Some(pivot), Some(rootBs)) if pivot > 0 =>
@@ -1034,7 +1111,7 @@ class SNAPSyncController(
                     maxInFlightRequests = snapSyncConfig.storageConcurrency,
                     requestTimeout = snapSyncConfig.timeout,
                     snapSyncController = self,
-                    initialMaxInFlightPerPeer = 3, // Recovery: accounts done, storage gets 3 of 5 per-peer budget
+                    initialMaxInFlightPerPeer = 1, // Besu-aligned D11: 1 request per peer, no pipelining
                     initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
                     minResponseBytes = snapSyncConfig.storageMinResponseBytes,
                     deferredMerkleization = snapSyncConfig.deferredMerkleization
@@ -1048,8 +1125,8 @@ class SNAPSyncController(
               scheduler.scheduleWithFixedDelay(0.seconds, 1.second, self, RequestStorageRanges)(ec)
             )
 
-            // Recovery budget: accounts done, bytecode=2, storage=3 (total 5 per peer)
-            bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(2))
+            // Besu-aligned D11: 1 request per peer, no pipelining.
+            bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(1))
 
             // Stream storage tasks from persisted file if available
             savedStoragePath.foreach { pathStr =>
@@ -1085,8 +1162,15 @@ class SNAPSyncController(
                     } finally raf.close()
                     totalTasks
                   }
+                  .recover { case ex: Exception =>
+                    log.warning(s"Recovery: failed to stream storage tasks from $filePath: ${ex.getMessage}")
+                    -1
+                  }
                   .foreach { count =>
-                    log.info(s"Recovery: streamed $count storage tasks from ${filePath}")
+                    if (count >= 0)
+                      log.info(s"Recovery: streamed $count storage tasks from ${filePath}")
+                    else
+                      log.warning(s"Recovery: storage file read failed, proceeding without storage tasks from $filePath")
                     // Signal no more tasks — sentinel allows completion
                     coordinator ! actors.Messages.NoMoreStorageTasks
                   }
@@ -1268,8 +1352,9 @@ class SNAPSyncController(
           context.become(syncing)
 
         case None =>
-          log.error("Genesis block header not available - cannot start SNAP sync")
-          context.parent ! FallbackToFastSync
+          // Besu-aligned: genesis not available is a transient startup error; retry instead of falling back.
+          log.error("Genesis block header not available — retrying SNAP sync start in 5s (Besu-aligned: no fallback)")
+          scheduler.scheduleOnce(5.seconds, self, Start)(ec)
       }
       return
     }
@@ -1419,79 +1504,18 @@ class SNAPSyncController(
     math.min(delaySeconds, BootstrapRetryMaxDelay.toSeconds).seconds
   }
 
-  /** Check if bootstrap retry has exceeded the maximum count. If so, falls back to fast sync. */
-  private def checkBootstrapRetryTimeout(context: String): Boolean =
+  /** Check if bootstrap retry has exceeded the maximum count.
+    * Besu-aligned: never fall back to fast sync. Reset counter and keep retrying indefinitely.
+    */
+  private def checkBootstrapRetryTimeout(context: String): Boolean = {
     if (bootstrapRetryCount >= MaxBootstrapRetries) {
       log.warning(
-        s"No peers found after $bootstrapRetryCount bootstrap retries ($context). Falling back to fast sync."
+        s"Reached max bootstrap retries ($bootstrapRetryCount, $context) — " +
+        "Besu-aligned: resetting counter and continuing to retry (no fallback to fast sync)."
       )
-      fallbackToFastSync()
-      true
-    } else {
-      if (bootstrapRetryCount > 0 && bootstrapRetryCount % 5 == 0) {
-        log.info(
-          s"Bootstrap retry diagnostics ($context): " +
-            s"attempt=$bootstrapRetryCount/$MaxBootstrapRetries, " +
-            s"handshakedPeers=${handshakedPeers.size}, " +
-            s"snapCapable=${handshakedPeers.values.count(_.peerInfo.remoteStatus.supportsSnap)}"
-        )
-      }
-      false
+      bootstrapRetryCount = 0
     }
-
-  /** Record a critical failure and check if we should fallback to fast sync. Critical failures are those that indicate
-    * SNAP sync cannot proceed.
-    *
-    * @param reason
-    *   Description of the failure
-    * @return
-    *   true if we should fallback to fast sync
-    */
-  private def recordCriticalFailure(reason: String): Boolean = {
-    criticalFailureCount += 1
-    log.warning(s"Critical SNAP sync failure ($criticalFailureCount/${snapSyncConfig.maxSnapSyncFailures}): $reason")
-
-    if (criticalFailureCount >= snapSyncConfig.maxSnapSyncFailures) {
-      log.error(s"SNAP sync failed ${criticalFailureCount} times, falling back to fast sync")
-      true
-    } else {
-      false
-    }
-  }
-
-  /** Trigger fallback to fast sync due to repeated SNAP sync failures */
-  private def fallbackToFastSync(): Unit = {
-    // Set phase to Completed FIRST to prevent aroundReceive guards (which check currentPhase)
-    // from re-triggering stagnation checks while we're tearing down.
-    currentPhase = Completed
-
-    log.warning("Triggering fallback to fast sync due to repeated SNAP sync failures")
-
-    // Cancel all scheduled tasks
-    accountRangeRequestTask.foreach(_.cancel())
-    bytecodeRequestTask.foreach(_.cancel())
-    storageRangeRequestTask.foreach(_.cancel())
-    healingRequestTask.foreach(_.cancel())
-    snapCapabilityCheckTask.foreach(_.cancel())
-    snapPeerEvictionTask.foreach(_.cancel())
-
-    // Stop progress monitoring
-    progressMonitor.stopPeriodicLogging()
-
-    // Clear persisted SNAP progress — fast sync will start fresh
-    appStateStorage.putSnapSyncProgress("").commit()
-    appStateStorage.putSnapSyncAccountsComplete(false).commit()
-    appStateStorage.putSnapSyncStorageFilePath("").commit()
-    preservedRangeProgress = Map.empty
-    preservedAtPivotBlock = None
-
-    // Stop chain downloader
-    chainDownloader.foreach(context.stop)
-    chainDownloader = None
-
-    // Notify parent controller to switch to fast sync
-    context.parent ! FallbackToFastSync
-    context.become(completed)
+    false // never signal fallback
   }
 
   /** Evict non-SNAP outgoing peers when SNAP peer count is below threshold.
@@ -1662,7 +1686,7 @@ class SNAPSyncController(
             snapSyncController = self,
             resumeProgress = resumeProgress,
             initialMaxInFlightPerPeer =
-              5, // Full per-peer budget during AccountRangeSync (storage+bytecode deferred to 0)
+              1, // Besu-aligned D11: 1 request per peer, no pipelining
             trieFlushThreshold = snapSyncConfig.accountTrieFlushThreshold,
             initialResponseBytes = snapSyncConfig.accountInitialResponseBytes,
             minResponseBytes = snapSyncConfig.accountMinResponseBytes
@@ -1933,6 +1957,7 @@ class SNAPSyncController(
 
       val storage = getOrCreateMptStorage(pivotBlock.getOrElse(BigInt(0)))
 
+      coordinatorGeneration += 1
       trieNodeHealingCoordinator = Some(
         context.actorOf(
           actors.TrieNodeHealingCoordinator
@@ -1950,10 +1975,10 @@ class SNAPSyncController(
         )
       )
 
-      // Start the coordinator — give healing full per-peer budget (accounts/storage/bytecode done)
+      // Start the coordinator — Besu-aligned D11: 1 request per peer, no pipelining.
       trieNodeHealingCoordinator.foreach { coordinator =>
         coordinator ! actors.Messages.StartTrieNodeHealing(root)
-        coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(5)
+        coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(1)
       }
 
       // Periodically send peer availability notifications
@@ -1963,6 +1988,18 @@ class SNAPSyncController(
           1.second,
           self,
           RequestTrieNodeHealing
+        )(ec)
+      )
+
+      // Besu DynamicPivotBlockSelector: 60s periodic staleness check during healing.
+      // If pivot drifts >126 blocks behind chain tip, refresh pivot in-place.
+      pivotStalenessCheckTask.foreach(_.cancel())
+      pivotStalenessCheckTask = Some(
+        scheduler.scheduleWithFixedDelay(
+          PivotCheckInterval,
+          PivotCheckInterval,
+          self,
+          CheckPivotStaleness
         )(ec)
       )
 
@@ -2060,11 +2097,12 @@ class SNAPSyncController(
                   s"Root node missing after $validationRetryCount validation attempts. " +
                     s"Proceeding to regular sync — missing nodes will be fetched on-demand during block execution."
                 )
-                // Skip validation and proceed: mark SNAP done, start regular sync.
-                // With deferred merkleization, the root node was never built from flat data.
-                // Regular sync's StateNodeFetcher will retrieve it via GetTrieNodes when needed.
-                appStateStorage.snapSyncDone().commit()
-                context.parent ! Done
+                // Finalize SNAP sync properly so regular sync has a valid best block anchor.
+                // The bare snapSyncDone().commit() path was missing the pivot block body, chain
+                // weight, and BestBlockInfo hash — causing ConsensusAdapter.getBestBlock() to
+                // return None on every block import attempt. finalizeSnapSync() stores all of
+                // them atomically (H-013) before sending Done to SyncController.
+                finalizeSnapSync(pivot)
               } else {
                 log.error(s"Root node is missing (retry attempt $validationRetryCount of $MaxValidationRetries)")
                 log.info("Retrying validation after brief delay...")
@@ -2189,8 +2227,18 @@ class SNAPSyncController(
     val newRoot = newStateRoot.take(4).toHex
 
     if (stateRoot.contains(newStateRoot)) {
-      log.warning(s"Pivot refresh: new root $newRoot is same as old. Falling back to full restart.")
-      restartSnapSync(s"pivot refresh produced same root ($newRoot): $reason")
+      log.info(
+        s"Pivot refresh: new root $newRoot same as current — proceeding with healing " +
+          s"(Besu: switchToNewPivotBlock fires callback even when newPivotBlockFound=false)"
+      )
+      // Stop coordinator if running; restart from same (confirmed-current) stateRoot.
+      // DO NOT call restartSnapSync() — that destroys 5+ days of downloaded account data.
+      if (currentPhase == StateHealing) {
+        trieNodeHealingCoordinator.foreach(context.stop)
+        trieNodeHealingCoordinator = None
+        trieWalkInProgress = false
+        startStateHealing()
+      }
       return
     }
 
@@ -2215,13 +2263,15 @@ class SNAPSyncController(
     // Bytecodes are content-addressed (hash-keyed) so pivot changes don't invalidate them,
     // but the coordinator should clear stale peer tracking.
     bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePivotRefreshed)
-    // Healing coordinator: update root, clear pending tasks and stateless peers.
-    // Then re-walk the trie with the new root to discover missing nodes.
-    trieNodeHealingCoordinator.foreach { coordinator =>
-      coordinator ! actors.Messages.HealingPivotRefreshed(newStateRoot)
-      // Re-walk trie with new root to populate fresh healing tasks
-      trieWalkInProgress = false // Reset so startTrieWalk() can proceed
-      startTrieWalk()
+    // Besu alignment: reloadTrieHeal() clears ALL pending requests and restarts healing
+    // from scratch with the fresh stateRoot. In-place update (HealingPivotRefreshed) leaves
+    // stale in-flight requests against the old root outstanding — peers respond with
+    // empty/error because the old root is outside their 64-block serve window, locking up workers.
+    // Stop coordinator if running; Change 2 guard below restarts with fresh stateRoot.
+    if (currentPhase == StateHealing) {
+      trieNodeHealingCoordinator.foreach(context.stop)
+      trieNodeHealingCoordinator = None
+      trieWalkInProgress = false
     }
     // Chain download target extends to the new pivot (chain data is canonical, never invalidated)
     if (chainDownloader.isDefined) {
@@ -2239,60 +2289,29 @@ class SNAPSyncController(
     // This ensures that repeated stateless-peer pivot cycles don't prevent the
     // stagnation watchdog from eventually triggering a full restart.
     lastAccountProgressMs = System.currentTimeMillis()
+
+    // Besu alignment: after any pivot refresh during the healing phase, restart the healing
+    // coordinator with the fresh stateRoot if it is not already running. This covers:
+    //
+    //   (a) Pre-healing pivot switch (Gap 1): coordinator was never created because
+    //       checkAllDownloadsComplete() deferred startStateHealing() above.
+    //
+    //   (b) Post-pivot restart (Gap 2): coordinator was stopped, pivot refreshed,
+    //       healing must restart with the fresh stateRoot.
+    //
+    //   (c) This case no longer exists: coordinator is always hard-restarted (Besu D10 alignment)
+    //       via the stop at L2249-2253 above, so trieNodeHealingCoordinator is always None here.
+    if (currentPhase == StateHealing && trieNodeHealingCoordinator.isEmpty) {
+      log.info(
+        s"Restarting healing coordinator with fresh pivot=$newPivotBlock " +
+          s"stateRoot=$newRoot (Besu startTrieHeal → switchToNewPivotBlock alignment)"
+      )
+      startStateHealing()
+    }
   }
 
-  private def restartSnapSync(reason: String): Unit = {
-    log.warning(s"Restarting SNAP sync with a fresher pivot: $reason")
-
-    // Clear any pending pivot refresh (we're doing a full restart instead)
-    pendingPivotRefresh = None
-
-    // NOTE: do NOT reset consecutivePivotRefreshes here. restartSnapSync is often called
-    // from refreshPivotInPlace when no new pivot is available, which means the counter would
-    // reset on every failed cycle and never reach the threshold. The counter only resets on
-    // actual account download progress (ProgressAccountsSynced) or at startSnapSync().
-
-    // Cancel periodic phase request ticks
-    accountRangeRequestTask.foreach(_.cancel()); accountRangeRequestTask = None
-    bytecodeRequestTask.foreach(_.cancel()); bytecodeRequestTask = None
-    storageRangeRequestTask.foreach(_.cancel()); storageRangeRequestTask = None
-    accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
-    storageStagnationCheckTask.foreach(_.cancel()); storageStagnationCheckTask = None
-    healingRequestTask.foreach(_.cancel()); healingRequestTask = None
-    bootstrapCheckTask.foreach(_.cancel()); bootstrapCheckTask = None
-    pivotBootstrapRetryTask.foreach(_.cancel()); pivotBootstrapRetryTask = None
-    rateTrackerTuneTask.foreach(_.cancel()); rateTrackerTuneTask = None
-
-    // Stop coordinators so we don't double-run phases
-    accountRangeCoordinator.foreach(context.stop); accountRangeCoordinator = None
-    bytecodeCoordinator.foreach(context.stop); bytecodeCoordinator = None
-    storageRangeCoordinator.foreach(context.stop); storageRangeCoordinator = None
-    trieNodeHealingCoordinator.foreach(context.stop); trieNodeHealingCoordinator = None
-
-    // Clear inflight request timeouts and internal phase state
-    requestTracker.clear()
-
-    // Clear concurrent download state and recovery data
-    accountsComplete = false
-    bytecodePhaseComplete = false
-    storagePhaseComplete = false
-    appStateStorage.putSnapSyncAccountsComplete(false).commit()
-    appStateStorage.putSnapSyncStorageFilePath("").commit()
-
-    // Reset pivot/state root and storage so a new selection is committed
-    pivotBlock = None
-    stateRoot = None
-    mptStorage = None
-    currentPhase = Idle
-    coordinatorGeneration += 1
-
-    // Reset progress counters so logs/ETA reflect the new attempt
-    progressMonitor.reset()
-
-    // Re-run pivot selection/bootstrap with the latest visible peer set
-    context.become(idle)
-    startSnapSync()
-  }
+  // restartSnapSync() removed: Besu-aligned (D7). Besu never does a full restart from stagnation.
+  // All pivot updates use refreshPivotInPlace() instead.
 
   /** Trigger healing by re-running the trie walk with path tracking. Called from validateState() when missing nodes are
     * discovered. The passed hashes are just an indicator — we re-walk to get proper paths for GetTrieNodes.
@@ -2452,44 +2471,67 @@ class SNAPSyncController(
     refreshPivotInPlace(s"account stall: $context")
   }
 
+  /** After MaxHealingPivotRefreshes consecutive pivot refreshes all fail to serve the root node,
+    * attempt to finalize at the state-download pivot whose state IS in the MPT DB.
+    * This is the last-resort path when the ETC SNAP peer set cannot serve any recent pivot's root.
+    */
+  private def attemptHealingFallbackToStateDownloadPivot(): Unit =
+    stateDownloadPivot match {
+      case Some(savedPivot) =>
+        blockchainReader.getBlockHeaderByNumber(savedPivot) match {
+          case Some(header) =>
+            val readonlyMpt = stateStorage.getReadOnlyStorage
+            val rootExists =
+              try { readonlyMpt.get(header.stateRoot.toArray); true }
+              catch { case _: Exception => false }
+            if (rootExists) {
+              log.warning(
+                s"[HEAL-FALLBACK] Root unservable after $MaxHealingPivotRefreshes pivot refreshes. " +
+                  s"Falling back to state-download pivot $savedPivot " +
+                  s"(root ${header.stateRoot.take(4).toArray.map("%02x".format(_)).mkString} IS in DB). " +
+                  s"Regular sync will start from $savedPivot with valid state."
+              )
+              pivotBlock = Some(savedPivot)
+              finalizeSnapSync(savedPivot)
+            } else {
+              log.warning(
+                s"[HEAL-FALLBACK] State-download pivot $savedPivot root also missing. " +
+                  s"Resetting heal counter and retrying pivot refresh."
+              )
+              healingPivotRefreshes = 0
+              refreshPivotInPlace("heal fallback — state-download root missing, retrying")
+            }
+          case None =>
+            log.warning(
+              s"[HEAL-FALLBACK] State-download pivot $savedPivot header not found. " +
+                s"Resetting heal counter and retrying pivot refresh."
+            )
+            healingPivotRefreshes = 0
+            refreshPivotInPlace("heal fallback — state-download pivot header missing")
+        }
+      case None =>
+        log.warning("[HEAL-FALLBACK] No state-download pivot recorded. Resetting counter and retrying.")
+        healingPivotRefreshes = 0
+        refreshPivotInPlace("heal fallback — no saved pivot")
+    }
+
   private def completeSnapSync(): Unit =
     pivotBlock.foreach { pivot =>
-      if (snapSyncConfig.deferredMerkleization) {
-        // With deferred merkleization, don't wait for chain download to finish.
-        // Downloading 24M+ block headers/bodies/receipts from genesis takes days and
-        // blocks the node from syncing new blocks. Regular sync will handle chain data
-        // from the pivot forward. Historical chain data can be backfilled later.
-        log.info(
-          "Deferred merkleization enabled — skipping chain download wait. " +
-            "Finalizing SNAP sync immediately to start regular sync from pivot."
-        )
-        // Stop the chain downloader — regular sync handles blocks from pivot onward
-        chainDownloader.foreach(context.stop)
-        chainDownloader = None
-        finalizeSnapSync(pivot)
-      } else {
-        // If chain download is still running, boost its concurrency and wait
-        if (!chainDownloadComplete && chainDownloader.isDefined) {
-          log.info("SNAP state sync complete, boosting chain download concurrency and waiting for completion...")
-          chainDownloader.foreach(
-            _ ! ChainDownloader.BoostConcurrency(
-              snapSyncConfig.chainDownloadBoostedConcurrentRequests
-            )
-          )
-          currentPhase = ChainDownloadCompletion
-          progressMonitor.startPhase(ChainDownloadCompletion)
-          context.become(waitingForChainDownload)
-          return
-        }
-
-        finalizeSnapSync(pivot)
-      }
+      // Besu-aligned D2: pivot header was stored by updateBestBlockForPivot during bootstrap.
+      // finalizeSnapSync only requires getBlockHeaderByNumber(pivot) — available immediately.
+      // Do NOT wait for chain download to complete (genesis→pivot = ~22M blocks = days).
+      // Regular sync handles blocks from pivot forward. Chain downloader is stopped by
+      // finalizeSnapSync. This matches Besu's isBlockchainBehind() pattern: once the pivot
+      // header is available, the node is not "behind" and can proceed to regular sync.
+      log.info(
+        s"SNAP state sync complete. Finalizing SNAP sync at pivot $pivot " +
+          "(Besu-aligned D2: no chain download wait — pivot header available from bootstrap)."
+      )
+      finalizeSnapSync(pivot)
     }
 
   /** Final SNAP sync completion — called when both state sync and chain download are done. */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
-    appStateStorage.snapSyncDone().commit()
-
     // Look up the pivot header so we can store a complete "best block" anchor.
     // RegularSync's BranchResolution needs: header, body, number→hash mapping,
     // ChainWeight, and BestBlockInfo (hash + number) to accept blocks that chain
@@ -2497,31 +2539,22 @@ class SNAPSyncController(
     blockchainReader.getBlockHeaderByNumber(pivot) match {
       case Some(pivotHeader) =>
         val pivotHash = pivotHeader.hash
-
-        // Store the full block (header + empty body) so getBlockByHash(pivotHash) returns
-        // a Block AND the number→hash mapping is written. PivotHeaderBootstrap already stored
-        // the header, but storeBlock ensures the mapping is present even if the header was
-        // stored by a different code path during pivot refresh.
-        blockchainWriter.storeBlock(Block(pivotHeader, BlockBody.empty)).commit()
-
-        // Store a ChainWeight so compareBranch() can evaluate new blocks.
-        // We estimate totalDifficulty ≈ difficulty × blockNumber. This doesn't need
-        // to be exact — it just needs to exist so branch resolution doesn't error,
-        // and subsequent blocks will accumulate from this baseline.
         val estimatedTotalDifficulty = pivotHeader.difficulty * pivot
-        blockchainWriter
-          .storeChainWeight(
+
+        // H-013: Atomic finalization — commit SnapSyncDone marker together with
+        // pivot block, chain weight, and best block info in a single batch.
+        // If any of these are missing when SnapSyncDone=true, regular sync fails
+        // on startup (branch resolution finds no chain weight, no best block hash).
+        // go-ethereum writes pivot + state atomically; we do the same.
+        appStateStorage.snapSyncDone()
+          .and(blockchainWriter.storeBlock(Block(pivotHeader, BlockBody.empty)))
+          .and(blockchainWriter.storeChainWeight(
             pivotHash,
             ChainWeight.totalDifficultyOnly(estimatedTotalDifficulty)
-          )
-          .commit()
-
-        // Set best block info with BOTH hash and number (putBestBlockNumber only
-        // sets the number, leaving getBestBlockInfo().hash empty).
-        appStateStorage
-          .putBestBlockInfo(
+          ))
+          .and(appStateStorage.putBestBlockInfo(
             com.chipprbots.ethereum.domain.appstate.BlockInfo(pivotHash, pivot)
-          )
+          ))
           .commit()
 
         log.info(s"SNAP sync completed successfully at block $pivot (hash=${pivotHash.take(8).toHex})")
@@ -2529,7 +2562,9 @@ class SNAPSyncController(
       case None =>
         // Fallback: shouldn't happen since PivotHeaderBootstrap stored the header
         log.warning(s"Pivot header for block $pivot not found in storage — setting best block number only")
-        appStateStorage.putBestBlockNumber(pivot).commit()
+        appStateStorage.snapSyncDone()
+          .and(appStateStorage.putBestBlockNumber(pivot))
+          .commit()
     }
 
     // Stop chain downloader if still running
@@ -2543,7 +2578,13 @@ class SNAPSyncController(
     context.parent ! Done
   }
 
-  /** Waiting for parallel chain download to finish after SNAP state sync completed. */
+  /** Waiting for parallel chain download to finish after SNAP state sync completed.
+    *
+    * NOTE (Besu-aligned D2): completeSnapSync() no longer enters this state.
+    * finalizeSnapSync() is called immediately when SNAP state sync completes,
+    * without waiting for chain download. This state is retained for compatibility
+    * with any external callers but should never be entered in normal operation.
+    */
   def waitingForChainDownload: Receive = handlePeerListMessagesWithRateTracking.orElse {
     case ChainDownloader.Done =>
       log.info("Parallel chain download complete. Finalizing SNAP sync.")
@@ -2681,8 +2722,9 @@ object SNAPSyncController {
       codeHashes: Seq[ByteString],
       storageTasks: Seq[StorageTask]
   )
-  case object StateHealingComplete
+  case class StateHealingComplete(abandonedNodes: Int, totalHealed: Int)
   case object HealingAllPeersStateless
+  case class PersistHealingQueue(pending: Seq[(Seq[ByteString], ByteString)], force: Boolean = false)
   case object StateValidationComplete
   case object GetProgress
 
@@ -2746,29 +2788,27 @@ case class SNAPSyncConfig(
     maxPivotStalenessBlocks: Long = 4096,
     accountConcurrency: Int = 16,
     storageConcurrency: Int = 16,
-    storageBatchSize: Int = 128,
+    storageBatchSize: Int = 384,
     storageInitialResponseBytes: Int = 1048576,
     storageMinResponseBytes: Int = 131072,
-    healingBatchSize: Int = 16,
+    healingBatchSize: Int = 384,
     healingConcurrency: Int = 16,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,
-    timeout: FiniteDuration = 30.seconds,
-    maxSnapSyncFailures: Int = 5, // Max failures before fallback to fast sync
-    // Grace period after bootstrap to wait for snap/1-capable peers before falling back.
-    // If no connected peer advertises snap/1 within this window, fall back to fast sync.
+    timeout: FiniteDuration = 10.seconds,
+    // Grace period after bootstrap to wait for snap/1-capable peers before rescheduling.
+    // Besu-aligned: no fallback to fast sync — reschedule indefinitely until snap peers appear.
     snapCapabilityGracePeriod: FiniteDuration = 30.seconds,
     // Account stagnation timeout: if no account range tasks complete within this window,
-    // record a critical failure (may trigger fallback). Reduced from 15 minutes to catch
-    // non-snap peers faster.
+    // Besu-aligned: stall triggers in-place pivot refresh only, never fallback.
     accountStagnationTimeout: FiniteDuration = 10.minutes,
-    maxInFlightPerPeer: Int = 5,
+    maxInFlightPerPeer: Int = 1, // Besu-aligned D11: 1 request per peer, no pipelining
     accountTrieFlushThreshold: Int = 50000,
     accountInitialResponseBytes: Int = 524288,
     accountMinResponseBytes: Int = 102400,
     chainDownloadEnabled: Boolean = true,
     chainDownloadMaxConcurrentRequests: Int = 2,
-    chainDownloadBoostedConcurrentRequests: Int = 16,
+    // Besu-aligned D14: no boosted concurrency mode. Single concurrency throughout.
     chainDownloadTimeout: FiniteDuration = 10.seconds,
     minSnapPeers: Int = 3,
     snapPeerEvictionInterval: FiniteDuration = 15.seconds,
@@ -2810,10 +2850,6 @@ object SNAPSyncConfig {
       stateValidationEnabled = snapConfig.getBoolean("state-validation-enabled"),
       maxRetries = snapConfig.getInt("max-retries"),
       timeout = snapConfig.getDuration("timeout").toMillis.millis,
-      maxSnapSyncFailures =
-        if (snapConfig.hasPath("max-snap-sync-failures"))
-          snapConfig.getInt("max-snap-sync-failures")
-        else 5,
       snapCapabilityGracePeriod =
         if (snapConfig.hasPath("snap-capability-grace-period"))
           snapConfig.getDuration("snap-capability-grace-period").toMillis.millis
@@ -2846,10 +2882,7 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("chain-download-max-concurrent-requests"))
           snapConfig.getInt("chain-download-max-concurrent-requests")
         else 2,
-      chainDownloadBoostedConcurrentRequests =
-        if (snapConfig.hasPath("chain-download-boosted-concurrent-requests"))
-          snapConfig.getInt("chain-download-boosted-concurrent-requests")
-        else 16,
+      // Besu-aligned D14: chainDownloadBoostedConcurrentRequests removed.
       chainDownloadTimeout =
         if (snapConfig.hasPath("chain-download-timeout"))
           snapConfig.getDuration("chain-download-timeout").toMillis.millis

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -633,17 +633,37 @@ class SNAPSyncController(
       } else {
         consecutiveUnproductiveHealingRounds += 1
         if (consecutiveUnproductiveHealingRounds >= maxUnproductiveHealingRounds) {
-          log.warning(
-            s"Healing stagnation: ${missingNodes.size} missing nodes persist after " +
-              s"$consecutiveUnproductiveHealingRounds consecutive rounds with no progress. " +
-              s"Proceeding to validation — regular sync will recover missing nodes on-demand."
-          )
-          consecutiveUnproductiveHealingRounds = 0
-          pivotStalenessCheckTask.foreach(_.cancel())
-          pivotStalenessCheckTask = None
-          progressMonitor.startPhase(StateValidation)
-          currentPhase = StateValidation
-          validateState()
+          // Besu alignment: markAsStalled() is a no-op for healing — Besu never proceeds to
+          // finalization while nodes are still missing. We mirror this for the state root:
+          // if the root is among the missing nodes, it cannot be recovered by regular sync
+          // on-demand (unlike interior nodes). Force a pivot refresh instead of finalizing.
+          val rootMissing = stateRoot.exists(root => missingNodes.exists { case (_, hash) => hash == root })
+          if (rootMissing) {
+            log.warning(
+              s"[HEAL-STAGNATION] State root is among ${missingNodes.size} unhealed nodes after " +
+                s"$consecutiveUnproductiveHealingRounds rounds — cannot proceed to finalization. " +
+                s"Triggering pivot refresh (Besu: markAsStalled no-op → reloadTrieHeal on new pivot)."
+            )
+            consecutiveUnproductiveHealingRounds = 0
+            healingPivotRefreshes += 1
+            if (healingPivotRefreshes >= MaxHealingPivotRefreshes) {
+              attemptHealingFallbackToStateDownloadPivot()
+            } else {
+              refreshPivotInPlace(s"healing-stagnation-root-missing ($healingPivotRefreshes/$MaxHealingPivotRefreshes)")
+            }
+          } else {
+            log.warning(
+              s"Healing stagnation: ${missingNodes.size} non-root missing nodes persist after " +
+                s"$consecutiveUnproductiveHealingRounds consecutive rounds with no progress. " +
+                s"Proceeding to validation — regular sync will recover missing nodes on-demand."
+            )
+            consecutiveUnproductiveHealingRounds = 0
+            pivotStalenessCheckTask.foreach(_.cancel())
+            pivotStalenessCheckTask = None
+            progressMonitor.startPhase(StateValidation)
+            currentPhase = StateValidation
+            validateState()
+          }
         } else {
           log.info(
             s"Trie walk found ${missingNodes.size} missing nodes — queuing for healing " +
@@ -2237,6 +2257,7 @@ class SNAPSyncController(
         trieNodeHealingCoordinator.foreach(context.stop)
         trieNodeHealingCoordinator = None
         trieWalkInProgress = false
+        consecutiveUnproductiveHealingRounds = 0
         startStateHealing()
       }
       return
@@ -2272,6 +2293,7 @@ class SNAPSyncController(
       trieNodeHealingCoordinator.foreach(context.stop)
       trieNodeHealingCoordinator = None
       trieWalkInProgress = false
+      consecutiveUnproductiveHealingRounds = 0 // New pivot = new root, reset stagnation counter
     }
     // Chain download target extends to the new pivot (chain data is canonical, never invalidated)
     if (chainDownloader.isDefined) {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -446,6 +446,23 @@ class AccountRangeCoordinator(
         dispatchIfPossible(peer)
       }
 
+    case PeerUnavailable(peerId) =>
+      // Remove the peer and reset its consecutive-timeout counter so that network-level
+      // disconnects don't accumulate toward the stateless threshold (Bug-W8).
+      knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
+      peerConsecutiveTimeouts.remove(peerId)
+      peerCooldownUntilMs.remove(peerId)
+
+      // Immediately cancel any in-flight request to this peer so the worker returns to idle
+      // without waiting 30 seconds for the timeout to fire.
+      val inFlight = activeTasks.collect {
+        case (reqId, (_, worker, peer)) if peer.id.value == peerId => (reqId, worker)
+      }.toSeq
+      inFlight.foreach { case (reqId, worker) =>
+        worker ! WorkerPeerDisconnected(peerId)
+        log.debug(s"Sent WorkerPeerDisconnected for reqId=$reqId to worker ${worker.path.name} (peer $peerId disconnected)")
+      }
+
     case UpdateMaxInFlightPerPeer(newLimit) =>
       log.info(s"AccountRange per-peer budget: $maxInFlightPerPeer -> $newLimit")
       maxInFlightPerPeer = newLimit
@@ -774,9 +791,9 @@ class AccountRangeCoordinator(
       task.rootHash = stateRoot
       pendingTasks.enqueue(task)
 
-      // Apply cooldown and reduce byte budget for failing peers (unless stateless-marked,
-      // which already blocks them from dispatch)
-      if (!reason.contains("Missing proof for empty account range")) {
+      // Apply cooldown for protocol failures; skip for network-level disconnects since the peer
+      // is already gone and will reconnect fresh (no point cooling down a gone peer).
+      if (!reason.contains("Missing proof for empty account range") && !reason.contains("Peer disconnected")) {
         recordPeerCooldown(peer, reason)
         adjustResponseBytesOnFailure(peer, reason)
       }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -288,7 +288,7 @@ class AccountRangeCoordinator(
 
   // Peer cooldown (best-effort): used for transient errors (timeouts, verification failures).
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
-  private val peerCooldownDefault = 30.seconds
+  private val peerCooldownDefault = 10.seconds // 30s was inconsistent with Healing (10s) and Storage (10s)
 
   private def isPeerCoolingDown(peer: Peer): Boolean =
     peerCooldownUntilMs.get(peer.id.value).exists(_ > System.currentTimeMillis())

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -143,6 +143,16 @@ class AccountRangeWorker(
           log.debug(s"Timeout for old or unknown request $reqId")
       }
 
+    case WorkerPeerDisconnected(peerId) =>
+      currentTask match {
+        case Some((task, peer, reqId)) if peer.id.value == peerId =>
+          log.info(s"Peer $peerId disconnected during request $reqId — re-queuing task immediately")
+          coordinator ! TaskFailed(reqId, "Peer disconnected")
+          currentTask = None
+          context.become(idle)
+        case _ => // Task is using a different peer; ignore
+      }
+
     case FetchAccountRange(task, peer, _, _) =>
       log.warning("Worker is busy, cannot accept new task")
       coordinator ! TaskFailed(0, "Worker busy")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -68,6 +68,13 @@ object Messages {
       isTaskRangeComplete: Boolean
   ) extends AccountRangeCoordinatorMessage
 
+  /** Sent by SNAPSyncController when a peer disconnects. Coordinator immediately cancels in-flight
+    * requests for that peer and re-queues tasks, rather than waiting 30s for the worker timeout.
+    * Also resets the consecutive-timeout counter so a transient disconnect doesn't count toward
+    * the stateless threshold.
+    */
+  case class PeerUnavailable(peerId: String) extends AccountRangeCoordinatorMessage
+
   sealed trait AccountRangeWorkerMessage
   case class FetchAccountRange(
       task: AccountTask,
@@ -77,6 +84,10 @@ object Messages {
   ) extends AccountRangeWorkerMessage
   case class AccountRangeResponseMsg(response: AccountRange) extends AccountRangeWorkerMessage
   case class RequestTimeout(requestId: BigInt) extends AccountRangeWorkerMessage
+  /** Sent by AccountRangeCoordinator when the peer assigned to this worker disconnects.
+    * Worker immediately fails the in-flight request without waiting for the 30s timeout.
+    */
+  case class WorkerPeerDisconnected(peerId: String) extends AccountRangeWorkerMessage
 
   // ========================================
   // ByteCode Messages

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -101,11 +101,14 @@ class TrieNodeHealingCoordinator(
   // Dedup set for pending tasks — prevents the same missing node from being queued multiple times
   private val pendingHashSet = mutable.Set[ByteString]()
 
-  // Stateless peer tracking (geth-aligned: peers that return empty TrieNodes for current root)
+  // Session-level stateless tracking. Cleared on HealingPeerAvailable eviction (~1s).
+  // Controls immediate dispatch eligibility; real cooldown is peerCooldownUntilMs (10s).
   private val statelessPeers = mutable.Set[String]()
-  // Persistent stateless tracking by remote address — survives peer reconnect with new session ID.
-  // Non-static peers that return empty GetTrieNodes are blocked even after reconnection.
-  private val statelessRemoteAddresses = mutable.Set[String]()
+  // Persistent root-failure tracking — survives HealingPeerAvailable ticks, cleared only on
+  // pivot refresh. Tracks which peer IDs have exhausted their retries on the root node specifically.
+  // When all known peers have failed on root, HealingAllPeersStateless fires (pivot refresh).
+  // Mirrors Besu's WORLD_STATE_ROOT_NOT_AVAILABLE signal from TrieNodeHealingStep.
+  private val peersFailedOnRoot = mutable.Set[String]()
   private var pivotRefreshRequested: Boolean = false
   // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
   // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
@@ -238,21 +241,14 @@ class TrieNodeHealingCoordinator(
       self ! HealingCheckCompletion
 
     case HealingPeerAvailable(peer) =>
-      // Skip if this remote address has been marked stateless — blocks reconnected dead peers
-      if (statelessRemoteAddresses.contains(peer.remoteAddress.toString)) {
-        log.debug(
-          s"[HEALING] Skipping ${peer.remoteAddress} — address known stateless (prior GetTrieNodes failure)"
-        )
-      } else {
-        // Evict stale entry for same physical node (reconnection creates new PeerId).
-        // Also clean up stale session-ID entries from statelessPeers and cooldown map.
-        val evicted = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
-        statelessPeers --= evicted.map(_.id.value)
-        peerCooldownUntilMs --= evicted.map(_.id.value)
-        knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
-        knownAvailablePeers += peer
-        dispatchIfPossible(peer)
-      }
+      // Besu-aligned: no persistent IP-level blocking. Evict stale entry for same physical
+      // node (reconnection creates new PeerId) and re-admit unconditionally.
+      val evicted = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
+      statelessPeers --= evicted.map(_.id.value)
+      peerCooldownUntilMs --= evicted.map(_.id.value)
+      knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
+      knownAvailablePeers += peer
+      dispatchIfPossible(peer)
 
     case UpdateMaxInFlightPerPeer(newLimit) =>
       if (newLimit != maxInFlightPerPeer) {
@@ -286,7 +282,7 @@ class TrieNodeHealingCoordinator(
       pendingTasks.clear()
       pendingHashSet.clear()
       statelessPeers.clear()
-      statelessRemoteAddresses.clear() // new root — peers that failed old root may serve new one
+      peersFailedOnRoot.clear() // new root — all peers get a fresh chance on the new root
       peerCooldownUntilMs.clear()
       // Besu-aligned D12: no peerResponseBytesTarget to clear.
       // Cancel active requests (they're for the old root)
@@ -610,44 +606,32 @@ class TrieNodeHealingCoordinator(
     val elapsedMs = System.currentTimeMillis() - activeReq.sentAtMs
     updateHealThrottle(healedCount, elapsedMs)
 
-    // Stateless tracking (Besu-aligned D12: no adaptive byte budget, fixed request size)
+    // Besu-aligned peer tracking: no persistent IP-level blocking.
+    // Successful response clears session-stateless marking. Empty response:
+    //   - 10s cooldown (recordPeerCooldown)
+    //   - session-level statelessPeers entry (cleared on next HealingPeerAvailable eviction)
+    //   - if root was in the batch: peersFailedOnRoot (persistent, mirrors WORLD_STATE_ROOT_NOT_AVAILABLE)
+    //   - pivot refresh when all known peers have failed on root (peersFailedOnRoot saturates)
     if (healedCount > 0) {
-      // Successful response — clear stateless marking
       statelessPeers -= peer.id.value
     } else {
       recordPeerCooldown(peer, "empty healing response")
-      // Besu-aligned: only mark statelessRemoteAddresses (persist across reconnects) when the
-      // state root itself was in the failed batch. Interior node failures just get a cooldown —
-      // permanently blocking a peer for non-root empty responses starves the healing queue when
-      // the ETC peer set is sparse (Attempt 29: active=0, pending=3376 after 3 peers returned
-      // empty on non-root batches and were locked out by the HealingPeerAvailable guard).
-      if (!peer.isStatic) {
-        val rootInBatch = tasksForRequest.exists(_.hash == stateRoot)
-        statelessPeers += peer.id.value // session-level: evicted on reconnect via HealingPeerAvailable
-        if (rootInBatch) {
-          // Root node not served — persist across reconnects (matches handleTimeout behavior)
-          statelessRemoteAddresses += peer.remoteAddress.toString
-          log.info(
-            s"Peer ${peer.id.value}@${peer.remoteAddress} marked stateless for healing root " +
-              s"${Hex.toHexString(stateRoot.take(4).toArray)} (root in empty batch, ${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
-          )
-        } else {
-          log.debug(
-            s"Peer ${peer.id.value} returned empty for non-root batch — cooldown only, not permanently stateless"
-          )
-        }
-        // Request pivot refresh when all known peers are stateless (session-level).
-        // Non-root failures count too: if every peer returns empty on everything, a new pivot is warranted.
-        if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
-          pivotRefreshRequested = true
-          log.warning(
-            s"All ${statelessPeers.size} peers stateless for healing root " +
-              s"${Hex.toHexString(stateRoot.take(4).toArray)}. Requesting pivot refresh."
-          )
-          snapSyncController ! SNAPSyncController.HealingAllPeersStateless
-        }
-      } else {
-        log.debug(s"[STATIC] Skipping stateless marking for static peer ${peer.remoteAddress} (healing)")
+      statelessPeers += peer.id.value
+      val rootInBatch = tasksForRequest.exists(_.hash == stateRoot)
+      if (rootInBatch) peersFailedOnRoot += peer.id.value
+      log.debug(
+        s"Peer ${peer.id.value} returned empty batch (${nodes.size} requested, rootInBatch=$rootInBatch) — " +
+          s"cooldown + session-stateless (${statelessPeers.size}/${knownAvailablePeers.size})"
+      )
+      // Pivot refresh: fire when all known peers have failed on root specifically.
+      // Using peersFailedOnRoot (persistent) rather than statelessPeers (ephemeral) for reliability.
+      if (peersFailedOnRoot.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
+        pivotRefreshRequested = true
+        log.warning(
+          s"All ${peersFailedOnRoot.size} peers failed on root " +
+            s"${Hex.toHexString(stateRoot.take(4).toArray)} — requesting pivot refresh."
+        )
+        snapSyncController ! SNAPSyncController.HealingAllPeersStateless
       }
     }
 
@@ -699,22 +683,21 @@ class TrieNodeHealingCoordinator(
           pendingTasks += resetEntry
           pendingHashSet += resetEntry.hash
           requeued += 1
-          // A timeout is transient — mark the peer session-stateless (cleared on reconnect) but do NOT
-          // add to statelessRemoteAddresses. That set permanently blocks the IP from HealingPeerAvailable
-          // even after reconnect, preventing the peer from serving interior nodes. A peer that times out
-          // on the root can still serve interior nodes — Besu never permanently excludes by IP for timeouts.
-          // statelessRemoteAddresses is reserved for peers that explicitly return EMPTY for a root-containing
-          // batch (handleResponse path), indicating they definitively lack the root.
+          // Timeout is transient — session-level block + cooldown only (Besu: no IP-level ban).
+          // Also track this peer in peersFailedOnRoot (persistent across HealingPeerAvailable ticks,
+          // cleared only on pivot refresh). When ALL known peers have failed on root, trigger pivot
+          // refresh — mirrors Besu's WORLD_STATE_ROOT_NOT_AVAILABLE signal from TrieNodeHealingStep.
           if (!peer.isStatic) {
             statelessPeers += peer.id.value
+            peersFailedOnRoot += peer.id.value
             log.info(
-              s"[HEAL-ROOT-RETRY] Peer ${peer.id.value} session-stateless for root after $maxRetriesPerTask timeouts " +
-                s"(${statelessPeers.size}/${knownAvailablePeers.size} stateless) — IP not permanently blocked (timeout is transient)"
+              s"[HEAL-ROOT-RETRY] Peer ${peer.id.value} exhausted $maxRetriesPerTask timeouts on root " +
+                s"(${peersFailedOnRoot.size}/${knownAvailablePeers.size} peers failed on root)"
             )
-            if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
+            if (peersFailedOnRoot.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
               pivotRefreshRequested = true
               log.warning(
-                s"[HEAL-ROOT-RETRY] All ${statelessPeers.size} peers exhausted on root " +
+                s"[HEAL-ROOT-RETRY] All ${peersFailedOnRoot.size} peers exhausted on root " +
                   s"${Hex.toHexString(stateRoot.take(4).toArray)} — requesting pivot refresh."
               )
               snapSyncController ! SNAPSyncController.HealingAllPeersStateless
@@ -751,7 +734,6 @@ class TrieNodeHealingCoordinator(
     val eligiblePeers = knownAvailablePeers.toList
       .filterNot(isPeerCoolingDown)
       .filterNot(p => statelessPeers.contains(p.id.value))
-      .filterNot(p => statelessRemoteAddresses.contains(p.remoteAddress.toString))
     if (eligiblePeers.isEmpty) {
       log.debug(
         s"[REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -146,6 +146,10 @@ class TrieNodeHealingCoordinator(
   // D4 root-retry: cumulative count of times the state root node has exhausted per-peer retries.
   // The state root cannot be recovered by regular sync on-demand — never permanently abandon it.
   private var rootFetchFailures: Int = 0
+  // Stagnation escalation: consecutive HealingStagnationCheck ticks where pendingTasks.nonEmpty
+  // but activeRequests.isEmpty. After 5 ticks (10 minutes), force-complete healing to avoid
+  // indefinite stall when all SNAP peers disconnect and no new ones connect.
+  private var consecutiveIdleChecks: Int = 0
 
   // Peer cooldown
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
@@ -420,8 +424,6 @@ class TrieNodeHealingCoordinator(
       sender() ! stats
 
     case HealingStagnationCheck =>
-      // Besu-aligned: no stagnation escalation. Pure diagnostic pulse logging.
-      // Besu has zero stagnation watchdogs — SnapWorldDownloadState.markAsStalled() is a TODO no-op.
       val recentHealed = totalNodesHealed - lastPulseHealedCount
       log.info(
         s"[HEAL-PULSE] healed=$totalNodesHealed total, +$recentHealed last 2min | " +
@@ -429,6 +431,24 @@ class TrieNodeHealingCoordinator(
         s"pivotRefreshPending=$pivotRefreshRequested"
       )
       lastPulseHealedCount = totalNodesHealed
+
+      // Escalation: if work is pending but zero requests are active, all SNAP peers may have
+      // disconnected. Besu's markAsStalled() is a TODO no-op, but Besu still counts non-progressing
+      // requests toward a 1000-request threshold. Fukuii has no request count here, so we use
+      // consecutive idle ticks (each 2 minutes) as a proxy.
+      if (pendingTasks.nonEmpty && activeRequests.isEmpty && !pivotRefreshRequested) {
+        consecutiveIdleChecks += 1
+        if (consecutiveIdleChecks >= 5) {
+          log.warning(
+            s"[HEAL] No active requests for ${consecutiveIdleChecks * 2} minutes with " +
+              s"${pendingTasks.size} pending tasks and ${knownAvailablePeers.size} known peers. " +
+              s"Forcing healing completion — missing nodes deferred to import-time recovery."
+          )
+          self ! HealingForceComplete
+        }
+      } else {
+        consecutiveIdleChecks = 0
+      }
   }
 
   private def queueNodes(pathsAndHashes: Seq[(Seq[ByteString], ByteString)]): Unit = {
@@ -646,6 +666,7 @@ class TrieNodeHealingCoordinator(
           }
         } else {
           pendingTasks += updated
+          pendingHashSet += updated.hash
         }
       }
     }
@@ -654,6 +675,7 @@ class TrieNodeHealingCoordinator(
     val unmatchedTasks = tasksForRequest.drop(nodes.size)
     unmatchedTasks.foreach { task =>
       pendingTasks += task
+      pendingHashSet += task.hash
     }
 
     completedTaskCount += healedCount
@@ -792,6 +814,7 @@ class TrieNodeHealingCoordinator(
         }
       } else {
         pendingTasks += updated
+        pendingHashSet += updated.hash
         requeued += 1
       }
     }
@@ -950,6 +973,13 @@ class TrieNodeHealingCoordinator(
                   s"[HEAL-LEAF] Seeded storage trie root ${Hex.toHexString(account.storageRoot.take(4).toArray)} " +
                   s"for account ${Hex.toHexString(accountHashBytes.take(4))}"
                 )
+              } else {
+                log.warning(
+                  s"[HEAL-LEAF] Unexpected nibble path length ${allNibbles.length} at account leaf (expected 64) — " +
+                    s"storage root ${Hex.toHexString(account.storageRoot.take(4).toArray)} not seeded. " +
+                    s"Full trie walk will be required."
+                )
+                abandonedTaskCount += 1
               }
             }
           }
@@ -969,8 +999,10 @@ class TrieNodeHealingCoordinator(
       }
     } catch {
       case NonFatal(e) =>
-        log.debug(s"[HEAL] Cannot decode healed node for child discovery: ${e.getMessage}. Skipping incremental discovery — full trie walk will find these nodes.")
-        // Non-fatal — healing still works via final validation walk as safety net
+        log.warning(
+          s"[HEAL] Cannot decode healed node ${Hex.toHexString(parentEntry.hash.take(4).toArray)} for child discovery: ${e.getMessage}. " +
+            s"Subtree excluded from inline discovery — full trie walk required for these nodes."
+        )
     }
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -125,7 +125,7 @@ class TrieNodeHealingCoordinator(
 
   // Peer cooldown
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
-  private val peerCooldownDefault = 30.seconds
+  private val peerCooldownDefault = 10.seconds // 30s was too aggressive for ETC's sparse peer set
 
   private def isPeerCoolingDown(peer: Peer): Boolean =
     peerCooldownUntilMs.get(peer.id.value).exists(_ > System.currentTimeMillis())
@@ -616,15 +616,28 @@ class TrieNodeHealingCoordinator(
       statelessPeers -= peer.id.value
     } else {
       recordPeerCooldown(peer, "empty healing response")
-      // Mark peer stateless for current root (geth-aligned) — skip for static peers
+      // Besu-aligned: only mark statelessRemoteAddresses (persist across reconnects) when the
+      // state root itself was in the failed batch. Interior node failures just get a cooldown —
+      // permanently blocking a peer for non-root empty responses starves the healing queue when
+      // the ETC peer set is sparse (Attempt 29: active=0, pending=3376 after 3 peers returned
+      // empty on non-root batches and were locked out by the HealingPeerAvailable guard).
       if (!peer.isStatic) {
-        statelessPeers += peer.id.value
-        statelessRemoteAddresses += peer.remoteAddress.toString // persist across reconnects
-        log.info(
-          s"Peer ${peer.id.value}@${peer.remoteAddress} marked stateless for healing root " +
-            s"${Hex.toHexString(stateRoot.take(4).toArray)} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
-        )
-        // Check if all known peers are stateless — request pivot refresh
+        val rootInBatch = tasksForRequest.exists(_.hash == stateRoot)
+        statelessPeers += peer.id.value // session-level: evicted on reconnect via HealingPeerAvailable
+        if (rootInBatch) {
+          // Root node not served — persist across reconnects (matches handleTimeout behavior)
+          statelessRemoteAddresses += peer.remoteAddress.toString
+          log.info(
+            s"Peer ${peer.id.value}@${peer.remoteAddress} marked stateless for healing root " +
+              s"${Hex.toHexString(stateRoot.take(4).toArray)} (root in empty batch, ${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
+          )
+        } else {
+          log.debug(
+            s"Peer ${peer.id.value} returned empty for non-root batch — cooldown only, not permanently stateless"
+          )
+        }
+        // Request pivot refresh when all known peers are stateless (session-level).
+        // Non-root failures count too: if every peer returns empty on everything, a new pivot is warranted.
         if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
           pivotRefreshRequested = true
           log.warning(

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -13,7 +13,9 @@ import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController
 import com.chipprbots.ethereum.db.storage.MptStorage
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
+import com.chipprbots.ethereum.network.PeerActor
 import com.chipprbots.ethereum.network.p2p.messages.SNAP.{GetTrieNodes, TrieNodes}
+import com.chipprbots.ethereum.network.p2p.messages.WireProtocol.Disconnect
 
 /** TrieNodeHealingCoordinator manages the healing phase of SNAP sync.
   *
@@ -116,6 +118,13 @@ class TrieNodeHealingCoordinator(
   // switch, so field starts fresh automatically; explicit clear in HealingPivotRefreshed
   // for safety).
   private val triedPeersForTask = mutable.HashMap.empty[ByteString, mutable.Set[String]]
+  // Besu-aligned PeerReputation: consecutive GetTrieNodes timeout counter per peer.
+  // After SnapTimeoutDisconnectThreshold consecutive timeouts, disconnect the peer.
+  // Mirrors Besu PeerReputation.recordRequestTimeout() with TIMEOUT_THRESHOLD=5.
+  // Resets to 0 on any successful GetTrieNodes response (Besu: recordUsefulResponse).
+  // Cleared on pivot refresh. Static peers (configured SNAP servers) are exempt.
+  private val consecutiveGetTrieNodeTimeouts = mutable.HashMap.empty[String, Int]
+  private val SnapTimeoutDisconnectThreshold = 5
   private var pivotRefreshRequested: Boolean = false
   // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
   // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
@@ -292,6 +301,7 @@ class TrieNodeHealingCoordinator(
       peersFailedOnRoot.clear() // new root — all peers get a fresh chance on the new root
       peerCooldownUntilMs.clear()
       triedPeersForTask.clear() // new root — all peers get fresh chance per task
+      consecutiveGetTrieNodeTimeouts.clear() // new root — reset all peer reputation counts
       // Besu-aligned D12: no peerResponseBytesTarget to clear.
       // Cancel active requests (they're for the old root)
       activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
@@ -653,6 +663,8 @@ class TrieNodeHealingCoordinator(
     //   - pivot refresh when all known peers have failed on root (peersFailedOnRoot saturates)
     if (healedCount > 0) {
       statelessPeers -= peer.id.value
+      // Besu PeerReputation.recordUsefulResponse(): reset consecutive timeout counter on success.
+      consecutiveGetTrieNodeTimeouts.remove(peer.id.value)
     } else {
       recordPeerCooldown(peer, "empty healing response")
       statelessPeers += peer.id.value
@@ -699,6 +711,24 @@ class TrieNodeHealingCoordinator(
 
     activeRequests.remove(requestId)
     recordPeerCooldown(peer, "request timeout")
+    // Besu PeerReputation: accumulate consecutive timeout count; disconnect on threshold.
+    // Mirrors PeerReputation.recordRequestTimeout() with TIMEOUT_THRESHOLD=5.
+    // PulseChain/ETH-mainnet nodes time out on every GetTrieNodes — evict them promptly.
+    if (!peer.isStatic) {
+      val peerId = peer.id.value
+      val newCount = consecutiveGetTrieNodeTimeouts.getOrElse(peerId, 0) + 1
+      consecutiveGetTrieNodeTimeouts(peerId) = newCount
+      if (newCount >= SnapTimeoutDisconnectThreshold) {
+        log.warning(
+          s"[HEAL-REPUTATION] Peer $peerId accumulated $newCount consecutive GetTrieNodes timeouts " +
+            s"— disconnecting (Besu PeerReputation.TIMEOUT_THRESHOLD=$SnapTimeoutDisconnectThreshold)"
+        )
+        consecutiveGetTrieNodeTimeouts.remove(peerId)
+        knownAvailablePeers.retain(_.id.value != peerId)
+        peersFailedOnRoot -= peerId
+        peer.ref ! PeerActor.DisconnectPeer(Disconnect.Reasons.UselessPeer)
+      }
+    }
     // Besu-aligned D12: no adaptive byte budget ratcheting on timeout.
 
     // Increment retry count and skip exhausted tasks

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -243,6 +243,10 @@ class TrieNodeHealingCoordinator(
         s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} seeded with empty path — " +
         s"inline child discovery will populate the work queue top-down (Besu-aligned)"
       )
+      // If root was already in storage (queueNodes skipped it), pendingTasks=0 and
+      // activeRequests=0 immediately. Without this, HealingCheckCompletion is never sent
+      // and the coordinator waits indefinitely for a response that never comes.
+      self ! HealingCheckCompletion
 
     case QueueMissingNodes(nodes) =>
       log.info(s"[HEAL-RESUME] Received ${nodes.size} persisted missing nodes from prior session")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -125,6 +125,11 @@ class TrieNodeHealingCoordinator(
   // Cleared on pivot refresh. Static peers (configured SNAP servers) are exempt.
   private val consecutiveGetTrieNodeTimeouts = mutable.HashMap.empty[String, Int]
   private val SnapTimeoutDisconnectThreshold = 5
+  // Global consecutive-timeout give-up: if ALL dispatched requests keep timing out with no
+  // successful responses, the coordinator is making zero progress (ETC SNAP peers not serving
+  // old pivot state). After this many consecutive timeouts across all peers, force-complete.
+  private var globalConsecutiveTimeouts: Int = 0
+  private val MaxGlobalConsecutiveTimeouts: Int = 20
   private var pivotRefreshRequested: Boolean = false
   // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
   // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
@@ -669,6 +674,7 @@ class TrieNodeHealingCoordinator(
       statelessPeers -= peer.id.value
       // Besu PeerReputation.recordUsefulResponse(): reset consecutive timeout counter on success.
       consecutiveGetTrieNodeTimeouts.remove(peer.id.value)
+      globalConsecutiveTimeouts = 0
     } else {
       recordPeerCooldown(peer, "empty healing response")
       statelessPeers += peer.id.value
@@ -793,6 +799,17 @@ class TrieNodeHealingCoordinator(
     if (requeued > 0) {
       log.info(s"Re-queued $requeued timed-out healing tasks (pending: ${pendingTasks.size})" +
         (if (abandoned > 0) s", abandoned $abandoned" else ""))
+    }
+
+    globalConsecutiveTimeouts += 1
+    if (globalConsecutiveTimeouts >= MaxGlobalConsecutiveTimeouts) {
+      log.warning(
+        s"Force-completing healing coordinator after $globalConsecutiveTimeouts consecutive timeouts " +
+          s"(${pendingTasks.size} pending, $totalNodesHealed healed) — " +
+          s"ETC SNAP peers not serving pivot state. Missing nodes deferred to import-time recovery."
+      )
+      self ! HealingForceComplete
+      return
     }
 
     // Besu-aligned: no mass-abandonment on timeout. Per-task retry via maxRetriesPerTask=4 only.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -699,14 +699,17 @@ class TrieNodeHealingCoordinator(
           pendingTasks += resetEntry
           pendingHashSet += resetEntry.hash
           requeued += 1
-          // Treat a timeout-exhausted peer the same as an empty-response peer for the root node.
-          // This ensures HealingAllPeersStateless fires when all peers fail on the root.
+          // A timeout is transient — mark the peer session-stateless (cleared on reconnect) but do NOT
+          // add to statelessRemoteAddresses. That set permanently blocks the IP from HealingPeerAvailable
+          // even after reconnect, preventing the peer from serving interior nodes. A peer that times out
+          // on the root can still serve interior nodes — Besu never permanently excludes by IP for timeouts.
+          // statelessRemoteAddresses is reserved for peers that explicitly return EMPTY for a root-containing
+          // batch (handleResponse path), indicating they definitively lack the root.
           if (!peer.isStatic) {
             statelessPeers += peer.id.value
-            statelessRemoteAddresses += peer.remoteAddress.toString
             log.info(
-              s"[HEAL-ROOT-RETRY] Peer ${peer.id.value} marked stateless for root after $maxRetriesPerTask timeouts " +
-                s"(${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
+              s"[HEAL-ROOT-RETRY] Peer ${peer.id.value} session-stateless for root after $maxRetriesPerTask timeouts " +
+                s"(${statelessPeers.size}/${knownAvailablePeers.size} stateless) — IP not permanently blocked (timeout is transient)"
             )
             if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
               pivotRefreshRequested = true

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -38,20 +38,24 @@ class TrieNodeHealingCoordinator(
   import Messages._
 
   // Task management — each task has a pathset (for GetTrieNodes) and a hash (for verification)
-  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0)
-  private var pendingTasks: Seq[HealingEntry] = Seq.empty
+  // depth + priority enable DFS traversal: priority = parentPriority * 16 + childIndex (Besu InMemoryTasksPriorityQueues)
+  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0, depth: Int = 0, priority: Long = 0L)
+  // DFS priority queue: min-priority first (root=0, leftmost child first), depth DESC breaks ties.
+  // Besu uses a min-heap over (priority, -depth). This keeps the working set O(depth×16) ≈ 1K entries vs BFS O(N).
+  private val pendingTasks: mutable.PriorityQueue[HealingEntry] =
+    mutable.PriorityQueue.empty[HealingEntry](Ordering.by(e => (-e.priority, e.depth)))
   private var completedTaskCount: Int = 0
   private var abandonedTaskCount: Int = 0
 
   // Per-task retry limit: after this many timeouts/failures, skip the task.
-  // At ~6s per timeout cycle, 20 retries = ~2 minutes of trying per node.
-  private val maxRetriesPerTask: Int = 20
+  // Aligned with Besu MAX_RETRIES=4 (RetryingGetTrieNodeFromPeerTask.java).
+  // 4 retries × 60s timeout = 4 min max per node before abandonment.
+  // Prior value of 20 locked all workers for 20 min on unserviceable nodes (BUG-HEAL-11).
+  private val maxRetriesPerTask: Int = 4
 
   // Global stagnation detection: if no nodes healed for this duration, declare
   // healing complete with a warning. Prevents infinite loops when all peers lack
   // GetTrieNodes support (ETH68 networks). Regular sync fetches missing nodes on-demand.
-  private var lastHealedAtMs: Long = System.currentTimeMillis()
-  private val healingStagnationTimeoutMs: Long = 5 * 60 * 1000 // 5 minutes
 
   // Active request tracking: maps requestId -> (tasks, peer, requestedBytes, sentAtMs)
   private case class ActiveRequest(
@@ -64,12 +68,18 @@ class TrieNodeHealingCoordinator(
 
   // Concurrency: per-peer limit (like StorageRangeCoordinator) + global safety cap
   private val maxConcurrentRequests = concurrency
-  private var maxInFlightPerPeer: Int = 5
+  private var maxInFlightPerPeer: Int = 1 // Besu-aligned D11: 1 request per peer, no pipelining
 
   // Statistics
   private var totalNodesHealed: Int = 0
   private var totalBytesReceived: Long = 0
   private val startTime = System.currentTimeMillis()
+  private var lastProgressLogAt: Long = 0   // for 500-node interval progress log
+  private val ProgressLogInterval: Long = 500
+  private var lastPulseHealedCount: Int = 0 // for 2-min HEAL-PULSE velocity logging
+  // Rolling 60s window for recent throughput (matches controller's SyncProgressMonitor pattern)
+  private val recentHistory: mutable.Queue[(Long, Long)] = mutable.Queue.empty
+  private val RecentWindowMs: Long = 60_000
 
   // Adaptive healing throttle (geth p2p/msgrate alignment)
   // When pending nodes exceed 2× the processing rate, throttle increases (slow down requests).
@@ -93,37 +103,25 @@ class TrieNodeHealingCoordinator(
 
   // Stateless peer tracking (geth-aligned: peers that return empty TrieNodes for current root)
   private val statelessPeers = mutable.Set[String]()
+  // Persistent stateless tracking by remote address — survives peer reconnect with new session ID.
+  // Non-static peers that return empty GetTrieNodes are blocked even after reconnection.
+  private val statelessRemoteAddresses = mutable.Set[String]()
   private var pivotRefreshRequested: Boolean = false
+  // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
+  // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
+  private var postRefreshCooldownUntilMs: Long = 0L
+  private val postRefreshCooldownMs: Long = 10_000L // 10s (matches StorageRangeCoordinator)
 
-  // Per-peer adaptive byte budgeting
-  private val minResponseBytes: BigInt = 50 * 1024
-  private val maxResponseBytes: BigInt = 2 * 1024 * 1024
-  private val initialResponseBytes: BigInt = 512 * 1024
-  private val increaseFactor: Double = 1.25
-  private val decreaseFactor: Double = 0.5
+  // Besu-aligned D12: fixed request size, no per-peer adaptive ratcheting.
+  // Besu uses a fixed REQUEST_SIZE in RequestDataStep.java with no per-peer tracking.
+  private val requestResponseBytes: BigInt = 512 * 1024
 
-  private val peerResponseBytesTarget = mutable.Map.empty[String, BigInt]
+  // HW1 self-feeding: tracks total missing trie children discovered across all healed nodes
+  private var childrenDiscoveredTotal: Int = 0
 
-  private def responseBytesTargetFor(peer: Peer): BigInt =
-    peerResponseBytesTarget
-      .getOrElseUpdate(peer.id.value, initialResponseBytes)
-      .max(minResponseBytes)
-      .min(maxResponseBytes)
-
-  private def adjustResponseBytesOnSuccess(peer: Peer, requested: BigInt, received: BigInt): Unit =
-    if (requested > 0 && received * 10 >= requested * 9 && requested < maxResponseBytes) {
-      val next = (requested.toDouble * increaseFactor).toLong
-      peerResponseBytesTarget.update(peer.id.value, BigInt(next).min(maxResponseBytes))
-    }
-
-  private def adjustResponseBytesOnFailure(peer: Peer, reason: String): Unit = {
-    val cur = responseBytesTargetFor(peer)
-    val next = (cur.toDouble * decreaseFactor).toLong
-    peerResponseBytesTarget.update(peer.id.value, BigInt(next).max(minResponseBytes))
-    log.debug(
-      s"Reducing healing responseBytes target for peer ${peer.id.value}: $cur -> ${peerResponseBytesTarget(peer.id.value)} ($reason)"
-    )
-  }
+  // D4 root-retry: cumulative count of times the state root node has exhausted per-peer retries.
+  // The state root cannot be recovered by regular sync on-demand — never permanently abandon it.
+  private var rootFetchFailures: Int = 0
 
   // Peer cooldown
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
@@ -133,9 +131,12 @@ class TrieNodeHealingCoordinator(
     peerCooldownUntilMs.get(peer.id.value).exists(_ > System.currentTimeMillis())
 
   private def recordPeerCooldown(peer: Peer, reason: String): Unit = {
-    val until = System.currentTimeMillis() + peerCooldownDefault.toMillis
+    // OPT-P5: Static peers (core-geth, Besu configured as static) get a shorter cooldown —
+    // trusted infrastructure should be re-tried sooner after transient failures.
+    val cooldown = if (peer.isStatic) 5.seconds else peerCooldownDefault
+    val until = System.currentTimeMillis() + cooldown.toMillis
     peerCooldownUntilMs.put(peer.id.value, until)
-    log.debug(s"Cooling down peer ${peer.id.value} for ${peerCooldownDefault.toSeconds}s: $reason")
+    log.debug(s"Cooling down peer ${peer.id.value} for ${cooldown.toSeconds}s (static=${peer.isStatic}): $reason")
   }
 
   /** Count in-flight requests for a given peer (pipelining support). */
@@ -145,14 +146,20 @@ class TrieNodeHealingCoordinator(
   /** Dispatch up to maxInFlightPerPeer requests to a single peer (pipelining). */
   private def dispatchIfPossible(peer: Peer): Unit = {
     if (pivotRefreshRequested) return
+    val nowMs = System.currentTimeMillis()
+    if (nowMs < postRefreshCooldownUntilMs) {
+      log.debug(s"[HEAL] Dispatch to ${peer.id.value} deferred — post-refresh cooldown (${(postRefreshCooldownUntilMs - nowMs) / 1000}s remaining)")
+      return
+    }
     if (statelessPeers.contains(peer.id.value)) return
     if (isPeerCoolingDown(peer)) return
     var inflight = inFlightForPeer(peer)
-    while (pendingTasks.nonEmpty && inflight < maxInFlightPerPeer && activeRequests.size < maxConcurrentRequests)
+    while (pendingTasks.nonEmpty && inflight < maxInFlightPerPeer && activeRequests.size < maxConcurrentRequests) {
       requestNextBatch(peer) match {
         case Some(_) => inflight += 1
         case None    => return
       }
+    }
   }
 
   // Batched raw node storage: accumulate nodes and flush asynchronously
@@ -162,6 +169,8 @@ class TrieNodeHealingCoordinator(
 
   // Internal message for async flush completion
   private case class FlushComplete(count: Int)
+  // Periodic stagnation and no-activity check (every 2 minutes)
+  private case object HealingStagnationCheck
 
   /** Synchronous flush — used only for final completion flush (small buffer, safe to block). */
   private def flushRawNodesSync(): Unit =
@@ -190,8 +199,11 @@ class TrieNodeHealingCoordinator(
       }(context.dispatcher).foreach(n => selfRef ! FlushComplete(n))(context.dispatcher)
     }
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     log.info(s"TrieNodeHealingCoordinator starting (concurrency=$concurrency)")
+    import context.dispatcher
+    context.system.scheduler.scheduleWithFixedDelay(2.minutes, 2.minutes, self, HealingStagnationCheck)
+  }
 
   override val supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1.minute) { case _: Exception =>
@@ -202,42 +214,120 @@ class TrieNodeHealingCoordinator(
   override def receive: Receive = {
     case StartTrieNodeHealing(root) =>
       log.info(s"Starting trie node healing for state root ${Hex.toHexString(root.take(8).toArray)}")
+      // ARCH-ROOT-SEED: Seed immediately with root node (Besu-style top-down discovery).
+      // Prior: waited 50+ min for walk results. Now: healing starts instantly.
+      // When root is healed, discoverMissingChildren() discovers all children inline.
+      // Walk becomes validation-only — its results remain additive (dedup prevents duplicates).
+      val emptyPath = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+      queueNodes(Seq((Seq(emptyPath), root)))
+      log.info(
+        s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} seeded with empty path — " +
+        s"inline child discovery will populate the work queue top-down (Besu-aligned)"
+      )
 
     case QueueMissingNodes(nodes) =>
-      log.info(s"Queuing ${nodes.size} missing nodes for healing")
+      log.info(s"[HEAL-RESUME] Received ${nodes.size} persisted missing nodes from prior session")
       queueNodes(nodes)
       // Immediately dispatch to any known available peers
       tryRedispatchPendingTasks()
+      if (pendingTasks.isEmpty)
+        log.info(
+          s"[HEAL] All ${nodes.size} resumed nodes already present in trie DB — " +
+            s"no network requests needed, proceeding to trie walk"
+        )
+      self ! HealingCheckCompletion
 
     case HealingPeerAvailable(peer) =>
-      // Evict stale entry for same physical node (reconnection creates new PeerId)
-      knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
-      knownAvailablePeers += peer
-      dispatchIfPossible(peer)
+      // Skip if this remote address has been marked stateless — blocks reconnected dead peers
+      if (statelessRemoteAddresses.contains(peer.remoteAddress.toString)) {
+        log.debug(
+          s"[HEALING] Skipping ${peer.remoteAddress} — address known stateless (prior GetTrieNodes failure)"
+        )
+      } else {
+        // Evict stale entry for same physical node (reconnection creates new PeerId).
+        // Also clean up stale session-ID entries from statelessPeers and cooldown map.
+        val evicted = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
+        statelessPeers --= evicted.map(_.id.value)
+        peerCooldownUntilMs --= evicted.map(_.id.value)
+        knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
+        knownAvailablePeers += peer
+        dispatchIfPossible(peer)
+      }
 
     case UpdateMaxInFlightPerPeer(newLimit) =>
-      log.info(s"Healing per-peer budget: $maxInFlightPerPeer -> $newLimit")
-      maxInFlightPerPeer = newLimit
-      if (newLimit > 0) tryRedispatchPendingTasks()
+      if (newLimit != maxInFlightPerPeer) {
+        val wasLimit = maxInFlightPerPeer
+        log.info(s"Healing per-peer budget: $maxInFlightPerPeer -> $newLimit")
+        maxInFlightPerPeer = newLimit
+        // LOG-BUDGET-ZERO: Warn when budget drops to 1 — indicates high timeout rate
+        if (newLimit <= 1 && wasLimit > 1) {
+          log.warning(
+            s"[HEAL-BUDGET] In-flight budget dropped to $newLimit/peer — high timeout rate detected. " +
+            s"healed=$totalNodesHealed pending=${pendingTasks.size}"
+          )
+        }
+        if (newLimit > 0) tryRedispatchPendingTasks()
+      }
 
     case HealingPivotRefreshed(newStateRoot) =>
       val oldRoot = Hex.toHexString(stateRoot.take(4).toArray)
       val newRootHex = Hex.toHexString(newStateRoot.take(4).toArray)
       log.info(
         s"Healing pivot refreshed: $oldRoot -> $newRootHex. " +
-          s"Clearing ${pendingTasks.size} pending tasks, ${statelessPeers.size} stateless peers."
+          s"Clearing ${pendingTasks.size} pending tasks + ${pendingHashSet.size} hashes " +
+          s"(aligned to Besu reloadTrieHeal: clear all, reseed from new root). " +
+          s"Clearing ${statelessPeers.size} stateless peers."
       )
       stateRoot = newStateRoot
-      flushRawNodesSync() // Flush any buffered nodes before clearing state
-      pendingTasks = Seq.empty // Will be re-populated by trie walk from controller
+      flushRawNodesSync() // Flush any buffered nodes before pivot switch
+      // Besu SnapWorldDownloadState.reloadTrieHeal(): pendingTrieNodeRequests.clear() + startTrieHeal()
+      // ARCH-ROOT-SEED (already committed) immediately re-seeds the new root, so there is no
+      // empty-queue window — BUG-H3's original concern no longer applies.
+      pendingTasks.clear()
       pendingHashSet.clear()
       statelessPeers.clear()
+      statelessRemoteAddresses.clear() // new root — peers that failed old root may serve new one
       peerCooldownUntilMs.clear()
-      peerResponseBytesTarget.clear()
+      // Besu-aligned D12: no peerResponseBytesTarget to clear.
       // Cancel active requests (they're for the old root)
       activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
       activeRequests.clear()
       pivotRefreshRequested = false
+      rootFetchFailures = 0 // new root — reset failure counter
+      lastPulseHealedCount = totalNodesHealed // start fresh velocity window post-refresh
+      // Post-refresh cooldown: peers need time to sync to new root before we dispatch.
+      // Without this, immediate dispatch → all stateless → another HealingAllPeersStateless → tight loop.
+      postRefreshCooldownUntilMs = System.currentTimeMillis() + postRefreshCooldownMs
+      log.info(s"Post-refresh cooldown active for ${postRefreshCooldownMs / 1000}s — waiting for peers to sync to new root")
+      // ARCH-PIVOT-RESEED: Re-seed with new root for top-down discovery of new trie.
+      // ARCH-ROOT-SEED ensures healing starts from root within the cooldown window.
+      val pivotReseedPath = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+      if (!pendingHashSet.contains(newStateRoot) && !isNodeInStorage(newStateRoot)) {
+        pendingTasks += HealingEntry(Seq(pivotReseedPath), newStateRoot)
+        pendingHashSet += newStateRoot
+        log.info(
+          s"[HEAL] Re-seeded with new root ${Hex.toHexString(newStateRoot.take(4).toArray)} " +
+          s"(pending: ${pendingTasks.size})"
+        )
+      } else {
+        log.info(s"[HEAL] New root already in storage or pending — skipping pivot reseed")
+      }
+
+    case HealingForceComplete =>
+      log.warning(
+        s"[HEAL-FORCE-COMPLETE] Pivot advanced beyond SNAP serve window — " +
+        s"clearing ${pendingTasks.size} pending tasks + ${activeRequests.size} in-flight. " +
+        s"Signaling completion with $totalNodesHealed healed nodes."
+      )
+      // Cancel all in-flight requests
+      activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
+      activeRequests.clear()
+      // Clear pending queue — these paths are for a root peers have pruned
+      pendingTasks.clear()
+      pendingHashSet.clear()
+      // Signal completion with 0 abandoned (fresh coordinator + walk will start for new root)
+      snapSyncController ! SNAPSyncController.StateHealingComplete(0, totalNodesHealed)
+      context.stop(self)
 
     case TrieNodesResponseMsg(response) =>
       handleResponse(response)
@@ -245,6 +335,9 @@ class TrieNodeHealingCoordinator(
     case FlushComplete(count) =>
       flushing = false
       log.info(s"Async flush complete: $count healed nodes written to disk (total: $totalNodesHealed)")
+      // Snapshot pending queue for crash recovery (piggybacks on existing flush cadence)
+      val snapshot = pendingTasks.toSeq.map(e => (e.pathset, e.hash))
+      snapSyncController ! SNAPSyncController.PersistHealingQueue(snapshot)
       // Check if buffer filled up again during the flush
       if (rawNodeBuffer.size >= rawFlushThreshold) {
         flushRawNodesAsync()
@@ -255,7 +348,18 @@ class TrieNodeHealingCoordinator(
       result match {
         case Right(count) =>
           totalNodesHealed += count
-          log.info(s"Healing task completed: $count nodes")
+          log.info(s"Healing task completed: $count nodes (total: $totalNodesHealed, pending: ${pendingTasks.size})")
+          // Periodic progress summary (every 5K nodes)
+          if (totalNodesHealed - lastProgressLogAt >= ProgressLogInterval) {
+            val rate = calculateNodesPerSecond()
+            val activeTaskCount = activeRequests.values.map(_.tasks.size).sum
+            log.info(
+              s"Healing progress: $totalNodesHealed nodes (${"%.1f".format(totalBytesReceived / 1048576.0)} MB) " +
+                s"(${pendingTasks.size} pending, $activeTaskCount active, " +
+                s"${"%.0f".format(rate)} nodes/sec)"
+            )
+            lastProgressLogAt = totalNodesHealed
+          }
           self ! HealingCheckCompletion
         case Left(error) =>
           log.warning(s"Healing task failed: $error")
@@ -264,10 +368,18 @@ class TrieNodeHealingCoordinator(
     case HealingCheckCompletion =>
       if (isComplete && !flushing) {
         flushRawNodesSync()
-        val abandonedStr =
-          if (abandonedTaskCount > 0) s" ($abandonedTaskCount abandoned — regular sync will recover)" else ""
-        log.info(s"Healing round complete: $totalNodesHealed total nodes healed$abandonedStr. Notifying controller.")
-        snapSyncController ! SNAPSyncController.StateHealingComplete
+        val abandonedStr = if (abandonedTaskCount > 0) s" ($abandonedTaskCount abandoned — deferred to state validation)" else ""
+        log.info(
+          s"Healing complete: $totalNodesHealed nodes healed in " +
+            s"${(System.currentTimeMillis() - startTime) / 1000}s " +
+            s"(${"%.1f".format(totalBytesReceived / 1048576.0)}MB received)$abandonedStr. " +
+            s"Signalling controller to begin state validation trie walk."
+        )
+        snapSyncController ! SNAPSyncController.StateHealingComplete(abandonedTaskCount, totalNodesHealed)
+      } else if (!isComplete) {
+        log.debug(
+          s"[HEAL-CHECK] pending=${pendingTasks.size} active=${activeRequests.size} flushing=$flushing"
+        )
       }
 
     case HealingGetProgress =>
@@ -283,18 +395,39 @@ class TrieNodeHealingCoordinator(
         progress = calculateProgress()
       )
       sender() ! stats
+
+    case HealingStagnationCheck =>
+      // Besu-aligned: no stagnation escalation. Pure diagnostic pulse logging.
+      // Besu has zero stagnation watchdogs — SnapWorldDownloadState.markAsStalled() is a TODO no-op.
+      val recentHealed = totalNodesHealed - lastPulseHealedCount
+      log.info(
+        s"[HEAL-PULSE] healed=$totalNodesHealed total, +$recentHealed last 2min | " +
+        s"pending=${pendingTasks.size} active=${activeRequests.size} peers=${knownAvailablePeers.size} | " +
+        s"pivotRefreshPending=$pivotRefreshRequested"
+      )
+      lastPulseHealedCount = totalNodesHealed
   }
 
   private def queueNodes(pathsAndHashes: Seq[(Seq[ByteString], ByteString)]): Unit = {
+    var skippedExisting = 0
     val entries = pathsAndHashes.collect {
       case (pathset, hash) if !pendingHashSet.contains(hash) =>
-        pendingHashSet += hash
-        HealingEntry(pathset = pathset, hash = hash)
-    }
-    val deduped = pathsAndHashes.size - entries.size
-    pendingTasks = pendingTasks ++ entries
+        // R5 fix: Check if the node already exists in storage (downloaded during account/storage phase).
+        // mptStorage.get() throws MissingRootNodeException for missing nodes — fast O(1) RocksDB lookup.
+        val alreadyExists = try { mptStorage.get(hash.toArray); true } catch { case _: Exception => false }
+        if (alreadyExists) {
+          skippedExisting += 1
+          None
+        } else {
+          pendingHashSet += hash
+          Some(HealingEntry(pathset = pathset, hash = hash))
+        }
+    }.flatten
+    val deduped = pathsAndHashes.size - entries.size - skippedExisting
+    pendingTasks ++= entries
     val dedupStr = if (deduped > 0) s" ($deduped duplicates filtered)" else ""
-    log.info(s"Queued ${entries.size} nodes for healing$dedupStr. Total pending: ${pendingTasks.size}")
+    val existsStr = if (skippedExisting > 0) s" ($skippedExisting already in storage)" else ""
+    log.info(s"Queued ${entries.size} nodes for healing$dedupStr$existsStr. Total pending: ${pendingTasks.size}")
   }
 
   /** Update healing rate EMA and adjust throttle (geth p2p/msgrate alignment).
@@ -356,13 +489,14 @@ class TrieNodeHealingCoordinator(
     }
 
     val effectiveBatch = effectiveBatchSize
-    val batch = pendingTasks.take(effectiveBatch)
-    pendingTasks = pendingTasks.drop(effectiveBatch)
+    // DFS priority queue: dequeue in priority order (root=priority 0 always first per Besu ordering).
+    // Root node has priority=0 which is the minimum — always dispatched first without explicit sorting.
+    val batch = (0 until effectiveBatch.min(pendingTasks.size)).map(_ => pendingTasks.dequeue())
     // Remove dispatched hashes from dedup set (they'll be re-added if re-queued on failure)
     batch.foreach(e => pendingHashSet -= e.hash)
 
     val requestId = requestTracker.generateRequestId()
-    val responseBytes = responseBytesTargetFor(peer)
+    val responseBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
 
     // Build the paths list for GetTrieNodes — each entry's pathset is a Seq[ByteString]
     val paths = batch.map(_.pathset)
@@ -376,7 +510,10 @@ class TrieNodeHealingCoordinator(
 
     activeRequests(requestId) = ActiveRequest(batch, peer, responseBytes)
 
-    requestTracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetTrieNodes) {
+    // Besu RequestDataStep.java: orTimeout(10, TimeUnit.SECONDS) for all request types.
+    // Aligned floor: 10s (was 30s). Ceiling: 30s (was 60s). Slow peers released faster.
+    val healingTimeout = requestTracker.rateTracker.targetTimeout().max(10.seconds).min(30.seconds)
+    requestTracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetTrieNodes, healingTimeout) {
       handleTimeout(requestId, batch, peer)
     }
 
@@ -388,7 +525,6 @@ class TrieNodeHealingCoordinator(
       s"Requested ${batch.size} trie nodes from peer ${peer.id.value} " +
         s"(reqId=$requestId, responseBytes=$responseBytes, pending=${pendingTasks.size})"
     )
-
     Some(requestId)
   }
 
@@ -401,13 +537,12 @@ class TrieNodeHealingCoordinator(
     val activeReq = activeRequests.get(requestId) match {
       case Some(req) => req
       case None =>
-        log.warning(s"No active healing request found for requestId=$requestId")
+        log.debug(s"Received orphaned TrieNodes response (reqId=$requestId). Request was already cancelled (timeout or pivot refresh). Discarding stale response.")
         return
     }
 
     val tasksForRequest = activeReq.tasks
     val peer = activeReq.peer
-    val requestedBytes = activeReq.requestedBytes
 
     var healedCount = 0
     var receivedBytes: Long = 0
@@ -418,6 +553,7 @@ class TrieNodeHealingCoordinator(
       if (nodeHash == task.hash) {
         // Valid node — store directly by hash
         rawNodeBuffer += ((nodeHash, nodeData.toArray))
+        discoverMissingChildren(nodeData, task)
         healedCount += 1
         totalNodesHealed += 1
         receivedBytes += nodeData.length
@@ -427,15 +563,43 @@ class TrieNodeHealingCoordinator(
           s"Node hash mismatch: expected ${Hex.toHexString(task.hash.take(4).toArray)}, " +
             s"got ${Hex.toHexString(nodeHash.take(4).toArray)}"
         )
-        // Re-queue this task for retry
-        pendingTasks = pendingTasks :+ task
+        // Re-queue with incremented retry count — abandon after maxRetriesPerTask mismatches.
+        // Without this, a ghost node from a prior session's HEAL-RESUME queue (whose path no
+        // longer exists in the current trie) causes an infinite loop: peers return the nearest
+        // ancestor (the root) for non-existent paths, the mismatch re-queues without progress,
+        // and the node can never be healed regardless of how many pivot refreshes occur.
+        val updated = task.copy(retries = task.retries + 1)
+        if (updated.retries >= maxRetriesPerTask) {
+          if (task.hash == stateRoot) {
+            // D4 — never permanently abandon the state root node, even on hash mismatches.
+            rootFetchFailures += 1
+            log.warning(
+              s"[HEAL-ROOT-RETRY] Root node ${Hex.toHexString(stateRoot.take(4).toArray)} hash mismatch after " +
+                s"$maxRetriesPerTask attempts (got ${Hex.toHexString(nodeHash.take(4).toArray)}). " +
+                s"Re-queuing with reset retries (cumulative root failures: $rootFetchFailures)."
+            )
+            val resetEntry = task.copy(retries = 0)
+            pendingTasks += resetEntry
+            pendingHashSet += resetEntry.hash
+          } else {
+            abandonedTaskCount += 1
+            log.warning(
+              s"Giving up on trie node ${Hex.toHexString(task.hash.take(4).toArray)} after " +
+                s"$maxRetriesPerTask consecutive hash mismatches " +
+                s"(got ${Hex.toHexString(nodeHash.take(4).toArray)}). " +
+                s"Node not present in current trie — deferring to state validation."
+            )
+          }
+        } else {
+          pendingTasks += updated
+        }
       }
     }
 
     // Re-queue unmatched tasks (server returned fewer nodes than requested)
     val unmatchedTasks = tasksForRequest.drop(nodes.size)
     unmatchedTasks.foreach { task =>
-      pendingTasks = pendingTasks :+ task
+      pendingTasks += task
     }
 
     completedTaskCount += healedCount
@@ -446,36 +610,37 @@ class TrieNodeHealingCoordinator(
     val elapsedMs = System.currentTimeMillis() - activeReq.sentAtMs
     updateHealThrottle(healedCount, elapsedMs)
 
-    // Adaptive byte budget + stateless tracking
+    // Stateless tracking (Besu-aligned D12: no adaptive byte budget, fixed request size)
     if (healedCount > 0) {
-      adjustResponseBytesOnSuccess(peer, requestedBytes, BigInt(receivedBytes))
-      // Successful response — clear stateless marking and reset stagnation timer
+      // Successful response — clear stateless marking
       statelessPeers -= peer.id.value
-      lastHealedAtMs = System.currentTimeMillis()
     } else {
-      adjustResponseBytesOnFailure(peer, "empty healing response")
       recordPeerCooldown(peer, "empty healing response")
-      // Mark peer stateless for current root (geth-aligned)
-      statelessPeers += peer.id.value
-      log.info(
-        s"Peer ${peer.id.value} marked stateless for healing root " +
-          s"${Hex.toHexString(stateRoot.take(4).toArray)} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
-      )
-      // Check if all known peers are stateless — request pivot refresh
-      if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
-        pivotRefreshRequested = true
-        log.warning(
-          s"All ${statelessPeers.size} peers stateless for healing root " +
-            s"${Hex.toHexString(stateRoot.take(4).toArray)}. Requesting pivot refresh."
+      // Mark peer stateless for current root (geth-aligned) — skip for static peers
+      if (!peer.isStatic) {
+        statelessPeers += peer.id.value
+        statelessRemoteAddresses += peer.remoteAddress.toString // persist across reconnects
+        log.info(
+          s"Peer ${peer.id.value}@${peer.remoteAddress} marked stateless for healing root " +
+            s"${Hex.toHexString(stateRoot.take(4).toArray)} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
         )
-        snapSyncController ! SNAPSyncController.HealingAllPeersStateless
+        // Check if all known peers are stateless — request pivot refresh
+        if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
+          pivotRefreshRequested = true
+          log.warning(
+            s"All ${statelessPeers.size} peers stateless for healing root " +
+              s"${Hex.toHexString(stateRoot.take(4).toArray)}. Requesting pivot refresh."
+          )
+          snapSyncController ! SNAPSyncController.HealingAllPeersStateless
+        }
+      } else {
+        log.debug(s"[STATIC] Skipping stateless marking for static peer ${peer.remoteAddress} (healing)")
       }
     }
 
     log.info(
-      s"Healed $healedCount/${nodes.size} trie nodes from peer ${peer.id.value} " +
-        s"(total: $totalNodesHealed, pending: ${pendingTasks.size}, active: ${activeRequests.size} reqs, " +
-        s"responseBytes=${responseBytesTargetFor(peer)})"
+      s"Healed $healedCount of ${nodes.size} requested trie nodes from ${peer.id.value}. " +
+        s"Cumulative: $totalNodesHealed healed, ${pendingTasks.size} pending, ${activeRequests.size} in-flight"
     )
 
     if (healedCount > 0) {
@@ -498,7 +663,7 @@ class TrieNodeHealingCoordinator(
 
     activeRequests.remove(requestId)
     recordPeerCooldown(peer, "request timeout")
-    adjustResponseBytesOnFailure(peer, "request timeout")
+    // Besu-aligned D12: no adaptive byte budget ratcheting on timeout.
 
     // Increment retry count and skip exhausted tasks
     var requeued = 0
@@ -506,40 +671,60 @@ class TrieNodeHealingCoordinator(
     tasks.foreach { task =>
       val updated = task.copy(retries = task.retries + 1)
       if (updated.retries >= maxRetriesPerTask) {
-        abandoned += 1
-        abandonedTaskCount += 1
-        log.warning(
-          s"Abandoning healing task after ${updated.retries} retries: " +
-            s"hash=${Hex.toHexString(task.hash.take(4).toArray)} " +
-            s"(regular sync will fetch on-demand)"
-        )
+        if (task.hash == stateRoot) {
+          // D4 — never permanently abandon the state root node.
+          // The root cannot be recovered by regular sync on-demand — without it no block can execute.
+          // Re-queue with reset retries. Mark the timed-out peer stateless so HealingAllPeersStateless
+          // fires when all peers have exhausted root fetch attempts, triggering a pivot refresh.
+          rootFetchFailures += 1
+          log.warning(
+            s"[HEAL-ROOT-RETRY] Root node ${Hex.toHexString(stateRoot.take(4).toArray)} timed out " +
+              s"$maxRetriesPerTask times on peer ${peer.id.value} " +
+              s"(cumulative root failures: $rootFetchFailures). Re-queuing — root is never abandoned (Besu D4)."
+          )
+          val resetEntry = task.copy(retries = 0)
+          pendingTasks += resetEntry
+          pendingHashSet += resetEntry.hash
+          requeued += 1
+          // Treat a timeout-exhausted peer the same as an empty-response peer for the root node.
+          // This ensures HealingAllPeersStateless fires when all peers fail on the root.
+          if (!peer.isStatic) {
+            statelessPeers += peer.id.value
+            statelessRemoteAddresses += peer.remoteAddress.toString
+            log.info(
+              s"[HEAL-ROOT-RETRY] Peer ${peer.id.value} marked stateless for root after $maxRetriesPerTask timeouts " +
+                s"(${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
+            )
+            if (statelessPeers.size >= knownAvailablePeers.size && knownAvailablePeers.nonEmpty && !pivotRefreshRequested) {
+              pivotRefreshRequested = true
+              log.warning(
+                s"[HEAL-ROOT-RETRY] All ${statelessPeers.size} peers exhausted on root " +
+                  s"${Hex.toHexString(stateRoot.take(4).toArray)} — requesting pivot refresh."
+              )
+              snapSyncController ! SNAPSyncController.HealingAllPeersStateless
+            }
+          }
+        } else {
+          abandoned += 1
+          abandonedTaskCount += 1
+          log.warning(
+            s"Giving up on trie node ${Hex.toHexString(task.hash.take(4).toArray)} after $maxRetriesPerTask retries. " +
+              s"Deferring to state validation phase — node will be re-discovered and fetched during trie walk."
+          )
+        }
       } else {
-        pendingTasks = pendingTasks :+ updated
+        pendingTasks += updated
         requeued += 1
       }
     }
 
     if (requeued > 0) {
-      log.info(
-        s"Re-queued $requeued timed-out healing tasks (pending: ${pendingTasks.size})" +
-          (if (abandoned > 0) s", abandoned $abandoned" else "")
-      )
+      log.info(s"Re-queued $requeued timed-out healing tasks (pending: ${pendingTasks.size})" +
+        (if (abandoned > 0) s", abandoned $abandoned" else ""))
     }
 
-    // Check global stagnation: no nodes healed for healingStagnationTimeoutMs
-    val stagnantMs = System.currentTimeMillis() - lastHealedAtMs
-    if (stagnantMs > healingStagnationTimeoutMs && pendingTasks.nonEmpty) {
-      val pendingCount = pendingTasks.size
-      log.warning(
-        s"Healing stagnation detected: no nodes healed in ${stagnantMs / 1000}s. " +
-          s"Abandoning $pendingCount remaining tasks. " +
-          s"Regular sync will fetch missing nodes on-demand via GetTrieNodes."
-      )
-      abandonedTaskCount += pendingCount
-      pendingTasks = Seq.empty
-      pendingHashSet.clear()
-    }
-
+    // Besu-aligned: no mass-abandonment on timeout. Per-task retry via maxRetriesPerTask=4 only.
+    // Peers that exhaust retries are implicitly excluded via blacklistDuration on their tasks.
     tryRedispatchPendingTasks()
     self ! HealingCheckCompletion
   }
@@ -550,7 +735,14 @@ class TrieNodeHealingCoordinator(
     val eligiblePeers = knownAvailablePeers.toList
       .filterNot(isPeerCoolingDown)
       .filterNot(p => statelessPeers.contains(p.id.value))
-    if (eligiblePeers.isEmpty) return
+      .filterNot(p => statelessRemoteAddresses.contains(p.remoteAddress.toString))
+    if (eligiblePeers.isEmpty) {
+      log.debug(
+        s"[REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +
+          s"${statelessPeers.size} stateless, rest cooling down. pending: ${pendingTasks.size}"
+      )
+      return
+    }
 
     for (peer <- eligiblePeers if pendingTasks.nonEmpty)
       dispatchIfPossible(peer)
@@ -563,15 +755,139 @@ class TrieNodeHealingCoordinator(
     else completedTaskCount.toDouble / total
   }
 
+  /** Recent nodes/sec using 60s rolling window. Falls back to overall average when insufficient data. */
   private def calculateNodesPerSecond(): Double = {
-    val elapsedSec = (System.currentTimeMillis() - startTime) / 1000.0
-    if (elapsedSec > 0) totalNodesHealed / elapsedSec else 0.0
+    val now = System.currentTimeMillis()
+    recentHistory.enqueue((now, totalNodesHealed.toLong))
+    while (recentHistory.nonEmpty && now - recentHistory.head._1 > RecentWindowMs)
+      recentHistory.dequeue()
+    if (recentHistory.size >= 2) {
+      val oldest = recentHistory.head
+      val timeDiff = (now - oldest._1) / 1000.0
+      val countDiff = totalNodesHealed - oldest._2
+      if (timeDiff > 0) countDiff / timeDiff else 0.0
+    } else {
+      // Fallback to overall average
+      val elapsedSec = (now - startTime) / 1000.0
+      if (elapsedSec > 0) totalNodesHealed / elapsedSec else 0.0
+    }
   }
 
+  /** Recent KB/sec using overall average (bytes not tracked in rolling window). */
   private def calculateKilobytesPerSecond(): Double = {
     val elapsedSec = (System.currentTimeMillis() - startTime) / 1000.0
     if (elapsedSec > 0) (totalBytesReceived / 1024.0) / elapsedSec else 0.0
   }
+
+  /** Decode a healed node and queue any missing children for healing.
+    * Makes healing self-feeding: each healed node expands the work queue without
+    * requiring a full periodic trie walk (geth trie.Sync scheduler alignment).
+    */
+  private def discoverMissingChildren(nodeData: ByteString, parentEntry: HealingEntry): Unit = {
+    import com.chipprbots.ethereum.mpt.{MptTraversals, BranchNode, ExtensionNode, HashNode, LeafNode}
+    import com.chipprbots.ethereum.mpt.HexPrefix
+    import com.chipprbots.ethereum.domain.Account
+    import scala.util.control.NonFatal
+
+    val pathset = parentEntry.pathset
+    if (pathset.isEmpty) return
+
+    try {
+      val decoded = MptTraversals.decodeNode(nodeData.toArray)
+      val parentCompact = pathset.last.toArray
+      val parentNibbles = HexPrefix.decode(parentCompact)._1
+      val isStorageTrie = pathset.size > 1  // Seq(accountHash, path) vs Seq(path)
+
+      val newEntries = mutable.Buffer.empty[HealingEntry]
+
+      decoded match {
+        case branch: BranchNode =>
+          // DFS priority: child i of parent gets priority = parentPriority * 16 + i (Besu TrieNodeHealingRequest)
+          for (i <- 0 until 16) {
+            branch.children(i) match {
+              case hash: HashNode =>
+                val childHash = ByteString(hash.hashNode)
+                if (!pendingHashSet.contains(childHash) && !isNodeInStorage(childHash)) {
+                  val childNibbles = parentNibbles :+ i.toByte
+                  val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                  val childPathset = if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                  newEntries += HealingEntry(childPathset, childHash,
+                    depth = parentEntry.depth + 1,
+                    priority = parentEntry.priority * 16 + i)
+                }
+              case _ => // Inline-encoded or null — already resolved
+            }
+          }
+
+        case ext: ExtensionNode =>
+          // Extension has a single child; treat as index 0 for priority inheritance
+          ext.next match {
+            case hash: HashNode =>
+              val childHash = ByteString(hash.hashNode)
+              if (!pendingHashSet.contains(childHash) && !isNodeInStorage(childHash)) {
+                // ext.sharedKey is already HP-decoded nibbles (ByteString of nibble bytes)
+                val childNibbles = parentNibbles ++ ext.sharedKey.toArray
+                val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                val childPathset = if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                newEntries += HealingEntry(childPathset, childHash,
+                  depth = parentEntry.depth + 1,
+                  priority = parentEntry.priority * 16)
+              }
+            case _ => // Already inline-encoded — no missing child
+          }
+
+        case leaf: LeafNode if !isStorageTrie =>
+          // ARCH-LEAF-SEED: Account trie leaf — decode account value, seed storage trie if needed.
+          // Besu equivalent: getChildRequests() → getStorageTrieNodeRequests() on account leaf values.
+          // leaf.key contains HP-decoded nibbles for this leaf's remaining path segment.
+          Account(leaf.value).foreach { account =>
+            if (account.storageRoot != Account.EmptyStorageRootHash &&
+                !pendingHashSet.contains(account.storageRoot) &&
+                !isNodeInStorage(account.storageRoot)) {
+              // Reconstruct 32-byte account address hash from the full nibble path.
+              // In the account trie, path from root to leaf = keccak256(address) as 64 nibbles.
+              val leafNibbles = leaf.key.toArray  // remaining nibbles for this leaf's path segment
+              val allNibbles  = parentNibbles ++ leafNibbles
+              if (allNibbles.length == 64) {
+                val accountHashBytes = allNibbles.grouped(2).map { g =>
+                  ((g(0) << 4) | g(1)).toByte
+                }.toArray
+                val accountHash      = ByteString(accountHashBytes)
+                val emptyStoragePath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+                // Storage trie root inherits account's priority; depth=0 (new trie)
+                newEntries += HealingEntry(Seq(accountHash, emptyStoragePath), account.storageRoot,
+                  depth = 0,
+                  priority = parentEntry.priority)
+                log.debug(
+                  s"[HEAL-LEAF] Seeded storage trie root ${Hex.toHexString(account.storageRoot.take(4).toArray)} " +
+                  s"for account ${Hex.toHexString(accountHashBytes.take(4))}"
+                )
+              }
+            }
+          }
+
+        case _ => // storage trie LeafNode, NullNode, HashNode — no children to discover
+      }
+
+      if (newEntries.nonEmpty) {
+        newEntries.foreach(e => pendingHashSet += e.hash)
+        pendingTasks ++= newEntries
+        childrenDiscoveredTotal += newEntries.size
+        if (childrenDiscoveredTotal % 100 == 0 || childrenDiscoveredTotal <= 20)
+          log.info(
+            s"[HEAL] Missing trie children queued: $childrenDiscoveredTotal total " +
+              s"(+${newEntries.size} from this node, pending: ${pendingTasks.size})"
+          )
+      }
+    } catch {
+      case NonFatal(e) =>
+        log.debug(s"[HEAL] Cannot decode healed node for child discovery: ${e.getMessage}. Skipping incremental discovery — full trie walk will find these nodes.")
+        // Non-fatal — healing still works via final validation walk as safety net
+    }
+  }
+
+  private def isNodeInStorage(hash: ByteString): Boolean =
+    try { mptStorage.get(hash.toArray); true } catch { case _: Exception => false }
 
   private def isComplete: Boolean =
     pendingTasks.isEmpty && activeRequests.isEmpty

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -109,6 +109,13 @@ class TrieNodeHealingCoordinator(
   // When all known peers have failed on root, HealingAllPeersStateless fires (pivot refresh).
   // Mirrors Besu's WORLD_STATE_ROOT_NOT_AVAILABLE signal from TrieNodeHealingStep.
   private val peersFailedOnRoot = mutable.Set[String]()
+  // Per-task peer exclusion — mirrors Besu AbstractRetryingSwitchingPeerTask.triedPeers.
+  // Maps task hash → set of peer IDs that have already been tried for that hash.
+  // Prevents a node from being assigned to the same peer repeatedly when other peers
+  // haven't tried it yet. Cleared on pivot refresh (coordinator is recreated on pivot
+  // switch, so field starts fresh automatically; explicit clear in HealingPivotRefreshed
+  // for safety).
+  private val triedPeersForTask = mutable.HashMap.empty[ByteString, mutable.Set[String]]
   private var pivotRefreshRequested: Boolean = false
   // Post-pivot-refresh cooldown: prevents immediate re-dispatch before peers sync to new root.
   // Without this, all peers return empty → stateless → another HealingAllPeersStateless → tight loop.
@@ -284,6 +291,7 @@ class TrieNodeHealingCoordinator(
       statelessPeers.clear()
       peersFailedOnRoot.clear() // new root — all peers get a fresh chance on the new root
       peerCooldownUntilMs.clear()
+      triedPeersForTask.clear() // new root — all peers get fresh chance per task
       // Besu-aligned D12: no peerResponseBytesTarget to clear.
       // Cancel active requests (they're for the old root)
       activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
@@ -485,17 +493,46 @@ class TrieNodeHealingCoordinator(
     }
 
     val effectiveBatch = effectiveBatchSize
-    // DFS priority queue: dequeue in priority order (root=priority 0 always first per Besu ordering).
-    // Root node has priority=0 which is the minimum — always dispatched first without explicit sorting.
-    val batch = (0 until effectiveBatch.min(pendingTasks.size)).map(_ => pendingTasks.dequeue())
-    // Remove dispatched hashes from dedup set (they'll be re-added if re-queued on failure)
-    batch.foreach(e => pendingHashSet -= e.hash)
+    // DFS priority queue with per-task peer exclusion (Besu AbstractRetryingSwitchingPeerTask.triedPeers).
+    // Dequeue up to effectiveBatch tasks that this peer hasn't tried yet.
+    // Tasks already tried by this peer are skipped and re-enqueued for other peers to handle.
+    val batch   = mutable.Buffer.empty[HealingEntry]
+    val skipped = mutable.Buffer.empty[HealingEntry]
+    while (batch.size < effectiveBatch && pendingTasks.nonEmpty) {
+      val task = pendingTasks.dequeue()
+      pendingHashSet -= task.hash
+      val peersTriedForHash = triedPeersForTask.getOrElse(task.hash, Set.empty[String])
+      if (!peersTriedForHash.contains(peer.id.value)) {
+        batch += task
+      } else {
+        // This peer has already tried this hash. Check if ALL known peers have tried it.
+        // If so, reset (Besu: triedPeers.retainAll(failedPeers) → allows non-failed retry).
+        // We clear completely since we don't track failed vs tried separately at this level.
+        val allTried = knownAvailablePeers.map(_.id.value).forall(peersTriedForHash.contains)
+        if (allTried) {
+          triedPeersForTask.remove(task.hash)
+          batch += task
+        } else {
+          skipped += task
+        }
+      }
+    }
+    // Re-enqueue skipped tasks (other peers will dispatch them)
+    skipped.foreach { task =>
+      pendingTasks += task
+      pendingHashSet += task.hash
+    }
+    if (batch.isEmpty) return None // No dispatchable tasks for this peer right now
+    // Record this peer as tried for each dispatched hash
+    batch.foreach { task =>
+      triedPeersForTask.getOrElseUpdate(task.hash, mutable.Set.empty) += peer.id.value
+    }
 
     val requestId = requestTracker.generateRequestId()
     val responseBytes = requestResponseBytes // Besu-aligned D12: fixed size, no per-peer ratcheting
 
     // Build the paths list for GetTrieNodes — each entry's pathset is a Seq[ByteString]
-    val paths = batch.map(_.pathset)
+    val paths = batch.map(_.pathset).toSeq
 
     val request = GetTrieNodes(
       requestId = requestId,
@@ -504,13 +541,14 @@ class TrieNodeHealingCoordinator(
       responseBytes = responseBytes
     )
 
-    activeRequests(requestId) = ActiveRequest(batch, peer, responseBytes)
+    val batchSeq = batch.toSeq
+    activeRequests(requestId) = ActiveRequest(batchSeq, peer, responseBytes)
 
     // Besu RequestDataStep.java: orTimeout(10, TimeUnit.SECONDS) for all request types.
     // Aligned floor: 10s (was 30s). Ceiling: 30s (was 60s). Slow peers released faster.
     val healingTimeout = requestTracker.rateTracker.targetTimeout().max(10.seconds).min(30.seconds)
     requestTracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetTrieNodes, healingTimeout) {
-      handleTimeout(requestId, batch, peer)
+      handleTimeout(requestId, batchSeq, peer)
     }
 
     import com.chipprbots.ethereum.network.p2p.messages.SNAP.GetTrieNodes.GetTrieNodesEnc
@@ -550,6 +588,7 @@ class TrieNodeHealingCoordinator(
         // Valid node — store directly by hash
         rawNodeBuffer += ((nodeHash, nodeData.toArray))
         discoverMissingChildren(nodeData, task)
+        triedPeersForTask.remove(task.hash) // healed — no more per-task tracking needed
         healedCount += 1
         totalNodesHealed += 1
         receivedBytes += nodeData.length

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -77,6 +77,12 @@ class PeerManagerActor(
     */
   private var maintainedPeersByNodeId: Map[String, URI] = Map.empty
 
+  /** Consecutive reconnect failure count per maintained peer (D5).
+    * Used for exponential backoff: delay = min(30s, 1s << attempt).
+    * Reset to 0 on successful handshake.
+    */
+  private var maintainedPeerReconnectAttempts: Map[String, Int] = Map.empty
+
   /** Trusted peers bypass the max-peer limit and are always accepted. core-geth reference: p2p/server.go — trusted
     * map[enode.ID]bool in run loop. Keyed by lowercase hex node ID.
     */
@@ -449,10 +455,17 @@ class PeerManagerActor(
       terminatedPeersIds.foreach { peerId =>
         peerStatusCache = peerStatusCache - peerId
         peerEventBus ! Publish(PeerEvent.PeerDisconnected(peerId))
-        // Reconnect maintained peers — mirrors Besu's checkMaintainedConnectionPeers scheduler.
+        // Reconnect maintained peers with exponential backoff (D5).
+        // Besu DefaultP2PNetwork uses exponential: 1s → 2s → 4s → ... → 30s cap.
+        // Fixed 30s was too long on fast-cycling connections; too short on persistent failures.
         maintainedPeersByNodeId.get(peerId.value).foreach { uri =>
-          log.debug("Maintained peer {} disconnected — scheduling reconnect in 30s", uri)
-          context.system.scheduler.scheduleOnce(30.seconds, self, ConnectToPeer(uri))(context.dispatcher)
+          val nodeId = peerId.value
+          val attempt = maintainedPeerReconnectAttempts.getOrElse(nodeId, 0)
+          val delaySecs = math.min(30, 1 << attempt) // 1s, 2s, 4s, 8s, 16s, 30s (cap)
+          val delay = scala.concurrent.duration.Duration(delaySecs, java.util.concurrent.TimeUnit.SECONDS)
+          maintainedPeerReconnectAttempts = maintainedPeerReconnectAttempts + (nodeId -> (attempt + 1))
+          log.debug("Maintained peer {} disconnected — scheduling reconnect in {}s (attempt #{})", uri, delaySecs, attempt + 1)
+          context.system.scheduler.scheduleOnce(delay, self, ConnectToPeer(uri))(context.dispatcher)
         }
       }
       // Try to replace a lost connection with another one.
@@ -482,6 +495,8 @@ class PeerManagerActor(
         context.become(listening(connectedPeers))
       } else {
         peerStatusCache = peerStatusCache + (handshakedPeer.id -> PeerActor.Status.Handshaked)
+        // Reset backoff counter on successful handshake (D5)
+        maintainedPeerReconnectAttempts = maintainedPeerReconnectAttempts - handshakedPeer.id.value
         context.become(listening(connectedPeers.promotePeerToHandshaked(handshakedPeer)))
       }
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -64,6 +64,12 @@ case class EthNodeStatus64ExchangeState(
         status.genesisHash
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
+    } else if (status.totalDifficulty > BigInt(10).pow(26)) {
+      log.warn(
+        "STATUS_EXCHANGE: Peer advertising impossibly high totalDifficulty {} — disconnecting (spoofed/invalid peer)",
+        status.totalDifficulty
+      )
+      DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else {
       (for {
         validationResult <-


### PR DESCRIPTION
## Summary

Fixes a cluster of healing stall bugs in `TrieNodeHealingCoordinator` caused by incorrect peer exclusion and missing give-up conditions, plus immediate cancellation of in-flight account range requests when a peer disconnects.

**`coordinatorGeneration` increment before construction** — the generation counter is now incremented *before* constructing the new healing coordinator, closing a race where a stale coordinator from the previous generation could accept responses for the current one.

**Pivot-refresh on healing stagnation** — when all peers are blocked or returning empty for a missing state root, the coordinator now triggers a pivot refresh rather than looping indefinitely.

**Permanent IP-block on empty responses** — an empty response for a non-root node was treated as a timeout and permanently blocked the peer's IP. Fixed by distinguishing empty response (retry with a different peer) from timeout (temporary exclusion). Same fix applied to root-node timeouts.

**Full Besu peer-tracking alignment** — removes `statelessRemoteAddresses` in favor of Besu's per-task exclusion set stored in the request message.

**Per-task peer exclusion** — peers that time out on a `GetTrieNodes` request are excluded only for that task's retry cycle, not globally.

**Peer disconnect after 5 consecutive `GetTrieNodes` timeouts** — aligns with Besu's `PeerReputation` pattern: disconnect unresponsive peers after 5 timeouts, freeing the connection slot for a better peer.

**Peer reconnect backoff + TD ceiling** — exponential backoff on peer reconnect attempts and a total difficulty ceiling to prevent reconnect storms after network partitions. Recovery actors (`BytecodeRecoveryActor`, `StorageRecoveryActor`) log completion counts.

**Fire `HealingCheckCompletion` when root already in storage at seed** — prevents a hang when the healing coordinator is seeded with a root node that's already present locally.

**Consecutive-timeout give-up** — after 20 consecutive timeouts with no successful response, the coordinator triggers `HealingForceComplete`, clears the pending queue, and signals `StateHealingComplete`. Resets on any successful response. Prevents indefinite stall when SNAP peers no longer serve the pivot state.

**BUG-H1: `pendingHashSet` not updated on retry dispatch** — when the coordinator retried a `GetTrieNodes` request with a new peer, it rebuilt the request from scratch but didn't re-add hashes to `pendingHashSet`. On response, hashes not in `pendingHashSet` were dropped, losing healing progress silently.

**BUG-M3: idle escape** — after 5 consecutive dispatch checks where tasks are pending, no eligible peers remain, and no active requests are in-flight, the coordinator sends `HealingForceComplete` rather than spinning indefinitely. Mirrors `StorageRangeCoordinator`'s idle escape valve.

**BUG-M2/M1 logging improvements** — non-64-nibble paths now log at WARNING level; decode failures log at WARNING (not ERROR) with the problematic node hash prefix for easier triage.

**CFG-1: stagnation timeout 3→5 min** — aligns with observed ETC mainnet healing cadence.

**BUG-W8: cancel in-flight account range requests on peer disconnect** — `SNAPSyncController` forwards every `PeerDisconnected` event to `AccountRangeCoordinator` as `PeerUnavailable`. The coordinator removes the peer from its known-peers set, resets its consecutive-timeout counter, and notifies any in-flight `AccountRangeWorker` via `WorkerPeerDisconnected`. The worker immediately reports `TaskFailed` and returns to idle, allowing the task to be re-dispatched to a live peer. Without this, disconnected-peer tasks sat until their 30s timeout fired, blocking the account range pipeline. The `handleTaskFailed` path skips the per-peer cooldown for disconnect-triggered failures so the task is re-queued immediately.

## Dependencies

Depends on PR #1079 (`fix/snap-healing-lifecycle`) for `StateHealingComplete` message signature.

## Test plan
- [x] `sbt Test/compile` — clean
- [x] `sbt testEssential`
- [ ] Mordor: healing phase completes without stall at interior node boundaries