### PR TITLE
build: upgrade to Scala 3.3.7 LTS and JDK 25 LTS

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # Fukuii - Ethereum Classic Client
 
 **Status:** ALPHA — active bug-hunting and stabilization | OLYMPIA hard fork implementation (ECIP-1111/1112/1121)
-**Language:** Scala 3.3.4 LTS on JDK 21 LTS
+**Language:** Scala 3.3.7 LTS on JDK 25 LTS
 **Build:** sbt 1.10.7
 **License:** Apache 2.0
 **Origin:** Fork of Mantis (IOHK), maintained by Chippr Robotics LLC
@@ -37,7 +37,7 @@ java -Xmx4g \
   -Dfukuii.network.rpc.http.port=8553 \
   -Dfukuii.network.server-address.port=30305 \
   -Dfukuii.network.discovery.port=30305 \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar mordor
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar mordor
 
 # ETC mainnet (fast sync only)
 java -Xmx4g \
@@ -49,7 +49,7 @@ java -Xmx4g \
   -Dfukuii.network.discovery.port=30305 \
   -Dfukuii.sync.do-fast-sync=true \
   -Dfukuii.sync.do-snap-sync=false \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar etc
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar etc
 
 # ETC mainnet (SNAP sync)
 java -Xmx4g \
@@ -61,7 +61,7 @@ java -Xmx4g \
   -Dfukuii.network.discovery.port=30305 \
   -Dfukuii.sync.do-fast-sync=true \
   -Dfukuii.sync.do-snap-sync=true \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar etc
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar etc
 ```
 
 Config path: `-Dfukuii.<key>=<value>` (HOCON, namespaced under `fukuii`)
@@ -72,7 +72,7 @@ Import pre-built chain data (RLP-encoded blocks) at startup:
 ```bash
 java -Xmx4g \
   -Dfukuii.import-chain-file=/path/to/chain.rlp \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar mordor
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar mordor
 ```
 
 Blocks are executed through the standard block validation + execution pipeline and persisted with receipts and chain weight. Used by hive test framework and for bootstrapping from exported chain data.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -6,9 +6,9 @@ This directory contains the configuration for GitHub Codespaces development envi
 
 The devcontainer configuration sets up a complete Scala development environment with:
 
-- **JDK 21** (Temurin distribution) - Required for building Fukuii
+- **JDK 25** (Temurin distribution) - Required for building Fukuii
 - **SBT 1.5.4+** - Scala Build Tool for compiling and testing
-- **Scala 3.3.4** (LTS) - Primary Scala version used by the project
+- **Scala 3.3.7** (LTS) - Primary Scala version used by the project
 - **Metals** - Scala Language Server for VS Code
 - **Git submodules** - Automatically initialized on container creation
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -32,7 +32,7 @@ if ! command -v sbt &> /dev/null; then
         echo "Installing SBT for Alpine Linux..."
         
         # Install dependencies
-        sudo apk add --no-cache bash curl openjdk21 || true
+        sudo apk add --no-cache bash curl openjdk25 || true
         
         # Download and install SBT
         SBT_VERSION="1.10.7"

--- a/.github/agents/eye.md
+++ b/.github/agents/eye.md
@@ -13,7 +13,7 @@ Ensure the fukuii Scala 3 migration maintains perfect functionality, performance
 ## Your Domain
 
 **Kingdom:** fukuii - Ethereum Classic client (Chordoes Fukuii - the worm controlling the zombie mantis)
-**Migration:** Scala 2.13.14 → Scala 3.3.4 (LTS) - now completed and running on Scala 3 primary
+**Migration:** Scala 2.13.14 → Scala 3.3.7 (LTS) - now completed and running on Scala 3 primary
 **Sacred duty:** ETC consensus compatibility with the network
 **Method:** Multi-layered validation from unit to consensus tests
 
@@ -30,7 +30,7 @@ Ensure the fukuii Scala 3 migration maintains perfect functionality, performance
 **Commands of power:**
 ```bash
 sbt clean compile
-sbt "++3.3.4" compile  # Scala 3 primary version
+sbt "++3.3.7" compile  # Scala 3 primary version
 sbt -Xfatal-warnings compile  # No mercy for warnings
 ```
 
@@ -471,7 +471,7 @@ sbt "testOnly *RegressionSpec" || exit 1
 
 echo "=== Coverage Check ==="
 sbt clean coverage test coverageReport || exit 1
-COVERAGE=$(cat target/scala-3.3.4/scoverage-report/index.html | grep -oP '\d+(?=%)')
+COVERAGE=$(cat target/scala-3.3.7/scoverage-report/index.html | grep -oP '\d+(?=%)')
 if [ "$COVERAGE" -lt "80" ]; then
   echo "❌ The Eye sees insufficient coverage: $COVERAGE%"
   exit 1

--- a/.github/agents/mithril.md
+++ b/.github/agents/mithril.md
@@ -13,7 +13,7 @@ Transform fukuii's compiled Scala 3 code into idiomatic, modern Scala 3. Apply n
 ## Your Realm
 
 **Kingdom:** fukuii - Ethereum Classic client (Chordoes Fukuii - the worm controlling the zombie mantis)
-**Current state:** Running on Scala 3.3.4 (LTS) - migration complete
+**Current state:** Running on Scala 3.3.7 (LTS) - migration complete
 **Your vision:** Leverage Scala 3's power - opaque types, enums, extensions, union types
 **Constraint:** Never break functionality, always improve
 

--- a/.github/agents/wraith.md
+++ b/.github/agents/wraith.md
@@ -15,7 +15,7 @@ Hunt and eliminate all Scala 3 compilation errors in the fukuii Ethereum Classic
 **Kingdom:** fukuii - Ethereum Classic client (Chordoes Fukuii - the worm controlling the zombie mantis)
 **Architecture:** Akka actors, functional patterns, PoW mining
 **Critical domains:** EVM execution, ETC consensus, Ethash mining, cryptography
-**Current state:** Scala 3.3.4 (LTS) - migration complete, now maintaining
+**Current state:** Scala 3.3.7 (LTS) - migration complete, now maintaining
 **Dark target:** Zero compilation errors and warnings in Scala 3
 
 ## The Hunt

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,13 +33,13 @@ This directory contains the GitHub Actions workflows for continuous integration,
 **Purpose:** Ensures code quality and tests pass before merging
 
 **Matrix Build:**
-- **JDK Version:** 21
+- **JDK Version:** 25
 - **Operating System:** ubuntu-latest
 - **Caching:** Coursier, Ivy, and SBT for faster builds
 
 **Steps:**
 1. Checks out code with submodules
-2. Sets up Java (21) with Temurin distribution
+2. Sets up Java (25) with Temurin distribution
 3. Configures Coursier and Ivy caching
 4. Installs SBT
 5. Compiles all modules (bytes, crypto, rlp, node)

--- a/.github/workflows/_hive-sim.yml
+++ b/.github/workflows/_hive-sim.yml
@@ -87,11 +87,11 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Cache Coursier / Ivy / sbt
@@ -126,9 +126,9 @@ jobs:
           # The hive adapter Dockerfile does `FROM chipprbots/fukuii:latest`, so we build the
           # base image by copying the just-built assembly into a thin overlay.
           mkdir -p target/quick-docker
-          cp target/scala-3.3.4/fukuii-assembly-*.jar target/quick-docker/
+          cp target/scala-3.3.7/fukuii-assembly-*.jar target/quick-docker/
           cat > target/quick-docker/Dockerfile <<'DOCKER'
-          FROM eclipse-temurin:21-jre-noble
+          FROM eclipse-temurin:25-jre-noble
           RUN apt-get update && apt-get install -y --no-install-recommends jq curl && rm -rf /var/lib/apt/lists/*
           WORKDIR /app
           RUN mkdir -p /app/fukuii/lib /app/data /app/hive-conf
@@ -174,7 +174,7 @@ jobs:
           cp -v "$GITHUB_WORKSPACE/hive/fukuii/mapper.jq" external/hive/clients/fukuii/mapper.jq
           cp -v "$GITHUB_WORKSPACE/hive/fukuii/enode.sh" external/hive/clients/fukuii/enode.sh 2>/dev/null || true
           cp -v "$GITHUB_WORKSPACE/hive/fukuii/hive.yaml" external/hive/clients/fukuii/hive.yaml 2>/dev/null || true
-          cp target/scala-3.3.4/fukuii-assembly-*.jar external/hive/clients/fukuii/
+          cp target/scala-3.3.7/fukuii-assembly-*.jar external/hive/clients/fukuii/
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test and Build (JDK 21, Scala 3.3.4)
+    name: Test and Build (JDK 25, Scala 3.3.7)
     runs-on: ubuntu-latest
     
     steps:
@@ -37,11 +37,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Cache Coursier
@@ -51,9 +51,9 @@ jobs:
             ~/.cache/coursier
             ~/.ivy2/cache
             ~/.sbt
-          key: ${{ runner.os }}-sbt-21-${{ hashFiles('**/build.sbt', '**/build.properties', '**/Dependencies.scala', '**/plugins.sbt') }}
+          key: ${{ runner.os }}-sbt-25-${{ hashFiles('**/build.sbt', '**/build.properties', '**/Dependencies.scala', '**/plugins.sbt') }}
           restore-keys: |
-            ${{ runner.os }}-sbt-21-
+            ${{ runner.os }}-sbt-25-
             ${{ runner.os }}-sbt-
       
       - name: Set up SBT
@@ -154,7 +154,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: coverage-reports-jdk21-scala-3.3.4
+          name: coverage-reports-jdk25-scala-3.3.7
           path: |
             **/target/scala-*/scoverage-report/**
             **/target/scala-*/scoverage-data/**
@@ -175,7 +175,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-results-jdk21-scala-3.3.4
+          name: test-results-jdk25-scala-3.3.7
           path: |
             **/target/test-reports/**
             **/target/scala-*/test-classes/**/*.log
@@ -187,7 +187,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ethereum-tests-results-jdk21-scala-3.3.4
+          name: ethereum-tests-results-jdk25-scala-3.3.7
           path: |
             **/target/scala-*/it-classes/**/*.log
             /tmp/fukuii-it-test/**/*.log
@@ -197,7 +197,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: fukuii-distribution-jdk21-scala-3.3.4
+          name: fukuii-distribution-jdk25-scala-3.3.7
           path: |
             target/universal/*.zip
             **/target/scala-*/*-assembly-*.jar

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
       
       - name: Set up SBT

--- a/.github/workflows/ethereum-tests-nightly.yml
+++ b/.github/workflows/ethereum-tests-nightly.yml
@@ -22,11 +22,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Cache Coursier

--- a/.github/workflows/fast-distro.yml
+++ b/.github/workflows/fast-distro.yml
@@ -30,11 +30,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Cache Coursier

--- a/.github/workflows/hive-prague.yml
+++ b/.github/workflows/hive-prague.yml
@@ -56,11 +56,11 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Cache Coursier
@@ -98,9 +98,9 @@ jobs:
           # The hive adapter Dockerfile does `FROM chipprbots/fukuii:latest`, so we build the
           # base image by copying the just-built assembly into a thin overlay.
           mkdir -p target/quick-docker
-          cp target/scala-3.3.4/fukuii-assembly-*.jar target/quick-docker/
+          cp target/scala-3.3.7/fukuii-assembly-*.jar target/quick-docker/
           cat > target/quick-docker/Dockerfile <<'DOCKER'
-          FROM eclipse-temurin:21-jre-noble
+          FROM eclipse-temurin:25-jre-noble
           RUN apt-get update && apt-get install -y --no-install-recommends jq curl && rm -rf /var/lib/apt/lists/*
           WORKDIR /app
           RUN mkdir -p /app/fukuii/lib /app/data /app/hive-conf
@@ -148,7 +148,7 @@ jobs:
           cp -v $GITHUB_WORKSPACE/hive/fukuii/fukuii.sh external/hive/clients/fukuii/fukuii.sh
           cp -v $GITHUB_WORKSPACE/hive/fukuii/mapper.jq external/hive/clients/fukuii/mapper.jq
           cp -v $GITHUB_WORKSPACE/hive/fukuii/enode.sh external/hive/clients/fukuii/enode.sh 2>/dev/null || true
-          cp target/scala-3.3.4/fukuii-assembly-*.jar external/hive/clients/fukuii/
+          cp target/scala-3.3.7/fukuii-assembly-*.jar external/hive/clients/fukuii/
 
       - name: Build hive
         working-directory: external/hive

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -162,11 +162,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
       
       - name: Cache Coursier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
           fetch-depth: 0
           ref: v${{ inputs.version }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'sbt'
 
       - name: Set up SBT
@@ -162,7 +162,7 @@ jobs:
           cat > release_notes.md << 'HEADER'
           ## Quick Start
 
-          **Universal JAR** (requires JDK 21+):
+          **Universal JAR** (requires JDK 25+):
           ```bash
           HEADER
           echo "java -jar fukuii-assembly-${VERSION}.jar" >> release_notes.md
@@ -196,7 +196,7 @@ jobs:
           echo "" >> release_notes.md
           echo "| File | Description | Platform |" >> release_notes.md
           echo "|------|-------------|----------|" >> release_notes.md
-          echo "| \`fukuii-assembly-${VERSION}.jar\` | Standalone executable JAR | All (JDK 21+) |" >> release_notes.md
+          echo "| \`fukuii-assembly-${VERSION}.jar\` | Standalone executable JAR | All (JDK 25+) |" >> release_notes.md
           echo "| \`fukuii-${VERSION}.zip\` | Distribution with launch scripts + config | All |" >> release_notes.md
           echo "| \`fukuii-${VERSION}.tgz\` | Distribution tarball | Linux/Mac |" >> release_notes.md
           echo "| \`SHA256SUMS.txt\` | Checksums for all artifacts | - |" >> release_notes.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ fukuii/
 ├── CHANGELOG.md                 # Release history
 ├── CONTRIBUTING.md              # Contribution guidelines
 ├── .claude/CLAUDE.md            # Claude Code project instructions (sync bugs, test tiers, boundaries)
-├── build.sbt                    # SBT build definition (Scala 3.3.4, JDK 21)
+├── build.sbt                    # SBT build definition (Scala 3.3.7, JDK 25)
 ├── version.sbt                  # Version: 0.1.240
 │
 ├── src/                         # Scala source code

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@
 **Project metadata**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Scala](https://img.shields.io/badge/Scala-3.3.4%20LTS-DC322F?logo=scala&logoColor=white)](https://www.scala-lang.org/)
-[![JDK](https://img.shields.io/badge/JDK-21%20LTS-orange?logo=openjdk&logoColor=white)](https://adoptium.net/)
+[![Scala](https://img.shields.io/badge/Scala-3.3.7%20LTS-DC322F?logo=scala&logoColor=white)](https://www.scala-lang.org/)
+[![JDK](https://img.shields.io/badge/JDK-25%20LTS-orange?logo=openjdk&logoColor=white)](https://adoptium.net/)
 [![Latest Release](https://img.shields.io/github/v/release/chippr-robotics/fukuii?include_prereleases&sort=semver)](https://github.com/chippr-robotics/fukuii/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/chipprbots/fukuii.svg)](https://hub.docker.com/r/chipprbots/fukuii)
 
@@ -117,7 +117,7 @@ See [CON-002: Bootstrap Checkpoints](docs/adr/consensus/CON-002-bootstrap-checkp
 
 ### 🛡️ Production-Ready
 
-- **Scala 3.3.4 (LTS)** and **JDK 21 (LTS)** for long-term stability
+- **Scala 3.3.7 (LTS)** and **JDK 25 (LTS)** for long-term stability
 - **Apache Pekko** actor system for reliable concurrency
 - **Full ECIP-1066 Compliance**: Implements all 14 ETC hard forks from Frontier through Spiral (block 19,250,000), including Magneto (ECIP-1103), Mystique (ECIP-1104), and Spiral (ECIP-1109), plus Olympia (ECIP-1111/1112/1121)
 - **2,314 Tests Passing**: Comprehensive unit, integration, and blockchain test suite
@@ -290,7 +290,7 @@ The fastest way to start developing is using GitHub Codespaces, which provides a
 
 1. Click the green "Code" button on the repository page
 2. Select "Open with Codespaces"
-3. Wait for the environment to initialize (automatically installs JDK 21, SBT, and Scala)
+3. Wait for the environment to initialize (automatically installs JDK 25, SBT, and Scala)
 
 See [.devcontainer/README.md](.devcontainer/README.md) for more details.
 
@@ -298,13 +298,13 @@ See [.devcontainer/README.md](.devcontainer/README.md) for more details.
 
 To build Fukuii from source locally you will need:
 
-- **JDK 21**
+- **JDK 25**
 - **sbt** (Scala build tool, version 1.10.7+)
 - **Python** (for certain auxiliary scripts)
 
 ### Scala Version Support
 
-Fukuii is built with **Scala 3.3.4 (LTS)**, providing modern language features, improved type inference, and better performance.
+Fukuii is built with **Scala 3.3.7 (LTS)**, providing modern language features, improved type inference, and better performance.
 
 ### Building the client
 
@@ -490,7 +490,7 @@ Prometheus metrics + Grafana dashboards provide deep visibility into sync phases
 
 ## Development and Future Plans
 
-**Technology Stack**: This project uses **Scala 3.3.4 (LTS)** and **JDK 21 (LTS)** as the primary and only supported versions. The migration from Scala 2.13 to Scala 3 and JDK 17 to JDK 21 was completed in October 2025, including:
+**Technology Stack**: This project uses **Scala 3.3.7 (LTS)** and **JDK 25 (LTS)** as the primary and only supported versions. The migration from Scala 2.13 to Scala 3 and JDK 17 to JDK 21 was completed in October 2025, with a subsequent upgrade to Scala 3.3.7 and JDK 25 LTS, including:
 - ✅ Migration from Akka to Apache Pekko (Scala 3 compatible)
 - ✅ Migration from Monix to Cats Effect 3 IO
 - ✅ Migration from Shapeless to native Scala 3 derivation

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ crossPaths := true
 // patch for error on 'early-semver' problems
 ThisBuild / evictionErrorLevel := Level.Info
 
-val `scala-3` = "3.3.4" // Scala 3 LTS version
+val `scala-3` = "3.3.7" // Scala 3 LTS version
 val supportedScalaVersions = List(`scala-3`) // Scala 3 only
 
 // Base scalac options

--- a/build.sbt
+++ b/build.sbt
@@ -544,7 +544,7 @@ addCommandAlias("testMPT", "testOnly -- -n MPTTest")
 addCommandAlias("testEthereum", "testOnly -- -n EthereumTest")
 
 // Scapegoat configuration for Scala 3
-(ThisBuild / scapegoatVersion) := "3.1.4"
+(ThisBuild / scapegoatVersion) := "3.3.4"
 scapegoatReports := Seq("xml", "html")
 scapegoatConsoleOutput := false
 scapegoatDisabledInspections := Seq("UnsafeTraversableMethods")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Multi-stage Dockerfile for Fukuii Ethereum Client
 # Stage 1: Build stage using full JDK
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # Install required build tools including SBT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -57,7 +57,7 @@ RUN cd target/universal && \
     mv "$DIST_DIR" /fukuii-dist
 
 # Stage 2: Runtime stage using slim JRE
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Ethereum Client"

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -2,7 +2,7 @@
 # Development image for Fukuii builds
 # This image includes JDK and SBT for development and CI/CD
 
-FROM eclipse-temurin:21-jdk-noble
+FROM eclipse-temurin:25-jdk-noble
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Development Image"

--- a/docker/Dockerfile.bootnode
+++ b/docker/Dockerfile.bootnode
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Multi-stage Dockerfile for Fukuii Ethereum Client - Bootnode
 # Pre-configured as a bootnode with high peer capacity and in-memory pruning
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # Install required build tools including SBT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -55,7 +55,7 @@ RUN cd target/universal && \
     mv "$DIST_DIR" /fukuii-dist
 
 # Stage 2: Runtime stage using slim JRE
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Ethereum Client - Bootnode"

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -3,7 +3,7 @@
 # This version uses Google's distroless image for maximum security and minimal size
 
 # Stage 1: Build stage using full JDK
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # Install required build tools including SBT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -59,7 +59,7 @@ RUN cd target/universal && \
     mv "$DIST_DIR" /fukuii-dist
 
 # Stage 2: Runtime stage using distroless
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM gcr.io/distroless/java25-debian13:nonroot
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Ethereum Client (Distroless)"

--- a/docker/Dockerfile.mainnet
+++ b/docker/Dockerfile.mainnet
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Multi-stage Dockerfile for Fukuii Ethereum Client - ETC Mainnet
 # Pre-configured for Ethereum Classic mainnet synchronization
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # Install required build tools including SBT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -55,7 +55,7 @@ RUN cd target/universal && \
     mv "$DIST_DIR" /fukuii-dist
 
 # Stage 2: Runtime stage using slim JRE
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Ethereum Client - ETC Mainnet"

--- a/docker/Dockerfile.mordor
+++ b/docker/Dockerfile.mordor
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Multi-stage Dockerfile for Fukuii Ethereum Client - Mordor Testnet
 # Pre-configured for Ethereum Classic Mordor testnet synchronization
-FROM eclipse-temurin:21-jdk-noble AS builder
+FROM eclipse-temurin:25-jdk-noble AS builder
 
 # Install required build tools including SBT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -55,7 +55,7 @@ RUN cd target/universal && \
     mv "$DIST_DIR" /fukuii-dist
 
 # Stage 2: Runtime stage using slim JRE
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # OCI labels for container metadata
 LABEL org.opencontainers.image.title="Fukuii Ethereum Client - Mordor Testnet"

--- a/docs/api/JSON_RPC_API_REFERENCE.md
+++ b/docs/api/JSON_RPC_API_REFERENCE.md
@@ -1378,7 +1378,7 @@ curl -X POST http://localhost:8546 \
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "Fukuii/v1.1.0/linux-amd64/scala3.3.4"
+  "result": "Fukuii/v1.1.0/linux-amd64/scala3.3.7"
 }
 ```
 

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -825,7 +825,7 @@ sequenceDiagram
 ## Technology Stack
 
 ### Languages & Frameworks
-- **Scala 3.3.4** (LTS): Primary programming language
+- **Scala 3.3.7** (LTS): Primary programming language
 - **Apache Pekko**: Actor-based concurrency framework (Scala 3 compatible fork of Akka)
 - **Cats Effect 3**: Functional effect system
 - **fs2**: Functional streaming library

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -171,10 +171,10 @@ docker run -d \
 ```
 
 ### 2. Development Image (`Dockerfile-dev`)
-A development image with JDK 21 and SBT for building and testing.
+A development image with JDK 25 and SBT for building and testing.
 
 **Features:**
-- Based on `eclipse-temurin:21-jdk-jammy` (full JDK)
+- Based on `eclipse-temurin:25-jdk-noble` (full JDK)
 - Includes SBT build tool
 - Includes Git for source management
 - Runs as non-root user
@@ -218,7 +218,7 @@ docker build -f docker/Dockerfile-base -t fukuii-base:latest .
 Maximum security image using Google's distroless base.
 
 **Features:**
-- Based on `gcr.io/distroless/java21-debian12:nonroot`
+- Based on `gcr.io/distroless/java25-debian13:nonroot`
 - Minimal attack surface - no shell, no package manager
 - Smallest possible image size
 - Direct Java execution (no bash wrapper)

--- a/docs/development/REPOSITORY_STRUCTURE.md
+++ b/docs/development/REPOSITORY_STRUCTURE.md
@@ -148,8 +148,8 @@ Fukuii uses a multi-module SBT build with the following structure:
 
 ### Code Organization
 - Package structure: `com.chipprbots.ethereum.*`
-- Scala version: 3.3.4 (LTS)
-- JDK version: 21 (LTS)
+- Scala version: 3.3.7 (LTS)
+- JDK version: 25 (LTS)
 
 ### Testing Conventions
 - Unit tests: `src/test/scala/`

--- a/docs/development/codespaces.md
+++ b/docs/development/codespaces.md
@@ -6,9 +6,9 @@ This directory contains the configuration for GitHub Codespaces development envi
 
 The devcontainer configuration sets up a complete Scala development environment with:
 
-- **JDK 21** (Temurin distribution) - Required for building Fukuii
+- **JDK 25** (Temurin distribution) - Required for building Fukuii
 - **SBT 1.5.4+** - Scala Build Tool for compiling and testing
-- **Scala 3.3.4** (LTS) - Primary Scala version used by the project
+- **Scala 3.3.7** (LTS) - Primary Scala version used by the project
 - **Metals** - Scala Language Server for VS Code
 - **Git submodules** - Automatically initialized on container creation
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -23,14 +23,14 @@ We are committed to providing a welcoming and inclusive environment for all cont
 
 To contribute to Fukuii, you'll need:
 
-- **JDK 21** - Required for building and running the project
+- **JDK 25** - Required for building and running the project
 - **sbt** - Scala build tool (version 1.10.7 or higher)
 - **Git** - For version control
 - **Optional**: Python (for auxiliary scripts)
 
 ### Scala Version Support
 
-Fukuii is built with **Scala 3.3.4 (LTS)**, the latest long-term support version of Scala 3, providing modern language features, improved type inference, and better tooling support.
+Fukuii is built with **Scala 3.3.7 (LTS)**, the latest long-term support version of Scala 3, providing modern language features, improved type inference, and better tooling support.
 
 ### Setting Up Your Development Environment
 
@@ -128,12 +128,12 @@ sbt testCoverage
 This will:
 1. Enable coverage instrumentation
 2. Run all tests across all modules
-3. Generate coverage reports in `target/scala-3.3.4/scoverage-report/`
+3. Generate coverage reports in `target/scala-3.3.7/scoverage-report/`
 4. Aggregate coverage across all modules
 
 **Coverage reports locations:**
-- HTML report: `target/scala-3.3.4/scoverage-report/index.html`
-- XML report: `target/scala-3.3.4/scoverage-report/cobertura.xml`
+- HTML report: `target/scala-3.3.7/scoverage-report/index.html`
+- XML report: `target/scala-3.3.7/scoverage-report/cobertura.xml`
 
 **Coverage thresholds:**
 - Minimum statement coverage: 70%
@@ -163,7 +163,7 @@ sbt pp
 
 ### Scala 3 Development
 
-Fukuii uses **Scala 3.3.4 (LTS)** and **JDK 21 (LTS)** exclusively. The migration from Scala 2.13 and JDK 17 was completed in October 2025.
+Fukuii uses **Scala 3.3.7 (LTS)** and **JDK 25 (LTS)** exclusively. The migration from Scala 2.13 and JDK 17 was completed in October 2025.
 
 **Key Scala 3 Features in Use:**
 - Native `given`/`using` syntax for implicit parameters
@@ -181,7 +181,7 @@ sbt testAll      # Run all tests
 **Notes:**
 - The project is Scala 3 only (no cross-compilation)
 - All dependencies are Scala 3 compatible
-- CI pipeline tests on Scala 3.3.4 with JDK 21
+- CI pipeline tests on Scala 3.3.7 with JDK 25
 - See [INF-001: Scala 3 Migration](../adr/infrastructure/INF-001-scala-3-migration.md) for the architectural decision
 - See [Migration History](../historical/MIGRATION_HISTORY.md) for details on the completed migration
 
@@ -486,7 +486,7 @@ task
 
 ### Continuous Integration
 
-Our CI pipeline automatically runs on Scala 3.3.4:
+Our CI pipeline automatically runs on Scala 3.3.7:
 - ✅ Compilation (`compile-all`)
 - ✅ Code formatting checks (`formatCheck` - includes scalafmt + scalafix)
 - ✅ Static bug detection (`runScapegoat`)
@@ -600,8 +600,8 @@ See [Agent Labels](https://github.com/chippr-robotics/fukuii/blob/develop/.githu
 
 ### Reminders
 
-- **JDK Compatibility**: Code must work on JDK 21
-- **Scala Version**: Code must compile on Scala 3.3.4 (LTS)
+- **JDK Compatibility**: Code must work on JDK 25
+- **Scala Version**: Code must compile on Scala 3.3.7 (LTS)
 - **Logging**: Use structured logging with appropriate levels (DEBUG, INFO, WARN, ERROR)
 - **Logger Configuration**: Update logback configurations when adding new packages
 - **Rebranding**: This is a rebrand from "Mantis" (IOHK) to "Fukuii" (Chippr Robotics) — update any remaining "mantis" or "io.iohk" references
@@ -634,7 +634,7 @@ See [Agent Labels](https://github.com/chippr-robotics/fukuii/blob/develop/.githu
 2. Add comprehensive tests (unit + integration if needed)
 3. Update documentation (README, scaladoc)
 4. Run formatCheck and linters
-5. Ensure JDK 21 compatibility
+5. Ensure JDK 25 compatibility
 ```
 
 **When refactoring:**
@@ -650,9 +650,9 @@ See [Agent Labels](https://github.com/chippr-robotics/fukuii/blob/develop/.githu
 1. Always use the latest stable versions to avoid future update cycles
 2. Check the GitHub Advisory Database for known vulnerabilities
 3. Verify compatibility with project requirements:
-   - JDK 21 compatibility
-   - Scala 3.3.4 support (primary version)
-4. Test thoroughly on JDK 21
+   - JDK 25 compatibility
+   - Scala 3.3.7 support (primary version)
+4. Test thoroughly on JDK 25
 5. Update version numbers in project/Dependencies.scala
 6. Document any breaking changes or migration steps
 7. Update security-sensitive dependencies (Netty, BouncyCastle, etc.) to latest patch versions
@@ -663,7 +663,7 @@ See [Agent Labels](https://github.com/chippr-robotics/fukuii/blob/develop/.githu
 Before submitting a PR, verify:
 - [ ] `sbt formatCheck` passes
 - [ ] `sbt compile-all` succeeds
-- [ ] `sbt testAll` passes (on JDK 21)
+- [ ] `sbt testAll` passes (on JDK 25)
 - [ ] `sbt "IntegrationTest / test"` passes for integration tests
 - [ ] No new compiler warnings introduced
 - [ ] Documentation updated for user-facing changes

--- a/docs/development/scala-build.md
+++ b/docs/development/scala-build.md
@@ -8,7 +8,7 @@ This document explains how the Fukuii build works after the Scala 3 migration a
 | --- | --- | --- |
 | JDK | 21 (Temurin) | Runtime/toolchain for Scala 3 and Pekko |
 | sbt | 1.10.7 | Single build driver (no nested builds) |
-| Scala | 3.3.4 (LTS) | Only Scala version compiled in this repo |
+| Scala | 3.3.7 (LTS) | Only Scala version compiled in this repo |
 | scalafmt / scalafix | 2.5.2 / 0.13.0 | Formatting and linting (invoked via sbt) |
 | protobuf (protoc) | >= 3.21 | Generates sources via `sbt-protoc` |
 | solc | 0.8.x | Solidity compiler for `solidityCompile` task |
@@ -29,7 +29,7 @@ root (node)
 
 Each sub-module inherits `commonSettings` defined in `build.sbt`, which sets:
 
-- Scala 3.3.4, fatal warnings disabled when `FUKUII_DEV=true`
+- Scala 3.3.7, fatal warnings disabled when `FUKUII_DEV=true`
 - shared scalac options and test settings
 - scalafix dependencies (organize-imports)
 - cross compilation configs for Integration/Evm/Rpc/Benchmark

--- a/docs/for-developers/index.md
+++ b/docs/for-developers/index.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-**Prerequisites:** JDK 21, sbt 1.10.7+, Git
+**Prerequisites:** JDK 25, sbt 1.10.7+, Git
 
 ```bash
 git clone https://github.com/chippr-robotics/fukuii.git

--- a/docs/for-node-operators/index.md
+++ b/docs/for-node-operators/index.md
@@ -12,14 +12,14 @@ sbt assembly
 java -Xmx4g \
   -Dfukuii.datadir=~/.fukuii/mordor \
   -Dfukuii.network=mordor \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar mordor
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar mordor
 
 # Run on ETC mainnet
 java -Xmx4g \
   -Dfukuii.datadir=~/.fukuii/etc \
   -Dfukuii.network=etc \
   -Dfukuii.sync.do-fast-sync=true \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar etc
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar etc
 ```
 
 ## Runbooks

--- a/docs/getting-started/build-from-source.md
+++ b/docs/getting-started/build-from-source.md
@@ -8,23 +8,23 @@ This guide covers building Fukuii from source for development or custom builds.
 
 | Software | Version | Purpose |
 |----------|---------|---------|
-| JDK | 21 | Runtime and build |
+| JDK | 25 | Runtime and build |
 | sbt | 1.10.7+ | Scala build tool |
 | Git | Any | Version control |
 
-### Install JDK 21
+### Install JDK 25
 
 === "Ubuntu/Debian"
 
     ```bash
     sudo apt-get update
-    sudo apt-get install openjdk-21-jdk
+    sudo apt-get install openjdk-25-jdk
     ```
 
 === "macOS"
 
     ```bash
-    brew install openjdk@21
+    brew install openjdk@25
     ```
 
 === "Windows"
@@ -35,7 +35,7 @@ Verify installation:
 
 ```bash
 java -version
-# Should show: openjdk version "21.x.x"
+# Should show: openjdk version "25.x.x"
 ```
 
 ### Install sbt
@@ -105,7 +105,7 @@ The distribution is created at: `target/universal/fukuii-<version>.zip`
 sbt assembly
 ```
 
-The JAR is created at: `target/scala-3.3.4/fukuii-assembly-<version>.jar`
+The JAR is created at: `target/scala-3.3.7/fukuii-assembly-<version>.jar`
 
 ## Run from Source
 
@@ -202,7 +202,7 @@ Increase heap size in `.jvmopts`:
 
 ### Compilation Errors
 
-Ensure you're using JDK 21:
+Ensure you're using JDK 25:
 
 ```bash
 java -version

--- a/docs/getting-started/codespaces.md
+++ b/docs/getting-started/codespaces.md
@@ -13,9 +13,9 @@ Fukuii includes a preconfigured GitHub Codespaces environment for development.
 
 The devcontainer configuration sets up a complete Scala development environment with:
 
-- **JDK 21** (Temurin distribution)
+- **JDK 25** (Temurin distribution)
 - **sbt 1.10.7+** — Scala Build Tool
-- **Scala 3.3.4 LTS** — Primary Scala version
+- **Scala 3.3.7 LTS** — Primary Scala version
 - **Metals** — Scala Language Server for VS Code
 - **Git submodules** — Automatically initialized
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -52,7 +52,7 @@ Get up and running with Fukuii quickly. Choose the installation method that best
 
 === "Source Build"
 
-    - JDK 21 (OpenJDK or Oracle JDK)
+    - JDK 25 (OpenJDK or Oracle JDK)
     - sbt 1.10.7 or later
     - Git
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -55,7 +55,7 @@ For development or custom builds.
 
 ### Prerequisites
 
-- JDK 21
+- JDK 25
 - sbt 1.10.7+
 - Git
 

--- a/docs/reports/ETC-HANDOFF.md
+++ b/docs/reports/ETC-HANDOFF.md
@@ -623,7 +623,7 @@ Removed three WITHDRAWN Mantis-era ECIPs that do not belong in a canonical ECIP-
 git checkout alpha
 sbt compile          # Should complete cleanly
 sbt test             # 2,195 tests, 0 failures
-sbt assembly          # Produces target/scala-3.3.4/fukuii-assembly-0.1.240.jar
+sbt assembly          # Produces target/scala-3.3.7/fukuii-assembly-0.1.240.jar
 ```
 
 ### 2. Mordor Testnet Smoke Test
@@ -634,7 +634,7 @@ java -Xmx4g \
   -Dfukuii.network.rpc.http.port=8553 \
   -Dfukuii.network.server-address.port=30305 \
   -Dfukuii.network.discovery.port=30305 \
-  -jar target/scala-3.3.4/fukuii-assembly-0.1.240.jar mordor
+  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar mordor
 ```
 
 **Verify:**

--- a/docs/reports/OLYMPIA-HANDOFF.md
+++ b/docs/reports/OLYMPIA-HANDOFF.md
@@ -4,7 +4,7 @@
 **Author:** Christopher Mercer (chris-mercer) + Claude Opus 4.6
 **Date:** 2026-03-06
 **Base:** Alpha stabilization (PR #998) — 54 commits, 2,195 tests passing
-**Build:** Scala 3.3.4 LTS, JDK 21, sbt 1.10.7
+**Build:** Scala 3.3.7 LTS, JDK 25, sbt 1.10.7
 **Reference:** `chris-mercer/core-geth` branch `olympia` (25 commits)
 
 ---

--- a/docs/runbooks/first-start.md
+++ b/docs/runbooks/first-start.md
@@ -41,7 +41,7 @@ This runbook guides you through the initial setup and first-time startup of a Fu
 - docker-compose (optional, for multi-container setups)
 
 **For source/binary deployment:**
-- JDK 21 (OpenJDK or Oracle JDK)
+- JDK 25 (OpenJDK or Oracle JDK)
 - (Optional) Python 3.x for auxiliary scripts
 
 ### Network Requirements
@@ -121,16 +121,16 @@ See the [Codespaces Setup](../development/codespaces.md) for details.
 #### Step 1: Install Dependencies
 
 ```bash
-# Install JDK 21
+# Install JDK 25
 # Ubuntu/Debian:
 sudo apt-get update
-sudo apt-get install openjdk-21-jdk
+sudo apt-get install openjdk-25-jdk
 
 # macOS (using Homebrew):
-brew install openjdk@21
+brew install openjdk@25
 
 # Verify installation
-java -version  # Should show version 21.x
+java -version  # Should show version 25.x
 ```
 
 #### Step 2: Install SBT
@@ -492,7 +492,7 @@ sudo ufw allow 9076/tcp comment "Fukuii P2P"
    ```bash
    java -version
    ```
-   Solution: Install JDK 21
+   Solution: Install JDK 25
 
 4. **Corrupted database**
    

--- a/docs/runbooks/known-issues.md
+++ b/docs/runbooks/known-issues.md
@@ -589,13 +589,13 @@ Add to `.jvmopts`:
 -XX:InitiatingHeapOccupancyPercent=45
 ```
 
-**Or use ZGC** (JDK 21+, for large heaps and low latency):
+**Or use ZGC** (JDK 25+, for large heaps and low latency):
 ```
 -XX:+UseZGC
 -XX:ZCollectionInterval=30
 ```
 
-**Or use Shenandoah GC** (JDK 21+, alternative low-pause collector):
+**Or use Shenandoah GC** (JDK 25+, alternative low-pause collector):
 ```
 -XX:+UseShenandoahGC
 ```
@@ -705,7 +705,7 @@ ERROR [JVM] - UnsupportedClassVersionError
 
 #### Root Cause
 
-- Wrong JVM version (Fukuii requires JDK 21)
+- Wrong JVM version (Fukuii requires JDK 25)
 - Multiple JVM installations causing confusion
 
 #### Workaround
@@ -713,7 +713,7 @@ ERROR [JVM] - UnsupportedClassVersionError
 ```bash
 # Check current Java version
 java -version
-# Should show: openjdk version "21.x.x" or similar
+# Should show: openjdk version "25.x.x" or similar
 
 # Check which Java is being used
 which java
@@ -722,15 +722,15 @@ update-alternatives --display java
 
 #### Permanent Fix
 
-**Install JDK 21**:
+**Install JDK 25**:
 ```bash
 # Ubuntu/Debian
 sudo apt-get update
-sudo apt-get install openjdk-21-jdk
+sudo apt-get install openjdk-25-jdk
 
 # Set as default
 sudo update-alternatives --config java
-# Select JDK 21
+# Select JDK 25
 
 # Verify
 java -version
@@ -738,7 +738,7 @@ java -version
 
 **Explicitly set JAVA_HOME** (in startup script or environment):
 ```bash
-export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64
 export PATH=$JAVA_HOME/bin:$PATH
 ```
 
@@ -746,7 +746,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 #### Status
 
-**Fixed**: Ensure JDK 21 is installed and used.
+**Fixed**: Ensure JDK 25 is installed and used.
 
 ---
 

--- a/docs/testing/E2E_STATE_TESTS.md
+++ b/docs/testing/E2E_STATE_TESTS.md
@@ -204,7 +204,7 @@ If tests fail to compile:
 ```bash
 # Ensure you're using the correct Scala version
 sbt "show scalaVersion"
-# Should output: 3.3.4
+# Should output: 3.3.7
 
 # Clean and recompile
 sbt clean

--- a/docs/testing/ETHEREUM_TESTS_CI_INTEGRATION.md
+++ b/docs/testing/ETHEREUM_TESTS_CI_INTEGRATION.md
@@ -33,13 +33,13 @@ The standard CI pipeline runs:
 
 #### Artifacts
 
-1. **ethereum-tests-results-jdk21-scala-3.3.4**
+1. **ethereum-tests-results-jdk25-scala-3.3.7**
    - Test execution logs
    - Integration test class outputs
    - Application logs from `/tmp/fukuii-it-test/`
    - **Retention:** 7 days
 
-2. **test-results-jdk21-scala-3.3.4**
+2. **test-results-jdk25-scala-3.3.7**
    - Standard test reports
    - Test class outputs
    - **Retention:** 7 days
@@ -195,7 +195,7 @@ Integration tests are configured to run in separate subprocesses:
    - Look for test summary at end of output
 
 3. **Download Artifacts**
-   - Click on artifact name (e.g., `ethereum-tests-results-jdk21-scala-3.3.4`)
+   - Click on artifact name (e.g., `ethereum-tests-results-jdk25-scala-3.3.7`)
    - Download and extract to view logs
 
 4. **Review Failures**

--- a/docs/testing/KPI_MONITORING_GUIDE.md
+++ b/docs/testing/KPI_MONITORING_GUIDE.md
@@ -42,7 +42,7 @@ This guide provides practical instructions for monitoring Key Performance Indica
 
 **Via GitHub Actions UI**:
 1. Navigate to PR → "Checks" tab
-2. Look for "Test and Build (JDK 21, Scala 3.3.4)" workflow
+2. Look for "Test and Build (JDK 25, Scala 3.3.7)" workflow
 3. Check "Validate KPI Baselines" step (should be ✅)
 4. Review test timing in "Run tests with coverage" step
 

--- a/docs/testing/PERFORMANCE_BASELINES.md
+++ b/docs/testing/PERFORMANCE_BASELINES.md
@@ -15,8 +15,8 @@ This document establishes performance baselines for critical operations in the F
 - **CPU**: 2 cores (Intel Xeon)
 - **Memory**: 7 GB RAM
 - **Storage**: SSD
-- **JVM**: OpenJDK 21 (Temurin)
-- **Scala**: 3.3.4
+- **JVM**: OpenJDK 25 (Temurin)
+- **Scala**: 3.3.7
 
 ### Benchmark Framework
 - **Tool**: ScalaTest with custom timing utilities

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -235,7 +235,7 @@ val isRegression = KPIBaselines.Validation.isRegression(actual, baseline)
 sbt testCoverage
 
 # View HTML report
-open target/scala-3.3.4/scoverage-report/index.html
+open target/scala-3.3.7/scoverage-report/index.html
 ```
 
 ## Monitoring and Alerting

--- a/run-classic.sh
+++ b/run-classic.sh
@@ -2,11 +2,11 @@
 # Run Fukuii on ETC mainnet (chain ID 61)
 # Ports: 8551 (HTTP), 30305 (P2P)
 # Config overrides default ports for multi-client setup
-# Requires: sbt assembly (builds target/scala-3.3.4/fukuii-assembly-*.jar)
+# Requires: sbt assembly (builds target/scala-3.3.7/fukuii-assembly-*.jar)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-JAR="$SCRIPT_DIR/target/scala-3.3.4/fukuii-assembly-0.1.240.jar"
+JAR="$SCRIPT_DIR/target/scala-3.3.7/fukuii-assembly-0.1.240.jar"
 if [ ! -f "$JAR" ]; then
   echo "ERROR: JAR not found at $JAR" >&2
   echo "Run 'sbt assembly' first." >&2

--- a/run-mordor.sh
+++ b/run-mordor.sh
@@ -2,11 +2,11 @@
 # Run Fukuii on Mordor testnet (ETC, chain ID 63)
 # Ports: 8551 (HTTP), 30305 (P2P)
 # Config overrides default ports for multi-client setup
-# Requires: sbt assembly (builds target/scala-3.3.4/fukuii-assembly-*.jar)
+# Requires: sbt assembly (builds target/scala-3.3.7/fukuii-assembly-*.jar)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-JAR="$SCRIPT_DIR/target/scala-3.3.4/fukuii-assembly-0.1.240.jar"
+JAR="$SCRIPT_DIR/target/scala-3.3.7/fukuii-assembly-0.1.240.jar"
 if [ ! -f "$JAR" ]; then
   echo "ERROR: JAR not found at $JAR" >&2
   echo "Run 'sbt assembly' first." >&2

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v5/README.md
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v5/README.md
@@ -213,7 +213,7 @@ To complete the implementation:
 
 ## Compatibility
 
-- **Scala**: 3.3.4+
+- **Scala**: 3.3.7+
 - **Cats Effect**: 3.x
 - **BouncyCastle**: 1.82
 - **Scodec**: 2.x


### PR DESCRIPTION
Bumps the toolchain to the latest LTS versions:
- Scala 3.3.4 → 3.3.7 (latest 3.3.x LTS, released 2025-10-13)
- JDK 21 → 25 (latest LTS, released 2025-09-16)

Updates:
- build.sbt scalaVersion
- All Dockerfiles: eclipse-temurin:21-* → 25-* and
  gcr.io/distroless/java21-debian12 → java25-debian13
- All GitHub Actions workflows: setup-java version + cache keys +
  artifact names + target/scala-3.3.4 → target/scala-3.3.7 paths
- run-classic.sh / run-mordor.sh JAR paths
- .devcontainer setup (Alpine openjdk21 → openjdk25)
- README, ARCHITECTURE, CLAUDE.md, contributing/codespaces/runbooks docs

Historical migration documents (MIGRATION_HISTORY, INF-001 ADR,
static-analysis reports) are intentionally left referencing the
3.3.4/JDK21 milestone since they describe the October 2025 migration
event.

https://claude.ai/code/session_012YVqjDuYAoTyQcuqhfE6Zh