### PR TITLE
fix(peers): maintained and trusted peer lifecycle improvements

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/ConnectedPeers.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/ConnectedPeers.scala
@@ -86,14 +86,15 @@ case class ConnectedPeers(
       numPeers: Int,
       priority: PeerId => Double = _ => 0.0,
       incoming: Boolean = true,
-      currentTimeMillis: Long = System.currentTimeMillis
+      currentTimeMillis: Long = System.currentTimeMillis,
+      excludedNodeIds: Set[ByteString] = Set.empty
   ): (Seq[Peer], ConnectedPeers) = {
     val ageThreshold = currentTimeMillis - minAge.toMillis
     if (lastPruneTimestamp > ageThreshold || numPeers == 0) {
       // Protect against hostile takeovers by limiting the frequency of pruning.
       (Seq.empty, this)
     } else {
-      val candidates = handshakedPeers.values.filter(canPrune(incoming, ageThreshold)).toSeq
+      val candidates = handshakedPeers.values.filter(canPrune(incoming, ageThreshold, excludedNodeIds)).toSeq
 
       val toPrune = candidates.sortBy(peer => priority(peer.id)).take(numPeers)
 
@@ -108,10 +109,13 @@ case class ConnectedPeers(
     }
   }
 
-  private def canPrune(incoming: Boolean, minCreateTimeMillis: Long)(peer: Peer): Boolean =
+  private def canPrune(incoming: Boolean, minCreateTimeMillis: Long, excludedNodeIds: Set[ByteString])(
+      peer: Peer
+  ): Boolean =
     peer.incomingConnection == incoming &&
       peer.createTimeMillis <= minCreateTimeMillis &&
-      !pruningPeers.contains(peer.id)
+      !pruningPeers.contains(peer.id) &&
+      peer.nodeId.forall(nid => !excludedNodeIds.contains(nid))
 }
 
 object ConnectedPeers {

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -26,6 +26,7 @@ import com.chipprbots.ethereum.network.p2p.messages.ETH62.NewBlockHashes
 import com.chipprbots.ethereum.network.p2p.messages.ETH66
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{BlockHeaders => ETH66BlockHeaders}
 import com.chipprbots.ethereum.network.p2p.messages.ETH64
+import com.chipprbots.ethereum.network.p2p.messages.ETH69
 import com.chipprbots.ethereum.network.p2p.messages.SNAP
 import com.chipprbots.ethereum.network.p2p.messages.SNAP._
 import com.chipprbots.ethereum.network.p2p.messages.WireProtocol.Disconnect
@@ -360,6 +361,8 @@ class NetworkPeerManagerActor(
         update(Seq((m.block.header.number, m.block.header.hash)))
       case m: NewBlockHashes =>
         update(m.hashes.map(h => (h.number, h.hash)))
+      case m: ETH69.BlockRangeUpdate =>
+        update(Seq((m.latestBlock, m.latestBlockHash)))
       case _ => initialPeerInfo
     }
   }
@@ -639,6 +642,7 @@ object NetworkPeerManagerActor {
     Codes.BlockHeadersCode,
     Codes.NewBlockCode,
     Codes.NewBlockHashesCode,
+    Codes.BlockRangeUpdateCode,
     // SNAP protocol response codes (responses we receive from peers)
     SNAP.Codes.AccountRangeCode,
     SNAP.Codes.StorageRangesCode,

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -86,10 +86,11 @@ class NetworkPeerManagerActor(
   def handleMessages(peersWithInfo: PeersWithInfo): Receive =
     handleCommonMessages(peersWithInfo).orElse(handlePeersInfoEvents(peersWithInfo))
 
-  private def peerHasUpdatedBestBlock(peerInfo: PeerInfo): Boolean = {
-    val peerBestBlockIsItsGenesisBlock = peerInfo.bestBlockHash == peerInfo.remoteStatus.genesisHash
-    peerBestBlockIsItsGenesisBlock || (!peerBestBlockIsItsGenesisBlock && peerInfo.maxBlockNumber > 0)
-  }
+  private def peerHasUpdatedBestBlock(@annotation.unused peerInfo: PeerInfo): Boolean =
+    // All handshaked peers are usable. go-ethereum has no equivalent gate (eth/peerset.go all()
+    // returns all peers unconditionally). ETH/69 peers carry latestBlock in Status; ETH/68 peers
+    // carry bestHash. Both are sufficient to identify the peer as having chain state.
+    true
 
   /** Processes both messages for sending messages and for requesting peer information
     *

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -82,6 +82,12 @@ class PeerManagerActor(
     */
   private var trustedPeersByNodeId: Set[String] = Set.empty
 
+  /** Tracks outbound peer actors that were spawned for maintained peers but have not yet completed the ETH handshake.
+    * When a Terminated fires with no matching PeerId in connectedPeers (pre-handshake death), this map identifies the
+    * URI so the reconnect timer can be scheduled. Cleared on successful handshake or actor termination.
+    */
+  private val pendingMaintainedConnections: mutable.Map[ActorRef, URI] = mutable.Map.empty
+
   /** Runtime max-outgoing-peers override set by admin_maxPeers. core-geth reference: eth/api_admin.go MaxPeers — sets
     * handler.maxPeers + p2pServer.MaxPeers.
     */
@@ -391,6 +397,9 @@ class PeerManagerActor(
       case Right(address) =>
         val (peer, newConnectedPeers) = createPeer(address, incomingConnection = false, connectedPeers)
         peer.ref ! PeerActor.ConnectTo(uri)
+        if (maintainedPeersByNodeId.values.exists(_ == uri)) {
+          pendingMaintainedConnections(peer.ref) = uri
+        }
         context.become(listening(newConnectedPeers))
 
       case Left(error) => handleConnectionErrors(error)
@@ -451,6 +460,18 @@ class PeerManagerActor(
       }
 
     case Terminated(ref) =>
+      // Pre-handshake path: if a maintained peer's TCP actor dies before the ETH handshake
+      // completes, no PeerId was assigned — the post-handshake reconnect path won't fire.
+      pendingMaintainedConnections.remove(ref).foreach { uri =>
+        log.debug(
+          "Maintained peer {} TCP connection failed pre-handshake — scheduling retry in {}",
+          uri,
+          peerConfiguration.connectRetryDelay
+        )
+        context.system.scheduler.scheduleOnce(peerConfiguration.connectRetryDelay, self, ConnectToPeer(uri))(
+          context.dispatcher
+        )
+      }
       val (terminatedPeersIds, newConnectedPeers) = connectedPeers.removeTerminatedPeer(ref)
       terminatedPeersIds.foreach { peerId =>
         peerStatusCache = peerStatusCache - peerId
@@ -490,6 +511,7 @@ class PeerManagerActor(
         // Keep the current connectedPeers state; the Terminated message will clean up the peer
         context.become(listening(connectedPeers))
       } else {
+        pendingMaintainedConnections.remove(handshakedPeer.ref)
         peerStatusCache = peerStatusCache + (handshakedPeer.id -> PeerActor.Status.Handshaked)
         context.become(listening(connectedPeers.promotePeerToHandshaked(handshakedPeer)))
       }

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -259,11 +259,17 @@ class PeerManagerActor(
 
   private def handleConnections(connectedPeers: ConnectedPeers): Receive = {
     case PeerClosedConnection(peerAddress, reason) =>
-      blacklist.add(
-        PeerAddress(peerAddress),
-        getBlacklistDuration(reason),
-        Blacklist.BlacklistReason.getP2PBlacklistReasonByDescription(Disconnect.reasonToString(reason))
-      )
+      val isMaintainedPeer = connectedPeers.peers.values
+        .find(_.remoteAddress.getHostString == peerAddress)
+        .flatMap(_.nodeId)
+        .exists(nid => maintainedPeersByNodeId.contains(Hex.toHexString(nid.toArray)))
+      if (!isMaintainedPeer) {
+        blacklist.add(
+          PeerAddress(peerAddress),
+          getBlacklistDuration(reason),
+          Blacklist.BlacklistReason.getP2PBlacklistReasonByDescription(Disconnect.reasonToString(reason))
+        )
+      }
 
     case HandlePeerConnection(connection, remoteAddress) =>
       handleConnection(connection, remoteAddress, connectedPeers)

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -544,13 +544,16 @@ class PeerManagerActor(
   ): ConnectedPeers = {
     val pruneCount = PeerManagerActor.numberOfIncomingConnectionsToPrune(connectedPeers, peerConfiguration)
     val now = System.currentTimeMillis
+    val excludedNodeIds =
+      (maintainedPeersByNodeId.keySet ++ trustedPeersByNodeId).map(hex => ByteString(Hex.decode(hex)))
     val (peersToPrune, prunedConnectedPeers) =
       connectedPeers.prunePeers(
         incoming = true,
         minAge = peerConfiguration.minPruneAge,
         numPeers = pruneCount,
         priority = prunePriority(stats, now),
-        currentTimeMillis = now
+        currentTimeMillis = now,
+        excludedNodeIds = excludedNodeIds
       )
 
     peersToPrune.foreach { peer =>

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -463,8 +463,11 @@ class PeerManagerActor(
       context.become(listening(newConnectedPeers))
 
     case PeerEvent.PeerHandshakeSuccessful(handshakedPeer, _) =>
+      val isMaintained = handshakedPeer.nodeId.exists(nid =>
+        maintainedPeersByNodeId.contains(Hex.toHexString(nid.toArray))
+      )
       if (
-        handshakedPeer.incomingConnection && connectedPeers.incomingHandshakedPeersCount >= peerConfiguration.maxIncomingPeers
+        handshakedPeer.incomingConnection && connectedPeers.incomingHandshakedPeersCount >= peerConfiguration.maxIncomingPeers && !isMaintained
       ) {
         handshakedPeer.ref ! PeerActor.DisconnectPeer(Disconnect.Reasons.TooManyPeers)
 

--- a/src/test/scala/com/chipprbots/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/EtcPeerManagerSpec.scala
@@ -217,7 +217,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     setupNewPeer(freshPeer, freshPeerProbe, freshPeerInfo.copy(maxBlockNumber = 0))
 
     requestSender.send(peersInfoHolder, GetHandshakedPeers)
-    requestSender.expectMsg(HandshakedPeers(Map.empty))
+    requestSender.expectMsg(HandshakedPeers(Map(freshPeer -> freshPeerInfo.copy(maxBlockNumber = 0))))
 
     val newMaxBlock: BigInt = freshPeerInfo.maxBlockNumber + 1
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = newMaxBlock)
@@ -276,6 +276,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
             Codes.BlockHeadersCode,
             Codes.NewBlockCode,
             Codes.NewBlockHashesCode,
+            Codes.BlockRangeUpdateCode,
             // SNAP protocol response codes
             com.chipprbots.ethereum.network.p2p.messages.SNAP.Codes.AccountRangeCode,
             com.chipprbots.ethereum.network.p2p.messages.SNAP.Codes.StorageRangesCode,
@@ -493,6 +494,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
               Codes.BlockHeadersCode,
               Codes.NewBlockCode,
               Codes.NewBlockHashesCode,
+              Codes.BlockRangeUpdateCode,
               // SNAP protocol response codes
               com.chipprbots.ethereum.network.p2p.messages.SNAP.Codes.AccountRangeCode,
               com.chipprbots.ethereum.network.p2p.messages.SNAP.Codes.StorageRangesCode,


### PR DESCRIPTION
## Description

Maintained (statically configured) and trusted peers were treated identically to ephemeral discovered peers — subject to the same inbound connection limits, pruning, blacklisting, and height-tracking gaps. This caused locally configured peers (e.g., a co-located SNAP server) to be occasionally displaced under peer pressure, disrupting SNAP sync throughput.

## Proposed Solution

Six related fixes across `PeerManagerActor`, `NetworkPeerManagerActor`, and `ConnectedPeers`:

- Exempt maintained peers from inbound max-peer limit
- Exempt maintained and trusted peers from incoming peer pruning
- Skip blacklisting for maintained peers on disconnect
- Reconnect maintained peers that fail pre-handshake TCP connection
- Track ETH/69 peer height via BlockRangeUpdate messages
- Accept all handshaked peers in GetHandshakedPeers response

Reference client: Besu `DefaultPeerPrivileges.canExceedConnectionLimits()` in `DefaultPeerPrivileges.java` — returns `true` for any peer in `MaintainedPeers`; `MaintainedPeers.add()` in `MaintainedPeers.java` registers static peers that are never pruned by connection count limits.

## Important Changes Introduced

`ConnectedPeers.scala`: maintained/trusted peers bypass peer count enforcement.
`PeerManagerActor.scala`: maintained peers exempt from blacklist on disconnect; automatic TCP reconnect on pre-handshake failure.
`NetworkPeerManagerActor.scala`: ETH/69 peer height tracked via BlockRangeUpdate; all handshaked peers returned in GetHandshakedPeers.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, pivot block 24,441,218): local Besu at 127.0.0.1:30304 maintained a stable priority connection throughout 90+ minutes of account phase with no spurious disconnects. `sbt test` — 2,529 passing (includes `EtcPeerManagerSpec` updates).