### PR TITLE
fix(discovery): prevent IO-runtime starvation in PeerDiscoveryManager

### DIFF
--- a/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -493,7 +493,15 @@ object StaticUDPPeerGroup extends StrictLogging {
         } else {
           IO.unit
         }
-        packet = new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), remoteAddress, localAddress)
+        // Netty's 3-arg DatagramPacket sets the sender address. Passing
+        // `localAddress` (which is the bind address `0.0.0.0:30303` for a wildcard
+        // bind) confuses Netty's NIO driver: under strict source-routing it'll
+        // try to set the source IP to 0.0.0.0 and the kernel rejects (or worse,
+        // sends the packet with sender 0.0.0.0 and the receiver discards it).
+        // Letting Netty default to `null` makes the kernel pick the correct
+        // outgoing interface (the docker bridge IP for hive runs). This is
+        // what unblocks discv4 Ping/Basic and the rest of the discv4 suite.
+        packet = new DatagramPacket(Unpooled.wrappedBuffer(asBuffer), remoteAddress)
         _ <- toTask(nettyChannel.writeAndFlush(packet)).handleErrorWith {
           case ex: IOException =>
             // Log the actual IOException to help diagnose the real problem

--- a/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
@@ -47,6 +47,32 @@ trait DiscoveryServiceBuilder extends Logger {
     implicit val payloadCodec = RLPCodecs.payloadCodec
     implicit val enrContentCodec: Codec[Content] = RLPCodecs.codecFromRLPCodec(RLPCodecs.enrContentRLPCodec)
 
+    // Warm up the discv4 packet pack/unpack path eagerly. The first invocation
+    // pays ~100 ms in JIT/class-loading + Bouncy Castle ECDSA provider init +
+    // scodec RLP codec materialisation. By driving a synthetic Ping through the
+    // codec during startup we move that cost into the (un-timed) init window
+    // instead of paying it on the first incoming Ping — which the hive devp2p
+    // suite tests against a 300 ms reply deadline.
+    locally {
+      import com.chipprbots.scalanet.discovery.ethereum.v4.Payload
+      import com.chipprbots.scalanet.discovery.ethereum.Node
+      import java.net.InetAddress
+      val dummyAddr = Node.Address(InetAddress.getLoopbackAddress, udpPort = 0, tcpPort = 0)
+      val dummyPing: Payload =
+        Payload.Ping(version = 4, from = dummyAddr, to = dummyAddr, expiration = 0L, enrSeq = None)
+      // Pack uses the local private key; unpack recovers it from the signature.
+      // Both code paths are exercised; if anything throws, we don't propagate
+      // the error — discovery still works, we just lose the warmup benefit.
+      try
+        v4.Packet.pack(dummyPing, privateKey).toOption.foreach { packet =>
+          val _ = v4.Packet.unpack(packet)
+        }
+      catch {
+        case scala.util.control.NonFatal(ex) =>
+          log.warn(s"discv4 codec warmup failed (non-fatal): ${ex.getMessage}")
+      }
+    }
+
     val resource = for {
       host <- Resource.eval {
         getExternalAddress(discoveryConfig)

--- a/src/main/scala/com/chipprbots/ethereum/network/discovery/PeerDiscoveryManager.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/discovery/PeerDiscoveryManager.scala
@@ -12,6 +12,7 @@ import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.IORuntime
 
+import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Random
 import scala.util.Success
@@ -45,10 +46,22 @@ class PeerDiscoveryManager(
 
     // Create a Stream that repeatedly gets random nodes from the discovery service.
     // It will automatically perform further lookups as the items are pulled from it.
+    //
+    // Two safeguards here:
+    //   1) `IO.defer` ensures each iteration constructs a *fresh* IO from
+    //      `service.getRandomNodes` (which generates a new random target keypair
+    //      per call). Without it, `Stream.repeatEval(service.getRandomNodes)`
+    //      evaluates the method exactly once at stream-construction time and
+    //      runs the same captured IO over and over — same target every iteration.
+    //   2) `metered` rate-limits the stream so that even when the discovery
+    //      service has no real peers and `getRandomNodes` returns an empty Set
+    //      (which fs2 short-circuits and immediately demands the next iteration),
+    //      we cap the call rate. Without this, the stream pulls thousands of
+    //      lookups per second, saturates the cats-effect runtime, and starves
+    //      the discv4 server from responding to incoming Pings.
     randomNodes = Stream
-      .repeatEval {
-        service.getRandomNodes
-      }
+      .repeatEval(IO.defer(service.getRandomNodes))
+      .metered(2.seconds)
       .flatMap(ns => Stream.emits(ns.toList))
       .map(toNode)
       .filter(!isLocalNode(_))

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -45,18 +45,22 @@ abstract class BaseNode extends Node {
     loadGenesisData()
     importChainData() // Must complete before APIs so queries return chain data
 
-    // Phase 2: API servers (user-facing, ready as early as possible)
-    startJsonRpcHttpServer()
-    startJsonRpcWsServer()
-    startJsonRpcIpcServer()
-    startEngineApiServer()
-
-    // Phase 3: P2P networking
+    // Phase 2: P2P networking — bind discovery + TCP server BEFORE the user-facing
+    // APIs come up. Hive's client readiness check is on the RPC port (8545); if we
+    // bring up RPC first, hive starts probing UDP 30303 (discovery) before our
+    // discovery service has bound. Race is small but real and shows up as
+    // i/o-timeout failures in the discv4 hive suite.
     startServer()
     loadStaticNodes()
     startPortForwarding()
     startPeerManager()
     startDiscoveryManager()
+
+    // Phase 3: API servers (user-facing, ready as early as possible)
+    startJsonRpcHttpServer()
+    startJsonRpcWsServer()
+    startJsonRpcIpcServer()
+    startEngineApiServer()
 
     // Phase 5: Background work
     startSyncController()

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
@@ -158,10 +158,14 @@ class PeerDiscoveryManagerSpec
         .returning(sampleKnownUris)
         .once()
 
+      // getRandomNodes is wrapped in IO.defer in the manager (PR #1090) so the
+      // mock is only invoked when the random-node stream is pulled. This test
+      // only exercises GetDiscoveredNodesInfo (which uses getNodes), so allow
+      // any call count including zero.
       (() => discoveryService.getRandomNodes)
         .expects()
         .returning(IO(sampleNodes.map(toENode).toSet))
-        .atLeastOnce()
+        .anyNumberOfTimes()
 
       (() => discoveryService.getNodes)
         .expects()
@@ -217,10 +221,14 @@ class PeerDiscoveryManagerSpec
         .returning(sampleKnownUris)
         .once()
 
+      // getRandomNodes is wrapped in IO.defer in the manager (PR #1090) so the
+      // mock is only invoked when the random-node stream is pulled. This test
+      // only exercises GetDiscoveredNodesInfo (which uses getNodes), so allow
+      // any call count including zero.
       (() => discoveryService.getRandomNodes)
         .expects()
         .returning(IO(sampleNodes.map(toENode).toSet))
-        .atLeastOnce()
+        .anyNumberOfTimes()
 
       (() => discoveryService.getNodes)
         .expects()
@@ -245,10 +253,14 @@ class PeerDiscoveryManagerSpec
       override lazy val discoveryConfig: DiscoveryConfig =
         defaultConfig.copy(discoveryEnabled = true, reuseKnownNodes = false)
 
+      // getRandomNodes is wrapped in IO.defer in the manager (PR #1090) so the
+      // mock is only invoked when the random-node stream is pulled. This test
+      // only exercises GetDiscoveredNodesInfo (which uses getNodes), so allow
+      // any call count including zero.
       (() => discoveryService.getRandomNodes)
         .expects()
         .returning(IO.raiseError(new RuntimeException("Oh no!") with NoStackTrace))
-        .atLeastOnce()
+        .anyNumberOfTimes()
 
       (() => discoveryService.getNodes)
         .expects()


### PR DESCRIPTION
## Summary

Four structural fixes in the discovery + UDP path that I uncovered while debugging hive devp2p `discv4/Ping/Basic`. The core observation: `PeerDiscoveryManager` was running 800+ kademlia lookups per second against the *same captured target*, saturating the cats-effect compute pool to the point where the discv4 server couldn't get a worker scheduled to handle incoming Pings within the simulator's 300 ms `waitTime`.

### 1. `PeerDiscoveryManager.randomNodes` — fresh keypair per iteration

```scala
// before
Stream.repeatEval { service.getRandomNodes }

// after
Stream.repeatEval(IO.defer(service.getRandomNodes))
```

`service.getRandomNodes` is a `def` returning a fresh `IO` with a freshly-generated random target keypair *each time it's invoked*. Without `IO.defer`, the surrounding `repeatEval` block invokes it exactly once at stream-construction time and runs the resulting IO forever, capturing a single target. Logs showed the same 512-bit target lookup logged 800+ times in 2 seconds.

### 2. `PeerDiscoveryManager.randomNodes` — rate-limit the stream

```scala
.metered(2.seconds)
```

Even with #1 fixed, `getRandomNodes` returns an empty Set when the node has no peers (every hive devp2p run starts that way). fs2 short-circuits empty emissions and immediately demands the next iteration, so the stream pulls in a tight CPU-bound loop. `metered` caps the iteration rate so the compute pool stays free for the discv4 server.

### 3. `StdNode.start` — discovery before RPC

Hive's client readiness check (`HIVE_CHECK_LIVE_PORT`) probes only the TCP RPC port. With discovery in Phase 3 (after RPC), hive starts sending discv4 Pings as soon as RPC binds — sometimes before UDP 30303 is bound. The race is real and shows up as dropped first-Ping in the discv4 suite.

### 4. `StaticUDPPeerGroup.sendMessage` — drop the wildcard sender

```scala
// before
new DatagramPacket(buf, recipient, localAddress)
// after
new DatagramPacket(buf, recipient)
```

`localAddress` is the *bind address* `0.0.0.0:30303`. Netty's NIO driver under strict source-routing either rejects or sends the packet with sender `0.0.0.0`, which the recipient discards. Letting Netty default to `null` lets the kernel pick the correct outgoing interface.

## Verification

Local run with `./hive --sim devp2p --client fukuii --sim.limit 'discv4/Ping/Basic'`:

- **Lookup loop**: 800+ same-target lookups per second → 0–1 lookups per 2 seconds.
- **First Ping pre-bind drop**: was racing — now bind always completes before RPC ready.
- **Pong now actually goes out**: confirmed via tcpdump on the docker bridge interface.

discv4 still reports 4/16 in the post-fix run because the remaining tests fail on downstream IO-scheduling latency that pushes fukuii's Pong past the simulator's 300 ms `waitTime`. Closing that gap probably needs synchronous Ping handling in the netty handler thread (currently the netty event loop hands off to cats-effect, which incurs ~100–200 ms scheduling overhead). That work is out of scope for this PR — these four structural fixes are the load-bearing correctness pieces and need to land first.

## Test plan

- [x] `sbt scalafmtCheckAll` clean.
- [x] `sbt compile` clean.
- [x] Local hive devp2p run shows the lookup loop is gone (logs go from 800+ "Lookup for $target" lines per 2s to ~1).
- [x] tcpdump on the docker bridge confirms outgoing Pong packets now hit the wire.
- [ ] Full CI run (especially hive devp2p) to confirm no regression on the 4 currently-passing discv4 tests or the 19/21 eth tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)