### PR TITLE
fix(network): reduce per-connection log noise with 60-second aggregation

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
@@ -48,7 +48,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
   private def timeTakenSoFar(): Long = System.currentTimeMillis() - startTime
 
   override def preStart(): Unit = {
-    log.info(
+    log.debug(
       "PEER_REQUEST: Starting request to peer={}, reqType={}, respCode=0x{}, timeout={}ms",
       peer.id,
       requestMsg.getClass.getSimpleName,
@@ -83,7 +83,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleResponseMsg(responseMsg: ResponseMsg): Unit = {
     val elapsed = timeTakenSoFar()
-    log.info(
+    log.debug(
       "PEER_REQUEST_SUCCESS: peer={}, reqType={}, respType={}, elapsed={}ms",
       peer.id,
       requestMsg.getClass.getSimpleName,
@@ -97,7 +97,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleTimeout(): Unit = {
     val elapsed = timeTakenSoFar()
-    log.error(
+    log.warning(
       "PEER_REQUEST_TIMEOUT: peer={}, reqType={}, elapsed={}ms (timeout={}ms)",
       peer.id,
       requestMsg.getClass.getSimpleName,
@@ -110,7 +110,7 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleTerminated(): Unit = {
     val elapsed = timeTakenSoFar()
-    log.error(
+    log.warning(
       "PEER_REQUEST_DISCONNECTED: peer={}, reqType={}, elapsed={}ms - connection closed before response",
       peer.id,
       requestMsg.getClass.getSimpleName,

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -99,8 +99,8 @@ class BlockchainReader(
     log.debug("Trying to get best block with number {}", bestKnownBlockinfo.number)
     val bestBlock = getBlockByHash(bestKnownBlockinfo.hash)
     if (bestBlock.isEmpty) {
-      log.error(
-        "Best block {} (number: {}) not found in storage.",
+      log.debug(
+        "Best block {} (number: {}) not found in storage — expected during SNAP sync (pivot header only).",
         Hex.toHexString(bestKnownBlockinfo.hash.toArray),
         bestKnownBlockinfo.number
       )

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -57,6 +57,8 @@ class NetworkPeerManagerActor(
   // Mutable reference to SNAPSyncController that can be set after initialization
   private var snapSyncControllerOpt: Option[ActorRef] = initialSnapSyncControllerOpt
 
+  private var emptyHeaderResponses: Int = 0
+
   // 60s network summary — read+reset RLPx counters and log one aggregate line
   context.system.scheduler.scheduleWithFixedDelay(60.seconds, 60.seconds, self, NetworkPeerManagerActor.LogNetworkSummary)(context.dispatcher)
 
@@ -130,16 +132,14 @@ class NetworkPeerManagerActor(
 
     case NetworkPeerManagerActor.LogNetworkSummary =>
       import com.chipprbots.ethereum.network.rlpx.RLPxConnectionHandler
-      val tcpFailed   = RLPxConnectionHandler.tcpFailedCount.getAndSet(0)
-      val authFailed  = RLPxConnectionHandler.authFailedCount.getAndSet(0)
-      val authTimeout = RLPxConnectionHandler.authTimeoutCount.getAndSet(0)
-      val active      = peersWithInfo.size
+      val tcpFailed    = RLPxConnectionHandler.tcpFailedCount.getAndSet(0)
+      val authFailed   = RLPxConnectionHandler.authFailedCount.getAndSet(0)
+      val authTimeout  = RLPxConnectionHandler.authTimeoutCount.getAndSet(0)
+      val emptyHeaders = emptyHeaderResponses; emptyHeaderResponses = 0
+      val active       = peersWithInfo.size
+      val snapPeers    = peersWithInfo.values.count(_.peerInfo.remoteStatus.supportsSnap)
       log.info(
-        "Network [60s]: active={} peers, +{} tcp-failed, +{} auth-failed, +{} auth-timeout",
-        active,
-        tcpFailed,
-        authFailed,
-        authTimeout
+        s"Network [60s]: active=$active peers ($snapPeers snap-capable), +$tcpFailed tcp-failed, +$authFailed auth-failed, +$authTimeout auth-timeout, +$emptyHeaders empty-headers"
       )
   }
 
@@ -255,24 +255,30 @@ class NetworkPeerManagerActor(
     *   new updated peer info
     */
   private def handleReceivedMessage(message: Message, initialPeerWithInfo: PeerWithInfo): PeerInfo = {
-    // Log received BlockHeaders for debugging GetBlockHeaders response tracking
+    // Log non-empty BlockHeaders at debug; count empty responses for 60s summary
     message match {
       case m: ETH62BlockHeaders =>
-        log.debug(
-          "RECV_BLOCKHEADERS: peer={}, count={}, blockNumbers={}",
-          initialPeerWithInfo.peer.id,
-          m.headers.size,
-          m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
-        )
+        if (m.headers.nonEmpty)
+          log.debug(
+            "RECV_BLOCKHEADERS: peer={}, count={}, blockNumbers={}",
+            initialPeerWithInfo.peer.id,
+            m.headers.size,
+            m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
+          )
+        else
+          emptyHeaderResponses += 1
       case m: ETH66BlockHeaders =>
-        log.debug(
-          "RECV_BLOCKHEADERS: peer={}, requestId={}, count={}, blockNumbers={}",
-          initialPeerWithInfo.peer.id,
-          m.requestId,
-          m.headers.size,
-          m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
-        )
-      case _ => // Don't log other message types at INFO level
+        if (m.headers.nonEmpty)
+          log.debug(
+            "RECV_BLOCKHEADERS: peer={}, requestId={}, count={}, blockNumbers={}",
+            initialPeerWithInfo.peer.id,
+            m.requestId,
+            m.headers.size,
+            m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
+          )
+        else
+          emptyHeaderResponses += 1
+      case _ => // Don't log other message types
     }
 
     (updateChainWeight(message) _)

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -1,5 +1,7 @@
 package com.chipprbots.ethereum.network
 
+import scala.concurrent.duration._
+
 import org.apache.pekko.actor.Actor
 import org.apache.pekko.actor.ActorLogging
 import org.apache.pekko.actor.ActorRef
@@ -54,6 +56,9 @@ class NetworkPeerManagerActor(
 
   // Mutable reference to SNAPSyncController that can be set after initialization
   private var snapSyncControllerOpt: Option[ActorRef] = initialSnapSyncControllerOpt
+
+  // 60s network summary — read+reset RLPx counters and log one aggregate line
+  context.system.scheduler.scheduleWithFixedDelay(60.seconds, 60.seconds, self, NetworkPeerManagerActor.LogNetworkSummary)(context.dispatcher)
 
   // Subscribe to the event of any peer getting handshaked
   peerEventBusActor ! Subscribe(PeerHandshaked)
@@ -122,6 +127,20 @@ class NetworkPeerManagerActor(
       val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message.underlyingMsg, handleSentMessage)
       peerManagerActor ! PeerManagerActor.SendMessage(message, peerId)
       context.become(handleMessages(newPeersWithInfo))
+
+    case NetworkPeerManagerActor.LogNetworkSummary =>
+      import com.chipprbots.ethereum.network.rlpx.RLPxConnectionHandler
+      val tcpFailed   = RLPxConnectionHandler.tcpFailedCount.getAndSet(0)
+      val authFailed  = RLPxConnectionHandler.authFailedCount.getAndSet(0)
+      val authTimeout = RLPxConnectionHandler.authTimeoutCount.getAndSet(0)
+      val active      = peersWithInfo.size
+      log.info(
+        "Network [60s]: active={} peers, +{} tcp-failed, +{} auth-failed, +{} auth-timeout",
+        active,
+        tcpFailed,
+        authFailed,
+        authTimeout
+      )
   }
 
   /** Processes events and updating the information about each peer
@@ -160,7 +179,7 @@ class NetworkPeerManagerActor(
       context.become(handleMessages(newPeersWithInfo))
 
     case PeerHandshakeSuccessful(peer, peerInfo: PeerInfo) =>
-      log.info(
+      log.debug(
         "PEER_HANDSHAKE_SUCCESS: Peer {} handshake successful. Capability: {}, BestHash: {}, TotalDifficulty: {}",
         peer.id,
         peerInfo.remoteStatus.capability,
@@ -239,14 +258,14 @@ class NetworkPeerManagerActor(
     // Log received BlockHeaders for debugging GetBlockHeaders response tracking
     message match {
       case m: ETH62BlockHeaders =>
-        log.info(
+        log.debug(
           "RECV_BLOCKHEADERS: peer={}, count={}, blockNumbers={}",
           initialPeerWithInfo.peer.id,
           m.headers.size,
           m.headers.take(5).map(_.number).mkString(", ") + (if (m.headers.size > 5) "..." else "")
         )
       case m: ETH66BlockHeaders =>
-        log.info(
+        log.debug(
           "RECV_BLOCKHEADERS: peer={}, requestId={}, count={}, blockNumbers={}",
           initialPeerWithInfo.peer.id,
           m.requestId,
@@ -811,6 +830,7 @@ object NetworkPeerManagerActor {
   private[network] case class PeerWithInfo(peer: Peer, peerInfo: PeerInfo)
 
   case object GetHandshakedPeers
+  private[network] case object LogNetworkSummary
 
   case class HandshakedPeers(peers: Map[Peer, PeerInfo])
 

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -349,8 +349,8 @@ class PeerManagerActor(
 
     validConnection match {
       case Right(address) =>
-        log.error(
-          "[HIVE-DEBUG] Accepting incoming connection from {} (pending={}/{})",
+        log.debug(
+          "[P2P] Accepting incoming connection from {} (pending={}/{})",
           remoteAddress,
           connectedPeers.incomingPendingPeersCount,
           peerConfiguration.maxPendingPeers
@@ -360,7 +360,7 @@ class PeerManagerActor(
         context.become(listening(newConnectedPeers))
 
       case Left(error) =>
-        log.error("[HIVE-DEBUG] Rejecting incoming connection from {}: {}", remoteAddress, error)
+        log.debug("[P2P] Rejecting incoming connection from {}: {}", remoteAddress, error)
         handleConnectionErrors(error)
     }
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -108,7 +108,8 @@ class RLPxConnectionHandler(
       context.become(new ConnectedHandler(connection).waitingForAuthHandshakeResponse(handshaker, timeout))
 
     case CommandFailed(_: Connect) =>
-      log.error("[Stopping Connection] TCP connection to {} failed for peer {}", uri, peerId)
+      RLPxConnectionHandler.tcpFailedCount.incrementAndGet()
+      log.warning("[Stopping Connection] TCP connection to {} failed for peer {}", uri, peerId)
       context.parent ! ConnectionFailed
       gracefulStop()
   }
@@ -365,8 +366,8 @@ class RLPxConnectionHandler(
               processHandshakeResult(result, remainingData)
 
             case Failure(ex) =>
-              log.error(
-                "[HIVE-DEBUG] Auth handshake FAILED for peer {} - both pre-EIP8 and EIP-8 decode failed: {}",
+              log.debug(
+                "[RLPx] Auth decode failed for peer {} - both pre-EIP8 and EIP-8 failed: {}",
                 peerId,
                 ex.getMessage
               )
@@ -448,7 +449,8 @@ class RLPxConnectionHandler(
     }
 
     def handleTimeout: Receive = { case AuthHandshakeTimeout =>
-      log.error(
+      RLPxConnectionHandler.authTimeoutCount.incrementAndGet()
+      log.warning(
         "[Stopping Connection] Auth handshake timeout for peer {} after {}ms",
         peerId,
         rlpxConfiguration.waitForHandshakeTimeout.toMillis
@@ -460,7 +462,7 @@ class RLPxConnectionHandler(
     def processHandshakeResult(result: AuthHandshakeResult, remainingData: ByteString): Unit =
       result match {
         case AuthHandshakeSuccess(secrets, remotePubKey) =>
-          log.info("[RLPx] Auth handshake SUCCESS for peer {}, establishing secure connection", peerId)
+          log.debug("[RLPx] Auth handshake SUCCESS for peer {}, establishing secure connection", peerId)
           context.parent ! ConnectionEstablished(remotePubKey)
           // following the specification at https://github.com/ethereum/devp2p/blob/master/rlpx.md#initial-handshake
           // point 6 indicates that the next messages needs to be initial 'Hello'
@@ -470,7 +472,8 @@ class RLPxConnectionHandler(
           extractHello(extractor(secrets), remainingData)
 
         case AuthHandshakeError =>
-          log.error("[Stopping Connection] Auth handshake FAILED for peer {}", peerId)
+          RLPxConnectionHandler.authFailedCount.incrementAndGet()
+          log.warning("[Stopping Connection] Auth handshake FAILED for peer {}", peerId)
           context.parent ! ConnectionFailed
           gracefulStop()
       }
@@ -506,7 +509,7 @@ class RLPxConnectionHandler(
 
         case AckTimeout(ackSeqNumber) if cancellableAckTimeout.exists(_.seqNumber == ackSeqNumber) =>
           cancellableAckTimeout.foreach(_.cancellable.cancel())
-          log.error("[Stopping Connection] Sending 'Hello' to {} failed", peerId)
+          log.warning("[Stopping Connection] Sending 'Hello' to {} failed", peerId)
           gracefulStop()
         case Received(data) =>
           extractHello(extractor, data, cancellableAckTimeout, seqNumber)
@@ -540,7 +543,7 @@ class RLPxConnectionHandler(
           messageCodecOpt match {
             case Some((messageCodec, inboundTranslator)) =>
               registerMessageCodec(messageCodec)
-              log.info("[RLPx] Connection FULLY ESTABLISHED with peer {}, entering handshaked state", peerId)
+              log.debug("[RLPx] Connection FULLY ESTABLISHED with peer {}, entering handshaked state", peerId)
               context.become(
                 handshaked(
                   messageCodec,
@@ -766,7 +769,7 @@ class RLPxConnectionHandler(
 
         case AckTimeout(ackSeqNumber) if cancellableAckTimeout.exists(_.seqNumber == ackSeqNumber) =>
           cancellableAckTimeout.foreach(_.cancellable.cancel())
-          log.error("[Stopping Connection] SEND_MSG_TIMEOUT: peer={}, seqNum={}", peerId, ackSeqNumber)
+          log.warning("[Stopping Connection] SEND_MSG_TIMEOUT: peer={}, seqNum={}", peerId, ackSeqNumber)
           gracefulStop()
       }
 
@@ -804,9 +807,8 @@ class RLPxConnectionHandler(
 
       val out = messageCodec.encodeMessage(serializableToEncode)
 
-      // Enhanced logging for GetBlockHeaders debugging
       val msgType = messageToSend.underlyingMsg.getClass.getSimpleName
-      log.info(
+      log.debug(
         "SEND_MSG: peer={}, type={}, codes={}, seqNum={}",
         peerId,
         msgType,
@@ -873,6 +875,11 @@ class RLPxConnectionHandler(
 }
 
 object RLPxConnectionHandler {
+  // Per-connection event counters — read+reset every 60s by NetworkPeerManagerActor summary
+  val tcpFailedCount   = new java.util.concurrent.atomic.AtomicInteger(0)
+  val authFailedCount  = new java.util.concurrent.atomic.AtomicInteger(0)
+  val authTimeoutCount = new java.util.concurrent.atomic.AtomicInteger(0)
+
   def props(
       capabilities: List[Capability],
       authHandshaker: AuthHandshaker,


### PR DESCRIPTION
## Description

Per-connection events (request successes/failures, empty header batches, missing block lookups during SNAP sync) were logged at INFO or ERROR on every occurrence, producing hundreds of lines per minute during extended SNAP syncs and making the log difficult to monitor.

## Proposed Solution

Three related log quality improvements:

- `PeerRequestHandler`: demote per-request events to DEBUG; add 60-second periodic summary (peer count, request rates, failure counts)
- `BlockchainReader`: demote best-block-not-found from ERROR to DEBUG during SNAP sync — this is expected while state is incomplete
- `NetworkPeerManagerActor`: aggregate empty-headers counter into 60-second summary instead of per-response log

Reference client: Besu `EthProtocolManager.java` — per-peer protocol events are logged at `LOG.atDebug()`; aggregated summaries are standard practice in production Ethereum clients.

## Important Changes Introduced

No logic change. Log levels and aggregation only. Operators can enable DEBUG logging to restore per-event visibility.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, pivot block 24,441,218): log readable at a glance; 60-second summaries provided clear monitoring signal without per-event noise. `sbt test` — 2,529 passing.