### PR TITLE
fix(engine-api): unblock CL upcheck and clean up routine peer logging

### DIFF
--- a/src/main/resources/conf/base/metrics.conf
+++ b/src/main/resources/conf/base/metrics.conf
@@ -11,17 +11,21 @@ metrics {
 
 kamon {
   modules {
-    # We expose Prometheus metrics via the node's Micrometer registry.
-    # Disable Kamon's Prometheus reporter to prevent port-binding conflicts (BindException: Address already in use).
-    "prometheus-reporter" {
-      enabled = false
+    # We expose Prometheus metrics via the node's Micrometer-backed
+    # io.prometheus.client.HTTPServer in Metrics.scala. Disable Kamon's own
+    # Prometheus reporter so it doesn't double-register or contend for the port.
+    prometheus-reporter {
+      enabled = no
     }
   }
 
   prometheus {
-    # Disable embedded HTTP server since we use io.prometheus.client.exporter.HTTPServer in Metrics.scala
-    # This prevents conflicts and startup failures
-    embedded-server.enabled = false
+    # The reference.conf from kamon-prometheus 2.7.x uses
+    # `start-embedded-http-server` (yes/no) — there is no `embedded-server.enabled`
+    # key. Without this, kamon binds 0.0.0.0:9095 (its default port), which
+    # collides with multi-instance setups where 9095 is the per-instance metrics
+    # port and produces "Address already in use" on the second chain.
+    start-embedded-http-server = no
   }
 
   instrumentation.pekko.filters {

--- a/src/main/resources/conf/base/pekko.conf
+++ b/src/main/resources/conf/base/pekko.conf
@@ -58,6 +58,23 @@ validation-context {
   throughput = 1
 }
 
+# Dedicated dispatcher for the Engine API HTTP server. CL clients (Lighthouse,
+# Prysm, etc.) issue forkchoiceUpdated and newPayload calls every ~12s and time
+# out hard at ~8s. Sharing the default dispatcher with peer-management actors
+# means a busy P2P session can stall every Engine API call, leaving the CL
+# stuck in optimistic mode and the EL effectively offline for staking. Keep
+# this isolated.
+engine-api-dispatcher {
+  type = Dispatcher
+  executor = "fork-join-executor"
+  fork-join-executor {
+    parallelism-min = 4
+    parallelism-factor = 1.0
+    parallelism-max = 8
+  }
+  throughput = 5
+}
+
 # DEBUGGING SETTING
 # Uncomment to enable non-standard mailbox for all actors
 # Mailbox will start logging actor path, when actor mailbox size will be bigger than `size-limit`

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
@@ -30,7 +30,10 @@ class EngineApiHttpServer(
     extends Logger {
 
   implicit val formats: Formats = DefaultFormats
-  implicit val ec: ExecutionContext = system.dispatcher
+  // Engine API runs on its own dispatcher so a busy default-dispatcher
+  // (e.g. peer-manager flooded with cross-network dialers) can't stall
+  // forkchoiceUpdated / newPayload and push the CL into optimistic mode.
+  implicit val ec: ExecutionContext = system.dispatchers.lookup("engine-api-dispatcher")
   implicit val ioRuntime: IORuntime = IORuntime.global
 
   private var bindingOpt: Option[Http.ServerBinding] = None

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -349,8 +349,8 @@ class PeerManagerActor(
 
     validConnection match {
       case Right(address) =>
-        log.error(
-          "[HIVE-DEBUG] Accepting incoming connection from {} (pending={}/{})",
+        log.debug(
+          "Accepting incoming connection from {} (pending={}/{})",
           remoteAddress,
           connectedPeers.incomingPendingPeersCount,
           peerConfiguration.maxPendingPeers
@@ -360,7 +360,7 @@ class PeerManagerActor(
         context.become(listening(newConnectedPeers))
 
       case Left(error) =>
-        log.error("[HIVE-DEBUG] Rejecting incoming connection from {}: {}", remoteAddress, error)
+        log.debug("Rejecting incoming connection from {}: {}", remoteAddress, error)
         handleConnectionErrors(error)
     }
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -108,7 +108,7 @@ class RLPxConnectionHandler(
       context.become(new ConnectedHandler(connection).waitingForAuthHandshakeResponse(handshaker, timeout))
 
     case CommandFailed(_: Connect) =>
-      log.error("[Stopping Connection] TCP connection to {} failed for peer {}", uri, peerId)
+      log.debug("TCP connect to {} failed for peer {}", uri, peerId)
       context.parent ! ConnectionFailed
       gracefulStop()
   }
@@ -362,8 +362,8 @@ class RLPxConnectionHandler(
               processHandshakeResult(result, remainingData)
 
             case Failure(ex) =>
-              log.error(
-                "[HIVE-DEBUG] Auth handshake FAILED for peer {} - both pre-EIP8 and EIP-8 decode failed: {}",
+              log.debug(
+                "Auth handshake decode failed for peer {} (pre-EIP8 and EIP-8): {}",
                 peerId,
                 ex.getMessage
               )
@@ -445,8 +445,8 @@ class RLPxConnectionHandler(
     }
 
     def handleTimeout: Receive = { case AuthHandshakeTimeout =>
-      log.error(
-        "[Stopping Connection] Auth handshake timeout for peer {} after {}ms",
+      log.debug(
+        "Auth handshake timeout for peer {} after {}ms",
         peerId,
         rlpxConfiguration.waitForHandshakeTimeout.toMillis
       )
@@ -467,7 +467,7 @@ class RLPxConnectionHandler(
           extractHello(extractor(secrets), remainingData)
 
         case AuthHandshakeError =>
-          log.error("[Stopping Connection] Auth handshake FAILED for peer {}", peerId)
+          log.debug("Auth handshake failed for peer {}", peerId)
           context.parent ! ConnectionFailed
           gracefulStop()
       }
@@ -503,7 +503,7 @@ class RLPxConnectionHandler(
 
         case AckTimeout(ackSeqNumber) if cancellableAckTimeout.exists(_.seqNumber == ackSeqNumber) =>
           cancellableAckTimeout.foreach(_.cancellable.cancel())
-          log.error("[Stopping Connection] Sending 'Hello' to {} failed", peerId)
+          log.debug("Sending 'Hello' to {} failed", peerId)
           gracefulStop()
         case Received(data) =>
           extractHello(extractor, data, cancellableAckTimeout, seqNumber)
@@ -547,8 +547,8 @@ class RLPxConnectionHandler(
                 )
               )
             case None =>
-              log.error(
-                "[Stopping Connection] Unable to negotiate protocol with peer {} — peerCaps=[{}], ourCaps=[{}]",
+              log.debug(
+                "Unable to negotiate protocol with peer {} — peerCaps=[{}], ourCaps=[{}]",
                 peerId,
                 hello.capabilities.mkString(", "),
                 capabilities.mkString(", ")
@@ -642,8 +642,8 @@ class RLPxConnectionHandler(
         } else {
           // For other decoding errors (truly malformed RLP, structure mismatches, etc.),
           // send proper Disconnect to remote peer before closing connection
-          log.error(
-            "DECODE_ERROR: Cannot decode message from {} - disconnecting. Error: {}",
+          log.warning(
+            "Cannot decode message from {} - disconnecting. Error: {}",
             peerId,
             ex.getMessage
           )
@@ -739,8 +739,8 @@ class RLPxConnectionHandler(
                   )
                 }
               case Left(err) =>
-                log.error(
-                  "RECV_MSG: peer={}, msg[{}] DECODE_ERROR: {}",
+                log.warning(
+                  "RECV_MSG decode error: peer={}, msg[{}]: {}",
                   peerId,
                   idx,
                   err.getMessage
@@ -763,7 +763,7 @@ class RLPxConnectionHandler(
 
         case AckTimeout(ackSeqNumber) if cancellableAckTimeout.exists(_.seqNumber == ackSeqNumber) =>
           cancellableAckTimeout.foreach(_.cancellable.cancel())
-          log.error("[Stopping Connection] SEND_MSG_TIMEOUT: peer={}, seqNum={}", peerId, ackSeqNumber)
+          log.debug("Send timeout: peer={}, seqNum={}", peerId, ackSeqNumber)
           gracefulStop()
       }
 


### PR DESCRIPTION
## Summary

Three independent fixes uncovered while debugging Lighthouse's persistent **\`Error during execution engine upcheck — operation timed out\`** against the Sepolia EL on the multi-network runtime.

### 1. Engine API on its own dispatcher
The Engine API HTTP server scheduled its response \`Future\`s on the default pekko dispatcher. With heavy P2P traffic (peer accepts, RLPx, message decoding) the default dispatcher saturates and CL calls back up behind actor work. CL clients time out at ~8s and flip the EL to optimistic mode.

Adds an \`engine-api-dispatcher\` (4–8 fork-join threads) and uses it as the implicit \`ExecutionContext\` in \`EngineApiHttpServer\` so \`newPayload\` / \`forkchoiceUpdated\` are insulated from peer-management bursts. Same shape as the existing \`sync-dispatcher\`.

### 2. Kamon stops fighting our Prometheus exporter
\`metrics.conf\` set \`kamon.prometheus.embedded-server.enabled = false\` — but the actual key in kamon-prometheus 2.7.x is \`start-embedded-http-server\` (yes/no). The disable flag silently did nothing, so Kamon was binding 0.0.0.0:9095 (its hardcoded default port) on every \`Kamon.init()\`. In multi-instance mode where 9095 is the per-instance metrics port, this triggered \`BindException: Address already in use\` during the second instance's startup. Use the correct key.

### 3. Drop routine peer-churn ERROR logs
Several \`PeerManagerActor\` / \`RLPxConnectionHandler\` sites were logging normal cross-network dialer events at ERROR level (left-over hive-debug instrumentation):

- \`[HIVE-DEBUG] Accepting incoming connection ...\`
- \`[HIVE-DEBUG] Rejecting incoming connection ...\`
- \`[HIVE-DEBUG] Auth handshake FAILED ...\`
- \`[Stopping Connection] TCP connection ... failed\`
- \`[Stopping Connection] Auth handshake timeout\`
- \`[Stopping Connection] Auth handshake FAILED\`
- \`[Stopping Connection] Sending 'Hello' ... failed\`
- \`[Stopping Connection] Unable to negotiate protocol\`
- \`[Stopping Connection] SEND_MSG_TIMEOUT\`

These fire dozens of times per minute on a public network. Drop the tag and demote to DEBUG. Genuinely-malformed RLP decode messages (\`RECV_MSG decode error\`, \`Cannot decode message\`) stay at WARN.

## Test plan

- [x] \`sbt compile\` passes
- [x] \`sbt assembly\` builds 197MB jar
- [x] Deployed to Barad-dûr Sepolia multi-network runtime
- [x] Both Mordor (9096) + Sepolia (9095) metric endpoints come up cleanly — no more BindException on second instance
- [x] Engine API \`eth_chainId\` via JWT now responds (previously hung indefinitely)
- [x] Engine API \`engine_exchangeCapabilities\` via JWT now responds (some timeouts remain — see Notes)
- [x] Logs no longer flooded with routine peer-churn ERROR lines
- [ ] Verify against full Lighthouse upcheck once Sepolia state caches warm up (currently the EL still occasionally exceeds Lighthouse's 8s timeout under Mordor sync load — separate problem)

## Notes / not-fixed-here

After deploy, occasional Engine API calls still take ~6–7s when Mordor regular-sync is hot (CPU at ~300% on the JVM). This is structural: two networks share one process, EVM execution on Mordor blocks JIT'd hot paths and IORuntime.global gets backed up. Real fix is either splitting Mordor back into its own container or wiring Engine API onto a custom \`IORuntime\`. This PR materially narrows the failure window but doesn't close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)