### PR TITLE
ci(auto-version): grant actions:write so release.yml dispatch succeeds

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -34,6 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # `gh workflow run release.yml` (final step) calls
+      # POST /actions/workflows/.../dispatches, which the default
+      # GITHUB_TOKEN cannot reach with only `contents: write`. Without
+      # this every auto-version run since PR #1118 has died at the
+      # dispatch step with `HTTP 403: Resource not accessible by
+      # integration`, leaving v0.2.x tags created but no release built.
+      actions: write
     outputs:
       version: ${{ steps.new-version.outputs.version }}
       increment_type: ${{ steps.version-type.outputs.increment_type }}


### PR DESCRIPTION
## Summary

PR #1118 replaced the `uses:` chain to release.yml with `gh workflow run release.yml` to dodge the SLSA-generator startup_failure. That part works. But the dispatch step has been failing on every auto-version run since:

\`\`\`
could not create workflow dispatch event: HTTP 403:
Resource not accessible by integration
(.../actions/workflows/.../dispatches)
\`\`\`

**Cause:** the auto-version job declares \`permissions: contents: write\` only. \`POST /actions/workflows/<id>/dispatches\` needs \`actions: write\` on the GITHUB_TOKEN. Without it \`gh workflow run\` 403s, the tag is already created and pushed (so the version sticks), but release.yml never runs and no artifacts get built.

**Net effect since PR #1118 (2026-04-27):** tags \`v0.2.0\` and \`v0.2.1\` exist on origin, but no GitHub releases were generated. From the user side: \"no one is able to get updates\".

**Fix:** add \`actions: write\` to the auto-version job's permissions block. One line.

## Verification path

- This PR's merge to develop will itself trigger auto-version → bump to v0.2.2 → tag → dispatch release.yml. Either we get a v0.2.2 patch release with artifacts (success), or release.yml fails and we see the actual error (no longer hidden behind the 403).
- After this lands, we may want a manual \`gh workflow run release.yml --ref v0.2.0 -f release_tier=full\` to backfill the missing v0.2.0 release (it was a minor bump, deserved \`full\` tier with Docker + SLSA).

## Test plan

- [x] Confirm none of the heavy hive workflows fire on this PR (PR #1120 already restricted them to main-bound).
- [ ] After merge: confirm auto-version run succeeds end-to-end (tag created **and** release dispatch succeeds — both visible in the run log).
- [ ] After merge: confirm a release.yml run appears for v0.2.2 (or whatever the next patch version is).
- [ ] If release.yml itself fails, that will be a separate follow-up — the goal of this PR is just to get the dispatch through so we can see the next layer of errors (or success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)