### PR TITLE
fix(consensus): ECIP-adapted EIP-7934 block size cap (8 MiB)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
@@ -20,10 +20,11 @@ import com.chipprbots.ethereum.utils.ByteUtils.or
 
 object StdBlockValidator extends BlockValidator {
 
-  /** EIP-7934: Max RLP-encoded block size (10 MiB exact per spec). Activates at Osaka. Pre-Osaka chains never produce
-    * blocks near this cap in practice, so leaving unconditional is safe.
+  /** ECIP adaptation of EIP-7934: Max RLP-encoded block size (8 MiB = 10 MiB - 2 MiB). Activates at Olympia.
+    * ETC adapts the Ethereum 10 MiB cap down to 8 MiB to match ETC's lower gas limits.
+    * Pre-Olympia chains never produce blocks near this cap in practice, so leaving unconditional is safe.
     */
-  val BlockRLPSizeCap: Long = 10L * 1024 * 1024 // 10,485,760
+  val BlockRLPSizeCap: Long = 8L * 1024 * 1024 // 8,388,608
 
   /** Validates [[com.chipprbots.ethereum.domain.BlockHeader.transactionsRoot]] matches [[BlockBody.transactionList]]
     * based on validations stated in section 4.4.2 of http://paper.gavwood.com/


### PR DESCRIPTION
## Summary

Sets `BlockRLPSizeCap` to 8 MiB (8,388,608 bytes) in `StdBlockValidator`.

EIP-7934 (included in Ethereum's Fusaka upgrade) introduces a block body RLP size cap at 10 MiB. ETC uses an 8 MiB cap per the corresponding ECIP, consistent with ETC's historically smaller block sizes and propagation expectations.

Previously `BlockRLPSizeCap` had no explicit value, leaving validation open to oversized blocks.

## Test plan
- [x] `sbt Test/compile` — clean
- [x] `sbt testEssential`
- [ ] ETC mainnet: blocks at or below 8 MiB accepted, blocks above rejected