### PR TITLE
fix(snap): StorageRangeCoordinator give-up after 100 consecutive task failures

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -77,6 +77,11 @@ class StorageRangeCoordinator(
   private val peerConsecutiveTimeouts = mutable.Map[String, Int]()
   private val consecutiveTimeoutThreshold = 3 // Mark stateless after 3 consecutive timeouts
 
+  // Global consecutive task failure counter: triggers ForceCompleteStorage when all SNAP peers
+  // stop serving storage data. Resets to zero on any successful slot download.
+  private var consecutiveTaskFailures: Int = 0
+  private val maxConsecutiveTaskFailures: Int = 100
+
   // Peer cooldown (best-effort): used for transient errors (timeouts, verification failures).
   // This is separate from stateless peer detection — cooldowns are short and per-error-type.
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
@@ -570,6 +575,7 @@ class StorageRangeCoordinator(
       result match {
         case Right(count) =>
           slotsDownloaded += count
+          consecutiveTaskFailures = 0
           log.info(s"Storage task completed: $count slots")
           self ! StorageCheckCompletion
         case Left(error) =>
@@ -1060,6 +1066,16 @@ class StorageRangeCoordinator(
       batchTasks.foreach { task =>
         task.pending = false
         tasks.enqueue(task)
+      }
+
+      consecutiveTaskFailures += 1
+      if (consecutiveTaskFailures >= maxConsecutiveTaskFailures) {
+        log.warning(
+          s"Force-completing storage coordinator after $consecutiveTaskFailures consecutive " +
+            s"task failures — SNAP peers not serving storage data. " +
+            s"Missing storage deferred to healing phase."
+        )
+        self ! ForceCompleteStorage
       }
     }
     // Re-dispatch re-queued tasks to any known available peer that isn't stateless or on cooldown.


### PR DESCRIPTION
## Problem

During `ByteCodeAndStorageSync`, `StorageRangeCoordinator` sends `GetStorageRanges` requests to SNAP/1 peers. On ETC mainnet, many peers advertise `snap/1` capability but stop responding after their internal serve window expires — every request from that point times out.

The coordinator tracked per-peer consecutive timeouts (marks peer stateless after 3) but had no global escape valve. If timeouts exhausted all peers and they were all marked stateless simultaneously, the coordinator could spin indefinitely without progressing, blocking the `ByteCodeAndStorageSync → StateHealing` phase transition.

## Fix

Add a global `consecutiveTaskFailures` counter (matching the pattern already in `ByteCodeCoordinator`):

- **Increments** on every timeout in `handleTimeout` (regardless of which peer)
- **Resets to zero** on any successful `StorageTaskComplete(_, Right(_))`
- At **100 consecutive failures** with no progress: logs a warning and sends `self ! ForceCompleteStorage`

`ForceCompleteStorage` already exists — it flushes buffered trie builds and signals `StorageRangeSyncComplete` to the controller, advancing to the healing phase where missing storage is recovered via `GetNodeData`.

## Testing

- `sbt "testOnly com.chipprbots.ethereum.blockchain.sync.snap.*"` — 73/73 pass
- Mirrors the identical fix in `ByteCodeCoordinator` (see PR fix/snap-bytecode-peer-tracking)

## Related

- ByteCodeCoordinator consecutive-failure guard: `fix/snap-bytecode-peer-tracking` (#1105)