### PR TITLE
fix(snap): restore pendingHashSet invariant and add healing stagnation escalation

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -53,6 +53,16 @@ class TrieNodeHealingCoordinator(
   private var lastHealedAtMs: Long = System.currentTimeMillis()
   private val healingStagnationTimeoutMs: Long = 5 * 60 * 1000 // 5 minutes
 
+  // Periodic idle stagnation escalation: fires even when no requests are active.
+  // The per-timeout stagnation check at handleTimeout() requires a live request to time out;
+  // if pendingTasks is non-empty but activeRequests is empty (all peers cooling down),
+  // healing can stall silently. After 5 consecutive 2-minute ticks with no active requests
+  // and no progress (10 minutes total), force-complete healing.
+  // Reference: Besu markAsStalled() is a TODO no-op; this is a fukuii-specific liveness guarantee.
+  private case object HealingStagnationCheck
+  private var consecutiveIdleChecks: Int = 0
+  private var lastPulseHealedCount: Int = 0
+
   // Active request tracking: maps requestId -> (tasks, peer, requestedBytes, sentAtMs)
   private case class ActiveRequest(
       tasks: Seq[HealingEntry],
@@ -190,8 +200,12 @@ class TrieNodeHealingCoordinator(
       }(context.dispatcher).foreach(n => selfRef ! FlushComplete(n))(context.dispatcher)
     }
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     log.info(s"TrieNodeHealingCoordinator starting (concurrency=$concurrency)")
+    context.system.scheduler.scheduleWithFixedDelay(2.minutes, 2.minutes, self, HealingStagnationCheck)(
+      context.dispatcher
+    )
+  }
 
   override val supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1.minute) { case _: Exception =>
@@ -238,6 +252,8 @@ class TrieNodeHealingCoordinator(
       activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
       activeRequests.clear()
       pivotRefreshRequested = false
+      consecutiveIdleChecks = 0
+      lastPulseHealedCount = totalNodesHealed
 
     case TrieNodesResponseMsg(response) =>
       handleResponse(response)
@@ -268,6 +284,35 @@ class TrieNodeHealingCoordinator(
           if (abandonedTaskCount > 0) s" ($abandonedTaskCount abandoned — regular sync will recover)" else ""
         log.info(s"Healing round complete: $totalNodesHealed total nodes healed$abandonedStr. Notifying controller.")
         snapSyncController ! SNAPSyncController.StateHealingComplete
+      }
+
+    case HealingStagnationCheck =>
+      val recentHealed = totalNodesHealed - lastPulseHealedCount
+      log.info(
+        s"[HEAL-PULSE] healed=$totalNodesHealed (+$recentHealed last 2min) | " +
+          s"pending=${pendingTasks.size} active=${activeRequests.size} peers=${knownAvailablePeers.size} | " +
+          s"pivotRefreshPending=$pivotRefreshRequested"
+      )
+      lastPulseHealedCount = totalNodesHealed
+
+      if (pendingTasks.nonEmpty && activeRequests.isEmpty && !pivotRefreshRequested) {
+        consecutiveIdleChecks += 1
+        if (consecutiveIdleChecks >= 5) {
+          val pendingCount = pendingTasks.size
+          log.warning(
+            s"[HEAL] No active requests for ${consecutiveIdleChecks * 2} minutes with " +
+              s"$pendingCount pending tasks and ${knownAvailablePeers.size} known peers. " +
+              s"Forcing healing completion — missing nodes deferred to import-time recovery."
+          )
+          abandonedTaskCount += pendingCount
+          pendingTasks = Seq.empty
+          pendingHashSet.clear()
+          self ! HealingCheckCompletion
+        } else {
+          tryRedispatchPendingTasks()
+        }
+      } else {
+        consecutiveIdleChecks = 0
       }
 
     case HealingGetProgress =>
@@ -427,7 +472,9 @@ class TrieNodeHealingCoordinator(
           s"Node hash mismatch: expected ${Hex.toHexString(task.hash.take(4).toArray)}, " +
             s"got ${Hex.toHexString(nodeHash.take(4).toArray)}"
         )
-        // Re-queue this task for retry
+        // Re-queue this task for retry and restore to dedup set so QueueMissingNodes
+        // doesn't add a duplicate entry for the same hash (BUG-H1 fix)
+        pendingHashSet += task.hash
         pendingTasks = pendingTasks :+ task
       }
     }
@@ -435,6 +482,7 @@ class TrieNodeHealingCoordinator(
     // Re-queue unmatched tasks (server returned fewer nodes than requested)
     val unmatchedTasks = tasksForRequest.drop(nodes.size)
     unmatchedTasks.foreach { task =>
+      pendingHashSet += task.hash
       pendingTasks = pendingTasks :+ task
     }
 
@@ -514,6 +562,7 @@ class TrieNodeHealingCoordinator(
             s"(regular sync will fetch on-demand)"
         )
       } else {
+        pendingHashSet += updated.hash
         pendingTasks = pendingTasks :+ updated
         requeued += 1
       }


### PR DESCRIPTION
## Description

Two related issues in `TrieNodeHealingCoordinator`:

**1. pendingHashSet invariant violation (BUG-H1)**

`pendingHashSet` tracks hashes currently in `pendingTasks` to prevent the concurrent trie-walk controller from re-enqueuing nodes already queued. When a dispatched task is re-queued (on hash mismatch, unmatched response, or timeout), its hash was not re-added to `pendingHashSet`. This allowed the SNAPSyncController's concurrent trie walk to re-discover those hashes via `QueueMissingNodes` and insert them a second time, creating duplicate concurrent requests for the same trie node.

**2. Healing idle stagnation**

The existing stagnation check only fires inside `handleTimeout`, requiring an active request to time out first. With `pendingTasks.nonEmpty` but `activeRequests.isEmpty` (all peers cooling down), healing could stall indefinitely with no self-recovery path.

## Proposed Solution

**BUG-H1:** Re-add `hash` to `pendingHashSet` at all three re-queue sites: hash mismatch, unmatched response, and timeout retry.

**Idle stagnation:** Add a 2-minute scheduled `HealingStagnationCheck` tick. After 5 consecutive idle checks (10 minutes of no active requests with pending work), remaining tasks are abandoned and healing is forced to completion — missing nodes are deferred to import-time `GetTrieNodes` recovery.

Reference client: Besu `SnapWorldDownloadState.markAsStalled()` in `SnapWorldDownloadState.java` is a TODO no-op — Besu has no periodic idle escalation for the healing phase. This fix adds a liveness guarantee specific to ETC mainnet's sparse SNAP server environment where peers serving trie node data are rare.

## Important Changes Introduced

`TrieNodeHealingCoordinator.scala`:
- Three `pendingHashSet += hash` additions at re-queue sites
- `HealingStagnationCheck` case object + 2-minute scheduler in `preStart()`
- `consecutiveIdleChecks` counter with force-complete at threshold 5

## Testing

`sbt test` — 2,529 passing. Live confirmation pending: `[HEAL-PULSE]` log lines every 2 minutes once the healing phase starts in ETC mainnet SNAP sync Attempt 29 (pivot block 24,441,218). Will update with log evidence when healing phase is reached.