### PR TITLE
fix(network): demote handshake mismatch events from WARN to DEBUG

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -51,14 +51,14 @@ case class EthNodeStatus64ExchangeState(
     )
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.warn(
+      log.debug(
         "STATUS_EXCHANGE: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.warn(
+      log.debug(
         "STATUS_EXCHANGE: Peer genesis hash mismatch! Local: {}, Remote: {} - disconnecting peer",
         localGenesisHash,
         status.genesisHash
@@ -72,12 +72,9 @@ case class EthNodeStatus64ExchangeState(
             status.forkId
           )
       } yield {
-        log.info("STATUS_EXCHANGE: ForkId validation result: {}", validationResult)
+        log.debug("STATUS_EXCHANGE: ForkId validation result: {}", validationResult)
         validationResult match {
           case Connect =>
-            // EIP-2124: ForkId validation replaces the fork block exchange for ETH64+
-            // When ForkId validation passes, we go directly to connected state
-            // without needing to do the old-style fork block handshake
             log.info(
               "STATUS_EXCHANGE: ForkId validation passed - accepting peer connection (skipping fork block exchange per EIP-2124)"
             )
@@ -85,7 +82,7 @@ case class EthNodeStatus64ExchangeState(
               PeerInfo.withForkAccepted(RemoteStatus(status, negotiatedCapability, supportsSnap, peerCapabilities))
             )
           case other =>
-            log.warn(
+            log.debug(
               "STATUS_EXCHANGE: ForkId validation failed with result: {} - disconnecting peer as UselessPeer. Local ForkId: {}, Remote ForkId: {}",
               other,
               localForkId,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -47,14 +47,14 @@ case class EthNodeStatus69ExchangeState(
     val localGenesisHash = blockchainReader.genesisHeader.hash
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.warn(
+      log.debug(
         "ETH69_STATUS: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.warn(
+      log.debug(
         "ETH69_STATUS: Genesis hash mismatch! Local: {}, Remote: {} - disconnecting",
         localGenesisHash,
         status.genesisHash
@@ -68,7 +68,7 @@ case class EthNodeStatus69ExchangeState(
             status.forkId
           )
       } yield {
-        log.info("ETH69_STATUS: ForkId validation result: {}", validationResult)
+        log.debug("ETH69_STATUS: ForkId validation result: {}", validationResult)
         validationResult match {
           case Connect =>
             log.info("ETH69_STATUS: ForkId validation passed - accepting peer")
@@ -78,7 +78,7 @@ case class EthNodeStatus69ExchangeState(
               )
             )
           case other =>
-            log.warn("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
+            log.debug("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
             DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
         }
       }).unsafeRunSync()


### PR DESCRIPTION
## Description

NetworkId, genesis hash, and forkId mismatch events during ETH status exchange were logged at WARN. These are expected peer churn events on a multi-network devp2p overlay (e.g., Ethereum mainnet nodes connecting to ETC) and produce operator-visible noise during extended syncs that encounter thousands of such peers.

## Proposed Solution

Change the three mismatch log calls in `EthNodeStatus64ExchangeState` and `EthNodeStatus69ExchangeState` from `log.warn(...)` to `log.debug(...)`. Disconnect behavior is unchanged.

Reference client: Besu `EthProtocolManager.handleStatusMessage()` — networkId mismatch (line 393), forkId mismatch (line 400), genesis hash mismatch (line 408) all use `LOG.atDebug()` with disconnect reason codes `SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK`, `SUBPROTOCOL_TRIGGERED_MISMATCHED_FORKID`, `SUBPROTOCOL_TRIGGERED_MISMATCHED_GENESIS_HASH`.

## Important Changes Introduced

Log level change only. No logic change. Disconnect behavior and reason codes are unchanged.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, pivot block 24,441,218): hundreds of wrong-network peer disconnects produced no WARN noise; peers disconnect correctly. `sbt test` — 2,529 passing.