### PR TITLE
fix(rpc): close last 9 eth_simulateV1 hive gaps for 100% rpc-compat

### DIFF
--- a/.github/workflows/hive-sync.yml
+++ b/.github/workflows/hive-sync.yml
@@ -68,6 +68,11 @@ jobs:
       # GitHub runner, four EL JVMs (fukuii + geth + nethermind + a 4th)
       # warm up concurrently and contend for CPU during the critical first
       # ~10s of startup, blowing the 60s budget on flaky tests like
-      # `sync fukuii from go-ethereum`. parallelism=2 makes total runtime
-      # 2× longer but eliminates the timeout flakes.
-      parallelism: 2
+      # `sync fukuii from go-ethereum`. parallelism=2 cut the worst flakes
+      # but the JVM under JIT warmup is still contending with one other EL
+      # for the 2 cores and occasionally tips past the 60s budget — the
+      # `eth_simulateV1` PR reliably hit this. parallelism=1 fully
+      # serializes the suite (~2× wall time) and gives every fukuii sink
+      # a full core for its 5–10 s JVM warmup, eliminating the timeout
+      # flake without touching the upstream hive 60s timeout.
+      parallelism: 1

--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthSimulateService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthSimulateService.scala
@@ -183,6 +183,10 @@ class EthSimulateService(
     val blockResults = mutable.ArrayBuffer[SimulateBlockResult]()
     val nonceMap = mutable.Map[Address, BigInt]() // Track nonces across blocks
     var globalAccumGas = BigInt(0) // Global gas accumulator across all blocks (geth shares the 50M pool)
+    // Once a blockOverride sets feeRecipient, geth keeps it as the default for any
+    // subsequent block in the same simulate request that doesn't override it
+    // (including auto-generated gap blocks).
+    var inheritedFeeRecipient: Option[Address] = None
 
     // Pre-compute total blocks including gap-filling to validate against limit
     var totalBlocks = 0
@@ -203,11 +207,13 @@ class EthSimulateService(
     for ((blockStateCall, blockIdx) <- req.blockStateCalls.zipWithIndex) {
       val targetNumber = blockStateCall.blockOverrides.flatMap(_.number).getOrElse(parentHeader.number + 1)
 
-      // Generate gap-filling empty blocks if the target number is ahead
+      // Generate gap-filling empty blocks if the target number is ahead.
+      // Gap blocks inherit the persistent feeRecipient if one was set earlier.
       while (parentHeader.number + 1 < targetNumber) {
+        val gapOverrides = inheritedFeeRecipient.map(fr => BlockOverrides(feeRecipient = Some(fr)))
         val gapResult = buildAndFinalizeBlock(
           parentHeader,
-          None,
+          gapOverrides,
           None,
           Seq.empty,
           req.validation,
@@ -229,10 +235,22 @@ class EthSimulateService(
         }
       }
 
+      // Merge inherited feeRecipient into this block's overrides if not specified.
+      val effectiveOverrides = blockStateCall.blockOverrides match {
+        case Some(ov) =>
+          if (ov.feeRecipient.isEmpty && inheritedFeeRecipient.isDefined)
+            Some(ov.copy(feeRecipient = inheritedFeeRecipient))
+          else Some(ov)
+        case None =>
+          inheritedFeeRecipient.map(fr => BlockOverrides(feeRecipient = Some(fr)))
+      }
+      // Persist any newly set feeRecipient for future blocks.
+      effectiveOverrides.flatMap(_.feeRecipient).foreach(fr => inheritedFeeRecipient = Some(fr))
+
       // Build the actual BSC block
       val bscResult = buildAndFinalizeBlock(
         parentHeader,
-        blockStateCall.blockOverrides,
+        effectiveOverrides,
         blockStateCall.stateOverrides,
         blockStateCall.calls.getOrElse(Seq.empty),
         req.validation,
@@ -297,7 +315,7 @@ class EthSimulateService(
       }
     }
 
-    // Execute calls
+    // Execute calls (pass through any blob base fee override from blockOverrides)
     val execResult = executeCalls(
       calls,
       simHeader,
@@ -306,7 +324,8 @@ class EthSimulateService(
       traceTransfers,
       nonceMap,
       precompileRelocations,
-      globalGasOffset
+      globalGasOffset,
+      blockOverrides.flatMap(_.blobBaseFee)
     )
     execResult match {
       case Left(err) => return Left(err)
@@ -315,6 +334,30 @@ class EthSimulateService(
     val (newWorld, callResults, txs, txSenders, receipts, gasUsed) = execResult.toOption.get
 
     world = newWorld
+
+    // Pre-merge: pay the static block reward (5/3/2 ETH per Byzantium/Constantinople)
+    // to the miner. Geth's eth_simulateV1 reflects the reward in the simulated
+    // stateRoot, so simulated pre-merge blocks must too. Post-merge blocks have no
+    // reward — execution layer pays nothing, withdrawals come from the CL.
+    val isPreMerge = simHeader.extraFields match {
+      case HefEmpty                                                                     => true
+      case _: HefPostOlympia | _: HefPostShanghai | _: HefPostCancun | _: HefPostPrague => false
+    }
+    if (isPreMerge) {
+      val reward = blockchainConfig.monetaryPolicyConfig.firstEraBlockReward
+      val byzantiumReward = blockchainConfig.monetaryPolicyConfig.firstEraReducedBlockReward
+      val constantinopleReward = blockchainConfig.monetaryPolicyConfig.firstEraConstantinopleReducedBlockReward
+      val n = simHeader.number
+      val byzantium = blockchainConfig.forkBlockNumbers.byzantiumBlockNumber
+      val constantinople = blockchainConfig.forkBlockNumbers.constantinopleBlockNumber
+      val finalReward =
+        if (n >= constantinople) constantinopleReward
+        else if (n >= byzantium) byzantiumReward
+        else reward
+      val minerAddr = Address(simHeader.beneficiary)
+      val acct = world.getAccount(minerAddr).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
+      world = world.saveAccount(minerAddr, acct.increaseBalance(UInt256(finalReward)))
+    }
 
     // Compute Merkle roots
     val transactionsRoot = computeTransactionsRoot(txs)
@@ -361,7 +404,12 @@ class EthSimulateService(
       )
     }
 
-    val body = BlockBody(txs, Nil, Some(Seq.empty))
+    // Pre-Shanghai blocks have no withdrawals field in the RLP body. Encoding
+    // Some(Seq.empty) adds a 1-byte extra `0xc0` to the body, which throws off
+    // both the reported "size" and the block hash for legacy blocks.
+    val withdrawalsOpt: Option[Seq[com.chipprbots.ethereum.domain.Withdrawal]] =
+      if (finalHeader.withdrawalsRoot.isDefined) Some(Seq.empty) else None
+    val body = BlockBody(txs, Nil, withdrawalsOpt)
     val blockResult = SimulateBlockResult(finalHeader, body, txs, txSenders, updatedCallResults, receipts)
     Right((finalHeader, world, blockResult, gasUsed))
   }
@@ -507,81 +555,95 @@ class EthSimulateService(
     var w = world
     var relocations = existingRelocations
 
-    // First pass: validate movePrecompileToAddress
+    // First pass: validate movePrecompileToAddress and detect collisions
+    val allPrecompiles = Set(
+      Address(1),
+      Address(2),
+      Address(3),
+      Address(4),
+      Address(5),
+      Address(6),
+      Address(7),
+      Address(8),
+      Address(9),
+      Address(0x0b),
+      Address(0x0c),
+      Address(0x0d),
+      Address(0x0e),
+      Address(0x0f),
+      Address(0x10),
+      Address(0x11),
+      Address(0x100)
+    )
+    val pendingMoves = scala.collection.mutable.ArrayBuffer[(Address, Address)]()
     for ((address, ov) <- overrides)
       ov.movePrecompileToAddress.foreach { targetAddr =>
-        // Check: source must be a known precompile
-        val allPrecompiles = Set(
-          Address(1),
-          Address(2),
-          Address(3),
-          Address(4),
-          Address(5),
-          Address(6),
-          Address(7),
-          Address(8),
-          Address(9),
-          Address(0x0b),
-          Address(0x0c),
-          Address(0x0d),
-          Address(0x0e),
-          Address(0x0f),
-          Address(0x10),
-          Address(0x11),
-          Address(0x100)
-        )
         if (!allPrecompiles.contains(address)) {
           return Left(JsonRpcError.LogicError(s"account ${address.toString} is not a precompile"))
         }
-        relocations = relocations + (address -> targetAddr)
+        pendingMoves += (address -> targetAddr)
       }
+    // Two precompiles moving to the same target is ambiguous — geth silently
+    // drops the colliding moves rather than erroring (matches the
+    // ethSimulate-move-two-accounts-to-same-38023 testdata expected response).
+    val targetCounts = pendingMoves.groupBy(_._2).view.mapValues(_.size).toMap
+    pendingMoves.foreach { case (src, tgt) =>
+      if (targetCounts.getOrElse(tgt, 0) <= 1) relocations = relocations + (src -> tgt)
+    }
 
-    // Second pass: apply overrides
+    // Second pass: apply overrides — only modify state when something other than
+    // movePrecompileToAddress is set; the precompile move is purely a routing
+    // override and must not create empty accounts at precompile source addresses.
     for ((address, ov) <- overrides) {
-      var account = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
+      val hasStateMutation =
+        ov.balance.isDefined || ov.nonce.isDefined || ov.code.isDefined ||
+          ov.state.isDefined || ov.stateDiff.isDefined
+      if (hasStateMutation) {
+        var account = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
 
-      ov.balance.foreach(bal => account = account.copy(balance = UInt256(bal)))
-      ov.nonce.foreach(n => account = account.copy(nonce = UInt256(n)))
+        ov.balance.foreach(bal => account = account.copy(balance = UInt256(bal)))
+        ov.nonce.foreach(n => account = account.copy(nonce = UInt256(n)))
 
-      w = w.saveAccount(address, account)
+        w = w.saveAccount(address, account)
 
-      ov.code.foreach { code =>
-        w = w.saveCode(address, code)
-        // Update the account's codeHash immediately (not just in cache)
-        // This prevents EIP-161 from deleting the account as "empty"
-        val codeHash = if (code.isEmpty) Account.EmptyCodeHash else ByteString(kec256(code.toArray))
-        val acctWithCode = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
-        w = w.saveAccount(address, acctWithCode.copy(codeHash = codeHash))
-      }
-
-      ov.state.foreach { slots =>
-        // Full state replacement: clear all storage, then set specified slots
-        // Persist first so any cached storage changes are committed
-        w = InMemoryWorldStateProxy.persistState(w)
-        // Reset storageRoot to empty and clear storage cache by delete+recreate
-        val currentAcct = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
-        // Delete and re-save account to clear storage cache
-        w = w.deleteAccount(address)
-        w = w.saveAccount(address, currentAcct.copy(storageRoot = Account.EmptyStorageRootHash))
-        // Re-apply code if it was set
-        if (currentAcct.codeHash != Account.EmptyCodeHash) {
-          // Code is in the EVM code storage, re-associate it
-          ov.code.foreach(code => w = w.saveCode(address, code))
+        ov.code.foreach { code =>
+          w = w.saveCode(address, code)
+          // Update the account's codeHash immediately (not just in cache)
+          // This prevents EIP-161 from deleting the account as "empty"
+          val codeHash = if (code.isEmpty) Account.EmptyCodeHash else ByteString(kec256(code.toArray))
+          val acctWithCode = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
+          w = w.saveAccount(address, acctWithCode.copy(codeHash = codeHash))
         }
-        // Write the new slots on fresh (empty) storage
-        val storage = w.getStorage(address)
-        var s = storage
-        for ((key, value) <- slots)
-          s = s.store(key, value)
-        w = w.saveStorage(address, s)
-      }
 
-      ov.stateDiff.foreach { slots =>
-        val storage = w.getStorage(address)
-        var s = storage
-        for ((key, value) <- slots)
-          s = s.store(key, value)
-        w = w.saveStorage(address, s)
+        ov.state.foreach { slots =>
+          // Full state replacement: clear all storage, then set specified slots
+          // Persist first so any cached storage changes are committed
+          w = InMemoryWorldStateProxy.persistState(w)
+          // Reset storageRoot to empty and clear storage cache by delete+recreate
+          val currentAcct = w.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce))
+          // Delete and re-save account to clear storage cache
+          w = w.deleteAccount(address)
+          w = w.saveAccount(address, currentAcct.copy(storageRoot = Account.EmptyStorageRootHash))
+          // Re-apply code if it was set
+          if (currentAcct.codeHash != Account.EmptyCodeHash) {
+            // Code is in the EVM code storage, re-associate it
+            ov.code.foreach(code => w = w.saveCode(address, code))
+          }
+          // Write the new slots on fresh (empty) storage
+          val storage = w.getStorage(address)
+          var s = storage
+          for ((key, value) <- slots)
+            s = s.store(key, value)
+          w = w.saveStorage(address, s)
+        }
+
+        ov.stateDiff.foreach { slots =>
+          val storage = w.getStorage(address)
+          var s = storage
+          for ((key, value) <- slots)
+            s = s.store(key, value)
+          w = w.saveStorage(address, s)
+        }
       }
     }
     Right((w, relocations))
@@ -595,7 +657,8 @@ class EthSimulateService(
       traceTransfers: Boolean,
       nonceMap: mutable.Map[Address, BigInt],
       precompileRelocations: Map[Address, Address] = Map.empty,
-      globalGasOffset: BigInt = BigInt(0)
+      globalGasOffset: BigInt = BigInt(0),
+      blobBaseFeeOverride: Option[BigInt] = None
   ): Either[
     JsonRpcError,
     (InMemoryWorldStateProxy, Seq[SimulateCallResult], Seq[SignedTransaction], Seq[Address], Seq[Receipt], BigInt)
@@ -607,6 +670,9 @@ class EthSimulateService(
     val receipts = mutable.ArrayBuffer[Receipt]()
     var accumGas = BigInt(0)
     val baseFee = blockHeader.baseFee.getOrElse(BigInt(0))
+    // Block-level logIndex counter — geth numbers logs globally across all calls
+    // in the block, including synthetic Transfer logs emitted for traceTransfers.
+    var globalLogIndex = 0
 
     for ((call, callIdx) <- calls.zipWithIndex) {
       val sender = call.from.getOrElse(Address(0))
@@ -769,7 +835,8 @@ class EthSimulateService(
           blockHeader,
           world,
           precompileRelocations,
-          traceTransfers
+          traceTransfers,
+          blobBaseFeeOverride
         )
 
       world = newWorld
@@ -785,13 +852,18 @@ class EthSimulateService(
       // Update nonce tracking
       nonceMap(sender) = (senderNonce + 1) % MaxUint64Plus1
 
-      // Build receipt
+      // EVM logs include synthetic Transfer logs (address 0xeeee...eeee) emitted by
+      // CALL/SELFDESTRUCT when traceTransfers is on. Those are API-only and must NOT
+      // appear in the receipt (they would change logsBloom + receiptsRoot).
+      val realLogs = if (traceTransfers) logs.filter(_.loggerAddress != EthTransferAddress) else logs
+
+      // Build receipt — receipts use real logs only
       val outcome = if (vmError.isDefined) FailureOutcome else SuccessOutcome
       val legacyReceipt = LegacyReceipt(
         postTransactionStateHash = outcome,
         cumulativeGasUsed = accumGas + gasUsed,
-        logsBloomFilter = BloomFilter.create(logs),
-        logs = logs
+        logsBloomFilter = BloomFilter.create(realLogs),
+        logs = realLogs
       )
       val receipt: Receipt = tx match {
         case _: BlobTransaction           => Type03Receipt(legacyReceipt)
@@ -805,11 +877,47 @@ class EthSimulateService(
       senders += sender
       receipts += receipt
 
-      // Build per-call result
-      val txLogs = logs.zipWithIndex.map { case (txLog, logIdx) =>
-        val globalLogIdx = receipts.dropRight(1).map(_.logs.size).sum + logIdx
-        TxLog(
-          logIndex = globalLogIdx,
+      // Build per-call result.
+      //
+      // For traceTransfers: prepend a synthetic top-level Transfer log so the API
+      // sees logIndex first for the outer (tx-initiated) transfer, then later for
+      // the inner CALL-emitted ones. This mirrors geth: the top-level value
+      // transfer is the first synthetic event, intra-call transfers come after in
+      // execution order. The EVM's CALL opcode already emits the inner transfer
+      // logs as part of `logs`.
+      val topLevelTransferLog =
+        if (traceTransfers && value > 0 && vmError.isEmpty)
+          Some(
+            com.chipprbots.ethereum.domain.TxLogEntry(
+              loggerAddress = EthTransferAddress,
+              logTopics = Seq(
+                TransferEventTopic,
+                ByteString(new Array[Byte](12) ++ sender.bytes.toArray),
+                ByteString(new Array[Byte](12) ++ toAddr.map(_.bytes.toArray).getOrElse(new Array[Byte](20)))
+              ),
+              data = {
+                val raw = UInt256(value).bytes
+                ByteString(new Array[Byte](32 - raw.length) ++ raw.toArray)
+              }
+            )
+          )
+        else None
+
+      val apiLogEntries = topLevelTransferLog.toSeq ++ logs
+
+      // Geth's logIndex counter advances by ONE per call that *would have* emitted
+      // a top-level synthetic transfer log (i.e., calls with value > 0 when
+      // traceTransfers is on), even when the call ends in error and produces no
+      // visible logs. This matches the observed behavior in the testdata: a
+      // sequence of failed value-transfers + one successful value-transfer puts
+      // the synthetic log at logIndex == failed-call-count. Real EVM logs from
+      // each call still increment the counter once per emitted entry.
+      val phantomBumps =
+        if (traceTransfers && value > 0 && vmError.isDefined) 1 else 0
+
+      val txLogs = apiLogEntries.map { txLog =>
+        val l = TxLog(
+          logIndex = globalLogIndex,
           transactionIndex = callIdx,
           transactionHash = stx.hash,
           blockHash = ByteString(new Array[Byte](32)), // Placeholder — updated after header finalized
@@ -819,40 +927,29 @@ class EthSimulateService(
           topics = txLog.logTopics,
           blockTimestamp = Some(BigInt(blockHeader.unixTimestamp))
         )
+        globalLogIndex += 1
+        l
       }
+      globalLogIndex += phantomBumps
 
-      // Add trace transfer logs if enabled
-      val allLogs = if (traceTransfers && value > 0 && vmError.isEmpty) {
-        val transferLog = TxLog(
-          logIndex = txLogs.size + receipts.dropRight(1).map(_.logs.size).sum,
-          transactionIndex = callIdx,
-          transactionHash = stx.hash,
-          blockHash = ByteString(new Array[Byte](32)),
-          blockNumber = blockHeader.number,
-          address = EthTransferAddress,
-          data = {
-            val raw = UInt256(value).bytes
-            ByteString(new Array[Byte](32 - raw.length) ++ raw.toArray)
-          },
-          topics = Seq(
-            TransferEventTopic,
-            ByteString(new Array[Byte](12) ++ sender.bytes.toArray),
-            ByteString(new Array[Byte](12) ++ toAddr.map(_.bytes.toArray).getOrElse(new Array[Byte](20)))
-          ),
-          blockTimestamp = Some(BigInt(blockHeader.unixTimestamp))
-        )
-        txLogs :+ transferLog
-      } else txLogs
+      val allLogs = txLogs
 
       val callResult = vmError match {
         case Some(com.chipprbots.ethereum.vm.RevertOccurs) =>
+          // Geth wire format for revert:
+          //   - call.returnData = "0x" (always empty; payload moves into error.data)
+          //   - error.data      = the raw revert payload (always present, even "0x")
+          //   - error.message   = "execution reverted" + ": <decoded>" when payload
+          //                       starts with the Error(string) selector 0x08c379a0.
+          val decoded = decodeErrorString(returnData)
+          val msg = decoded.fold("execution reverted")(s => s"execution reverted: $s")
           SimulateCallResult(
             status = BigInt(0),
-            returnData = returnData,
+            returnData = ByteString.empty,
             gasUsed = gasUsed,
             maxUsedGas = gasUsed,
             logs = Seq.empty,
-            error = Some(SimulateError(3, "execution reverted", if (returnData.nonEmpty) Some(returnData) else None))
+            error = Some(SimulateError(3, msg, Some(returnData)))
           )
         case Some(err) =>
           // Map VM error names to geth-compatible lowercase messages
@@ -984,5 +1081,25 @@ class EthSimulateService(
       val blooms = receipts.map(_.logsBloomFilter.toArray)
       ByteString(ByteUtils.or(EmptyBloom.toArray +: blooms: _*))
     }
+
+  /** ABI-decode the string payload of an `Error(string)` revert (selector 0x08c379a0). Returns None for any other
+    * revert payload (custom errors, raw bytes, etc.) so the caller falls back to the bare "execution reverted" message
+    * — matching geth's behavior.
+    */
+  private def decodeErrorString(returnData: ByteString): Option[String] = {
+    if (returnData.length < 4 + 32 + 32) return None
+    val bytes = returnData.toArray
+    val selector = (bytes(0) & 0xff, bytes(1) & 0xff, bytes(2) & 0xff, bytes(3) & 0xff)
+    if (selector != (0x08, 0xc3, 0x79, 0xa0)) return None
+    // ABI: head[0] = offset (always 0x20 for a single string arg)
+    // head[1] = string length (right-aligned uint256)
+    // head[2..] = string bytes (padded to 32-byte boundary)
+    val payload = bytes.drop(4)
+    val offset = BigInt(1, payload.slice(0, 32))
+    if (offset != 32) return None
+    val length = BigInt(1, payload.slice(32, 64)).toInt
+    if (length < 0 || 64 + length > payload.length) return None
+    scala.util.Try(new String(payload.slice(64, 64 + length), "UTF-8")).toOption
+  }
 
 }

--- a/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/ledger/BlockPreparator.scala
@@ -142,9 +142,14 @@ class BlockPreparator(
     val blobGasCost = stx.tx match {
       case bt: com.chipprbots.ethereum.domain.BlobTransaction =>
         val blobGasUsed = BigInt(bt.blobVersionedHashes.size) * BigInt(131072)
-        val blobBaseFee = blockHeader.excessBlobGas
-          .map(eg => computeBlobBaseFee(eg, blockHeader.unixTimestamp))
-          .getOrElse(BigInt(1))
+        // eth_simulateV1's blockOverrides.blobBaseFee lets the caller force a
+        // specific blob fee that doesn't necessarily match what excessBlobGas
+        // would derive (e.g. blobBaseFee=0 when excessBlobGas=0 would yield 1).
+        val blobBaseFee = _simulateBlobBaseFeeOverride.getOrElse(
+          blockHeader.excessBlobGas
+            .map(eg => computeBlobBaseFee(eg, blockHeader.unixTimestamp))
+            .getOrElse(BigInt(1))
+        )
         blobGasUsed * blobBaseFee
       case _ => BigInt(0)
     }
@@ -386,21 +391,25 @@ class BlockPreparator(
       blockHeader: BlockHeader,
       world: InMemoryWorldStateProxy,
       precompileRelocations: Map[Address, Address] = Map.empty,
-      traceTransfers: Boolean = false
+      traceTransfers: Boolean = false,
+      blobBaseFeeOverride: Option[BigInt] = None
   )(implicit blockchainConfig: BlockchainConfig): TxResult = {
     // Store simulation flags temporarily for runVM to pick up
     _simulatePrecompileRelocations = precompileRelocations
     _simulateTraceTransfers = traceTransfers
+    _simulateBlobBaseFeeOverride = blobBaseFeeOverride
     try executeTransaction(stx, senderAddress, blockHeader, world)
     finally {
       _simulatePrecompileRelocations = Map.empty
       _simulateTraceTransfers = false
+      _simulateBlobBaseFeeOverride = None
     }
   }
 
   // Thread-local-like storage for precompile relocations during simulation
   @volatile private var _simulatePrecompileRelocations: Map[Address, Address] = Map.empty
   @volatile private var _simulateTraceTransfers: Boolean = false
+  @volatile private var _simulateBlobBaseFeeOverride: Option[BigInt] = None
 
   private[ledger] def executeTransaction(
       stx: SignedTransaction,


### PR DESCRIPTION
Brings hive `ethereum/rpc-compat` from 188/200 to 200/200 by closing the nine remaining `eth_simulateV1` failures. The rpc-compat eth_simulateV1 subset is now 91/91 (was 82/91).

## Failures fixed (one per upstream `ethereum/execution-apis` testcase)

- **ethSimulate-blobs** — `blockOverrides.blobBaseFee` was ignored; sender paid the fee derived from `excessBlobGas` even when override said 0.
- **ethSimulate-empty-with-block-num-set-firstblock** — pre-merge simulated blocks didnt credit the static block reward; pre-Shanghai body emitted `withdrawals=Some([])` adding 1 byte to the RLP.
- **ethSimulate-eth-send-should-not-produce-logs-on-revert** — revert wire format wrong: `returnData` carried payload, `error.data` was missing, message lacked the decoded `Error(string)` reason.
- **ethSimulate-eth-send-should-produce-more-logs-on-forward** — top-level synthetic Transfer log was appended, not prepended; `logIndex` ordering didnt match geth.
- **ethSimulate-eth-send-should-produce-no-logs-on-forward-revert** — `error.data` field omitted when revert payload was empty.
- **ethSimulate-fee-recipient-receiving-funds** — same `error.data` omission on a validation-fail call.
- **ethSimulate-move-two-accounts-to-same-38023** — `movePrecompileToAddress` overrides created empty accounts at precompile source addresses, so pure routing changes mutated stateRoot.
- **ethSimulate-self-destructive-contract-produces-logs** — synthetic Transfer logs leaked into receipt `logsBloom` and `receiptsRoot`.
- **ethSimulate-use-as-many-features-as-possible** — `feeRecipient` didnt persist across blocks within a single simulate call; block-level `logIndex` reset per call instead of being globally counted.

## Notable behavior choices

- **-38023 is a no-op, not an error.** The testdata response for `move-two-accounts-to-same-38023` is a successful empty block, not the literal -38023 error the test name hints at. We mirror geth and silently drop colliding moves instead of raising `SimulateMoveToSameTarget`.
- **Phantom logIndex bumps.** When `traceTransfers=true`, geths block-level `logIndex` counter advances even for failed value-transfer calls so the next successful transfers logIndex matches its transactionIndex.
- **Pre-merge block reward in simulation.** Simulated pre-merge blocks now credit 5/3/2 ETH to the miner (Byzantium/Constantinople-aware). Required for the firstblock test where a single empty pre-merge block changes stateRoot.
- **withdrawals=None for pre-Shanghai bodies.** Some(Seq.empty) adds a trailing 0xc0 to the body RLP, throwing off both reported size and the block hash.

## Test plan

- [x] `sbt assembly` clean
- [x] `sbt testOnly com.chipprbots.ethereum.jsonrpc.* com.chipprbots.ethereum.ledger.* -- -l SlowTest -l IntegrationTest -l SyncTest -l DisabledTest -l FlakyTest` — 463/463 pass
- [x] `hive --sim ethereum/rpc-compat --client fukuii --sim.limit "rpc-compat/eth_simulateV1"` — 91/91 pass
- [x] `hive --sim ethereum/rpc-compat --client fukuii` (full) — 200/200 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)