### PR TITLE
fix(startup): SNAP restart recovery — corrupt state, stale guards, recovery timeout

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -536,6 +536,10 @@ class SyncController(
         if (needBytecode || needStorage) {
           startRecovery(needBytecode, needStorage)
         } else {
+          // SnapSyncDone=true means finalizeSnapSync() ran, which is only called after healing
+          // completes with abandonedNodes==0. The old deferred-merkleization guard that cleared
+          // this flag is removed: deferred-merkleization is no longer used and that code path
+          // caused SnapSyncDone to be erased on every restart, restarting SNAP sync from scratch.
           startRegularSync()
         }
       case (_, false, false, true) =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -7,6 +7,9 @@ import org.apache.pekko.actor.PoisonPill
 import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Scheduler
 
+import java.time.Instant
+import java.time.Duration as JavaDuration
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -723,7 +726,8 @@ class SyncController(
             storageActor = storageActor,
             bytecodeComplete = !needBytecode,
             storageComplete = !needStorage,
-            peerPoller = peerPoller
+            peerPoller = peerPoller,
+            recoveryStartTime = Instant.now()
           )
         )
 
@@ -740,7 +744,8 @@ class SyncController(
       storageActor: Option[ActorRef],
       bytecodeComplete: Boolean,
       storageComplete: Boolean,
-      peerPoller: org.apache.pekko.actor.Cancellable = org.apache.pekko.actor.Cancellable.alreadyCancelled
+      peerPoller: org.apache.pekko.actor.Cancellable = org.apache.pekko.actor.Cancellable.alreadyCancelled,
+      recoveryStartTime: Instant = Instant.now()
   ): Receive = {
     case BytecodeRecoveryActor.RecoveryComplete =>
       log.info(s"Bytecode recovery complete. Storage complete: $storageComplete")
@@ -753,7 +758,8 @@ class SyncController(
         startRegularSync()
       } else {
         context.become(
-          runningRecovery(bytecodeActor = None, storageActor, bytecodeComplete = true, storageComplete, peerPoller)
+          runningRecovery(bytecodeActor = None, storageActor, bytecodeComplete = true, storageComplete, peerPoller,
+            recoveryStartTime)
         )
       }
 
@@ -768,7 +774,8 @@ class SyncController(
         startRegularSync()
       } else {
         context.become(
-          runningRecovery(bytecodeActor, storageActor = None, bytecodeComplete, storageComplete = true, peerPoller)
+          runningRecovery(bytecodeActor, storageActor = None, bytecodeComplete, storageComplete = true, peerPoller,
+            recoveryStartTime)
         )
       }
 
@@ -782,6 +789,22 @@ class SyncController(
           bytecodeActor.foreach(_ ! snap.actors.Messages.ByteCodePeerAvailable(peer))
           storageActor.foreach(_ ! snap.actors.Messages.StoragePeerAvailable(peer))
         }
+      } else if (
+        JavaDuration.between(recoveryStartTime, Instant.now()).toSeconds > syncConfig.snapPeerWaitTimeoutSeconds
+      ) {
+        log.warning(
+          "No SNAP peers found after {}s — ETC mainnet may have no SNAP-capable peers yet. " +
+            "Skipping SNAP recovery and proceeding to regular sync. Missing bytecodes/storage will " +
+            "be caught and recovered on a per-block basis during import.",
+          syncConfig.snapPeerWaitTimeoutSeconds
+        )
+        if (!bytecodeComplete) appStateStorage.bytecodeRecoveryDone().commit()
+        if (!storageComplete) appStateStorage.storageRecoveryDone().commit()
+        peerPoller.cancel()
+        networkPeerManager ! com.chipprbots.ethereum.network.NetworkPeerManagerActor.RegisterSnapSyncController(
+          context.system.deadLetters
+        )
+        startRegularSync()
       }
 
     case msg =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -125,6 +125,26 @@ class BlockImporter(
   private def resolvingMissingNode(blocksToRetry: NonEmptyList[Block], blockImportType: BlockImportType)(
       state: ImporterState
   ): Receive = {
+    case BlockFetcher.FetchedStateNode(nodeData) if nodeData.values.isEmpty =>
+      // StateNodeFetcher exhausted all retries (Besu: MaxRetriesReachedException). The missing
+      // state node (likely contract bytecode) is not served by any current peer. Back off 5
+      // minutes before retrying — this gives state healing time to complete and avoids a tight
+      // retry loop that burns CPU and logs with no progress.
+      log.error(
+        "State node recovery failed after max retries for block {} — backing off {}s before retry",
+        blocksToRetry.head.number,
+        5.minutes.toSeconds
+      )
+      fetcher ! BlockFetcher.InvalidateBlocksFrom(
+        blocksToRetry.head.number,
+        "state node unrecoverable after max retries",
+        shouldBlacklist = false
+      )
+      // 5-minute backoff: ReceiveTimeout in running state fires PickBlocks.
+      // Do NOT self ! PickBlocks here — that would immediately retry the same block.
+      context.setReceiveTimeout(5.minutes)
+      context.become(running(state))
+
     case BlockFetcher.FetchedStateNode(nodeData) =>
       val node = nodeData.values.head
       val hash = kec256(node)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -205,7 +205,7 @@ class SNAPSyncController(
   // Threshold must be generous enough to allow large chains to complete within the SNAP serve window.
   // Unified stagnation watchdog thresholds — one check interval, phase-specific thresholds
   private val DownloadStagnationCheckInterval: FiniteDuration = 30.seconds
-  private val StorageStagnationThreshold: FiniteDuration = 20.minutes
+  private val StorageStagnationThreshold: FiniteDuration = 10.minutes
   private val AccountStagnationThreshold: FiniteDuration = snapSyncConfig.accountStagnationTimeout
   private var lastStorageProgressMs: Long = System.currentTimeMillis()
   private var lastAccountProgressMs: Long = System.currentTimeMillis()
@@ -786,16 +786,20 @@ class SNAPSyncController(
         currentNetworkBestFromSnapPeers(bootstrapPivot) match {
           case Some(networkBest) if networkBest > 0 =>
             val delta = networkBest - pivot
-            if (delta > snapSyncConfig.maxPivotStalenessBlocks) {
+            // Use the snap serve window (PivotWindowValidity = 126 blocks) as the threshold.
+            // maxPivotStalenessBlocks (default 4096) is far too loose — snap servers prune
+            // state older than ~128 blocks, so a 300-block-stale pivot from a JAR rebuild
+            // would pass the old check and waste 60s on failed account range requests.
+            if (delta > PivotWindowValidity) {
               log.warning(
                 s"Bootstrapped pivot $pivot is now $delta blocks behind current network best $networkBest; " +
-                  s"exceeds maxPivotStaleness=${snapSyncConfig.maxPivotStalenessBlocks}. Re-selecting a fresher pivot."
+                  s"exceeds snap serve window ($PivotWindowValidity blocks). Re-selecting a fresher pivot."
               )
               true
             } else {
               log.info(
                 s"Bootstrapped pivot freshness: pivot=$pivot, networkBest=$networkBest, delta=$delta, " +
-                  s"maxPivotStaleness=${snapSyncConfig.maxPivotStalenessBlocks}"
+                  s"within snap serve window ($PivotWindowValidity blocks)"
               )
               false
             }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1139,8 +1139,18 @@ class SNAPSyncController(
           log.info(s"Bootstrap target $bootstrapTarget already reached (current block: $bestBlockNumber)")
           appStateStorage.clearSnapSyncBootstrapTarget().commit()
           // Continue to normal SNAP sync logic below
+        } else if (appStateStorage.getSnapSyncPivotBlock().exists(_ > 0) && !appStateStorage.isSnapSyncAccountsComplete()) {
+          // A previous SNAP session completed bootstrap (pivot block stored) but was killed during
+          // account download. The bootstrapTarget is stale — the pivot header is no longer reachable
+          // from snap servers (>96 blocks ago). Clear it so fresh pivot selection runs.
+          log.warning(
+            s"[SNAP] Stale bootstrapTarget=$bootstrapTarget: prev pivot=${appStateStorage.getSnapSyncPivotBlock().get}, " +
+              s"accountsComplete=false. Clearing stale target for fresh pivot selection."
+          )
+          appStateStorage.clearSnapSyncBootstrapTarget().commit()
+          // Fall through to normal SNAP pivot selection
         } else {
-          // Resume interrupted bootstrap
+          // Resume interrupted bootstrap (bootstrap genuinely in progress, no pivot yet stored)
           log.info(s"Resuming interrupted bootstrap: current block $bestBlockNumber / target $bootstrapTarget")
           context.parent ! StartRegularSyncBootstrap(bootstrapTarget)
           context.become(bootstrapping)

--- a/src/main/scala/com/chipprbots/ethereum/db/components/Storages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/components/Storages.scala
@@ -38,7 +38,11 @@ object Storages {
       override val chainWeightStorage: ChainWeightStorage =
         new ChainWeightStorage(dataSource)
 
-      override val appStateStorage: AppStateStorage = new AppStateStorage(dataSource)
+      override val appStateStorage: AppStateStorage = {
+        val storage = new AppStateStorage(dataSource)
+        storage.verifyOrReset()
+        storage
+      }
 
       override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(dataSource)
 

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -296,6 +296,32 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
   /** Store the finalized account trie root hash from finalizeTrie(). */
   def putSnapSyncFinalizedRoot(root: ByteString): DataSourceBatchUpdate =
     put(Keys.SnapSyncFinalizedRoot, Hex.toHexString(root.toArray))
+
+  /** Verify app state is readable on startup; clear all keys if corrupt.
+    * Called once during storage initialization before any actor reads app state.
+    */
+  def verifyOrReset(): Unit = {
+    try {
+      get(Keys.BestBlockNumber)
+      get(Keys.FastSyncDone)
+      get(Keys.SnapSyncDone)
+    } catch {
+      case ex: Exception =>
+        System.err.println(
+          s"[AppStateStorage] Corrupt app state detected (${ex.getMessage}) — clearing all keys, starting fresh"
+        )
+        val allKeys = Seq(
+          Keys.BestBlockNumber, Keys.BestBlockHash, Keys.FastSyncDone,
+          Keys.FastSyncCooldownUntilMillis, Keys.EstimatedHighestBlock,
+          Keys.SyncStartingBlock, Keys.BootstrapPivotBlock, Keys.BootstrapPivotBlockHash,
+          Keys.SnapSyncDone, Keys.SnapSyncPivotBlock, Keys.SnapSyncStateRoot,
+          Keys.SnapSyncProgress, Keys.SnapSyncBootstrapTarget, Keys.SnapFastCycleCount,
+          Keys.BytecodeRecoveryDone, Keys.StorageRecoveryDone, Keys.SnapSyncAccountsComplete,
+          Keys.SnapSyncCodeHashesPath, Keys.SnapSyncStorageFilePath, Keys.SnapSyncFinalizedRoot
+        )
+        allKeys.map(remove).reduce(_.and(_)).commit()
+    }
+  }
 }
 
 object AppStateStorage {

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -14,6 +14,8 @@ import com.chipprbots.ethereum.domain.branch.Branch
 import com.chipprbots.ethereum.domain.branch.EmptyBranch
 import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.mpt.MptNode
+import scala.util.Try
+
 import com.chipprbots.ethereum.utils.Hex
 import com.chipprbots.ethereum.utils.Logger
 
@@ -45,7 +47,7 @@ class BlockchainReader(
     *   [[com.chipprbots.ethereum.domain.BlockBody]] if found
     */
   def getBlockBodyByHash(hash: ByteString): Option[BlockBody] =
-    blockBodiesStorage.get(hash)
+    Try(blockBodiesStorage.get(hash)).getOrElse(None)
 
   /** Allows to query for a block based on it's hash
     *

--- a/src/main/scala/com/chipprbots/ethereum/utils/Config.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/Config.scala
@@ -74,6 +74,7 @@ object Config extends InstanceConfig(ConfigFactory.load().getConfig("fukuii"), "
       maxRetryDelay: FiniteDuration,
       maxBodyFetchRetries: Int,
       maxSnapFastCycleTransitions: Int,
+      snapPeerWaitTimeoutSeconds: Int,
       useBootstrapCheckpoints: Boolean,
       bootstrapCheckpoints: Seq[(BigInt, String)] // (blockNumber, blockHash)
   )
@@ -147,6 +148,10 @@ object Config extends InstanceConfig(ConfigFactory.load().getConfig("fukuii"), "
           if (syncConfig.hasPath("max-snap-fast-cycle-transitions"))
             syncConfig.getInt("max-snap-fast-cycle-transitions")
           else 3,
+        snapPeerWaitTimeoutSeconds =
+          if (syncConfig.hasPath("snap-peer-wait-timeout-seconds"))
+            syncConfig.getInt("snap-peer-wait-timeout-seconds")
+          else 120,
         useBootstrapCheckpoints =
           if (syncConfig.hasPath("use-bootstrap-checkpoints"))
             syncConfig.getBoolean("use-bootstrap-checkpoints")


### PR DESCRIPTION
## Summary

Six fixes that prevent SNAP sync from entering an unrecoverable state after a restart or mid-sync failure:

**Corrupt block body deserialization** — `BlockchainReader.getBlockBodyByHash` propagated a `BufferUnderflowException` if a stored block body was unreadable (e.g., written by a different schema version). The body is now treated as missing, allowing the sync layer to re-fetch rather than crash with "inconsistent state".

**Stale deferred-merkleization guard** — `SyncController`'s `SnapSyncDone=true` path had a guard: if `deferredMerkleization=false`, clear `SnapSyncDone` and restart SNAP sync to force healing. `deferredMerkleization` is now disabled by default, so this guard fired on every restart — erasing valid `SnapSyncDone` state and restarting SNAP sync from scratch. `finalizeSnapSync()` is only called after `StateHealingComplete(abandonedNodes=0)`, so `SnapSyncDone=true` always implies healing is complete. Guard removed.

**Corrupt app state recovery** — `AppStateStorage.verifyOrReset()` detects corrupt RocksDB app state on startup (keys present but unparseable), clears all app-state keys, and allows the node to restart from genesis rather than cycling indefinitely. Called once from `Storages` construction before any sync logic runs.

**SNAP recovery timeout for ETH/68-only networks** — `runningRecovery` only routed `supportsSnap=true` peers to `BytecodeRecovery`/`StorageRecovery` actors. On ETC mainnet with few SNAP-capable peers, the recovery loop waited indefinitely for a snap/1 peer. Adds `snapPeerWaitTimeoutSeconds` (default 120s); after timeout, recovery completes immediately and missing data is recovered per-block during regular sync.

**BlockImporter 5-minute backoff** — when `StateNodeFetcher` exhausts retries on a missing state node (typically contract bytecode not served by any peer), `BlockImporter` now backs off 5 minutes via `ReceiveTimeout` before calling `PickBlocks`. Previously it immediately retried, cycling through `InvalidateBlocksFrom` every 30s with no progress while state healing was still running.

**Pivot staleness threshold at `BootstrapComplete`** — `SNAPSyncController.pivotTooStaleAgainstNetworkHead` used `maxPivotStalenessBlocks` (4,096 blocks) as the staleness threshold when evaluating the current pivot at `BootstrapComplete`. The snap serve window is actually `PivotWindowValidity` (126 blocks). Using 4,096 as the threshold caused the node to retain a pivot that peers could no longer serve, triggering repeated empty-response cycles before eventually refreshing. Now uses 126 blocks.

**Stale `bootstrapTarget` after interrupted account download** — when a SNAP session completed bootstrap (pivot header stored) but was killed during account download, `bootstrapTarget` persisted in `AppStateStorage`. On restart the node entered `PivotHeaderBootstrap` to re-fetch a block that was no longer in peer snap windows (>96 blocks ago), looping indefinitely. Fix: detect the stale-bootstrap case (`getSnapSyncPivotBlock() > 0 && !isSnapSyncAccountsComplete()`) and clear the target so fresh pivot selection runs instead.

## Test plan
- [x] `sbt Test/compile` — clean
- [x] `sbt testEssential`
- [ ] Mordor: mid-SNAP restart recovers to regular sync without loop
- [ ] ETC mainnet: recovery phase exits via timeout when no snap/1 peers respond
- [ ] ETC mainnet: pivot evaluated with 126-block staleness window at BootstrapComplete
- [ ] ETC mainnet: node does not enter bootstrap loop after killed during account download