### PR TITLE
ci(release): remove SLSA generator job (causes startup_failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,18 +363,17 @@ jobs:
           echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
-  generate-slsa-provenance:
-    name: Generate SLSA Provenance
-    if: inputs.release_tier == 'full'
-    needs: [create-release, build-and-push-image]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563 # v1.10.0
-    with:
-      image: ghcr.io/chippr-robotics/fukuii
-      digest: ${{ needs.build-and-push-image.outputs.image-digest }}
-      registry-username: ${{ github.actor }}
-    secrets:
-      registry-password: ${{ secrets.GITHUB_TOKEN }}
+  # SLSA provenance generation removed (2026-04-27) — the slsa-framework
+  # reusable workflow reference was causing GitHub's startup-time
+  # validation to reject release.yml itself, even though the job was
+  # gated on `if: inputs.release_tier == 'full'`. GitHub loads referenced
+  # reusable workflows when parsing the calling workflow, regardless of
+  # job-level conditionals; if that load fails, the parent workflow goes
+  # into `startup_failure` with 0 jobs created and no log surfaced. That
+  # blocked every release run since 2025-12-29.
+  #
+  # Cosign image signing in build-and-push-image still provides a
+  # baseline supply-chain attestation. To re-introduce SLSA provenance,
+  # validate the slsa-framework pin in an isolated test workflow first
+  # (e.g., a single-job dispatchable .yml that calls the reusable
+  # workflow alone) before adding back here.


### PR DESCRIPTION
## Summary

After PR #1121 fixed the auto-version dispatch permission, release.yml on v0.2.2 still failed — now with \`startup_failure\` again (run [25024452385](https://github.com/chippr-robotics/fukuii/actions/runs/25024452385): 0 jobs, no log).

**Cause:** the \`generate-slsa-provenance\` job at the bottom of release.yml uses the slsa-framework reusable workflow. GitHub loads that reusable workflow when parsing release.yml at startup — *regardless of job-level conditionals* like \`if: inputs.release_tier == 'full'\`. When that load fails validation, the parent workflow can't start.

The pinned SHA \`5a775b367a\` does resolve to a real tagged release (v2.0.0, mislabelled as \`# v1.10.0\` in a stale comment), and the inputs/secrets match the SLSA workflow's signature, so the precise validation failure isn't visible via the API.

## Fix

Remove the \`generate-slsa-provenance\` job entirely. We were already producing 0 SLSA attestations (every full-tier dispatch since 2025-12-29 was startup_failure), so this is a no-op for users while unblocking the patch and full release pipelines.

Cosign image signing in \`build-and-push-image\` stays — that's a separate code path and still provides a baseline supply-chain attestation for full-tier releases.

## Test plan

- [ ] After merge, auto-version on develop → bumps to v0.2.3 → tags it → dispatches release.yml at v0.2.3.
- [ ] release.yml at v0.2.3 should now START (no startup_failure).
- [ ] If it runs to completion, we get a v0.2.3 GitHub release with JAR + dist artifacts.
- [ ] If it fails *during* the run (different failure mode than startup_failure), we'll finally see actual error logs we can act on.

## Future SLSA re-introduction (out of scope)

Build a standalone single-job test workflow that calls only the slsa-framework reusable workflow with the same inputs/secrets, dispatch it in isolation until it validates, then re-introduce the job in release.yml with the verified-working pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)