### PR TITLE
ops(grafana): add Sepolia staking-operator dashboard suite

### DIFF
--- a/ops/barad-dur/prometheus/prometheus.yml
+++ b/ops/barad-dur/prometheus/prometheus.yml
@@ -69,6 +69,19 @@ scrape_configs:
           network: 'mordor'
           environment: 'staging'
 
+  # Lighthouse beacon node (Sepolia consensus layer)
+  - job_name: 'lighthouse-sepolia'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['172.21.0.1:5054']
+        labels:
+          instance: 'lighthouse-sepolia'
+          role: 'consensus'
+          network: 'sepolia'
+          environment: 'staging'
+
   # Kong API Gateway metrics
   - job_name: 'kong'
     scrape_interval: 10s

--- a/ops/barad-dur/sepolia/docker-compose-multi.yml
+++ b/ops/barad-dur/sepolia/docker-compose-multi.yml
@@ -32,6 +32,9 @@ services:
       - /chipprbots/blockchain/chain-data/etc/fukuii-mordor-multi:/app/data/mordor
       - ./fukuii-conf:/app/conf:ro
       - ./jwt.hex:/app/jwt/jwt.hex:ro
+    # Override the in-image entrypoint (which hardcodes a versioned jar name and
+    # ignores our flags). Run java directly so JVM args land before -jar.
+    entrypoint: ["java"]
     command:
       - "-Xmx4g"
       - "-Xms1g"
@@ -58,6 +61,7 @@ services:
     restart: unless-stopped
     ports:
       - "5052:5052"
+      - "5054:5054"   # Prometheus metrics
       - "9100:9000/tcp"
       - "9100:9000/udp"
     volumes:
@@ -77,6 +81,10 @@ services:
       - "--port=9000"
       - "--target-peers=50"
       - "--checkpoint-sync-url=https://sepolia.beaconstate.info"
+      - "--metrics"
+      - "--metrics-address=0.0.0.0"
+      - "--metrics-port=5054"
+      - "--metrics-allow-origin=*"
     depends_on:
       fukuii-multi:
         condition: service_healthy

--- a/ops/grafana/fukuii-engine-api-detail.json
+++ b/ops/grafana/fukuii-engine-api-detail.json
@@ -1,0 +1,262 @@
+{
+  "annotations": { "list": [] },
+  "description": "Engine API detail — every Engine API signal a staking operator can use to debug EL/CL friction.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:8px 0\"><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#b4a7d6\">ENGINE API</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#93c47d\"> DETAIL</span><br/><span style=\"font-size:12px;color:#999;letter-spacing:2px\">EL ⇄ CL traffic and latencies</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Total newPayload calls received from CL.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#b4a7d6" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 3 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "newPayload total",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_newpayload_total{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Cumulative VALID payload responses.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#93c47d" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 3 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "VALID",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_newpayload_valid{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Cumulative SYNCING (parent unknown) responses. Drops to ~0 once EL catches up.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#f6b26b" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 3 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "SYNCING",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_newpayload_syncing{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Cumulative INVALID. Non-zero is a strong signal of consensus drift or implementation bug.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#93c47d", "value": null }, { "color": "#e06666", "value": 1 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 3 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "INVALID",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_newpayload_invalid{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "fcU calls received from CL.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#6fa8dc" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 3 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "forkchoiceUpdated total",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_forkchoice_total{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Wall-clock seconds since the last payload the EL executed. > slot duration (12s on Sepolia) = falling behind.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#93c47d", "value": null }, { "color": "#f6b26b", "value": 24 }, { "color": "#e06666", "value": 60 }] },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 3 },
+      "id": 6,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Last payload age",
+      "type": "stat",
+      "targets": [{ "expr": "(time() - app_engine_latest_payload_timestamp{instance=\"fukuii-sepolia\"}) and (app_engine_latest_payload_timestamp{instance=\"fukuii-sepolia\"} > 0)", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "newPayload outcome rate, stacked. Healthy = mostly VALID with brief SYNCING bursts during reorgs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "valid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#93c47d" } }] },
+          { "matcher": { "id": "byName", "options": "syncing" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#f6b26b" } }] },
+          { "matcher": { "id": "byName", "options": "invalid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#e06666" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "id": 10,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "newPayload status mix",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_engine_newpayload_valid{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "valid", "refId": "A" },
+        { "expr": "rate(app_engine_newpayload_syncing{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "syncing", "refId": "B" },
+        { "expr": "rate(app_engine_newpayload_invalid{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "invalid", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "fcU outcome rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "valid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#93c47d" } }] },
+          { "matcher": { "id": "byName", "options": "syncing" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#f6b26b" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "id": 11,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "forkchoiceUpdated status mix",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_engine_forkchoice_valid{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "valid", "refId": "A" },
+        { "expr": "rate(app_engine_forkchoice_syncing{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "syncing", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Average Engine API call latency on the EL (sum/count of the JSON-RPC timer summary, filtered to engine_* methods).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 20,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "EL Engine API average latency",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_json_rpc_methods_timer_seconds_sum{instance=\"fukuii-sepolia\",method=~\"engine_.*\"}[5m]) / clamp_min(rate(app_json_rpc_methods_timer_seconds_count{instance=\"fukuii-sepolia\",method=~\"engine_.*\"}[5m]), 1e-9)", "legendFormat": "{{method}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Time the CL spends in EL Engine API calls (CL-side histogram). The high tail (p99) is what determines whether you propose blocks on time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "CL → EL request latency p50/p95/p99",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p50 {{method}}", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p95 {{method}}", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p99 {{method}}", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "JSON-RPC method errors and exceptions on the EL.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 23 },
+      "id": 30,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "JSON-RPC errors / exceptions (EL)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_json_rpc_methods_error_counter_total{instance=\"fukuii-sepolia\"}[5m])", "legendFormat": "error {{method}}", "refId": "A" },
+        { "expr": "rate(app_json_rpc_methods_exception_counter_total{instance=\"fukuii-sepolia\"}[5m])", "legendFormat": "exception {{method}}", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Total Engine API requests per minute, broken out by method.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 23 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Engine API throughput (per method)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_json_rpc_methods_timer_seconds_count{instance=\"fukuii-sepolia\",method=~\"engine_.*\"}[1m])", "legendFormat": "{{method}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Block height the EL has executed via newPayload.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineInterpolation": "smooth", "lineWidth": 2, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 30 },
+      "id": 40,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "EL latest payload block over time",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "app_engine_latest_payload_block{instance=\"fukuii-sepolia\"}", "legendFormat": "fukuii payload block", "refId": "A" }
+      ]
+    },
+    {
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 37 },
+      "id": 99,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:4px 0\"><span style=\"font-size:10px;color:#666;letter-spacing:3px\">ENGINE API DETAIL</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">EL: Fukuii (Sepolia)</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">CL: Lighthouse</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["fukuii", "engine-api", "sepolia"],
+  "time": { "from": "now-3h", "to": "now" },
+  "title": "Engine API Detail",
+  "uid": "engine-api-detail",
+  "version": 1
+}

--- a/ops/grafana/fukuii-lighthouse.json
+++ b/ops/grafana/fukuii-lighthouse.json
@@ -1,0 +1,328 @@
+{
+  "annotations": { "list": [] },
+  "description": "Lighthouse beacon-node detail — CL-side health, peers, attestations, store. Pair with the staking-ops dashboard.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:8px 0\"><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#b4a7d6\">LIGHTHOUSE</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#93c47d\"> BEACON NODE</span><br/><span style=\"font-size:12px;color:#999;letter-spacing:2px\">consensus layer detail — sepolia</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "1 = synced, 0 = syncing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [{ "options": { "0": { "color": "#e06666", "text": "SYNCING" }, "1": { "color": "#93c47d", "text": "SYNCED" } }, "type": "value" }],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#e06666", "value": null }, { "color": "#93c47d", "value": 1 }] }
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 3 },
+      "id": 1,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Sync status",
+      "type": "stat",
+      "targets": [{ "expr": "sync_eth2_synced{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Slots/sec the syncer is currently processing.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#6fa8dc" }, "unit": "none", "decimals": 1 } },
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 3 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Sync speed (slots/s)",
+      "type": "stat",
+      "targets": [{ "expr": "sync_slots_per_second{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "How many slots behind the wall-clock head we are.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#93c47d", "value": null }, { "color": "#f6b26b", "value": 32 }, { "color": "#e06666", "value": 1024 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 3 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Sync distance (slots)",
+      "type": "stat",
+      "targets": [{ "expr": "slotclock_present_slot{job=\"lighthouse-sepolia\"} - notifier_head_slot{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Estimated time to head at current speed.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#b4a7d6" }, "unit": "s" } },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 3 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "ETA to head",
+      "type": "stat",
+      "targets": [{ "expr": "(slotclock_present_slot{job=\"lighthouse-sepolia\"} - notifier_head_slot{job=\"lighthouse-sepolia\"}) / clamp_min(sync_slots_per_second{job=\"lighthouse-sepolia\"}, 0.01)", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Total libp2p peers across all gossipsub protocols (sums protocol versions).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#e06666", "value": null }, { "color": "#f6b26b", "value": 10 }, { "color": "#93c47d", "value": 30 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 3 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "libp2p peers",
+      "type": "stat",
+      "targets": [{ "expr": "sum(gossipsub_peers_per_protocol{job=\"lighthouse-sepolia\"})", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Active discovery sessions (peer search).",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#ffd966" }, "unit": "none" } },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 3 },
+      "id": 6,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "discovery sessions",
+      "type": "stat",
+      "targets": [{ "expr": "discovery_sessions{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Head slot vs wall-clock slot. Diverging lines = falling behind.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 10,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Slot progress",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "slotclock_present_slot{job=\"lighthouse-sepolia\"}", "legendFormat": "wall-clock", "refId": "A" },
+        { "expr": "notifier_head_slot{job=\"lighthouse-sepolia\"}", "legendFormat": "head", "refId": "B" },
+        { "expr": "beacon_head_state_slot{job=\"lighthouse-sepolia\"}", "legendFormat": "head state", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Justified and finalized epochs over time. Healthy chains advance both every 32 slots.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 11,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Justified / finalized",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "beacon_finalized_epoch{job=\"lighthouse-sepolia\"}", "legendFormat": "finalized", "refId": "A" },
+        { "expr": "beacon_current_justified_epoch{job=\"lighthouse-sepolia\"}", "legendFormat": "current justified", "refId": "B" },
+        { "expr": "beacon_previous_justified_epoch{job=\"lighthouse-sepolia\"}", "legendFormat": "previous justified", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Mesh peer count per protocol — diversity matters.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+      "id": 20,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "gossipsub peers per protocol",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "gossipsub_peers_per_protocol{job=\"lighthouse-sepolia\"}", "legendFormat": "{{protocol}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Mesh peer churn — high churn correlates with poor scoring or unstable network.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Mesh peer churn (events/s)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(gossipsub_mesh_peer_inclusion_events{job=\"lighthouse-sepolia\"}[5m])", "legendFormat": "include {{reason}}", "refId": "A" },
+        { "expr": "rate(gossipsub_mesh_peer_churn_events{job=\"lighthouse-sepolia\"}[5m])", "legendFormat": "churn {{reason}}", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Operations sitting in the pool waiting for inclusion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 23 },
+      "id": 30,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Beacon op pool",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "beacon_op_pool_attestations_total{job=\"lighthouse-sepolia\"}", "legendFormat": "attestations", "refId": "A" },
+        { "expr": "beacon_op_pool_attestation_data_total{job=\"lighthouse-sepolia\"}", "legendFormat": "attestation data", "refId": "B" },
+        { "expr": "beacon_op_pool_sync_contributions_total{job=\"lighthouse-sepolia\"}", "legendFormat": "sync contributions", "refId": "C" },
+        { "expr": "beacon_op_pool_attester_slashings_total{job=\"lighthouse-sepolia\"}", "legendFormat": "attester slashings", "refId": "D" },
+        { "expr": "beacon_op_pool_proposer_slashings_total{job=\"lighthouse-sepolia\"}", "legendFormat": "proposer slashings", "refId": "E" },
+        { "expr": "beacon_op_pool_voluntary_exits_total{job=\"lighthouse-sepolia\"}", "legendFormat": "voluntary exits", "refId": "F" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Sync committee participation per slot — 512 max.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 23 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["lastNotNull", "min", "mean"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Sync committee per slot",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "beacon_sync_comm_observation_slot_signers{job=\"lighthouse-sepolia\"}", "legendFormat": "signers", "refId": "A" },
+        { "expr": "beacon_sync_comm_observation_slot_aggregators{job=\"lighthouse-sepolia\"}", "legendFormat": "aggregators", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Network bandwidth in/out from libp2p.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 30 },
+      "id": 40,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "libp2p bandwidth",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(network_node_bytes_total_received{job=\"lighthouse-sepolia\"}[1m])", "legendFormat": "rx", "refId": "A" },
+        { "expr": "rate(network_node_bytes_total_transmit{job=\"lighthouse-sepolia\"}[1m])", "legendFormat": "tx", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Beacon hot DB and freezer footprint.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 25, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 30 },
+      "id": 41,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Store size",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "store_disk_db_size{job=\"lighthouse-sepolia\"}", "legendFormat": "hot DB", "refId": "A" },
+        { "expr": "store_freezer_db_size{job=\"lighthouse-sepolia\"}", "legendFormat": "freezer", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Process CPU and memory.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true }
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".*RSS.*" }, "properties": [{ "id": "unit", "value": "bytes" }, { "id": "custom.axisPlacement", "value": "right" }] },
+          { "matcher": { "id": "byRegexp", "options": ".*CPU.*" }, "properties": [{ "id": "unit", "value": "percentunit" }] }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 37 },
+      "id": 50,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Process resources",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(process_cpu_seconds_total{job=\"lighthouse-sepolia\"}[1m])", "legendFormat": "CPU", "refId": "A" },
+        { "expr": "process_resident_memory_bytes{job=\"lighthouse-sepolia\"}", "legendFormat": "RSS", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Disk read/write rate from the host node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "iops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 37 },
+      "id": 51,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Disk I/O",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(disk_node_reads_total{job=\"lighthouse-sepolia\"}[1m])", "legendFormat": "reads/s", "refId": "A" },
+        { "expr": "rate(disk_node_writes_total{job=\"lighthouse-sepolia\"}[1m])", "legendFormat": "writes/s", "refId": "B" }
+      ]
+    },
+    {
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 44 },
+      "id": 99,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:4px 0\"><span style=\"font-size:10px;color:#666;letter-spacing:3px\">LIGHTHOUSE BEACON NODE</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">Sepolia CL</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["lighthouse", "consensus", "sepolia", "beacon"],
+  "time": { "from": "now-3h", "to": "now" },
+  "title": "Lighthouse Beacon Node",
+  "uid": "lighthouse-beacon",
+  "version": 1
+}

--- a/ops/grafana/fukuii-multi-network-resources.json
+++ b/ops/grafana/fukuii-multi-network-resources.json
@@ -1,0 +1,281 @@
+{
+  "annotations": { "list": [] },
+  "description": "Multi-network resources for the fukuii-multi process (Sepolia + Mordor in one JVM). JVM metrics are shared, app_* metrics are per-instance.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:8px 0\"><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#b4a7d6\">FUKUII</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#93c47d\"> MULTI-NETWORK</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#6fa8dc\"> RESOURCES</span><br/><span style=\"font-size:12px;color:#999;letter-spacing:2px\">one JVM, two chains — process-level + per-instance</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "JVM heap used vs max for the shared process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 25, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 3 },
+      "id": 1,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "JVM heap (shared)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "jvm_memory_bytes_used{area=\"heap\",instance=\"fukuii-sepolia\"}", "legendFormat": "heap used", "refId": "A" },
+        { "expr": "jvm_memory_bytes_committed{area=\"heap\",instance=\"fukuii-sepolia\"}", "legendFormat": "heap committed", "refId": "B" },
+        { "expr": "jvm_memory_bytes_max{area=\"heap\",instance=\"fukuii-sepolia\"}", "legendFormat": "heap max", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "G1 generational pool sizes — Eden + Survivor + Old.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 3 },
+      "id": 2,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "JVM heap pools (G1)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "jvm_memory_pool_bytes_used{instance=\"fukuii-sepolia\",pool=~\"G1.*\"}", "legendFormat": "{{pool}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "GC time per collector. High Old Gen pause time = heap pressure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 11 },
+      "id": 10,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "GC time per collector",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(jvm_gc_collection_seconds_sum{instance=\"fukuii-sepolia\"}[5m])", "legendFormat": "{{gc}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "GC collection counts per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 11 },
+      "id": 11,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "GC collections/s",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(jvm_gc_collection_seconds_count{instance=\"fukuii-sepolia\"}[5m])", "legendFormat": "{{gc}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Threads currently in JVM. Pekko sync-dispatcher + default + validation contexts contribute.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 18 },
+      "id": 20,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" } },
+      "title": "Threads",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "jvm_threads_current{instance=\"fukuii-sepolia\"}", "legendFormat": "current", "refId": "A" },
+        { "expr": "jvm_threads_daemon{instance=\"fukuii-sepolia\"}", "legendFormat": "daemon", "refId": "B" },
+        { "expr": "jvm_threads_peak{instance=\"fukuii-sepolia\"}", "legendFormat": "peak", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Open file descriptors. Climbing FDs without bound is a leak.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 18 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "File descriptors",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "process_open_fds{instance=\"fukuii-sepolia\"}", "legendFormat": "open", "refId": "A" },
+        { "expr": "process_max_fds{instance=\"fukuii-sepolia\"}", "legendFormat": "max", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Process CPU and resident memory.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "RSS" }, "properties": [{ "id": "unit", "value": "bytes" }, { "id": "custom.axisPlacement", "value": "right" }] },
+          { "matcher": { "id": "byName", "options": "CPU" }, "properties": [{ "id": "unit", "value": "percentunit" }] }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 18 },
+      "id": 22,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Process CPU & RSS",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(process_cpu_seconds_total{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "CPU", "refId": "A" },
+        { "expr": "process_resident_memory_bytes{instance=\"fukuii-sepolia\"}", "legendFormat": "RSS", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Block height progress per instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineInterpolation": "smooth", "lineWidth": 2, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 30,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Per-instance block height",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "app_engine_latest_payload_block{instance=\"fukuii-sepolia\"}", "legendFormat": "Sepolia (CL-driven)", "refId": "A" },
+        { "expr": "app_regularsync_block_current_number_gauge{instance=\"fukuii-mordor-multi\"}", "legendFormat": "Mordor (regular sync)", "refId": "B" },
+        { "expr": "app_regularsync_block_bestKnown_number_gauge{instance=\"fukuii-mordor-multi\"}", "legendFormat": "Mordor best known", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Peer counts split by network.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Per-instance peer counts",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"fukuii-(sepolia|mordor-multi)\"} + app_network_peers_outgoing_handshaked_gauge{instance=~\"fukuii-(sepolia|mordor-multi)\"}", "legendFormat": "{{instance}} handshaked", "refId": "A" },
+        { "expr": "app_network_peers_pending_gauge{instance=~\"fukuii-(sepolia|mordor-multi)\"}", "legendFormat": "{{instance}} pending", "refId": "B" },
+        { "expr": "app_network_discovery_foundPeers_gauge{instance=~\"fukuii-(sepolia|mordor-multi)\"}", "legendFormat": "{{instance}} discovery found", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Successful JSON-RPC calls per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 33 },
+      "id": 40,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "JSON-RPC throughput per instance",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_json_rpc_methods_success_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[1m])", "legendFormat": "{{instance}} success", "refId": "A" },
+        { "expr": "rate(app_json_rpc_methods_error_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[1m])", "legendFormat": "{{instance}} error", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "P2P message rates per instance — a quiet network is a sick network.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 33 },
+      "id": 41,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "P2P messages per instance",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_network_messages_received_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[1m])", "legendFormat": "{{instance}} rx", "refId": "A" },
+        { "expr": "rate(app_network_messages_sent_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[1m])", "legendFormat": "{{instance}} tx", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Peer blacklist rates by group — surge in fastSyncGroup or regularSyncGroup blacklists points to bad sync peers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 40 },
+      "id": 50,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Peer blacklist activity",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_network_peers_blacklisted_p2pGroup_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[5m])", "legendFormat": "{{instance}} p2p", "refId": "A" },
+        { "expr": "rate(app_network_peers_blacklisted_fastSyncGroup_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[5m])", "legendFormat": "{{instance}} fastSync", "refId": "B" },
+        { "expr": "rate(app_network_peers_blacklisted_regularSyncGroup_counter_total{instance=~\"fukuii-(sepolia|mordor-multi)\"}[5m])", "legendFormat": "{{instance}} regularSync", "refId": "C" }
+      ]
+    },
+    {
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 47 },
+      "id": 99,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:4px 0\"><span style=\"font-size:10px;color:#666;letter-spacing:3px\">FUKUII MULTI-NETWORK RESOURCES</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">JVM shared, app_* per instance</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["fukuii", "multi-network", "resources", "jvm"],
+  "time": { "from": "now-3h", "to": "now" },
+  "title": "Fukuii Multi-Network Resources",
+  "uid": "fukuii-multi-resources",
+  "version": 1
+}

--- a/ops/grafana/fukuii-sepolia-staking.json
+++ b/ops/grafana/fukuii-sepolia-staking.json
@@ -1,0 +1,392 @@
+{
+  "annotations": { "list": [] },
+  "description": "Sepolia staking operator dashboard — combined EL (Fukuii) + CL (Lighthouse) view of everything that matters for a validator.",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:8px 0\"><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#b4a7d6\">SEPOLIA</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#93c47d\"> STAKING</span><span style=\"font-size:28px;letter-spacing:4px;font-weight:200;color:#6fa8dc\"> OPERATIONS</span><br/><span style=\"font-size:12px;color:#999;letter-spacing:2px\">fukuii (EL) + lighthouse (CL) — single pane</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Beacon chain sync status. 1 = synced to head, 0 = syncing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "#e06666", "text": "SYNCING" }, "1": { "color": "#93c47d", "text": "SYNCED" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#e06666", "value": null }, { "color": "#93c47d", "value": 1 }] }
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 3 },
+      "id": 1,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value" },
+      "title": "CL Sync",
+      "type": "stat",
+      "targets": [{ "expr": "sync_eth2_synced{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "How far behind the beacon chain head we are. Low = healthy, growing = falling behind.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#93c47d", "value": null }, { "color": "#f6b26b", "value": 32 }, { "color": "#e06666", "value": 1024 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 3 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "CL Sync Distance (slots)",
+      "type": "stat",
+      "targets": [{ "expr": "slotclock_present_slot{job=\"lighthouse-sepolia\"} - notifier_head_slot{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Current beacon chain head slot.",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "#b4a7d6" }, "unit": "none" }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 3 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "CL Head Slot",
+      "type": "stat",
+      "targets": [{ "expr": "notifier_head_slot{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Latest payload block executed by the EL via Engine API newPayload.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#6fa8dc" }, "unit": "none" } },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 3 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "EL Latest Payload",
+      "type": "stat",
+      "targets": [{ "expr": "app_engine_latest_payload_block{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Wall-clock age of the most recent payload the EL executed. Should stay under one slot (12s); if it climbs the EL is falling behind the CL.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#93c47d", "value": null }, { "color": "#f6b26b", "value": 24 }, { "color": "#e06666", "value": 60 }] },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 3 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "EL Block Age",
+      "type": "stat",
+      "targets": [{ "expr": "(time() - app_engine_latest_payload_timestamp{instance=\"fukuii-sepolia\"}) and (app_engine_latest_payload_timestamp{instance=\"fukuii-sepolia\"} > 0)", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Active validators in the beacon state.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#ffd966" }, "unit": "none" } },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 3 },
+      "id": 6,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Active Validators",
+      "type": "stat",
+      "targets": [{ "expr": "beacon_head_state_active_validators_total{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Finalized epoch. Should advance every ~6.4 minutes (32 slots).",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#93c47d" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "id": 7,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Finalized Epoch",
+      "type": "stat",
+      "targets": [{ "expr": "beacon_finalized_epoch{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Current justified epoch. Lagging finalization by 1 epoch is healthy.",
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "#6fa8dc" }, "unit": "none" } },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 8 },
+      "id": 8,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Justified Epoch",
+      "type": "stat",
+      "targets": [{ "expr": "beacon_current_justified_epoch{job=\"lighthouse-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "CL libp2p peers actively in the beacon block mesh — the peers we receive blocks from.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#e06666", "value": null }, { "color": "#f6b26b", "value": 8 }, { "color": "#93c47d", "value": 25 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
+      "id": 9,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "CL Block Mesh Peers",
+      "type": "stat",
+      "targets": [{ "expr": "sum(block_mesh_peers_per_client{job=\"lighthouse-sepolia\"})", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "EL peers handshaked (incoming + outgoing).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#e06666", "value": null }, { "color": "#f6b26b", "value": 5 }, { "color": "#93c47d", "value": 15 }] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 8 },
+      "id": 10,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "EL Peers",
+      "type": "stat",
+      "targets": [{ "expr": "app_network_peers_incoming_handshaked_gauge{instance=\"fukuii-sepolia\"} + app_network_peers_outgoing_handshaked_gauge{instance=\"fukuii-sepolia\"}", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "newPayload outcomes from the CL. Sustained INVALID is the loudest alarm a staking operator can have.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "valid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#93c47d" } }] },
+          { "matcher": { "id": "byName", "options": "syncing" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#f6b26b" } }] },
+          { "matcher": { "id": "byName", "options": "invalid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#e06666" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 20,
+      "options": { "legend": { "calcs": ["lastNotNull", "sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "newPayload status mix",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_engine_newpayload_valid{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "valid", "refId": "A" },
+        { "expr": "rate(app_engine_newpayload_syncing{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "syncing", "refId": "B" },
+        { "expr": "rate(app_engine_newpayload_invalid{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "invalid", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Time the CL spends in EL Engine API calls. p99 > 2s means the CL may struggle to publish blocks on time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "CL → EL request latency (Lighthouse)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p50 {{method}}", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p95 {{method}}", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le, method) (rate(execution_layer_request_times_bucket{job=\"lighthouse-sepolia\"}[5m])))", "legendFormat": "p99 {{method}}", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Block flow: CL head slot vs EL latest payload (left axis is the CL slot, right axis is the EL block number).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineInterpolation": "smooth", "lineWidth": 2, "spanNulls": true }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "EL latest payload" }, "properties": [{ "id": "custom.axisPlacement", "value": "right" }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 20 },
+      "id": 30,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Chain progress — CL slot vs EL block",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "notifier_head_slot{job=\"lighthouse-sepolia\"}", "legendFormat": "CL head slot", "refId": "A" },
+        { "expr": "slotclock_present_slot{job=\"lighthouse-sepolia\"}", "legendFormat": "Wall-clock slot", "refId": "B" },
+        { "expr": "app_engine_latest_payload_block{instance=\"fukuii-sepolia\"}", "legendFormat": "EL latest payload", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Forkchoice updates from CL. Should match newPayload rate plus extra fcU-only refreshes for proposers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 20 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" } },
+      "title": "Engine API call rate",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(app_engine_newpayload_total{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "newPayload/s", "refId": "A" },
+        { "expr": "rate(app_engine_forkchoice_total{instance=\"fukuii-sepolia\"}[1m])", "legendFormat": "forkchoiceUpdated/s", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Validator participation by epoch — gwei attesting to the target. Drops indicate slot-level network or fork-choice trouble.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 25, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "decgbytes"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 28 },
+      "id": 40,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Target-attesting balance (gwei progressive)",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "beacon_participation_curr_epoch_target_attesting_gwei_progressive_total{job=\"lighthouse-sepolia\"} / 1e18", "legendFormat": "current epoch", "refId": "A" },
+        { "expr": "beacon_participation_prev_epoch_target_attesting_gwei_progressive_total{job=\"lighthouse-sepolia\"} / 1e18", "legendFormat": "previous epoch", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Sync committee participation per slot. 512 = full attendance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 28 },
+      "id": 41,
+      "options": { "legend": { "calcs": ["lastNotNull", "min", "mean"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Sync committee per slot",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "beacon_sync_comm_observation_slot_signers{job=\"lighthouse-sepolia\"}", "legendFormat": "signers", "refId": "A" },
+        { "expr": "beacon_sync_comm_observation_slot_aggregators{job=\"lighthouse-sepolia\"}", "legendFormat": "aggregators", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Mesh peers per CL client implementation — diversity matters for liveness.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 35 },
+      "id": 50,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "CL block-mesh peers per client",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "block_mesh_peers_per_client{job=\"lighthouse-sepolia\"}", "legendFormat": "{{client}}", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "EL peer counts and churn — sustained blacklist activity points to bad peers or buggy protocol handling.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true }
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 35 },
+      "id": 51,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "EL peers and blacklist",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "app_network_peers_incoming_handshaked_gauge{instance=\"fukuii-sepolia\"}", "legendFormat": "incoming", "refId": "A" },
+        { "expr": "app_network_peers_outgoing_handshaked_gauge{instance=\"fukuii-sepolia\"}", "legendFormat": "outgoing", "refId": "B" },
+        { "expr": "app_network_peers_blacklisted_gauge{instance=\"fukuii-sepolia\"}", "legendFormat": "blacklisted", "refId": "C" },
+        { "expr": "rate(app_network_peers_blacklisted_p2pGroup_counter_total{instance=\"fukuii-sepolia\"}[5m])", "legendFormat": "p2p blacklist/s", "refId": "D" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Resource use across both processes — keep an eye on heap headroom and EL+CL CPU together.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 42 },
+      "id": 60,
+      "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" } },
+      "title": "Memory usage — EL JVM heap + CL RSS",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "jvm_memory_bytes_used{area=\"heap\",instance=\"fukuii-sepolia\"}", "legendFormat": "EL heap used", "refId": "A" },
+        { "expr": "jvm_memory_bytes_max{area=\"heap\",instance=\"fukuii-sepolia\"}", "legendFormat": "EL heap max", "refId": "B" },
+        { "expr": "process_resident_memory_bytes{job=\"lighthouse-sepolia\"}", "legendFormat": "CL RSS", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Disk used by the CL store — beacon DB + freezer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 25, "lineInterpolation": "smooth", "lineWidth": 1, "spanNulls": true, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 42 },
+      "id": 61,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" } },
+      "title": "CL store size",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "store_disk_db_size{job=\"lighthouse-sepolia\"}", "legendFormat": "hot DB", "refId": "A" },
+        { "expr": "store_freezer_db_size{job=\"lighthouse-sepolia\"}", "legendFormat": "freezer", "refId": "B" }
+      ]
+    },
+    {
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 49 },
+      "id": 99,
+      "options": {
+        "content": "<div style=\"text-align:center;padding:4px 0\"><span style=\"font-size:10px;color:#666;letter-spacing:3px\">SEPOLIA STAKING OPS</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">EL: Fukuii</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">CL: Lighthouse</span> <span style=\"color:#555\">|</span> <span style=\"font-size:10px;color:#666\">Chippr Robotics</span></div>",
+        "mode": "html"
+      },
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["fukuii", "sepolia", "staking", "consensus", "engine-api"],
+  "time": { "from": "now-3h", "to": "now" },
+  "title": "Sepolia Staking Operations",
+  "uid": "sepolia-staking-ops",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Build out a comprehensive Grafana setup for the `fukuii-multi` runtime (Mordor + Sepolia in one JVM) so a staking node operator can see the full EL ⇄ CL story in one place.

- Enables Lighthouse Prometheus metrics on port `5054` and adds a scrape job so beacon-node telemetry (`notifier_head_slot`, `sync_eth2_synced`, `beacon_finalized_epoch`, gossipsub peers, `execution_layer_request_times`, store sizes, etc.) is available to Grafana.
- Adds **four** new dashboards under `ops/grafana/`, all wired up by the existing provisioning symlink:

| Dashboard | Purpose |
|-----------|---------|
| `fukuii-sepolia-staking.json` | Single-pane staking-operator view: EL block age, CL sync distance, finalized/justified, peer counts, newPayload status mix, CL→EL latency p50/95/99, attesting balance, sync committee. |
| `fukuii-lighthouse.json` | CL-only deep dive: slot progress, justified/finalized, gossipsub per protocol, mesh churn, op pool, libp2p bandwidth, store sizes, disk I/O. |
| `fukuii-engine-api-detail.json` | Engine API focus: newPayload/fcU rate + status, EL per-method `engine_*` latency, CL-side request histograms, JSON-RPC error trends. |
| `fukuii-multi-network-resources.json` | Shared JVM heap, G1 pools, GC, threads/FDs/CPU/RSS, plus per-instance block height, peers, RPC throughput, P2P traffic and blacklist activity for Sepolia + Mordor side-by-side. |

Block-age stat tiles guard against zero timestamps so they render "No data" instead of the Unix epoch when the EL has not yet executed a CL payload.

## Test plan

- [x] JSON parses cleanly on all four new dashboards (22, 18, 15, 14 panels)
- [x] Prometheus /api/v1/targets shows lighthouse-sepolia up after recreate + reload
- [x] Spot-checked live Prometheus queries return real series: notifier_head_slot, sync_eth2_synced, sum(gossipsub_peers_per_protocol), beacon_finalized_epoch, app_engine_latest_payload_block, app_regularsync_block_current_number_gauge
- [x] Grafana /api/search lists all four dashboards under their UIDs (sepolia-staking-ops, lighthouse-beacon, engine-api-detail, fukuii-multi-resources)
- [ ] Visual confirmation once Lighthouse finishes initial sync

## Notes

Lighthouse is currently logging "Error during execution engine upcheck — operation timed out" against fukuii-multi:8551, so app_engine_* counters are still 0 for Sepolia. Separate engine-API responsiveness bug worth chasing on its own; the new dashboards just make it immediately visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)