### PR TITLE
fix(snap): accept empty account/storage range as valid SNAP response

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
@@ -5,7 +5,6 @@ import org.apache.pekko.util.ByteString
 import com.chipprbots.ethereum.domain.Account
 import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.mpt.MptTraversals
-import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.mpt.LeafNode
 import com.chipprbots.ethereum.mpt.ExtensionNode
 import com.chipprbots.ethereum.mpt.BranchNode
@@ -51,11 +50,8 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       endHash: ByteString
   ): Either[String, Unit] = {
 
-    // For non-empty tries, even an empty account range must come with a proof proving non-existence.
-    // The only case where empty proof + empty accounts is valid is an empty trie.
     if (proof.isEmpty && accounts.isEmpty) {
-      if (rootHash == ByteString(MerklePatriciaTrie.EmptyRootHash)) return Right(())
-      return Left("Missing proof for empty account range")
+      return Right(())
     }
 
     // If we have accounts, we need a proof
@@ -344,16 +340,8 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       endHash: ByteString
   ): Either[String, Unit] = {
 
-    val emptyRoot = ByteString(com.chipprbots.ethereum.mpt.MerklePatriciaTrie.EmptyRootHash)
-
-    // snap/1 nuance:
-    // - Proofs are only sent when the server needs to prove a boundary (non-zero origin) or
-    //   the response was capped. Full responses commonly have empty proofs.
-    // - A reply with no slots and no proofs is only meaningful if the expected storageRoot is empty.
-    //   Otherwise it usually indicates the peer can't serve the requested state.
     if (slots.isEmpty && proof.isEmpty) {
-      return if (rootHash == emptyRoot) Right(())
-      else Left("Empty StorageRanges response (no slots, no proof) for non-empty storageRoot")
+      return Right(())
     }
 
     // Without proofs, we can still validate basic invariants (ordering + bounds) and accept.

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
@@ -13,7 +13,10 @@ import com.chipprbots.ethereum.testing.TestMptStorage
 
 class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
-  "MerkleProofVerifier" should "reject empty proof for empty account list when trie is non-empty" taggedAs UnitTest in {
+  "MerkleProofVerifier" should "accept empty proof for empty account list as valid empty range" taggedAs UnitTest in {
+    // Empty accounts + empty proof is a valid SNAP response meaning the keyspace region has
+    // no accounts. Previously this returned Left("Missing proof for empty account range") which
+    // triggered false stateless-peer marking. Fixed by BUG-EMPTY-RANGE (a80b2434d).
     val stateRoot = kec256(ByteString("test-root"))
     val verifier = MerkleProofVerifier(stateRoot)
 
@@ -24,8 +27,7 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
       endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
     )
 
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("Missing proof for empty account range")
+    result shouldBe Right(())
   }
 
   it should "accept empty proof for empty account list when trie is empty" taggedAs UnitTest in {


### PR DESCRIPTION
## Problem

An empty `AccountRange` or `StorageRange` response (empty accounts list, empty proof) is a **valid** SNAP protocol response meaning the requested keyspace region contains no data. The prior code treated it as an error:

```
Left("Missing proof for empty account range")
```

This triggered false stateless-peer marking — the peer that correctly reported an empty range was penalized and avoided, blocking full keyspace coverage.

## Root Cause

`MerkleProofVerifier.verifyAccountRange` required a non-empty proof whenever the state root was non-empty, even when the accounts list was also empty. go-ethereum `snap/sync.go` and Besu `SnapSynchronizer.java` both accept empty range responses unconditionally.

## Fix

Return `Right(())` for empty accounts + empty proof regardless of state root. The "missing proof" error is only appropriate when `accounts.nonEmpty` but `proof.isEmpty`.

Updated `MerkleProofVerifierSpec` to match: the test `"should reject empty proof for empty account list when trie is non-empty"` is renamed to `"should accept empty proof for empty account list as valid empty range"` and asserts `Right(())`.

## Verification

```bash
sbt "testOnly *MerkleProofVerifierSpec"
# 9 tests, all pass
```

Reference: go-ethereum `eth/protocols/snap/sync.go` empty-range handling; Besu `SnapSynchronizer.java` range response acceptance.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)