### PR TITLE
feat(discovery): synchronous discv4 fast-path for sub-300ms Ping/Pong

### DIFF
--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -74,7 +74,13 @@ object DiscoveryNetwork {
       // Sent in pings; some clients use the the TCP port in the `from` so it should be accurate.
       localNodeAddress: Node.Address,
       toNodeAddress: A => Node.Address,
-      config: DiscoveryConfig
+      config: DiscoveryConfig,
+      // When the optional sync fast-path responds to a Ping, it marks the Ping
+      // hash here so this async pipeline skips its own Pong send and avoids
+      // emitting a duplicate. Pass `Discv4SyncResponder.PingDedup` shared with
+      // the responder, or a no-op `PingDedup` instance when the fast-path is
+      // not in use (asynchronous pipeline becomes the sole Pong source).
+      pingDedup: Discv4SyncResponder.PingDedup = new Discv4SyncResponder.PingDedup
   )(implicit codec: Codec[Payload], sigalg: SigAlg, temporal: Temporal[IO]): IO[DiscoveryNetwork[A]] = IO {
     new DiscoveryNetwork[A] with LazyLogging {
 
@@ -172,11 +178,26 @@ object DiscoveryNetwork {
         val caller = Peer(remotePublicKey, channel.to)
 
         payload match {
-          case Ping(_, _, to, _, maybeRemoteEnrSeq) =>
+          case Ping(_, _, _, _, maybeRemoteEnrSeq) =>
+            // Pong.to per discv4.md is "the address from which the packet was
+            // received" — i.e., the SENDER's address as we observed it on the
+            // wire — NOT a copy of Ping.to (which is the address of US, the
+            // recipient). Hive's discv4 simulator validates this and rejects
+            // any Pong whose `to` field doesn't match its own UDP source.
+            val pongTo = toNodeAddress(channel.to)
             maybeRespond {
               handler.ping(caller)(maybeRemoteEnrSeq)
             } { maybeLocalEnrSeq =>
-              channel.send(Pong(to, hash, 0, maybeLocalEnrSeq)).void
+              // Skip the Pong send if the sync fast-path already answered
+              // this Ping — keeps us at exactly one Pong on the wire per Ping
+              // (spec compliance: hive's simulator counts and rejects duplicates).
+              // `handler.ping` ran above for its bookkeeping side-effects, so the
+              // bonding pipeline is unaffected by the deduplication.
+              if (pingDedup.isAlreadyResponded(hash)) {
+                IO(logger.debug(s"discv4 async-pong skipped — sync fast-path already responded for ${channel.to}"))
+              } else {
+                channel.send(Pong(pongTo, hash, 0, maybeLocalEnrSeq)).void
+              }
             }
 
           case FindNode(target, expiration) =>

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
@@ -1,0 +1,115 @@
+package com.chipprbots.scalanet.discovery.ethereum.v4
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.util.control.NonFatal
+
+import com.chipprbots.scalanet.discovery.crypto.PrivateKey
+import com.chipprbots.scalanet.discovery.crypto.SigAlg
+import com.chipprbots.scalanet.peergroup.udp.StaticUDPPeerGroup
+import com.typesafe.scalalogging.LazyLogging
+import scodec.Codec
+import scodec.bits.BitVector
+
+/** Synchronous discv4 fast-path responder, designed for the hive devp2p suite's
+  * 300 ms Ping/Pong deadline that the cats-effect IO scheduler can't hit under load.
+  *
+  * Hooked into `StaticUDPPeerGroup.channelRead` via the `syncResponder` Config field.
+  * Runs on the netty event-loop thread for every inbound datagram. If the bytes
+  * decode as a non-expired Ping, the responder builds, signs, and returns the Pong
+  * bytes — netty then writes them back to the sender without a fiber hop.
+  *
+  * The async pipeline still receives the same Ping and runs `handler.ping(caller)`
+  * as before, so bonding and kademlia bookkeeping are unaffected. The async path's
+  * Pong is redundant but not wrong (idempotent at the protocol layer); accepting
+  * one extra Pong per Ping is the price we pay for not threading "already responded"
+  * state down through the layers. Worst case the simulator gets two valid Pongs.
+  *
+  * Design contract:
+  *   - Total work is dominated by two ECDSA ops (verify Ping sig, sign Pong),
+  *     ~3–5 ms each on a modern x86 — well under the 300 ms budget.
+  *   - The responder MUST NOT throw. Any exception is caught and swallowed; the
+  *     async path then handles the Ping normally.
+  *   - Reads no IO state. The local ENR seq comes from an `AtomicReference`
+  *     supplier that the discovery service updates whenever the ENR rotates.
+  */
+object Discv4SyncResponder extends LazyLogging {
+
+  /** Build a SyncResponder for discv4 Ping → Pong.
+    *
+    * @param privateKey local node's secp256k1 private key, used to sign Pong
+    * @param expirationSeconds how far into the future to set the Pong's `expiration` field
+    * @param maxClockDriftSeconds incoming Pings older than `now - drift` are ignored
+    * @param localEnrSeqRef supplier of the local ENR seq number; pass an
+    *        `AtomicReference[Option[Long]]` so the discovery service can update it
+    *        as the ENR rotates without re-allocating the responder
+    */
+  def apply(
+      privateKey: PrivateKey,
+      expirationSeconds: Long,
+      maxClockDriftSeconds: Long,
+      localEnrSeqRef: AtomicReference[Option[Long]]
+  )(implicit
+      payloadCodec: Codec[Payload],
+      packetCodec: Codec[Packet],
+      sigalg: SigAlg
+  ): StaticUDPPeerGroup.SyncResponder = (sender: InetSocketAddress, incomingBits: BitVector) => {
+    try respond(sender, incomingBits, privateKey, expirationSeconds, maxClockDriftSeconds, localEnrSeqRef)
+    catch {
+      case NonFatal(ex) =>
+        logger.warn(
+          s"discv4 sync-fastpath: unexpected error producing Pong for $sender: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+        )
+        None
+    }
+  }
+
+  private def respond(
+      sender: InetSocketAddress,
+      incomingBits: BitVector,
+      privateKey: PrivateKey,
+      expirationSeconds: Long,
+      maxClockDriftSeconds: Long,
+      localEnrSeqRef: AtomicReference[Option[Long]]
+  )(implicit
+      payloadCodec: Codec[Payload],
+      packetCodec: Codec[Packet],
+      sigalg: SigAlg
+  ): Option[BitVector] = {
+    // Decode the wire-format Packet wrapper (hash + sig + payload bytes).
+    val packet = packetCodec.decode(incomingBits).toOption.map(_.value).orNull
+    if (packet == null) return None
+
+    // Unpack: verify the Ping's hash and signature, decode the payload.
+    val unpacked = Packet.unpack(packet).toOption.orNull
+    if (unpacked == null) return None
+    val (payload, _) = unpacked
+
+    payload match {
+      case ping: Payload.Ping =>
+        val nowSeconds = System.currentTimeMillis() / 1000
+        if (ping.expiration < nowSeconds - maxClockDriftSeconds) {
+          // Expired — let the async path log and drop.
+          None
+        } else {
+          val pong = Payload.Pong(
+            to = ping.to,
+            pingHash = packet.hash,
+            expiration = nowSeconds + expirationSeconds,
+            enrSeq = localEnrSeqRef.get()
+          )
+          Packet.pack(pong, privateKey).toOption.flatMap { pongPacket =>
+            packetCodec.encode(pongPacket).toOption.map { pongBits =>
+              logger.debug(s"discv4 sync-fastpath: replied to Ping from $sender")
+              pongBits
+            }
+          }
+        }
+
+      case _ =>
+        // FindNode, ENRRequest, Pong, etc. — let the async path handle.
+        None
+    }
+  }
+}

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
@@ -1,6 +1,7 @@
 package com.chipprbots.scalanet.discovery.ethereum.v4
 
 import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -9,6 +10,7 @@ import scala.util.control.NonFatal
 
 import com.chipprbots.scalanet.discovery.crypto.PrivateKey
 import com.chipprbots.scalanet.discovery.crypto.SigAlg
+import com.chipprbots.scalanet.discovery.hash.Hash
 import com.chipprbots.scalanet.peergroup.udp.StaticUDPPeerGroup
 import com.typesafe.scalalogging.LazyLogging
 import scodec.Codec
@@ -50,6 +52,42 @@ object Discv4SyncResponder extends LazyLogging {
   private val DefaultTokensPerSecond = 200
   private val DefaultMaxBurst = 100
 
+  /** TTL after which a recently-responded Ping hash is considered stale and pruned
+    * from the dedup set. Set well above the round-trip time so the async path's
+    * Ping handler still sees the hash, but short enough that map memory stays bounded.
+    */
+  private val DedupTtlMillis = 10_000L
+
+  /** Cache size cap before we sweep entries older than the TTL. */
+  private val DedupSweepThreshold = 4_096
+
+  /** Tracks Ping hashes the sync responder has just answered, so the async path
+    * can skip its own Pong send and avoid the duplicate. The map is shared with
+    * `DiscoveryNetwork` (which calls `dedupMarkSent` after sending Pong via the
+    * sync path, and `dedupCheckSent` before sending via the async path).
+    *
+    * Entries are pruned lazily on insert when the map exceeds DedupSweepThreshold.
+    */
+  class PingDedup {
+    private val responded = new ConcurrentHashMap[Hash, java.lang.Long](2048)
+
+    /** Mark the given Ping hash as having been responded-to via the sync path. */
+    def markSent(pingHash: Hash): Unit = {
+      val now = System.currentTimeMillis()
+      responded.put(pingHash, java.lang.Long.valueOf(now))
+      if (responded.size > DedupSweepThreshold) {
+        val cutoff = now - DedupTtlMillis
+        responded.entrySet.removeIf(e => e.getValue < cutoff)
+      }
+    }
+
+    /** Returns true if the Ping hash was responded-to recently (within TTL). */
+    def isAlreadyResponded(pingHash: Hash): Boolean = {
+      val ts = responded.get(pingHash)
+      ts != null && (System.currentTimeMillis() - ts) < DedupTtlMillis
+    }
+  }
+
   /** Build a SyncResponder for discv4 Ping → Pong.
     *
     * @param privateKey local node's secp256k1 private key, used to sign Pong
@@ -58,6 +96,10 @@ object Discv4SyncResponder extends LazyLogging {
     * @param localEnrSeqRef supplier of the local ENR seq number; pass an
     *        `AtomicReference[Option[Long]]` so the discovery service can update it
     *        as the ENR rotates without re-allocating the responder
+    * @param dedup shared dedup state — every Ping the sync path answers is
+    *        marked here so DiscoveryNetwork's async pipeline can skip the
+    *        duplicate Pong it would otherwise send. Must be the same instance
+    *        passed to DiscoveryNetwork.
     * @param rateLimiter optional override of the default token-bucket. Pass a custom
     *        instance to tune the global sync-path budget (e.g., disable for tests).
     */
@@ -66,6 +108,7 @@ object Discv4SyncResponder extends LazyLogging {
       expirationSeconds: Long,
       maxClockDriftSeconds: Long,
       localEnrSeqRef: AtomicReference[Option[Long]],
+      dedup: PingDedup,
       rateLimiter: RateLimiter = new RateLimiter(DefaultTokensPerSecond, DefaultMaxBurst)
   )(implicit
       payloadCodec: Codec[Payload],
@@ -79,7 +122,7 @@ object Discv4SyncResponder extends LazyLogging {
       logger.debug(s"discv4 sync-fastpath: rate-limited request from $sender")
       None
     } else {
-      try respond(sender, incomingBits, privateKey, expirationSeconds, maxClockDriftSeconds, localEnrSeqRef)
+      try respond(sender, incomingBits, privateKey, expirationSeconds, maxClockDriftSeconds, localEnrSeqRef, dedup)
       catch {
         case NonFatal(ex) =>
           logger.warn(
@@ -139,7 +182,8 @@ object Discv4SyncResponder extends LazyLogging {
       privateKey: PrivateKey,
       expirationSeconds: Long,
       maxClockDriftSeconds: Long,
-      localEnrSeqRef: AtomicReference[Option[Long]]
+      localEnrSeqRef: AtomicReference[Option[Long]],
+      dedup: PingDedup
   )(implicit
       payloadCodec: Codec[Payload],
       packetCodec: Codec[Packet],
@@ -161,14 +205,26 @@ object Discv4SyncResponder extends LazyLogging {
           // Expired — let the async path log and drop.
           None
         } else {
+          // Pong.to per discv4.md is "the address from which the packet was
+          // received" — i.e., the SENDER's address as seen by us, NOT a copy
+          // of Ping.to (which is the address of US, the recipient). Hive's
+          // simulator validates this and rejects the Pong otherwise.
+          val pongTo = com.chipprbots.scalanet.discovery.ethereum.Node.Address(
+            ip = sender.getAddress,
+            udpPort = sender.getPort,
+            tcpPort = 0
+          )
           val pong = Payload.Pong(
-            to = ping.to,
+            to = pongTo,
             pingHash = packet.hash,
             expiration = nowSeconds + expirationSeconds,
             enrSeq = localEnrSeqRef.get()
           )
           Packet.pack(pong, privateKey).toOption.flatMap { pongPacket =>
             packetCodec.encode(pongPacket).toOption.map { pongBits =>
+              // Record the Ping hash so DiscoveryNetwork's async path skips
+              // its own Pong send for this hash.
+              dedup.markSent(packet.hash)
               logger.debug(s"discv4 sync-fastpath: replied to Ping from $sender")
               pongBits
             }

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/Discv4SyncResponder.scala
@@ -1,6 +1,8 @@
 package com.chipprbots.scalanet.discovery.ethereum.v4
 
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.util.control.NonFatal
@@ -36,6 +38,18 @@ import scodec.bits.BitVector
   */
 object Discv4SyncResponder extends LazyLogging {
 
+  /** Default global rate: 200 sync responses/second, burst 100.
+    *
+    * Tuned for legitimate hive-style bursts (≤16 Pings in ~22 ms intervals all
+    * served from the burst budget) while capping sustained ECDSA cost on the
+    * single netty event-loop thread. ECDSA sign/verify is ~3–5 ms each, so
+    * 200/sec × 10 ms ≈ 100% of one thread at the sustained rate. Above that
+    * the responder returns None and the async path handles the Ping (slowly,
+    * but on a different thread pool).
+    */
+  private val DefaultTokensPerSecond = 200
+  private val DefaultMaxBurst = 100
+
   /** Build a SyncResponder for discv4 Ping → Pong.
     *
     * @param privateKey local node's secp256k1 private key, used to sign Pong
@@ -44,25 +58,79 @@ object Discv4SyncResponder extends LazyLogging {
     * @param localEnrSeqRef supplier of the local ENR seq number; pass an
     *        `AtomicReference[Option[Long]]` so the discovery service can update it
     *        as the ENR rotates without re-allocating the responder
+    * @param rateLimiter optional override of the default token-bucket. Pass a custom
+    *        instance to tune the global sync-path budget (e.g., disable for tests).
     */
   def apply(
       privateKey: PrivateKey,
       expirationSeconds: Long,
       maxClockDriftSeconds: Long,
-      localEnrSeqRef: AtomicReference[Option[Long]]
+      localEnrSeqRef: AtomicReference[Option[Long]],
+      rateLimiter: RateLimiter = new RateLimiter(DefaultTokensPerSecond, DefaultMaxBurst)
   )(implicit
       payloadCodec: Codec[Payload],
       packetCodec: Codec[Packet],
       sigalg: SigAlg
   ): StaticUDPPeerGroup.SyncResponder = (sender: InetSocketAddress, incomingBits: BitVector) => {
-    try respond(sender, incomingBits, privateKey, expirationSeconds, maxClockDriftSeconds, localEnrSeqRef)
-    catch {
-      case NonFatal(ex) =>
-        logger.warn(
-          s"discv4 sync-fastpath: unexpected error producing Pong for $sender: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
-        )
-        None
+    if (!rateLimiter.tryAcquire()) {
+      // Rate-limited: drop the sync-path response and let the async path take over.
+      // Logged at debug to avoid noise under sustained traffic; the warn logger fires
+      // on actual responder errors, not on intentional rate-limit drops.
+      logger.debug(s"discv4 sync-fastpath: rate-limited request from $sender")
+      None
+    } else {
+      try respond(sender, incomingBits, privateKey, expirationSeconds, maxClockDriftSeconds, localEnrSeqRef)
+      catch {
+        case NonFatal(ex) =>
+          logger.warn(
+            s"discv4 sync-fastpath: unexpected error producing Pong for $sender: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+          )
+          None
+      }
     }
+  }
+
+  /** Token-bucket rate limiter for the sync-path responder.
+    *
+    * Bounds the netty event-loop thread cost under flood. Tokens are replenished
+    * lazily on each call (no scheduled task), so the cost of the limiter itself
+    * is just a few atomic CAS ops — well below the ECDSA cost it gates.
+    *
+    * `tryAcquire()` is wait-free and safe to call from any thread, but in this
+    * codebase it's only ever called from the single netty event-loop thread, so
+    * contention is effectively zero.
+    */
+  class RateLimiter(tokensPerSecond: Int, maxBurst: Int) {
+    require(tokensPerSecond > 0, "tokensPerSecond must be positive")
+    require(maxBurst > 0, "maxBurst must be positive")
+
+    private val tokens = new AtomicInteger(maxBurst)
+    private val lastRefillNanos = new AtomicLong(System.nanoTime())
+    private val nanosPerToken: Long = 1_000_000_000L / tokensPerSecond.toLong
+
+    def tryAcquire(): Boolean = {
+      // Lazy refill — top up the bucket based on elapsed wall-clock time.
+      val now = System.nanoTime()
+      val last = lastRefillNanos.get()
+      val elapsed = now - last
+      if (elapsed >= nanosPerToken) {
+        val toAdd = (elapsed / nanosPerToken).toInt
+        if (toAdd > 0 && lastRefillNanos.compareAndSet(last, now)) {
+          tokens.updateAndGet(t => math.min(t + toAdd, maxBurst))
+        }
+      }
+      // Try to consume a token. Loop on contention; in practice this runs on
+      // a single netty thread so the CAS rarely fails.
+      var t = tokens.get()
+      while (t > 0) {
+        if (tokens.compareAndSet(t, t - 1)) return true
+        t = tokens.get()
+      }
+      false
+    }
+
+    /** Test/diag accessor — current available tokens. Volatile read, may be stale. */
+    private[v4] def availableTokens: Int = tokens.get()
   }
 
   private def respond(

--- a/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -281,6 +281,39 @@ class StaticUDPPeerGroup[M] private (
                         val remoteAddress = datagram.sender
                         try {
                           logger.debug(s"Server channel at $localAddress read message from $remoteAddress")
+                          // Read the incoming bytes once; both the sync responder and the
+                          // async decode path share this view. `nioBuffer` is a window over
+                          // the netty ByteBuf — it shares storage but advances independently.
+                          val incomingBits = BitVector(datagram.content.nioBuffer)
+
+                          // Sync fast-path: if the configured responder produces reply bytes,
+                          // write them back on this same netty thread before yielding to the
+                          // async pipeline. The pipeline still runs for bonding/kademlia
+                          // bookkeeping; we just don't wait on cats-effect to send the reply.
+                          // The responder is contract-bound not to throw, but defend anyway.
+                          val maybeReply: Option[BitVector] =
+                            try config.syncResponder(remoteAddress, incomingBits)
+                            catch {
+                              case NonFatal(ex) =>
+                                logger.warn(
+                                  s"Sync responder threw for $remoteAddress: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+                                )
+                                None
+                            }
+                          maybeReply.foreach { replyBits =>
+                            try {
+                              val replyBuf = Unpooled.wrappedBuffer(replyBits.toByteBuffer)
+                              val replyPacket = new DatagramPacket(replyBuf, remoteAddress)
+                              ctx.writeAndFlush(replyPacket)
+                              ()
+                            } catch {
+                              case NonFatal(ex) =>
+                                logger.warn(
+                                  s"Sync responder write failed for $remoteAddress: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+                                )
+                            }
+                          }
+
                           handleMessage(remoteAddress, tryDecodeDatagram(datagram))
                         } catch {
                           case NonFatal(ex) =>
@@ -367,17 +400,42 @@ class StaticUDPPeerGroup[M] private (
 }
 
 object StaticUDPPeerGroup extends StrictLogging {
+  /** Synchronous fast-path responder. Invoked on the netty event-loop thread for every
+    * inbound datagram BEFORE the async cats-effect channel-replication path runs. If it
+    * returns `Some(replyBits)`, those bytes are written back to the sender via
+    * `writeAndFlush` on the same netty thread — no fiber hop, no compute-pool scheduling.
+    *
+    * The async path STILL runs after, so any side-effects (bonding, kademlia bookkeeping)
+    * still happen normally. The sync path just gets the response out the door fast.
+    *
+    * Used by the discv4 layer to send `Pong` replies inside hive's 300 ms `waitTime`
+    * deadline that the cats-effect IO scheduler can't meet under load (~600 ms observed
+    * end-to-end with structural fixes alone).
+    *
+    * Implementations MUST be fast (< 5 ms) and MUST NOT throw — any exception is caught
+    * by the peer group and the responder is treated as having returned None.
+    */
+  type SyncResponder = (InetSocketAddress, BitVector) => Option[BitVector]
+
+  /** Default no-op responder — always defers to the async path. */
+  val NoSyncResponder: SyncResponder = (_, _) => None
+
   case class Config(
       bindAddress: InetSocketAddress,
       processAddress: InetMultiAddress,
       // Maximum number of messages in the queue associated with the channel; 0 means unlimited.
       channelCapacity: Int,
       // Maximum size of an incoming message; 0 means the maximum 64KiB is allocated for each message.
-      receiveBufferSizeBytes: Int
+      receiveBufferSizeBytes: Int,
+      // Optional synchronous response hook; see `SyncResponder`.
+      // No default here because Scala 3 forbids overloaded `apply` methods that
+      // each carry default args. Callers either pass `NoSyncResponder` explicitly
+      // or use the simpler bind-address-only companion `apply` below.
+      syncResponder: SyncResponder
   )
   object Config {
     def apply(bindAddress: InetSocketAddress, channelCapacity: Int = 0, receiveBufferSizeBytes: Int = 0): Config =
-      Config(bindAddress, InetMultiAddress(bindAddress), channelCapacity, receiveBufferSizeBytes)
+      Config(bindAddress, InetMultiAddress(bindAddress), channelCapacity, receiveBufferSizeBytes, NoSyncResponder)
   }
 
   private type ChannelAlloc[M] = (ChannelImpl[M], Release)

--- a/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
@@ -104,14 +104,20 @@ trait DiscoveryServiceBuilder extends Logger {
       // the DiscoveryService.stateRef so the seq stays in sync with ENR
       // rotations is a follow-up. Most discv4 hive tests don't check seq.
       localEnrSeqRef = new AtomicReference[Option[Long]](None)
+      // Shared dedup state between the sync responder and the async pipeline.
+      // The sync path marks every Ping it answers; the async pipeline checks
+      // before sending its own Pong so we don't emit duplicates on the wire
+      // (hive's discv4 simulator counts and rejects duplicate Pongs).
+      pingDedup = new v4.Discv4SyncResponder.PingDedup
       syncResponder = v4.Discv4SyncResponder(
         privateKey = privateKey,
         expirationSeconds = discoveryConfig.messageExpiration.toSeconds,
         maxClockDriftSeconds = discoveryConfig.maxClockDrift.toSeconds,
-        localEnrSeqRef = localEnrSeqRef
+        localEnrSeqRef = localEnrSeqRef,
+        dedup = pingDedup
       )
       udpConfig = makeUdpConfig(discoveryConfig, host, syncResponder)
-      network <- makeDiscoveryNetwork(privateKey, localNode, v4Config, udpConfig)
+      network <- makeDiscoveryNetwork(privateKey, localNode, v4Config, udpConfig, pingDedup)
       service <- makeDiscoveryService(privateKey, localNode, v4Config, network)
       _ <- Resource.eval {
         setDiscoveryStatus(nodeStatusHolder, ServerStatus.Listening(udpConfig.bindAddress))
@@ -218,7 +224,8 @@ trait DiscoveryServiceBuilder extends Logger {
       privateKey: PrivateKey,
       localNode: ENode,
       v4Config: v4.DiscoveryConfig,
-      udpConfig: StaticUDPPeerGroup.Config
+      udpConfig: StaticUDPPeerGroup.Config,
+      pingDedup: v4.Discv4SyncResponder.PingDedup
   )(implicit
       payloadCodec: Codec[v4.Payload],
       packetCodec: Codec[v4.Packet],
@@ -237,7 +244,8 @@ trait DiscoveryServiceBuilder extends Logger {
               udpPort = address.inetSocketAddress.getPort,
               tcpPort = 0
             ),
-          config = v4Config
+          config = v4Config,
+          pingDedup = pingDedup
         )
       }
     } yield network

--- a/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/discovery/DiscoveryServiceBuilder.scala
@@ -88,7 +88,29 @@ trait DiscoveryServiceBuilder extends Logger {
       v4Config <- Resource.eval {
         makeDiscoveryConfig(discoveryConfig, knownNodesStorage)
       }
-      udpConfig = makeUdpConfig(discoveryConfig, host)
+      // Synchronous discv4 fast-path: replies to Ping with Pong on the netty
+      // event-loop thread, bypassing the cats-effect IO scheduler. This is the
+      // only path that meets hive's 300 ms `waitTime` deadline; the structural
+      // fixes in PR #1090 reduced same-target lookup spam and the first-Ping
+      // JIT cost, but the full async pipeline is still ~600 ms end-to-end
+      // under load. The responder is opt-in via the SyncResponder Config.
+      //
+      // The async pipeline still runs after the sync reply for bonding /
+      // kademlia bookkeeping; the only side-effect of the fast-path is that
+      // a duplicate Pong may also leave the async pipeline. Both are valid;
+      // the simulator (and any well-behaved peer) ignores duplicates.
+      //
+      // localEnrSeqRef is currently a static `None` — adding a wire-up to
+      // the DiscoveryService.stateRef so the seq stays in sync with ENR
+      // rotations is a follow-up. Most discv4 hive tests don't check seq.
+      localEnrSeqRef = new AtomicReference[Option[Long]](None)
+      syncResponder = v4.Discv4SyncResponder(
+        privateKey = privateKey,
+        expirationSeconds = discoveryConfig.messageExpiration.toSeconds,
+        maxClockDriftSeconds = discoveryConfig.maxClockDrift.toSeconds,
+        localEnrSeqRef = localEnrSeqRef
+      )
+      udpConfig = makeUdpConfig(discoveryConfig, host, syncResponder)
       network <- makeDiscoveryNetwork(privateKey, localNode, v4Config, udpConfig)
       service <- makeDiscoveryService(privateKey, localNode, v4Config, network)
       _ <- Resource.eval {
@@ -176,12 +198,17 @@ trait DiscoveryServiceBuilder extends Logger {
         }
     }
 
-  private def makeUdpConfig(discoveryConfig: DiscoveryConfig, host: InetAddress): StaticUDPPeerGroup.Config =
+  private def makeUdpConfig(
+      discoveryConfig: DiscoveryConfig,
+      host: InetAddress,
+      syncResponder: StaticUDPPeerGroup.SyncResponder
+  ): StaticUDPPeerGroup.Config =
     StaticUDPPeerGroup.Config(
       bindAddress = new InetSocketAddress(discoveryConfig.interface, discoveryConfig.port),
       processAddress = InetMultiAddress(new InetSocketAddress(host, discoveryConfig.port)),
       channelCapacity = discoveryConfig.channelCapacity,
-      receiveBufferSizeBytes = v4.Packet.MaxPacketBitsSize / 8 * 2
+      receiveBufferSizeBytes = v4.Packet.MaxPacketBitsSize / 8 * 2,
+      syncResponder = syncResponder
     )
 
   private def setDiscoveryStatus(nodeStatusHolder: AtomicReference[NodeStatus], status: ServerStatus): IO[Unit] =

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
@@ -1,0 +1,149 @@
+package com.chipprbots.ethereum.network.discovery
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicReference
+
+import com.chipprbots.scalanet.discovery.crypto.SigAlg
+import com.chipprbots.scalanet.discovery.ethereum.Node
+import com.chipprbots.scalanet.discovery.ethereum.v4.Discv4SyncResponder
+import com.chipprbots.scalanet.discovery.ethereum.v4.Packet
+import com.chipprbots.scalanet.discovery.ethereum.v4.Payload
+import com.chipprbots.scalanet.discovery.hash.Hash
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scodec.Codec
+import scodec.bits.BitVector
+
+import com.chipprbots.ethereum.network.discovery.codecs.RLPCodecs
+import com.chipprbots.ethereum.testing.Tags._
+
+class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
+
+  // Match the codecs used in DiscoveryServiceBuilder.
+  implicit val sigalg: SigAlg = new Secp256k1SigAlg
+  implicit val packetCodec: Codec[Packet] = Packet.packetCodec(allowDecodeOverMaxPacketSize = true)
+  implicit val payloadCodec: Codec[Payload] = RLPCodecs.payloadCodec
+
+  private val sender = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 31000)
+
+  private val expirationSeconds: Long = 60L
+  private val maxClockDriftSeconds: Long = 15L
+
+  private def makeAddress(port: Int): Node.Address =
+    Node.Address(InetAddress.getByName("127.0.0.1"), udpPort = port, tcpPort = port + 1)
+
+  private def freshKeyPair = sigalg.newKeyPair
+
+  private def encodePacket(packet: Packet): BitVector =
+    packetCodec.encode(packet).require
+
+  private def buildResponder(
+      privateKey: com.chipprbots.scalanet.discovery.crypto.PrivateKey,
+      enrSeqRef: AtomicReference[Option[Long]] = new AtomicReference(None)
+  ) =
+    Discv4SyncResponder(privateKey, expirationSeconds, maxClockDriftSeconds, enrSeqRef)
+
+  behavior.of("Discv4SyncResponder")
+
+  it should "produce a Pong for a valid, non-expired Ping" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val responder = buildResponder(privateKey)
+
+    val pingTo = makeAddress(31002)
+    val pingFrom = makeAddress(31000)
+    val ping = Payload.Ping(
+      version = 4,
+      from = pingFrom,
+      to = pingTo,
+      expiration = System.currentTimeMillis() / 1000 + expirationSeconds,
+      enrSeq = None
+    )
+    val pingPacket = Packet.pack(ping, privateKey).require
+    val incomingBits = encodePacket(pingPacket)
+
+    val maybeReply = responder(sender, incomingBits)
+    maybeReply should not be empty
+
+    val replyPacket = packetCodec.decode(maybeReply.get).require.value
+    val (replyPayload, _) = Packet.unpack(replyPacket).require
+    replyPayload shouldBe a[Payload.Pong]
+    val pong = replyPayload.asInstanceOf[Payload.Pong]
+    pong.pingHash shouldBe pingPacket.hash
+    pong.to shouldBe pingTo
+    pong.expiration should be > (System.currentTimeMillis() / 1000)
+    pong.enrSeq shouldBe None
+  }
+
+  it should "include the local ENR seq from the AtomicReference" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val enrSeqRef = new AtomicReference[Option[Long]](Some(42L))
+    val responder = buildResponder(privateKey, enrSeqRef)
+
+    val ping = Payload.Ping(
+      version = 4,
+      from = makeAddress(31000),
+      to = makeAddress(31002),
+      expiration = System.currentTimeMillis() / 1000 + expirationSeconds,
+      enrSeq = None
+    )
+    val pingPacket = Packet.pack(ping, privateKey).require
+    val replyBits = responder(sender, encodePacket(pingPacket)).get
+    val replyPacket = packetCodec.decode(replyBits).require.value
+    val pong = Packet.unpack(replyPacket).require._1.asInstanceOf[Payload.Pong]
+    pong.enrSeq shouldBe Some(42L)
+  }
+
+  it should "return None for an expired Ping" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val responder = buildResponder(privateKey)
+
+    val expiredPing = Payload.Ping(
+      version = 4,
+      from = makeAddress(31000),
+      to = makeAddress(31002),
+      expiration = System.currentTimeMillis() / 1000 - maxClockDriftSeconds - 60,
+      enrSeq = None
+    )
+    val expiredPacket = Packet.pack(expiredPing, privateKey).require
+    responder(sender, encodePacket(expiredPacket)) shouldBe None
+  }
+
+  it should "return None for a non-Ping payload (FindNode)" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val (otherPub, _) = freshKeyPair
+    val responder = buildResponder(privateKey)
+
+    val findNode = Payload.FindNode(
+      target = otherPub,
+      expiration = System.currentTimeMillis() / 1000 + expirationSeconds
+    )
+    val findNodePacket = Packet.pack(findNode, privateKey).require
+    responder(sender, encodePacket(findNodePacket)) shouldBe None
+  }
+
+  it should "return None for malformed bytes" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val responder = buildResponder(privateKey)
+    val tooShort = BitVector(Array.ofDim[Byte](16))
+    responder(sender, tooShort) shouldBe None
+  }
+
+  it should "return None for bytes that decode but fail unpack (corrupt hash)" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val responder = buildResponder(privateKey)
+
+    val ping = Payload.Ping(
+      version = 4,
+      from = makeAddress(31000),
+      to = makeAddress(31002),
+      expiration = System.currentTimeMillis() / 1000 + expirationSeconds,
+      enrSeq = None
+    )
+    val pingPacket = Packet.pack(ping, privateKey).require
+    val corruptHashBytes = Array.ofDim[Byte](32)
+    new java.util.Random(1).nextBytes(corruptHashBytes)
+    val corrupt = pingPacket.copy(hash = Hash(BitVector(corruptHashBytes)))
+    responder(sender, encodePacket(corrupt)) shouldBe None
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
@@ -40,9 +40,10 @@ class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
 
   private def buildResponder(
       privateKey: com.chipprbots.scalanet.discovery.crypto.PrivateKey,
-      enrSeqRef: AtomicReference[Option[Long]] = new AtomicReference(None)
+      enrSeqRef: AtomicReference[Option[Long]] = new AtomicReference(None),
+      dedup: Discv4SyncResponder.PingDedup = new Discv4SyncResponder.PingDedup
   ) =
-    Discv4SyncResponder(privateKey, expirationSeconds, maxClockDriftSeconds, enrSeqRef)
+    Discv4SyncResponder(privateKey, expirationSeconds, maxClockDriftSeconds, enrSeqRef, dedup)
 
   behavior.of("Discv4SyncResponder")
 
@@ -70,7 +71,11 @@ class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
     replyPayload shouldBe a[Payload.Pong]
     val pong = replyPayload.asInstanceOf[Payload.Pong]
     pong.pingHash shouldBe pingPacket.hash
-    pong.to shouldBe pingTo
+    // Per discv4.md, Pong.to is "the address from which the packet was received" —
+    // i.e., the SENDER's address, NOT a copy of Ping.to.
+    pong.to.ip shouldBe sender.getAddress
+    pong.to.udpPort shouldBe sender.getPort
+    pong.to.tcpPort shouldBe 0
     pong.expiration should be > (System.currentTimeMillis() / 1000)
     pong.enrSeq shouldBe None
   }
@@ -157,6 +162,7 @@ class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
       expirationSeconds = expirationSeconds,
       maxClockDriftSeconds = maxClockDriftSeconds,
       localEnrSeqRef = new java.util.concurrent.atomic.AtomicReference[Option[Long]](None),
+      dedup = new Discv4SyncResponder.PingDedup,
       rateLimiter = limiter
     )
 
@@ -186,5 +192,24 @@ class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
     limiter.tryAcquire() shouldBe false
     Thread.sleep(20) // wait for at least 1 token to refill
     limiter.tryAcquire() shouldBe true
+  }
+
+  it should "mark Ping hashes in PingDedup so the async pipeline skips its Pong" taggedAs (UnitTest, NetworkTest) in {
+    val (_, privateKey) = freshKeyPair
+    val dedup = new Discv4SyncResponder.PingDedup
+    val responder = buildResponder(privateKey, dedup = dedup)
+
+    val ping = Payload.Ping(
+      version = 4,
+      from = makeAddress(31000),
+      to = makeAddress(31002),
+      expiration = System.currentTimeMillis() / 1000 + expirationSeconds,
+      enrSeq = None
+    )
+    val pingPacket = Packet.pack(ping, privateKey).require
+
+    dedup.isAlreadyResponded(pingPacket.hash) shouldBe false
+    responder(sender, encodePacket(pingPacket)) should not be empty
+    dedup.isAlreadyResponded(pingPacket.hash) shouldBe true
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/Discv4SyncResponderSpec.scala
@@ -146,4 +146,45 @@ class Discv4SyncResponderSpec extends AnyFlatSpec with Matchers {
     val corrupt = pingPacket.copy(hash = Hash(BitVector(corruptHashBytes)))
     responder(sender, encodePacket(corrupt)) shouldBe None
   }
+
+  it should "drop sync-path responses once the global rate limit is exhausted" taggedAs (UnitTest, NetworkTest) in {
+    // Tight rate limit: 1 token/sec, burst 2. Three Pings in quick succession —
+    // first two consume the burst, third hits the empty bucket and falls through.
+    val (_, privateKey) = freshKeyPair
+    val limiter = new Discv4SyncResponder.RateLimiter(tokensPerSecond = 1, maxBurst = 2)
+    val responder = Discv4SyncResponder(
+      privateKey = privateKey,
+      expirationSeconds = expirationSeconds,
+      maxClockDriftSeconds = maxClockDriftSeconds,
+      localEnrSeqRef = new java.util.concurrent.atomic.AtomicReference[Option[Long]](None),
+      rateLimiter = limiter
+    )
+
+    def freshPingBits(): BitVector = {
+      val ping = Payload.Ping(
+        version = 4,
+        from = makeAddress(31000),
+        to = makeAddress(31002),
+        expiration = System.currentTimeMillis() / 1000 + expirationSeconds,
+        enrSeq = None
+      )
+      encodePacket(Packet.pack(ping, privateKey).require)
+    }
+
+    // Burst of 2 — both should be served.
+    responder(sender, freshPingBits()) should not be empty
+    responder(sender, freshPingBits()) should not be empty
+
+    // Third within the same second — bucket empty, sync path drops.
+    responder(sender, freshPingBits()) shouldBe None
+  }
+
+  it should "refill rate-limit tokens lazily based on elapsed time" taggedAs (UnitTest, NetworkTest) in {
+    // 100 tokens/sec → 1 token per 10 ms. Burst of 1.
+    val limiter = new Discv4SyncResponder.RateLimiter(tokensPerSecond = 100, maxBurst = 1)
+    limiter.tryAcquire() shouldBe true
+    limiter.tryAcquire() shouldBe false
+    Thread.sleep(20) // wait for at least 1 token to refill
+    limiter.tryAcquire() shouldBe true
+  }
 }


### PR DESCRIPTION
## Summary

**Closes the discv4 hive suite from 4/16 → 16/16** by fixing two longstanding bugs and adding a sub-300 ms sync-path responder. Follows up on #1090 (structural fixes that were prerequisites but didn't move the discv4 pass rate).

## Empirical results (CI on this branch)

| Suite | Pass | Fail | Vs main baseline |
|---|---:|---:|---|
| **discv4** | **16/16** | **0** | was 4/16 — **+12 tests** |
| discv5 | 1/8 | 7 | unchanged (no v5 impl, separate PR) |
| eth | 19/21 | 2 | unchanged (Trend #3 pending-nonce, separate PR) |
| snap | 6/6 | 0 | unchanged |
| **Total devp2p** | **42/51** | **9** | **was 30/51** |

3 stable runs locally at 16/16 confirm the fix isn't flaky.

## What's in the PR

### 1. Synchronous discv4 fast-path (`StaticUDPPeerGroup.SyncResponder`)

Opt-in `(InetSocketAddress, BitVector) => Option[BitVector]` callback in `StaticUDPPeerGroup.Config`. `channelRead` invokes it on the netty event-loop thread and writes any returned reply directly via `ctx.writeAndFlush` — no fiber hop, no compute-pool scheduling. Default `NoSyncResponder` makes existing call-sites a no-op.

### 2. Discv4 responder (`Discv4SyncResponder`)

Decodes the inbound `Packet`, recovers the public key (~3–5 ms ECDSA), and signs a `Pong` for valid non-expired Pings. Returns `None` for everything else; the async pipeline still handles those normally.

### 3. **Spec-correct `Pong.to`** (the actual root-cause fix)

Per discv4.md, `Pong.to` is "the address from which the packet was received" — the SENDER's address — not a copy of `Ping.to` (which is OUR address from the sender's perspective). Both the existing async pipeline AND my new sync responder were echoing `Ping.to`, so every Pong hive received looked like fukuii's own address and was rejected immediately. Fixed both paths.

### 4. **Sync-vs-async Pong dedup** (`Discv4SyncResponder.PingDedup`)

With (3) fixed, simulator started seeing 2 Pongs per Ping (one from each path) and rejected the duplicates ("expected 1 PING (got 0) and 1 PONG (got 2)"). A TTL-bounded `ConcurrentHashMap` of recently-answered Ping hashes is shared between the responder and `DiscoveryNetwork`. Sync marks on send; async checks before sending and skips on hit. Lazy sweep keeps memory bounded.

### 5. **Token-bucket rate limiter** (DoS mitigation)

ECDSA on the netty event-loop thread is bounded ~200 ops/s — an attacker flooding Pings could DoS the netty pool. `Discv4SyncResponder.RateLimiter` (default 200 tokens/sec, burst 100) caps the sustained sync-path rate; above the limit the responder returns `None` and the async pipeline (on the cats-effect compute pool, different threads) handles. Legitimate hive bursts (≤16 Pings in ~22 ms) all served from the burst budget.

## Test coverage (`Discv4SyncResponderSpec` — 9 tests, all passing on JDK 25 / Scala 3.3.7)

- valid Ping → Pong with spec-correct `to.ip` matching the UDP sender
- ENR seq plumbed via the `AtomicReference` supplier
- expired Ping → None
- non-Ping payload → None
- malformed bytes → None
- corrupt hash → None
- rate limit exhaustion drops further sync responses
- rate limit refills lazily based on elapsed time
- `PingDedup.markSent` flips `isAlreadyResponded` to true after a Pong is sent

## Architecture notes

- `localEnrSeqRef` is currently a static `None`. Wiring it to `DiscoveryService.stateRef` so it tracks ENR rotations is a follow-up — most discv4 hive tests don't check the field.
- Scala 3 forbids two overloaded `apply`s with default args. Resolved by removing the default on the case class `syncResponder` field; the convenience companion `apply(bindAddress, channelCapacity, receiveBufferSizeBytes)` passes `NoSyncResponder` explicitly.
- Async path's `handler.ping(caller)` still runs for bonding / kademlia bookkeeping side-effects — only the duplicate `channel.send(Pong)` is suppressed.

## Test plan

- [x] `sbt testEssential` — all tiers green
- [x] Unit tests for `Discv4SyncResponderSpec` (9/9 passing)
- [x] Local hive devp2p discv4: 16/16 across 3 stable consecutive runs
- [x] CI Hive · devp2p: 16/16 confirmed
- [x] CI Hive · graphql/pyspec/rpc/rpc-compat/sync/smoke-genesis/smoke-network: all green
- [ ] CI Hive · consensus/engine/consume-engine/consume-rlp: in progress (long sims, unaffected by discovery changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)