### PR TITLE
fix(network): force supportsSnap=true for ETH/69 peers (EIP-7642)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -76,7 +76,9 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
         EthNodeStatus63ExchangeState(handshakerConfiguration, supportsSnap, peerCapabilities)
       case Some(Capability.ETH69) =>
         log.debug("PROTOCOL_NEGOTIATED: clientId={}, protocol=eth/69 (EIP-7642)", hello.clientId)
-        EthNodeStatus69ExchangeState(handshakerConfiguration, Capability.ETH69, supportsSnap, peerCapabilities)
+        // ETH/69 mandates SNAP as a co-protocol (EIP-7642). Peers that negotiate ETH/69
+        // never separately advertise snap/1 in Hello — it is implicit. Force supportsSnap=true.
+        EthNodeStatus69ExchangeState(handshakerConfiguration, Capability.ETH69, supportsSnap = true, peerCapabilities)
       case Some(
             negotiated @ (Capability.ETH64 | Capability.ETH65 | Capability.ETH66 | Capability.ETH67 | Capability.ETH68)
           ) =>


### PR DESCRIPTION
## Description

ETH/69 peers (EIP-7642) are required to support snap/1 as a co-protocol. Fukuii was not setting `supportsSnap=true` during ETH/69 capability negotiation, causing ETH/69-only peers to be excluded from SNAP sync even when they support it by spec.

## Proposed Solution

Force `supportsSnap = true` in `EtcHelloExchangeState` when the negotiated ETH capability version is ≥ 69.

Reference client: EIP-7642 § "All nodes that support eth/69 MUST also support snap/1." Besu: `EthPeers.checkIsSnapServer()` in `EthPeers.java` validates snap capability independently of ETH version — ETH/69 peers are implicitly snap-capable by spec and do not need to advertise snap/1 separately in their Hello.

## Important Changes Introduced

`EtcHelloExchangeState.scala`: sets `supportsSnap = true` when negotiated capability version ≥ 69. No change to handshake state machine logic.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, clean datadir, pivot block 24,441,218): Besu peer at 64.225.0.245:30303 (ETH/69) confirmed serving AccountRange responses throughout the account phase. `sbt test` — 2,529 passing.