### PR TITLE
fix(consensus): clear hive consensus client-side regressions (9/11)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/data/ChainImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/data/ChainImporter.scala
@@ -93,13 +93,12 @@ class ChainImporter(
               .getOrElse(ChainWeight.zero)
             val newWeight = parentWeight.increase(block.header)
 
-            // Post-Cancun (EIP-4844) blocks carrying blob transactions need KZG sidecars
-            // to be re-executed, and chain.rlp doesn't ship them. go-ethereum's `geth import`
-            // rejects such blocks; we keep them in the DB (so queries by number work) but
-            // don't advance the best-block pointer into the gap. A Cancun block with
-            // blobGasUsed == 0 has no blob txs, so sidecars aren't needed — advance as usual.
-            val hasBlobTxs = block.header.blobGasUsed.exists(_ > 0)
-            blockchainWriter.save(block, receipts, newWeight, saveAsBestBlock = !hasBlobTxs)
+            // Block was fully validated and executed, including all transactions (blob ones
+            // included). Sidecars don't participate in the consensus state transition — they
+            // are network-layer attachments verified separately at gossip time. The hive
+            // consensus / consume-engine fixtures expect head to advance over blob blocks;
+            // mainnet ingestion uses Engine API + sidecar verification, not chain.rlp.
+            blockchainWriter.save(block, receipts, newWeight, saveAsBestBlock = true)
             imported += 1
 
             if (imported % 10 == 0 || blockNum == blocks.last.header.number) {

--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidator.scala
@@ -141,7 +141,6 @@ object StdBlockValidator extends BlockValidator {
       _ <- validateOmmersHash(block)
       _ <- validateBlockRLPSize(block)
       _ <- validateWithdrawalsPresence(block)
-      _ <- validateWithdrawalsOrdering(block)
       _ <- validateWithdrawalsRoot(block)
     } yield BlockValid
   }
@@ -161,25 +160,6 @@ object StdBlockValidator extends BlockValidator {
       case (None, Some(_)) => Left(BlockWithdrawalsOrphanedError)
       case _               => Right(BlockValid)
     }
-
-  /** EIP-4895: withdrawals within a block must have strictly increasing `index` values. The beacon chain assigns
-    * indices globally and they drain in order, so a block that reorders or duplicates indices is invalid regardless of
-    * whether the declared `withdrawalsRoot` happens to match the (mis-ordered) trie.
-    *
-    * Without this check a malicious producer can pair any out-of-order withdrawal list with its own trie root and the
-    * block-level root comparison in [[validateWithdrawalsRoot]] will still pass — the root is computed over the same
-    * bad order, so it matches itself.
-    */
-  private def validateWithdrawalsOrdering(block: Block): Either[BlockError, BlockValid] =
-    block.body.withdrawals match {
-      case None                                              => Right(BlockValid)
-      case Some(ws) if ws.size < 2                           => Right(BlockValid)
-      case Some(ws) if isStrictlyIncreasing(ws.map(_.index)) => Right(BlockValid)
-      case Some(_)                                           => Left(BlockWithdrawalsIndexError)
-    }
-
-  private def isStrictlyIncreasing(values: Seq[BigInt]): Boolean =
-    values.zip(values.tail).forall { case (a, b) => a < b }
 
   /** EIP-4895: if the header declares a withdrawalsRoot, it must equal the trie root computed from
     * block.body.withdrawals (indexed like transactions/receipts). Pre-Shanghai headers have no withdrawalsRoot and no
@@ -245,9 +225,6 @@ object StdBlockValidator extends BlockValidator {
 
   /** EIP-4895: body carries withdrawals but the header did not reserve a withdrawalsRoot (pre-Shanghai header). */
   case object BlockWithdrawalsOrphanedError extends BlockError
-
-  /** EIP-4895: within-block withdrawal indices must be strictly increasing. */
-  case object BlockWithdrawalsIndexError extends BlockError
 
   case class BlockRLPSizeError(size: Long, cap: Long) extends BlockError
 

--- a/src/main/scala/com/chipprbots/ethereum/vm/OpCode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/vm/OpCode.scala
@@ -1404,16 +1404,25 @@ case object SELFDESTRUCT extends OpCode(0xff, 1, 0, _.G_selfdestruct) {
     val gasRefund: BigInt =
       if (state.addressesToDelete contains state.ownAddress) 0 else state.config.feeSchedule.R_selfdestruct
 
-    val world =
-      if (state.ownAddress == refundAddr)
-        state.world.removeAllEther(state.ownAddress)
-      else
-        state.world.transfer(state.ownAddress, refundAddr, state.ownBalance)
-
     // EIP-6780: Post-Olympia, SELFDESTRUCT only destroys contracts created in the same transaction.
     // Pre-existing contracts only have their balance transferred.
     val createdInThisTx = !state.originalWorld.accountExists(state.ownAddress)
     val shouldDelete = !state.config.eip6780Enabled || createdInThisTx
+
+    // Self-transfer ether handling differs by deletion outcome:
+    //  - shouldDelete: account is wiped at end-of-tx (deleteAccounts), so the balance is destroyed
+    //    regardless. Pre-EIP-6780 always reached here; matched the historical "transfer-to-self
+    //    burns ether" Subtlety. We zero now so intermediate reads (BALANCE within the same tx)
+    //    see 0, matching geth/besu.
+    //  - !shouldDelete (Cancun+ pre-existing contract): balance must be preserved. The "transfer
+    //    self → self" is a no-op in any rational accounting. Required by bcValidBlockTest/
+    //    reentrencySuicide, which calls SELFDESTRUCT(self) and expects the balance to remain.
+    val world =
+      if (state.ownAddress == refundAddr) {
+        if (shouldDelete) state.world.removeAllEther(state.ownAddress)
+        else state.world.touchAccounts(state.ownAddress)
+      } else
+        state.world.transfer(state.ownAddress, refundAddr, state.ownBalance)
 
     // Emit synthetic Transfer log for traceTransfers (SELFDESTRUCT value transfers)
     val transferLogs =

--- a/src/test/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidatorWithdrawalsSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/validators/std/StdBlockValidatorWithdrawalsSpec.scala
@@ -16,12 +16,12 @@ import com.chipprbots.ethereum.testing.Tags._
 
 /** Direct coverage for EIP-4895 withdrawal-validation additions to `StdBlockValidator`:
   *   - `validateWithdrawalsPresence` — reject body-only withdrawals with a pre-Shanghai header.
-  *   - `validateWithdrawalsOrdering` — reject duplicated or out-of-order withdrawal indices.
+  *   - `validateWithdrawalsRoot` — the body's withdrawals must hash to the header's declared root.
   *
-  * Corresponds to the `InvalidBlocks/bc4895-withdrawals` hive consensus sub-suite — tests that submit malformed
-  * withdrawal blocks and expect rejection. Previously Fukuii accepted any block whose `header.withdrawalsRoot` matched
-  * a trie computed over its own (bad) body, because the root comparison is self-consistent: a mis-ordered body produces
-  * a matching mis-ordered root.
+  * Note: the EL does NOT enforce strict ordering of withdrawal `index` values. Indices are CL-side metadata; the EL
+  * trusts whatever the CL hands it as long as the trie root matches the body. The `bc4895-withdrawals` hive fixtures
+  * (`twoIdenticalIndex`, `differentValidatorToTheSameAddress`, etc.) explicitly exercise this — they ship blocks with
+  * non-monotonic / duplicate indices and `expectException: None`, expecting the block to be accepted.
   */
 class StdBlockValidatorWithdrawalsSpec extends AnyFlatSpec with Matchers {
 
@@ -29,13 +29,6 @@ class StdBlockValidatorWithdrawalsSpec extends AnyFlatSpec with Matchers {
   // Fixtures.Blocks.ValidBlock.body, so the earlier checks in validateHeaderAndBody pass.
   private val preShanghaiHeader: BlockHeader = Fixtures.Blocks.ValidBlock.header
   private val preShanghaiBody = Fixtures.Blocks.ValidBlock.body
-
-  // A dummy Shanghai withdrawals root — the withdrawals root check happens AFTER presence +
-  // ordering, so tests that expect a presence/ordering error don't care what's here.
-  private val dummyRoot: ByteString = ByteString(Hex.decode("00" * 32))
-
-  private def shanghaiHeader(root: ByteString = dummyRoot): BlockHeader =
-    preShanghaiHeader.copy(extraFields = HefPostShanghai(BigInt(0), root))
 
   private val defaultAddr = Address(Hex.decode("4675c7e5baafbffbca748158becba61ef3b0a263"))
 
@@ -70,39 +63,6 @@ class StdBlockValidatorWithdrawalsSpec extends AnyFlatSpec with Matchers {
     val body = preShanghaiBody.copy(withdrawals = Some(Seq(withdrawal(0))))
     val result = StdBlockValidator.validateHeaderAndBody(preShanghaiHeader, body)
     result shouldBe Left(BlockWithdrawalsOrphanedError)
-  }
-
-  it should "reject a Shanghai block whose withdrawals have duplicate indices" taggedAs (
-    UnitTest,
-    ConsensusTest
-  ) in {
-    val bad = Seq(withdrawal(3), withdrawal(3))
-    val body = preShanghaiBody.copy(withdrawals = Some(bad))
-    val result = StdBlockValidator.validateHeaderAndBody(shanghaiHeader(), body)
-    result shouldBe Left(BlockWithdrawalsIndexError)
-  }
-
-  it should "reject a Shanghai block whose withdrawals decrease in index" taggedAs (
-    UnitTest,
-    ConsensusTest
-  ) in {
-    val bad = Seq(withdrawal(5), withdrawal(4))
-    val body = preShanghaiBody.copy(withdrawals = Some(bad))
-    val result = StdBlockValidator.validateHeaderAndBody(shanghaiHeader(), body)
-    result shouldBe Left(BlockWithdrawalsIndexError)
-  }
-
-  it should "run ordering validation before root validation (so a bad root and bad ordering both register as Index)" taggedAs (
-    UnitTest,
-    ConsensusTest
-  ) in {
-    // Header declares the dummy root; body has out-of-order withdrawals. The root comparison
-    // would fail later, but the ordering check should short-circuit first — so the reported
-    // error must be BlockWithdrawalsIndexError, not BlockWithdrawalsRootError.
-    val bad = Seq(withdrawal(10), withdrawal(3))
-    val body = preShanghaiBody.copy(withdrawals = Some(bad))
-    val result = StdBlockValidator.validateHeaderAndBody(shanghaiHeader(dummyRoot), body)
-    result shouldBe Left(BlockWithdrawalsIndexError)
   }
 
   it should "accept a Shanghai block whose body declares explicitly-empty withdrawals matching the EmptyMpt root" taggedAs (

--- a/src/test/scala/com/chipprbots/ethereum/vm/OlympiaSelfDestructSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/OlympiaSelfDestructSpec.scala
@@ -177,8 +177,16 @@ class OlympiaSelfDestructSpec extends AnyWordSpec with Matchers {
 
     "edge cases" should {
 
-      "handle self-destruct to self (removes all ether)" taggedAs (UnitTest, VMTest, OlympiaTest) in {
-        // SELFDESTRUCT to own address
+      "preserve balance on self-destruct to self for pre-existing contract (EIP-6780)" taggedAs (
+        UnitTest,
+        VMTest,
+        OlympiaTest
+      ) in {
+        // SELFDESTRUCT to own address. Per EIP-6780, a pre-existing contract is NOT deleted
+        // and "transfer self → self" is a no-op — balance must be preserved. The hive
+        // bcValidBlockTest/reentrencySuicide_Cancun fixture relies on this; the previous
+        // unconditional `removeAllEther` here burned 3 wei in call #2 of the reentrancy
+        // chain and produced a divergent state root.
         val codeSelfDestructToSelf: Assembly = Assembly(
           PUSH20,
           ownerAddr.bytes,
@@ -201,9 +209,7 @@ class OlympiaSelfDestructSpec extends AnyWordSpec with Matchers {
         val result = vm.run(context)
 
         result.error shouldBe None
-        // Pre-existing: balance sent to self, but since same address, removeAllEther is called
-        result.world.getBalance(ownerAddr) shouldEqual UInt256.Zero
-        // Pre-existing in Olympia: should NOT be deleted
+        result.world.getBalance(ownerAddr) shouldEqual ownerBalance
         result.addressesToDelete should not contain ownerAddr
       }
 


### PR DESCRIPTION
## Summary

Closes 9 of the 11 outstanding hive `ethereum/consensus` failures via three surgical fixes (withdrawal ordering, blob best-block, EIP-6780 SELFDESTRUCT-to-self). The remaining 2 are `test file loader` meta-tests from the hive simulator's `forks.go` not knowing about the Prague network — a hive-side limitation, not a fukuii bug. Newer hive includes Prague; CI should pass.

**Do not auto-merge develop → main** — release timing is the user's call.

## Per-bucket changes

- **bc4895-withdrawals (3 tests)**: EL was enforcing strict monotonicity of withdrawal `index`, but the consensus fixtures ship non-monotonic / duplicate indices with `expectException: None` — the EL must accept them. Drop `validateWithdrawalsOrdering` and `BlockWithdrawalsIndexError`. Trust `withdrawalsRoot`.
- **bcEIP4844-blobtransactions (1 test)**: `ChainImporter` skipped advancing best block past `blobGasUsed > 0` because of KZG sidecar concern. Sidecars don't participate in the consensus state transition — always advance after a fully-validated import.
- **bcValidBlockTest/reentrencySuicide + badOpcodes_d11g0v0 (5 tests)**: Pre-EIP-6780 `removeAllEther` on SELFDESTRUCT-to-self was unconditional. Cancun+ keeps pre-existing contracts alive — balance must be preserved when `shouldDelete = false`. Branch the self-transfer path on `shouldDelete`.

## Local verification

Hive `ethereum/consensus`, `legacy`, `legacy-cancun` scoped to the originally-failing tests:
- `bc4895-withdrawals/*` (5 fixtures) — all pass
- `bcEIP4844-blobtransactions/blockWithAllTransactionTypes` — pass
- `bcValidBlockTest/reentrencySuicide_Cancun` — pass (was state-root divergence)
- `badOpcodes_d11g0v0_{Byzantium,Constantinople,ConstantinopleFix,EIP158}` — all pass
- `legacy-cancun` 31/31 pass

## Test plan

- [ ] CI hive-consensus completes (target 572/572 if CI hive includes Prague).
- [ ] CI hive-engine and hive-sync show no regressions.
- [ ] sbt testEssential green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)