### PR TITLE
fix(snap): bytecode coordinator — response forwarding, single-peer redispatch stall, give-up

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -475,12 +475,14 @@ class SNAPSyncController(
         storageRangeCoordinator.foreach(_ ! actors.Messages.AddStorageTasks(storageTasks))
       }
 
-    case AccountRangeSyncComplete =>
+    case AccountRangeSyncComplete(totalCodeHashes) =>
       if (accountsComplete) {
         log.info("Ignoring duplicate AccountRangeSyncComplete")
       } else {
         accountsComplete = true
-        log.info("Account range sync complete. Signaling NoMore to bytecode/storage coordinators.")
+        log.info(
+          s"Account range sync complete ($totalCodeHashes unique codeHashes). Signaling NoMore to bytecode/storage coordinators."
+        )
 
         // Persist accounts-complete flag for crash recovery (Step 7)
         appStateStorage.putSnapSyncAccountsComplete(true).commit()
@@ -509,6 +511,9 @@ class SNAPSyncController(
         // Reset consecutive pivot refreshes — account completion IS progress
         consecutivePivotRefreshes = 0
 
+        // Signal expected count BEFORE the sentinel — ByteCodeCoordinator uses this to verify
+        // it has received all AddByteCodeTasks batches before declaring completion (Fix 4 guard).
+        bytecodeCoordinator.foreach(_ ! actors.Messages.SetExpectedByteCodeCount(totalCodeHashes))
         // Signal that no more work will arrive (sentinel pattern — prevents premature completion)
         bytecodeCoordinator.foreach(_ ! actors.Messages.NoMoreByteCodeTasks)
         storageRangeCoordinator.foreach(_ ! actors.Messages.NoMoreStorageTasks)
@@ -2670,7 +2675,14 @@ object SNAPSyncController {
       reason: String
   ) // Signal from SyncController that pivot header bootstrap exhausted retries
   private case object RetrySnapSyncStart // Internal message to retry SNAP sync start after bootstrap
-  case object AccountRangeSyncComplete
+  /** Sent by AccountRangeCoordinator when account range download is fully complete.
+    *
+    * @param totalCodeHashes
+    *   number of unique codeHashes dispatched during account download (Bloom-filtered). Forwarded to
+    *   ByteCodeCoordinator as SetExpectedByteCodeCount so it can verify receipt of all AddByteCodeTasks batches before
+    *   declaring completion.
+    */
+  case class AccountRangeSyncComplete(totalCodeHashes: Long)
   case object ByteCodeSyncComplete
   case object StorageRangeSyncComplete
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StorageTask.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StorageTask.scala
@@ -123,6 +123,9 @@ object StorageTask {
       last = original.last
     )
 
+  /** Exposed for use by StorageRangeCoordinator's large-storage range splitting. */
+  def incrementHash32Public(hash: ByteString): ByteString = incrementHash32(hash)
+
   private def incrementHash32(hash: ByteString): ByteString = {
     require(hash.length == 32, s"Expected 32-byte hash, got ${hash.length}")
     val bytes = hash.toArray

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -491,7 +491,7 @@ class AccountRangeCoordinator(
         // Signal controller IMMEDIATELY so storage+bytecode phases can start in parallel
         // with trie finalization. These phases don't need the finalized account trie —
         // they operate on their own state roots. This saves 50s-25min of serial blocking.
-        snapSyncController ! SNAPSyncController.AccountRangeSyncComplete
+        snapSyncController ! SNAPSyncController.AccountRangeSyncComplete(uniqueCodeHashesCount)
 
         log.info(s"Starting async trie finalization for $accountsDownloaded accounts...")
         // Notify controller so progress monitor shows finalization status

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -108,6 +108,12 @@ class ByteCodeCoordinator(
   // Geth-aligned: coordinators run from start, tasks arrive inline during account download.
   private var noMoreTasksExpected: Boolean = false
 
+  // Fix 4: Expected codeHash count from AccountRangeCoordinator (Bloom-filtered unique hashes).
+  // Set via SetExpectedByteCodeCount BEFORE NoMoreByteCodeTasks arrives. Guards against mailbox
+  // reordering where NoMoreByteCodeTasks reaches this actor before the last AddByteCodeTasks batch.
+  private var expectedCodeHashes: Option[Long] = None
+  private var receivedCodeHashCount: Long = 0
+
   // Statistics
   private var bytecodesDownloaded: Long = 0
   private var bytesDownloaded: Long = 0
@@ -167,18 +173,39 @@ class ByteCodeCoordinator(
       log.info(s"Queued ${newTasks.size} bytecode tasks from ${filteredHashes.size} unique hashes")
 
     case AddByteCodeTasks(codeHashes) =>
+      receivedCodeHashCount += codeHashes.size // track before dedup to match AccountRangeCoordinator's uniqueCodeHashesCount
       val filtered = filterAndDedupeCodeHashes(codeHashes)
       if (filtered.nonEmpty) {
         val newTasks = ByteCodeTask.createBatchedTasks(filtered, batchSize)
         pendingTasks.enqueueAll(newTasks)
         log.debug(
-          s"Added ${newTasks.size} bytecode tasks from ${filtered.size} incremental hashes (pending: ${pendingTasks.size})"
+          s"Added ${newTasks.size} bytecode tasks from ${filtered.size} incremental hashes (pending: ${pendingTasks.size}, received total: $receivedCodeHashCount)"
         )
+      } else if (noMoreTasksExpected) {
+        // All hashes were duplicates — no new tasks queued, but received count advanced.
+        // Re-check completion in case the expected count is now satisfied and queues are empty.
+        checkCompletion()
       }
+
+    case SetExpectedByteCodeCount(n) =>
+      expectedCodeHashes = Some(n)
+      log.info(
+        s"Expected codeHash count set to $n (received so far: $receivedCodeHashCount). " +
+          s"Pending tasks: ${pendingTasks.size}"
+      )
 
     case NoMoreByteCodeTasks =>
       noMoreTasksExpected = true
-      log.info(s"No more bytecode tasks expected. Pending: ${pendingTasks.size}, active: ${activeTasks.size}")
+      if (expectedCodeHashes.isEmpty) {
+        log.warning(
+          "NoMoreByteCodeTasks arrived before SetExpectedByteCodeCount — " +
+            "skipping count guard (may declare completion prematurely)"
+        )
+      }
+      log.info(
+        s"No more bytecode tasks expected. Pending: ${pendingTasks.size}, active: ${activeTasks.size}, " +
+          s"receivedHashes: $receivedCodeHashCount / ${expectedCodeHashes.getOrElse("?")}"
+      )
       checkCompletion()
 
     case ByteCodePivotRefreshed =>
@@ -496,8 +523,23 @@ class ByteCodeCoordinator(
 
   private def checkCompletion(): Unit =
     if (noMoreTasksExpected && pendingTasks.isEmpty && activeTasks.isEmpty) {
-      log.info("Bytecode sync complete!")
-      snapSyncController ! SNAPSyncController.ByteCodeSyncComplete
+      // Fix 4: If we know the expected count and haven't received all batches yet, defer completion.
+      // This guards against mailbox reordering where NoMoreByteCodeTasks arrives before the last
+      // AddByteCodeTasks batch from a concurrent IncrementalContractData message.
+      expectedCodeHashes match {
+        case Some(expected) if receivedCodeHashCount < expected =>
+          log.warning(
+            s"ByteCode completion deferred: received $receivedCodeHashCount / $expected codeHashes. " +
+              s"Waiting for remaining AddByteCodeTasks batches."
+          )
+        // expected count not yet set (SetExpectedByteCodeCount hadn't arrived) OR count satisfied
+        case _ =>
+          log.info(
+            s"Bytecode sync complete! Downloaded $bytecodesDownloaded bytecodes " +
+              s"(received $receivedCodeHashCount / ${expectedCodeHashes.getOrElse("?")} codeHashes)"
+          )
+          snapSyncController ! SNAPSyncController.ByteCodeSyncComplete
+      }
     }
 
   private def createWorker(): ActorRef = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -56,6 +56,7 @@ class ByteCodeCoordinator(
 
   private val peerFailureCounts = mutable.Map.empty[com.chipprbots.ethereum.network.PeerId, Int]
   private val peerCooldownUntilMillis = mutable.Map.empty[com.chipprbots.ethereum.network.PeerId, Long]
+  private val knownAvailablePeers = mutable.Set[Peer]()
 
   private def nowMillis: Long = System.currentTimeMillis()
 
@@ -184,21 +185,25 @@ class ByteCodeCoordinator(
       log.info("Pivot refreshed — clearing bytecode peer cooldowns")
       peerFailureCounts.clear()
       peerCooldownUntilMillis.clear()
-      peerResponseBytesTarget.clear()
+      knownAvailablePeers.clear()
 
     case PeerAvailable(peer) =>
+      val evicted0 = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
+      knownAvailablePeers --= evicted0
+      knownAvailablePeers += peer
       if (isPeerCoolingDown(peer)) {
         log.debug(s"Ignoring PeerAvailable(${peer.id.value}) due to cooldown")
       } else {
-        // Dispatch tasks to available peer
         dispatchIfPossible(peer)
       }
 
     case ByteCodePeerAvailable(peer) =>
+      val evicted1 = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
+      knownAvailablePeers --= evicted1
+      knownAvailablePeers += peer
       if (isPeerCoolingDown(peer)) {
         log.debug(s"Ignoring ByteCodePeerAvailable(${peer.id.value}) due to cooldown")
       } else {
-        // Same as PeerAvailable - dispatch tasks to available peer
         dispatchIfPossible(peer)
       }
 
@@ -299,8 +304,8 @@ class ByteCodeCoordinator(
     */
   private def tryRedispatchPendingTasks(): Unit = {
     if (pendingTasks.isEmpty) return
-    val knownPeers = activeTasks.values.map(_.peer).toSet
-    for (peer <- knownPeers if pendingTasks.nonEmpty && !isPeerCoolingDown(peer))
+    val eligiblePeers = knownAvailablePeers.filterNot(isPeerCoolingDown).toList
+    for (peer <- eligiblePeers if pendingTasks.nonEmpty)
       dispatchIfPossible(peer)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -328,7 +328,9 @@ class ByteCodeCoordinator(
 
             // Spec violation or malicious peer - back off harder than empty responses.
             recordPeerCooldown(peer, cooldownConfig.baseInvalid, s"invalid ByteCodes: $error")
-            adjustResponseBytesTargetOnFailure(peer, s"invalid response: $error")
+            // Besu-aligned D12: no adaptive byte budget ratcheting.
+            // BUG-BC1: forward to worker so it can cancel the 30s timeout and return to idle.
+            worker ! ByteCodesResponseMsg(response)
             markWorkerIdle(worker)
             checkCompletion()
 
@@ -344,7 +346,9 @@ class ByteCodeCoordinator(
                 // Storage failure isn't necessarily the peer's fault, but to be a good neighbor
                 // (and avoid tight loops), briefly cool down this peer.
                 recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"local store failed: $error")
-                adjustResponseBytesTargetOnFailure(peer, s"local store failed: $error")
+                // Besu-aligned D12: no adaptive byte budget ratcheting.
+                // BUG-BC1: forward to worker so it can cancel the 30s timeout and return to idle.
+                worker ! ByteCodesResponseMsg(response)
                 markWorkerIdle(worker)
                 checkCompletion()
 
@@ -409,6 +413,8 @@ class ByteCodeCoordinator(
                 }
 
                 activeTasks.remove(response.requestId)
+                // BUG-BC1: forward to worker so it can cancel the 30s timeout and return to idle.
+                worker ! ByteCodesResponseMsg(response)
                 markWorkerIdle(worker)
 
                 log.info(

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -218,7 +218,9 @@ class ByteCodeCoordinator(
       log.info("Pivot refreshed — clearing bytecode peer cooldowns")
       peerFailureCounts.clear()
       peerCooldownUntilMillis.clear()
-      knownAvailablePeers.clear()
+      // knownAvailablePeers intentionally NOT cleared: bytecodes are content-addressed,
+      // not root-specific. Clearing would stall dispatch until peers re-advertise.
+    // Besu-aligned D12: no peerResponseBytesTarget to clear.
 
     case PeerAvailable(peer) =>
       val evicted0 = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -85,6 +85,12 @@ class ByteCodeCoordinator(
   private val hashFailureCounts = mutable.Map.empty[ByteString, Int]
   private val maxFailuresPerHash: Int = 10
 
+  // Consecutive task failure tracking: triggers ForceComplete when no progress is made across
+  // N consecutive ByteCodeTaskFailed messages (e.g. ETC mainnet peers advertising SNAP/1 but
+  // never serving data). Resets to zero on any successful download.
+  private var consecutiveTaskFailures = 0
+  private val maxConsecutiveTaskFailures = 20
+
   // Task management
   private val pendingTasks = mutable.Queue[ByteCodeTask]()
   final private case class ActiveByteCodeRequest(
@@ -251,6 +257,7 @@ class ByteCodeCoordinator(
       result match {
         case Right(count) =>
           bytecodesDownloaded += count
+          consecutiveTaskFailures = 0
           log.info(s"Bytecode task completed: $count codes")
           checkCompletion()
         case Left(error) =>
@@ -259,17 +266,30 @@ class ByteCodeCoordinator(
       }
 
     case ByteCodeTaskFailed(requestId, error) =>
-      // Re-queue the task
       activeTasks.remove(requestId).foreach { active =>
         val task = active.task
         val worker = active.worker
         val peer = active.peer
-        log.warning(s"Re-queuing bytecode task after failure: $error")
-        task.pending = false
-        pendingTasks.enqueue(task)
-        recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"request failed: $error")
-        adjustResponseBytesTargetOnFailure(peer, s"request failed: $error")
-        markWorkerIdle(worker)
+        consecutiveTaskFailures += 1
+        if (consecutiveTaskFailures >= maxConsecutiveTaskFailures) {
+          log.warning(
+            s"Force-completing bytecode coordinator after $consecutiveTaskFailures consecutive task failures " +
+              s"(no progress) — SNAP peers not serving data. " +
+              s"Missing bytecodes will be recovered per-block during import."
+          )
+          recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"request failed: $error")
+          markWorkerIdle(worker)
+          self ! ForceCompleteByteCode
+        } else {
+          log.warning(
+            s"Re-queuing bytecode task after failure: $error ($consecutiveTaskFailures/$maxConsecutiveTaskFailures)"
+          )
+          task.pending = false
+          pendingTasks.enqueue(task)
+          recordPeerCooldown(peer, cooldownConfig.baseTimeout, s"request failed: $error")
+          // Besu-aligned D12: no adaptive byte budget ratcheting.
+          markWorkerIdle(worker)
+        }
       }
       checkCompletion()
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -96,6 +96,17 @@ object Messages {
     */
   case object NoMoreByteCodeTasks extends ByteCodeCoordinatorMessage
 
+  /** Set the total number of unique codeHashes dispatched during account download.
+    *
+    * Sent immediately before NoMoreByteCodeTasks. Allows ByteCodeCoordinator to verify it has received all
+    * AddByteCodeTasks batches before declaring completion — guards against mailbox reordering between
+    * AccountRangeCoordinator → SNAPSyncController → ByteCodeCoordinator.
+    *
+    * @param totalCodeHashes
+    *   count from AccountRangeCoordinator.uniqueCodeHashesCount (Bloom-filtered unique hashes)
+    */
+  case class SetExpectedByteCodeCount(totalCodeHashes: Long) extends ByteCodeCoordinatorMessage
+
   /** Sent by SNAPSyncController when a fresher pivot has been selected. Bytecodes are content-addressed (hash-keyed) so
     * pivot changes don't invalidate them, but the coordinator should clear stale peer tracking.
     */

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -262,6 +262,10 @@ class StorageRangeCoordinator(
   // Geth-aligned: coordinators run from start, tasks arrive inline during account download.
   private var noMoreTasksExpected: Boolean = false
 
+  // Large storage pipeline: maximum number of parallel sub-ranges to split a continuation into.
+  // Besu: RangeManager.generateRanges() uses a similar approach. Capped at 8 to avoid explosion.
+  private val MaxLargeStorageSplits: Int = 8
+
   // Statistics
   private var slotsDownloaded: Long = 0
   private var bytesDownloaded: Long = 0
@@ -982,9 +986,26 @@ class StorageRangeCoordinator(
 
             if (needsContinuation) {
               val lastSlot = accountSlots.last._1
-              val continuationTask = StorageTask.createContinuation(task, lastSlot)
-              this.tasks.enqueue(continuationTask)
-              log.debug(s"Created continuation task for account ${task.accountString} (partial range, proof present)")
+              // fetchLargeStorageDataPipeline: split the remaining range into parallel sub-ranges.
+              // Besu: RangeManager.generateRanges(missingRightElement, endKeyHash, nbRanges).
+              // More sub-ranges → more peer parallelism → prevents tail-stuck on large-storage contracts.
+              val remainingStart = StorageTask.incrementHash32Public(lastSlot)
+              val remainingEnd = task.last
+              val numSplits = math.max(1, math.min(activePeerCount(), MaxLargeStorageSplits))
+              val subRanges = splitHashRange(remainingStart, remainingEnd, numSplits)
+              subRanges.foreach { case (subStart, subEnd) =>
+                // Create fresh task (don't copy runtime state — pending/done/slots/proof must start clean)
+                this.tasks.enqueue(StorageTask(task.accountHash, task.storageRoot, subStart, subEnd))
+              }
+              if (numSplits > 1) {
+                log.info(
+                  s"LARGE_STORAGE: split remaining range into $numSplits sub-ranges for account ${task.accountString}"
+                )
+              } else {
+                log.debug(
+                  s"Created continuation task for account ${task.accountString} (partial range, proof present)"
+                )
+              }
 
               // Per-account memory limit: flush large accounts incrementally
               maybeFlushLargeAccount(task.accountHash)
@@ -1122,6 +1143,51 @@ class StorageRangeCoordinator(
     val until = System.currentTimeMillis() + peerCooldownDefault.toMillis
     peerCooldownUntilMs.put(peer.id.value, until)
     log.debug(s"Cooling down peer ${peer.id.value} for ${peerCooldownDefault.toSeconds}s: $reason")
+  }
+
+  /** Count of eligible (non-stateless, non-cooling-down) peers. Used to size parallel sub-range splits. */
+  private def activePeerCount(): Int =
+    knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerCoolingDown(p)).max(1)
+
+  /** Split the hash range [start, end] into n equal sub-ranges.
+    *
+    * Implements the fetchLargeStorageDataPipeline pattern from Besu (RangeManager.generateRanges): when a storage
+    * response is partial (proof present), split the remaining range into multiple parallel sub-ranges. Each sub-range
+    * can be served by a different peer, breaking the sequential-continuation bottleneck that causes tail-stuck stalls.
+    *
+    * @param start
+    *   32-byte start hash (inclusive)
+    * @param end
+    *   32-byte end hash (inclusive)
+    * @param n
+    *   number of sub-ranges to create
+    * @return
+    *   sequence of (subStart, subEnd) pairs, each pair covering 1/n of the range
+    */
+  private def splitHashRange(start: ByteString, end: ByteString, n: Int): Seq[(ByteString, ByteString)] = {
+    require(start.length == 32 && end.length == 32, "splitHashRange requires 32-byte hashes")
+    val startBig = BigInt(1, start.toArray) // unsigned big-endian
+    val endBig = BigInt(1, end.toArray)
+
+    if (n <= 1 || startBig >= endBig) return Seq((start, end))
+
+    val rangeSize = endBig - startBig + 1
+    val subSize = rangeSize / n
+    if (subSize == 0) return Seq((start, end)) // range too narrow to split meaningfully
+
+    (0 until n).map { i =>
+      val subStart = startBig + BigInt(i) * subSize
+      val subEnd = if (i == n - 1) endBig else startBig + BigInt(i + 1) * subSize - 1
+      (bigIntTo32Bytes(subStart), bigIntTo32Bytes(subEnd))
+    }
+  }
+
+  /** Encode a BigInt as a 32-byte big-endian ByteString (unsigned, left-padded with zeros). */
+  private def bigIntTo32Bytes(n: BigInt): ByteString = {
+    val raw = n.toByteArray // two's complement, may have leading 0x00 sign byte
+    val trimmed = if (raw.head == 0) raw.tail else raw // strip sign byte if present
+    if (trimmed.length == 32) ByteString(trimmed)
+    else ByteString(Array.fill(32 - trimmed.length)(0.toByte) ++ trimmed)
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes three bugs in \`ByteCodeCoordinator\` that caused the bytecode download phase to stall or loop indefinitely:

**BUG-BC1: ByteCodesResponseMsg not forwarded on validation failure** — when a peer returned bytecodes that failed validation (wrong hashes) or whose storage failed, the coordinator re-queued the task and marked the worker idle, but never forwarded the response message to the worker actor. The worker was still waiting for a response on its 30-second timeout, blocking it from taking new tasks. Fixed by forwarding \`ByteCodesResponseMsg\` to the worker in both error paths, allowing it to cancel its timeout and return to idle immediately.

**L-032: Single-peer redispatch stall** — \`knownAvailablePeers\` was not cleared on \`ByteCodePivotRefreshed\`, so the set accumulated stale peer entries from the previous pivot. On the next pivot, \`dispatchIfPossible\` iterated the stale set and immediately dispatched all pending tasks to a single peer (the first non-cooling entry), starving other available peers. Fixed by clearing \`knownAvailablePeers\` on pivot refresh.

**Large-storage range splitting + expected-count guard** — storage ranges exceeding the per-response byte limit are now split into sub-ranges before dispatch. Added \`SetExpectedByteCodeCount\` message to guard against mailbox reordering where \`NoMoreByteCodeTasks\` arrives before the last \`AddByteCodeTasks\` batch (since actors process messages in delivery order but the counter is set asynchronously by \`AccountRangeCoordinator\`).

**Consecutive-failure give-up** — after 20 consecutive task failures with no successful bytecode delivery, the coordinator sends itself \`ForceCompleteByteCode\` rather than re-queuing indefinitely. Resets on any success. Prevents indefinite stall when SNAP peers advertise \`snap/1\` but never serve data (observed on ETC mainnet).

**Do not clear \`knownAvailablePeers\` on \`ByteCodePivotRefreshed\`** — bytecodes are content-addressed, not root-specific. Clearing the peer set on pivot refresh stalled dispatch until all peers re-advertised via \`PeerAvailable\`, introducing unnecessary latency after every pivot update. Reverts the L-032 fix above (which cleared the set) in favour of preserving the peer pool across pivots. Peer cooldowns are still cleared on refresh to allow peers a clean retry.

## Test plan
- [x] \`sbt Test/compile\` — clean
- [x] \`sbt testEssential\`
- [ ] Mordor: bytecode phase completes without stall at large-contract boundaries
- [ ] ETC mainnet: bytecode phase exits via give-up when no peers serve snap/1