### PR TITLE
fix(snap): suppress false storage stall watchdog during account sync phase

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -143,7 +143,7 @@ class StorageRangeCoordinator(
     // (SNAPRequestTracker timeouts are poll-based, not scheduled), so we check
     // activity time regardless of in-flight count.
     val now = System.currentTimeMillis()
-    val dispatchStalled = !allStateless && tasks.nonEmpty &&
+    val dispatchStalled = !allStateless && tasks.nonEmpty && maxInFlightPerPeer > 0 &&
       (now - lastDispatchOrResponseMs) > noActivityTimeoutMs
 
     if (dispatchStalled) {


### PR DESCRIPTION
## Description

The storage range dispatch stall watchdog in `StorageRangeCoordinator` would fire even when `maxInFlightPerPeer` was zero — i.e., when there were no active requests because no peers were available yet. This produced spurious "dispatch stalled" log events during the account phase when storage tasks are queued but not yet dispatched.

## Proposed Solution

Add a `maxInFlightPerPeer > 0` guard to the stall watchdog check, so it only fires when there are actually active in-flight requests that have stopped making progress — not when the coordinator is simply waiting for peers.

Reference client: Besu `WorldDownloadState.requestComplete()` in `WorldDownloadState.java` (lines 189–201) — stall declared only after `requestsSinceLastProgress >= maxRequestsWithoutProgress`; `SnapWorldDownloadState.markAsStalled()` (line 159) overrides to a no-op, meaning Besu never fires a stall when no requests are outstanding.

## Important Changes Introduced

`StorageRangeCoordinator.scala`: one-line guard added to stall watchdog condition. No change to stall detection when requests are active.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, pivot block 24,441,218): ran 90+ minutes through the account phase with storage queue growing from 0 to 90,000+ tasks — zero "dispatch stalled" events. `sbt test` — 2,529 passing.