### PR TITLE
fix(discovery): filter port-0 entries from Neighbors responses

### DIFF
--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -304,7 +304,7 @@ object DiscoveryNetwork {
               channel.collectAndFoldResponses(peer.id, config.kademliaTimeout, Vector.empty[Node]) {
                 case Neighbors(nodes, _) => nodes
               } { (acc, nodes) =>
-                val found = (acc ++ nodes).take(config.kademliaBucketSize)
+                val found = (acc ++ nodes.filter(n => n.address.udpPort > 0 && n.address.tcpPort > 0)).take(config.kademliaBucketSize)
                 if (found.size < config.kademliaBucketSize) Left(found) else Right(found)
               }
             }


### PR DESCRIPTION
## Problem

Some peers advertise `udpPort=0` or `tcpPort=0` in discovery `Neighbors` responses. Every attempt to contact these nodes fails immediately:

```
Failed to send UDP packet to /X.X.X.X:0 — Resource temporarily unavailable
```

This error repeated continuously, flooding logs with noise for every port-0 entry in the routing table.

## Fix

Filter out any `Node` entry with `udpPort == 0` or `tcpPort == 0` before adding it to the routing table in `DiscoveryNetwork`. One-line guard added to the `Neighbors` response handler.

## Verification

```bash
sbt "testOnly *DiscoverySpec"
# 6 tests, all pass
```

Reference: go-ethereum `p2p/discover/table.go` — nodes with port 0 are rejected as invalid. Besu `DiscoveryPeer.java` — port validation on peer creation.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)