### PR TITLE
fix(jsonrpc): EthTxService uses per-instance BlockchainConfig

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/jsonrpc/EthTxService.scala
@@ -23,7 +23,6 @@ import com.chipprbots.ethereum.transactions.PendingTransactionsManager
 import com.chipprbots.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 import com.chipprbots.ethereum.transactions.TransactionPicker
 import com.chipprbots.ethereum.utils.BlockchainConfig
-import com.chipprbots.ethereum.utils.Config
 
 object EthTxService {
   case class GetTransactionByHashRequest(txHash: ByteString) // rename to match request
@@ -50,11 +49,16 @@ class EthTxService(
     val pendingTransactionsManager: ActorRef,
     val getTransactionFromPoolTimeout: FiniteDuration,
     transactionMappingStorage: TransactionMappingStorage
-) extends TransactionPicker
+)(implicit val blockchainConfig: BlockchainConfig)
+    extends TransactionPicker
     with ResolveBlock {
   import EthTxService._
-
-  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+  // blockchainConfig is taken as an implicit constructor parameter so multi-instance
+  // runtime callers (NodeBuilder) automatically supply the per-instance config in scope
+  // (see NodeBuilder line 72), instead of every service silently shadowing it with the
+  // global Config.blockchains.blockchainConfig singleton — which yields the FIRST chain's
+  // config and breaks EIP-155 sender recovery for non-default chains (chainId mismatch
+  // → InvalidRequest -32600 on legacy txs).
 
   /** Implements the eth_getRawTransactionByHash - fetch raw transaction data of a transaction with the given hash.
     *

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -560,6 +560,7 @@ trait EthMiningServiceBuilder {
 }
 trait EthTxServiceBuilder {
   self: BlockchainBuilder
+    with BlockchainConfigBuilder
     with PendingTransactionsManagerBuilder
     with MiningBuilder
     with TxPoolConfigBuilder


### PR DESCRIPTION
## Summary

In multi-instance runtime, `EthTxService` silently shadowed the per-instance implicit `blockchainConfig` from `NodeBuilder` by re-declaring its own pointing at the global `Config.blockchains.blockchainConfig` singleton. The first chain instance's config wins; every other chain's EIP-155 sender recovery breaks because the chainId extracted from the tx's `v` doesn't match the (wrong) `blockchainConfig.chainId`.

## Reproduction

1. Stand up multi-instance fukuii with mordor (chainId=63) on a runtime where the global `Config` was initialised from a different chain.
2. Sign a legacy EIP-155 tx for chainId=63 and POST it via `eth_sendRawTransaction`.

```bash
$ python3 -c "..."
0xf86b818c8504a817c80082520894...   # well-formed legacy EIP-155 tx
$ curl -X POST http://localhost:8547 -d '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xf86b..."],"id":1}'
{"jsonrpc":"2.0","error":{"code":-32600,"message":"The JSON sent is not a valid Request object"},"id":1}

# Same bytes via canonical Mordor RPC:
$ curl -X POST https://rpc.mordor.etccooperative.org -d '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xf86b..."],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x4357fc0c..."}    # accepted, mined block 16,057,262
```

The misleading "JSON sent is not a valid Request object" comes from `JsonRpcError.InvalidRequest` (`-32600`), returned by `EthTxService.sendRawTransaction` when `Try(req.data.toArray.toSignedTransactionWithSidecar)` throws. The throw is from `getLegacyTransactionRawSignature` falling to the catch-all `IllegalStateException` because `extractChainId` returned `None` (chainId match against the wrong global config failed).

## Fix

`EthTxService` takes `blockchainConfig` as an implicit constructor parameter. `EthTxServiceBuilder` adds `BlockchainConfigBuilder` to its self-type so the per-instance implicit at `NodeBuilder.scala:72` is supplied automatically.

```diff
 class EthTxService(
     val blockchain: Blockchain,
     ...
     transactionMappingStorage: TransactionMappingStorage
-) extends TransactionPicker
+)(implicit val blockchainConfig: BlockchainConfig)
+    extends TransactionPicker
     with ResolveBlock {
   import EthTxService._

-  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+  // blockchainConfig is taken as an implicit constructor parameter so multi-instance
+  // runtime callers (NodeBuilder) automatically supply the per-instance config in scope
+  // (see NodeBuilder line 72), instead of every service silently shadowing it with the
+  // global Config.blockchains.blockchainConfig singleton ...
```

## Test plan

- [x] `sbt compile` clean (4 unrelated warnings)
- [x] `sbt 'testOnly *EthTxServiceSpec'` — 30/31 pass; the 1 failure is **pre-existing on develop** (unrelated `transactionLogIndex` mismatch in "should calculate correct contract address" test)
- [x] End-to-end: signed legacy tx accepted by canonical Mordor RPC and **mined in block 16,057,262** (status `0x1`)
- [x] Manually verified single-instance fukuii (where global `Config` matches chain) accepts the same bytes — proves the bug is purely the multi-instance singleton leak

## Follow-up

Seven sibling JSON-RPC services share the same singleton-leak pattern (Bug-29 family). Same treatment in a separate PR:

- `TraceService.scala:113`
- `FukuiiService.scala:46`
- `DebugTracingService.scala:101`
- `EthBlocksService.scala:89`
- `TransactionResponse.scala:58` (object — needs implicit on `apply` methods)
- `EthSimulateJsonMethodsImplicits.scala:247`
- `graphql/GraphQLSchema.scala:74`

Also worth filing separately: fukuii admits EIP-1559 type-2 txs on Mordor (which never adopted London) — needs tx-type-vs-fork validation in `EthTxService.sendRawTransaction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)