### PR TITLE
ci(release): unfreeze auto-version pipeline + remove 0.1.240 pins

### DIFF
--- a/.github/workflows/_hive-sim.yml
+++ b/.github/workflows/_hive-sim.yml
@@ -162,8 +162,8 @@ jobs:
           RUN apt-get update && apt-get install -y --no-install-recommends jq curl && rm -rf /var/lib/apt/lists/*
           WORKDIR /app
           RUN mkdir -p /app/fukuii/lib /app/data /app/hive-conf
-          COPY fukuii-assembly-*.jar /app/fukuii/lib/fukuii-assembly-0.1.240.jar
-          ENTRYPOINT ["java", "-jar", "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"]
+          COPY fukuii-assembly-*.jar /app/fukuii/lib/fukuii-assembly.jar
+          ENTRYPOINT ["java", "-jar", "/app/fukuii/lib/fukuii-assembly.jar"]
           DOCKER
           docker build -t chipprbots/fukuii:latest target/quick-docker/
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -163,17 +163,22 @@ jobs:
 
           echo "Created and pushed tag v$NEW_VERSION"
 
-  trigger-release:
-    name: Trigger Release
-    needs: auto-version
-    if: needs.auto-version.outputs.version_changed == 'true'
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-      actions: read
-    uses: ./.github/workflows/release.yml
-    with:
-      version: ${{ needs.auto-version.outputs.version }}
-      release_tier: ${{ needs.auto-version.outputs.release_tier }}
-    secrets: inherit
+      # Dispatch release.yml via the workflows API. We dispatch instead of
+      # chaining release.yml as a reusable workflow (`uses:`) because that
+      # chain pulled in slsa-github-generator and failed GitHub's startup
+      # validation — every auto-version run since 2026-02-19 was a 0-job
+      # `startup_failure` until this change. workflow_dispatch is the one
+      # event GITHUB_TOKEN can fire that re-enters the Actions runtime, so
+      # the dispatched release run is independent of this job's success.
+      - name: Dispatch release workflow
+        if: steps.commit-version.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.new-version.outputs.version }}
+          RELEASE_TIER: ${{ steps.version-type.outputs.release_tier }}
+        run: |
+          gh workflow run release.yml \
+            --ref "v${NEW_VERSION}" \
+            -f "version=${NEW_VERSION}" \
+            -f "release_tier=${RELEASE_TIER}"
+          echo "Dispatched release.yml at tag v${NEW_VERSION} (tier=${RELEASE_TIER})"

--- a/.github/workflows/hive-prague.yml
+++ b/.github/workflows/hive-prague.yml
@@ -104,8 +104,8 @@ jobs:
           RUN apt-get update && apt-get install -y --no-install-recommends jq curl && rm -rf /var/lib/apt/lists/*
           WORKDIR /app
           RUN mkdir -p /app/fukuii/lib /app/data /app/hive-conf
-          COPY fukuii-assembly-*.jar /app/fukuii/lib/fukuii-assembly-0.1.240.jar
-          ENTRYPOINT ["java", "-jar", "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"]
+          COPY fukuii-assembly-*.jar /app/fukuii/lib/fukuii-assembly.jar
+          ENTRYPOINT ["java", "-jar", "/app/fukuii/lib/fukuii-assembly.jar"]
           DOCKER
           docker build -t chipprbots/fukuii:latest target/quick-docker/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,16 @@
 name: Release
 
 on:
-  workflow_call:
-    inputs:
-      version:
-        required: true
-        type: string
-        description: 'Version to release (e.g., 0.1.240)'
-      release_tier:
-        required: false
-        type: string
-        default: 'patch'
-        description: 'Release tier: patch (JAR+ZIP only) or full (+ Docker, signing, SBOM)'
+  # Triggered by auto-version.yml via `gh workflow run` after a version
+  # bump+tag, and available for manual dispatch from the Actions UI.
+  # NOTE: do NOT add `workflow_call:` here — chaining release.yml as a
+  # reusable workflow caused persistent `startup_failure` (the SLSA
+  # generator reference in the chain failed GitHub's startup-time
+  # validation, leaving 0 jobs created and no log surfaced via API).
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 0.1.240)'
+        description: 'Version to release (e.g., 0.1.241)'
         required: true
         type: string
       release_tier:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,15 @@ COPY --from=builder --chown=fukuii:fukuii /fukuii-dist /app/fukuii
 # Users can mount their own config files at /app/conf to override defaults
 COPY --from=builder --chown=fukuii:fukuii /fukuii-dist/conf /app/conf
 
+# Stable, version-agnostic symlink for the assembly JAR. Compose files,
+# hive adapters, and any other consumer should reference this path —
+# never the versioned filename — so a version bump doesn't require a
+# coordinated edit across every downstream config.
+RUN cd /app/fukuii/lib && \
+    ln -sf "$(ls fukuii-assembly-*.jar | head -1)" fukuii-assembly.jar && \
+    basename "$(readlink -f fukuii-assembly.jar)" \
+      | sed -E 's/^fukuii-assembly-(.*)\.jar$/fukuii-\1/' > /version.txt
+
 # Create healthcheck script
 RUN echo '#!/bin/bash\n\
 # Health check script for Fukuii\n\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,20 +41,25 @@ RUN --mount=type=cache,target=/root/.ivy2 \
 # Copy source code
 COPY . /build
 
-# Build distribution
+# Build distribution AND fat assembly JAR in a single sbt invocation so they
+# share the compile cache and JVM startup. The dist gives us the launcher
+# script + dependency JARs; the assembly JAR is what compose files and the
+# hive adapter run via `java -jar`.
 # Note: Submodules are already initialized by the GitHub Actions checkout step
 # or should be initialized manually before building (git submodule update --init --recursive)
 RUN --mount=type=cache,target=/root/.ivy2 \
     --mount=type=cache,target=/root/.sbt \
     --mount=type=cache,target=/root/.cache \
-    sbt dist
+    sbt assembly dist
 
-# Extract the distribution zip
+# Extract the distribution zip and drop the assembly JAR alongside the dist
+# libs so the runtime stage has both layouts available under /fukuii-dist.
 RUN cd target/universal && \
     DIST_FILE=$(ls fukuii-*.zip | head -1) && \
     unzip "$DIST_FILE" && \
     DIST_DIR=$(ls -d fukuii-*/ | head -1) && \
-    mv "$DIST_DIR" /fukuii-dist
+    mv "$DIST_DIR" /fukuii-dist && \
+    cp /build/target/scala-*/fukuii-assembly-*.jar /fukuii-dist/lib/
 
 # Stage 2: Runtime stage using slim JRE
 FROM eclipse-temurin:25-jre-noble

--- a/hive/fukuii/Dockerfile
+++ b/hive/fukuii/Dockerfile
@@ -15,7 +15,8 @@ COPY mapper.jq /mapper.jq
 COPY enode.sh /hive-bin/enode.sh
 RUN chmod +x /fukuii.sh /hive-bin/enode.sh
 
-RUN echo "fukuii-0.1.240" > /version.txt
+# /version.txt is created by the base image (chipprbots/fukuii:latest) from
+# the actual JAR filename, so a version bump propagates automatically.
 
 EXPOSE 8545 8546 8551 30303 30303/udp
 

--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -143,5 +143,5 @@ exec java \
     -XX:MaxMetaspaceSize=256m \
     -XX:+ExitOnOutOfMemoryError \
     $FLAGS \
-    -jar /app/fukuii/lib/fukuii-assembly-0.1.240.jar \
+    -jar /app/fukuii/lib/fukuii-assembly.jar \
     hive

--- a/ops/barad-dur/docker-compose.yml
+++ b/ops/barad-dur/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       - "-Dconfig.file=/app/conf/etc.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "etc"
     networks:
       - fukuii-network
@@ -164,7 +164,7 @@ services:
       - "-Dconfig.file=/app/conf/mordor.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "mordor"
     networks:
       - fukuii-network

--- a/ops/barad-dur/multi-etc-mordor/docker-compose.yml
+++ b/ops/barad-dur/multi-etc-mordor/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - "-XX:MaxGCPauseMillis=200"
       - "-Dconfig.file=/app/conf/multi-network.conf"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "runtime"
     networks:
       - multi-etc-mordor-net

--- a/ops/barad-dur/sepolia/docker-compose-multi.yml
+++ b/ops/barad-dur/sepolia/docker-compose-multi.yml
@@ -40,7 +40,7 @@ services:
       - "-XX:MaxGCPauseMillis=200"
       - "-Dconfig.file=/app/conf/multi-network.conf"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "runtime"
     networks:
       - sepolia-network

--- a/ops/barad-dur/sepolia/docker-compose.yml
+++ b/ops/barad-dur/sepolia/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "-Dconfig.file=/app/conf/sepolia.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "sepolia"
     networks:
       - sepolia-network

--- a/ops/cirith-ungol/docker-compose.yml
+++ b/ops/cirith-ungol/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - "-Dfukuii.trace.block=${FUKUII_TRACE_BLOCK:-}"
       - "-Dfukuii.trace.tx=${FUKUII_TRACE_TX:-}"
       - "-jar"
-      - "/app/fukuii/lib/fukuii-assembly-0.1.240.jar"
+      - "/app/fukuii/lib/fukuii-assembly.jar"
       - "mordor"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8545/health"]

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiController.scala
@@ -19,6 +19,7 @@ import com.chipprbots.ethereum.domain.Withdrawal
 import com.chipprbots.ethereum.jsonrpc.JsonRpcError
 import com.chipprbots.ethereum.jsonrpc.JsonRpcRequest
 import com.chipprbots.ethereum.jsonrpc.JsonRpcResponse
+import com.chipprbots.ethereum.utils.BuildInfo
 import com.chipprbots.ethereum.utils.Logger
 
 /** Handles Engine API JSON-RPC methods (engine_* namespace). This controller processes raw JSON requests and delegates
@@ -528,7 +529,7 @@ class EngineApiController(
         JObject(
           "code" -> JString("FK"),
           "name" -> JString("Fukuii"),
-          "version" -> JString("0.1.240"),
+          "version" -> JString(BuildInfo.version),
           "commit" -> JString(com.chipprbots.ethereum.utils.Config.clientVersion.takeRight(8))
         )
       )


### PR DESCRIPTION
## Summary

Two related fixes in one PR — the auto-version pipeline that has been silently failing for two months, and the version-pin debt that would have surfaced as soon as it started bumping again.

### Commit 1: dispatch release.yml via gh API

Auto-version pipeline has been broken since **2026-02-19 (PR #995)** — every run since v0.1.240 was a `startup_failure` with 0 jobs created, so the project version has been frozen at **0.1.240** and no releases have been generated.

Root cause: `e254e8af5` turned `release.yml` into a `workflow_call` reusable workflow chained from `auto-version.yml` via `uses:`. The chain transitively validates `slsa-framework/slsa-github-generator/.../generator_container_slsa3.yml@v2.0.0`, and GitHub's startup-time validation of the chain fails. The error is not surfaced via API (`gh run view` only says *workflow file issue*); the job list comes back empty.

Fix: decouple the two workflows so the chain is broken, and use `workflow_dispatch` (the one event GITHUB_TOKEN can fire that re-enters the Actions runtime) to trigger releases from auto-version.

- **release.yml**: drop `workflow_call:` block; keep only `workflow_dispatch:` (with `version` + `release_tier` inputs).
- **auto-version.yml**: remove the `trigger-release` job. Replace it with an inline `gh workflow run release.yml --ref v$VERSION -f version=… -f release_tier=…` step.

### Commit 2: drop hard-coded 0.1.240 from runtime artifacts

Once the version starts moving, every assembly-jar reference in the repo would have to track the new version or break. This commit cuts that dependency by introducing a stable, version-agnostic path `/app/fukuii/lib/fukuii-assembly.jar` that the production Dockerfile maintains as a symlink to whatever versioned JAR is in the image.

- **docker/Dockerfile** — symlink `fukuii-assembly.jar` → `fukuii-assembly-X.Y.Z.jar` in the runtime stage; also write `/version.txt` from the JAR filename.
- **`_hive-sim.yml`, `hive-prague.yml`** — inline base-image Dockerfile copies straight to the stable name.
- **`ops/**/docker-compose.yml`** (5 files: barad-dur, barad-dur/sepolia x2, barad-dur/multi-etc-mordor, cirith-ungol) — use the stable path.
- **`hive/fukuii/Dockerfile`** — drop the `RUN echo "fukuii-0.1.240" > /version.txt` line; the base image now provides that.
- **`hive/fukuii/fukuii.sh`** — invoke the stable path.
- **`EngineApiController.scala`** — `engine_getClientVersion` returns `BuildInfo.version` (from sbt-buildinfo, generated from `version.sbt`) instead of a hard-coded `"0.1.240"`.

After this, **`version.sbt` is the single source of truth**: bumping it auto-propagates to the JAR artifact, the symlink, `/version.txt`, and the Engine API response.

## Evidence

- Last successful auto-version run: 2026-02-17 (commit `f0629cd1`, PR #994)
- First failure: 2026-02-19 (commit `a3db2e96`, PR #995)
- Failures since: 80 consecutive `startup_failure` runs with 0 jobs

## Test plan

- [ ] Merge → next push to `develop` produces a successful Auto Version Increment run that bumps `version.sbt` from 0.1.240 to 0.1.241, creates+pushes tag `v0.1.241`, and dispatches `release.yml`.
- [ ] Confirm the dispatched `release.yml` run uses `release_tier=patch` (develop policy) and uploads the JAR + ZIP artifacts to the v0.1.241 GitHub release.
- [ ] Verify subsequent develop pushes continue to bump → 0.1.242, 0.1.243, … without manual intervention.
- [ ] When develop is next merged to main, confirm the main push triggers a `release_tier=full` dispatch (Docker + signing + SBOM + SLSA).
- [ ] Verify `chipprbots/fukuii:0.1.241` image has both `/app/fukuii/lib/fukuii-assembly-0.1.241.jar` and the `fukuii-assembly.jar` symlink.
- [ ] Verify hive runs against the new image still produce the right `/version.txt` (e.g. `fukuii-0.1.241`).
- [ ] Verify `engine_getClientVersion` JSON-RPC response carries the new version.

Generated with [Claude Code](https://claude.com/claude-code)