### PR TITLE
fix(snap): cancel in-flight requests immediately when peer disconnects

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -176,6 +176,7 @@ class SNAPSyncController(
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
       handlePeerListMessages(msg)
       requestTracker.rateTracker.removePeer(peerId.value)
+      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
   }
 
   /** Wrap handlePeerListMessages to also update the PeerRateTracker when peers connect/disconnect. Tracks previous peer
@@ -198,6 +199,7 @@ class SNAPSyncController(
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
       handlePeerListMessages(msg) // removes from handshakedPeers
       requestTracker.rateTracker.removePeer(peerId.value)
+      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
   }
 
   // Storage stagnation watchdog: if storage stops advancing while tasks remain, repivot/restart.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -451,6 +451,23 @@ class AccountRangeCoordinator(
       maxInFlightPerPeer = newLimit
       if (newLimit > 0) tryRedispatchPendingTasks()
 
+    case PeerUnavailable(peerId) =>
+      // Peer disconnected — remove from available set, reset its timeout counter so network-level
+      // disconnects don't accumulate toward the stateless threshold. Then immediately cancel any
+      // in-flight request to this peer so workers return to idle without waiting for 30s timeout.
+      // go-ethereum eth/protocols/snap/sync.go:1621 (revertRequests) and Besu
+      // AbstractRetryingPeerTask.java:158 both treat disconnect as transient re-queue, not failure.
+      knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
+      peerConsecutiveTimeouts.remove(peerId)
+      peerCooldownUntilMs.remove(peerId)
+      val inFlight = activeTasks.collect {
+        case (reqId, (_, worker, peer)) if peer.id.value == peerId => (reqId, worker)
+      }.toSeq
+      if (inFlight.nonEmpty) {
+        log.debug(s"Peer $peerId disconnected — cancelling ${inFlight.size} in-flight request(s)")
+        inFlight.foreach { case (_, worker) => worker ! WorkerPeerDisconnected(peerId) }
+      }
+
     case TaskComplete(requestId, result) =>
       handleTaskComplete(requestId, result)
 
@@ -774,9 +791,9 @@ class AccountRangeCoordinator(
       task.rootHash = stateRoot
       pendingTasks.enqueue(task)
 
-      // Apply cooldown and reduce byte budget for failing peers (unless stateless-marked,
-      // which already blocks them from dispatch)
-      if (!reason.contains("Missing proof for empty account range")) {
+      // Apply cooldown and reduce byte budget for protocol failures; skip for network-level
+      // disconnects since the peer is already gone and will reconnect fresh.
+      if (!reason.contains("Missing proof for empty account range") && !reason.contains("Peer disconnected")) {
         recordPeerCooldown(peer, reason)
         adjustResponseBytesOnFailure(peer, reason)
       }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -143,6 +143,17 @@ class AccountRangeWorker(
           log.debug(s"Timeout for old or unknown request $reqId")
       }
 
+    case WorkerPeerDisconnected(peerId) =>
+      currentTask match {
+        case Some((_, peer, reqId)) if peer.id.value == peerId =>
+          log.debug(s"Peer $peerId disconnected — re-queuing task immediately (reqId=$reqId)")
+          requestTracker.completeRequest(reqId, 0)
+          coordinator ! TaskFailed(reqId, "Peer disconnected")
+          currentTask = None
+          context.become(idle)
+        case _ => // Different peer or no task; ignore
+      }
+
     case FetchAccountRange(task, peer, _, _) =>
       log.warning("Worker is busy, cannot accept new task")
       coordinator ! TaskFailed(0, "Worker busy")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -30,6 +30,7 @@ object Messages {
       result: Either[String, (Int, Seq[(ByteString, com.chipprbots.ethereum.domain.Account)], Seq[ByteString])]
   ) extends AccountRangeCoordinatorMessage
   case class TaskFailed(requestId: BigInt, reason: String) extends AccountRangeCoordinatorMessage
+  case class PeerUnavailable(peerId: String)               extends AccountRangeCoordinatorMessage
   case object GetProgress extends AccountRangeCoordinatorMessage
   case object GetContractAccounts extends AccountRangeCoordinatorMessage
   case class ContractAccountsResponse(accounts: Seq[(ByteString, ByteString)]) extends AccountRangeCoordinatorMessage
@@ -76,7 +77,8 @@ object Messages {
       responseBytes: BigInt = BigInt(512 * 1024)
   ) extends AccountRangeWorkerMessage
   case class AccountRangeResponseMsg(response: AccountRange) extends AccountRangeWorkerMessage
-  case class RequestTimeout(requestId: BigInt) extends AccountRangeWorkerMessage
+  case class RequestTimeout(requestId: BigInt)               extends AccountRangeWorkerMessage
+  case class WorkerPeerDisconnected(peerId: String)          extends AccountRangeWorkerMessage
 
   // ========================================
   // ByteCode Messages


### PR DESCRIPTION
## Description

When a SNAP peer disconnected, in-flight requests assigned to that peer were left in the active-requests map until they timed out (up to the full request timeout). This held worker slots occupied by dead requests, reducing effective concurrency and causing throughput stalls proportional to the timeout window after each peer loss.

## Proposed Solution

On peer disconnect, immediately cancel all in-flight SNAP requests assigned to that peer by sending a `PeerDisconnected` message to the relevant coordinators. Coordinators re-queue affected tasks and reset the consecutive-timeout counter so the peer's failures don't penalize future peer scoring.

Reference client: Besu `RequestManager.close()` in `RequestManager.java` (line 98) — calls `closeOutstandingStreams(responseStreams.values())`, closing every in-flight `ResponseStream` immediately when the peer lifecycle ends.

## Important Changes Introduced

`SNAPSyncController.scala`: forwards peer disconnect events to coordinators.
`AccountRangeCoordinator.scala`: handles `PeerDisconnected` — cancels active tasks for that peer, re-queues them, resets timeout counter.
`AccountRangeWorker.scala`: clears in-flight state on disconnect signal.
`Messages.scala`: adds `PeerDisconnected` message type.

## Testing

ETC mainnet SNAP sync Attempt 29 (JAR `337b7b7c7`, pivot block 24,441,218): worker count remained stable at 7 after peer churn events — no hung workers observed holding slots after disconnects. `sbt test` — 2,529 passing.