### PR TITLE
ci(release): create draft + publish to satisfy Immutable Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,19 +220,37 @@ jobs:
 
           cat release_notes.md
 
-      - name: Create GitHub Release
+      # Create the release as a *draft* with assets, then publish it in
+      # the next step. This is the supported pattern for repos with
+      # GitHub's Immutable Releases enabled — once a release is
+      # published, asset uploads are forbidden, so attempting `draft:
+      # false` here fails after some files upload (action-gh-release
+      # uploads the release record first, then assets).
+      - name: Create GitHub Release (draft)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}
           body_path: release_notes.md
-          draft: false
+          draft: true
           prerelease: ${{ inputs.release_tier != 'full' }}
           files: |
             release-artifacts/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Flip the draft to published. This atomically commits the release
+      # + its uploaded assets, satisfying the immutable-releases
+      # invariant. Downstream automation that watches `release.published`
+      # fires from this point.
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release edit "v${{ inputs.version }}" --draft=false
+          echo "Published v${{ inputs.version }}"
 
       - name: Update milestone
         if: inputs.release_tier == 'full'


### PR DESCRIPTION
## Summary

PR #1122 unblocked release.yml's startup_failure. The next run on v0.2.3 actually started and built artifacts, but failed at upload with:

\`\`\`
Cannot upload asset fukuii-0.2.3.tgz to an immutable release.
GitHub only allows asset uploads before a release is published...
keep the release as a draft with draft: true, then publish it later
from that draft.
\`\`\`

The repo has GitHub's [Immutable Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#release-immutability) enabled. \`softprops/action-gh-release@v3\` with \`draft: false\` publishes the release record before uploading assets, so Immutable Releases freezes it and subsequent uploads fail. v0.2.3 ended up as an empty published prerelease.

## Fix

Standard draft → publish pattern:

1. \`draft: true\` on \`softprops/action-gh-release\` — uploads assets to a draft (legal because drafts aren't immutable yet).
2. New \`Publish GitHub Release\` step right after — flips \`draft=false\` via \`gh release edit\`. The release publishes atomically with its full asset set.

## Existing v0.2.3 release

Leaving the empty v0.2.3 prerelease in place as a historical record. v0.2.4 (next auto-bump after this merges) will be the first release with actual artifacts.

## Test plan

- [ ] Merge → auto-version bumps to v0.2.4 → tags it → dispatches release.yml.
- [ ] release.yml at v0.2.4 starts (no startup_failure — already proven by v0.2.3 run).
- [ ] \`Create GitHub Release (draft)\` step uploads JAR + zip + tgz + SHA256SUMS.
- [ ] \`Publish GitHub Release\` step flips it to published.
- [ ] \`gh release view v0.2.4\` shows ≥4 assets and \`isDraft=false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)