### PR TITLE
fix(snap): trie validation — BFS→DFS, stale epoch guard, HealingImpossible signal chain, root mismatch restart

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -549,6 +549,15 @@ class SyncController(
       return
     }
 
+    // Recovery flag: -Dfukuii.snap.clearDoneOnStart=true clears SnapSyncDone to re-enter healing.
+    // Use when healing completed prematurely (BUG-006: root mismatch) to resume without a full re-sync.
+    if (doSnapSync && System.getProperty("fukuii.snap.clearDoneOnStart", "false").toBoolean) {
+      if (appStateStorage.isSnapSyncDone()) {
+        log.warning("fukuii.snap.clearDoneOnStart=true: clearing SnapSyncDone to re-enter SNAP healing")
+        appStateStorage.clearSnapSyncDone().commit()
+      }
+    }
+
     (appStateStorage.isSnapSyncDone(), appStateStorage.isFastSyncDone(), doSnapSync, doFastSync) match {
       case (false, _, true, _) =>
         // SNAP sync requested - just start it

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -72,6 +72,15 @@ class SyncController(
   // SNAP<->Fast sync bounce cycle counter, persisted across restarts.
   private var snapFastCycleCount: Int = appStateStorage.getSnapFastCycleCount()
 
+  // D1: Circuit breaker for HealingImpossible. After maxHealingRestarts consecutive failures,
+  // back off before re-pivoting. Mirrors Besu PivotSyncDownloader: fixed 5s retry, but ETC peer
+  // pool is smaller so we use exponential backoff (30s base, 5min cap).
+  // Reset to 0 on ImportedBlock milestone (evidence that healing succeeded).
+  private var healingRestartCount: Int = 0
+  private val maxHealingRestarts: Int  = 3
+  private val healingRestartBaseDelay: FiniteDuration  = 30.seconds
+  private val healingRestartMaxDelay: FiniteDuration   = 5.minutes
+
   private def stopSyncChildren(): Unit = {
     // Stop all sync-related child actors. Names may have generation suffixes
     // (e.g. "fast-sync-3") because PoisonPill is async and a new actor can
@@ -230,6 +239,7 @@ class SyncController(
       snapSync ! PoisonPill
       log.info("SNAP sync completed, transitioning to regular sync")
       resetSnapFastCycleCount()
+      healingRestartCount = 0 // D1: fresh SNAP success clears the circuit breaker
       startRegularSync()
 
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.FallbackToFastSync =>
@@ -258,13 +268,6 @@ class SyncController(
       case RestartFastSyncNow =>
         doRestartFastSyncNow()
       case SyncProtocol.RegularSyncStuck(blockNumber, missingHash) =>
-        // Regular sync can't make progress: state-node recovery has exhausted on the same hash
-        // 3+ times. Local parent state is too far behind canonical tip for any peer's snap-serve
-        // window, so trie-node fetches keep returning empty. Only viable recovery is to re-run
-        // SNAP from a recent pivot. Kill regular sync, clear both SnapSyncDone AND FastSyncDone
-        // (so a subsequent restart re-evaluates start() and enters SNAP rather than getting
-        // stuck in `do-fast-sync is true but fast sync already completed` → regular-sync), then
-        // start SNAP directly.
         log.error(
           "Regular sync stuck on block {} (missing {}). Re-triggering SNAP sync from a recent pivot.",
           blockNumber,
@@ -274,6 +277,34 @@ class SyncController(
         appStateStorage.clearSnapSyncDone().commit()
         appStateStorage.clearFastSyncDone().commit()
         startSnapSync()
+
+      case SyncProtocol.HealingImpossible =>
+        // D1: Circuit breaker for repeated healing failures.
+        // Besu: PivotSyncDownloader.handleFailure(StalledDownloadException) → findPivotBlock().
+        // go-ethereum: HasState(head.Root) → false → SnapSync re-enabled.
+        // ETC peer pool is small, so we use exponential backoff after maxHealingRestarts.
+        healingRestartCount += 1
+        appStateStorage.clearSnapSyncDone().commit()
+        regularSync ! PoisonPill
+        if (healingRestartCount <= maxHealingRestarts) {
+          log.warning(
+            "Trie healing impossible (attempt {}/{}) — pivot state root pruned on all peers. " +
+              "Restarting SNAP sync with a fresh current pivot.",
+            healingRestartCount,
+            maxHealingRestarts
+          )
+          startSnapSync()
+        } else {
+          val backoffRaw = healingRestartBaseDelay * math.pow(2.0, (healingRestartCount - maxHealingRestarts).toDouble).toLong
+          val backoff    = if (backoffRaw > healingRestartMaxDelay) healingRestartMaxDelay else backoffRaw
+          log.error(
+            "Trie healing impossible after {} consecutive restarts. " +
+              "Backing off {}s before re-pivoting. All known peers have pruned the pivot state root.",
+            healingRestartCount,
+            backoff.toSeconds
+          )
+          scheduler.scheduleOnce(backoff, self, RestartFastSyncNow)(context.dispatcher)
+        }
       case msg =>
         regularSync.forward(msg)
     }
@@ -402,6 +433,7 @@ class SyncController(
       peersClient ! PoisonPill
       originalSnapSyncRef ! PoisonPill
       resetSnapFastCycleCount()
+      healingRestartCount = 0 // D1: fresh SNAP success clears the circuit breaker
       startRegularSync()
 
     case msg =>
@@ -577,50 +609,80 @@ class SyncController(
           bestBlockNum,
           snapStateRoot == pivotStateRoot
         )
-        // After SNAP sync with deferred merkleization + pivot refreshes, the finalized trie root
-        // may differ from the pivot block header's stateRoot. The trie nodes are stored under
-        // the finalized root's hash, but the pivot header references the original (now orphaned) root.
-        // Fix: substitute the finalized root into the pivot block header.
-        bestBlockHeader.foreach { header =>
-          val mptStorage = stateStorage.getReadOnlyStorage
-          val pivotRootExists =
-            try { mptStorage.get(header.stateRoot.toArray); true }
-            catch { case _: Exception => false }
-          log.info(
-            "State root availability check: pivotRoot({})={}",
-            header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString,
-            if (pivotRootExists) "EXISTS" else "MISSING"
-          )
-          if (!pivotRootExists) {
-            val finalizedRoot = appStateStorage.getSnapSyncFinalizedRoot()
-            finalizedRoot match {
-              case Some(fRoot) =>
-                val fRootExists =
-                  try { mptStorage.get(fRoot.toArray); true }
-                  catch { case _: Exception => false }
-                log.info(
-                  "Finalized trie root {} availability: {}",
-                  fRoot.take(8).toArray.map("%02x".format(_)).mkString,
-                  if (fRootExists) "EXISTS" else "MISSING"
-                )
-                if (fRootExists) {
-                  log.warning(
-                    "Substituting finalized trie root {} into pivot block header (replacing missing root {})",
+        // D3: Startup HasState gate — mirrors go-ethereum eth/downloader/syncmode.go:52
+        // (chain.HasState(fullBlock.Root) → re-enable snap sync) and Besu
+        // FullSyncTargetManager.java:60-75 (isWorldStateAvailable → gate entry to full sync).
+        // If the pivot state root is unreachable, clear SnapSyncDone and restart SNAP rather
+        // than entering regular sync against an incomplete trie.
+        val stateRootReachable: Boolean = bestBlockHeader match {
+          case None =>
+            // Can't verify — assume ok (pivot header missing is a separate problem)
+            true
+          case Some(header) =>
+            val mptStorage = stateStorage.getReadOnlyStorage
+            val pivotRootExists =
+              try { mptStorage.get(header.stateRoot.toArray); true }
+              catch { case _: Exception => false }
+            log.info(
+              "State root availability check: pivotRoot({})={}",
+              header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString,
+              if (pivotRootExists) "EXISTS" else "MISSING"
+            )
+            if (pivotRootExists) {
+              true
+            } else {
+              // Pivot root missing — check if a finalized root was stored (from deferred
+              // merkleization / pivot refresh). If it exists, substitute it into the header
+              // and continue (existing recovery path). If not, restart SNAP.
+              val finalizedRoot = appStateStorage.getSnapSyncFinalizedRoot()
+              finalizedRoot match {
+                case Some(fRoot) =>
+                  val fRootExists =
+                    try { mptStorage.get(fRoot.toArray); true }
+                    catch { case _: Exception => false }
+                  log.info(
+                    "Finalized trie root {} availability: {}",
                     fRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                    if (fRootExists) "EXISTS" else "MISSING"
+                  )
+                  if (fRootExists) {
+                    log.warning(
+                      "Substituting finalized trie root {} into pivot block header (replacing missing root {})",
+                      fRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                      header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
+                    )
+                    val updatedHeader = header.copy(stateRoot = fRoot)
+                    blockchainWriter.storeBlockHeader(updatedHeader).commit()
+                    true
+                  } else {
+                    log.error(
+                      "Pivot state root {} MISSING and finalized root {} also not in storage.",
+                      header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                      fRoot.take(8).toArray.map("%02x".format(_)).mkString
+                    )
+                    false
+                  }
+                case None =>
+                  log.error(
+                    "Pivot state root {} MISSING and no finalized root stored.",
                     header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
                   )
-                  val updatedHeader = header.copy(stateRoot = fRoot)
-                  blockchainWriter.storeBlockHeader(updatedHeader).commit()
-                }
-              case None =>
-                log.error(
-                  "Pivot state root {} MISSING and no finalized root stored! " +
-                    "Database is in an unrecoverable state — clear data and re-sync.",
-                  header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
-                )
+                  false
+              }
             }
-          }
         }
+
+        if (!stateRootReachable) {
+          log.warning(
+            "SnapSyncDone=true but pivot state root is unreachable in storage. " +
+              "Clearing SnapSyncDone and restarting SNAP sync with a fresh pivot. " +
+              "(mirrors go-ethereum chain.HasState gate in eth/downloader/syncmode.go:52)"
+          )
+          appStateStorage.clearSnapSyncDone().commit()
+          startSnapSync()
+          return
+        }
+
         val needBytecode = !appStateStorage.isBytecodeRecoveryDone()
         val needStorage = !appStateStorage.isStorageRecoveryDone()
         if (needBytecode || needStorage) {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -77,9 +77,9 @@ class SyncController(
   // pool is smaller so we use exponential backoff (30s base, 5min cap).
   // Reset to 0 on ImportedBlock milestone (evidence that healing succeeded).
   private var healingRestartCount: Int = 0
-  private val maxHealingRestarts: Int  = 3
-  private val healingRestartBaseDelay: FiniteDuration  = 30.seconds
-  private val healingRestartMaxDelay: FiniteDuration   = 5.minutes
+  private val maxHealingRestarts: Int = 3
+  private val healingRestartBaseDelay: FiniteDuration = 30.seconds
+  private val healingRestartMaxDelay: FiniteDuration = 5.minutes
 
   private def stopSyncChildren(): Unit = {
     // Stop all sync-related child actors. Names may have generation suffixes
@@ -295,8 +295,9 @@ class SyncController(
           )
           startSnapSync()
         } else {
-          val backoffRaw = healingRestartBaseDelay * math.pow(2.0, (healingRestartCount - maxHealingRestarts).toDouble).toLong
-          val backoff    = if (backoffRaw > healingRestartMaxDelay) healingRestartMaxDelay else backoffRaw
+          val backoffRaw =
+            healingRestartBaseDelay * math.pow(2.0, (healingRestartCount - maxHealingRestarts).toDouble).toLong
+          val backoff = if (backoffRaw > healingRestartMaxDelay) healingRestartMaxDelay else backoffRaw
           log.error(
             "Trie healing impossible after {} consecutive restarts. " +
               "Backing off {}s before re-pivoting. All known peers have pruned the pivot state root.",

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncProtocol.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncProtocol.scala
@@ -26,9 +26,9 @@ object SyncProtocol {
     */
   final case class RegularSyncStuck(blockNumber: BigInt, missingHash: String) extends SyncProtocolMsg
 
-  /** Sent by RegularSync when trie healing is permanently stuck (GetTrieNodes returns empty from all peers,
-    * meaning the pivot state root has been pruned). SyncController clears SnapSyncDone and restarts SNAP sync
-    * with a fresh current pivot. Mirrors Besu's StalledDownloadException → PivotSyncDownloader.handleFailure().
+  /** Sent by RegularSync when trie healing is permanently stuck (GetTrieNodes returns empty from all peers, meaning the
+    * pivot state root has been pruned). SyncController clears SnapSyncDone and restarts SNAP sync with a fresh current
+    * pivot. Mirrors Besu's StalledDownloadException → PivotSyncDownloader.handleFailure().
     */
   case object HealingImpossible extends SyncProtocolMsg
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncProtocol.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncProtocol.scala
@@ -26,6 +26,12 @@ object SyncProtocol {
     */
   final case class RegularSyncStuck(blockNumber: BigInt, missingHash: String) extends SyncProtocolMsg
 
+  /** Sent by RegularSync when trie healing is permanently stuck (GetTrieNodes returns empty from all peers,
+    * meaning the pivot state root has been pruned). SyncController clears SnapSyncDone and restarts SNAP sync
+    * with a fresh current pivot. Mirrors Besu's StalledDownloadException → PivotSyncDownloader.handleFailure().
+    */
+  case object HealingImpossible extends SyncProtocolMsg
+
   sealed trait Status {
     def syncing: Boolean = this match {
       case Status.Syncing(_, _, _) => true

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -112,10 +112,11 @@ class BlockImporter(
       // B1: Only reset healingStallCount on a CLEAN import (no state node fetches required).
       // Mirrors Besu WorldDownloadState.requestComplete(madeProgress): resets only when madeProgress==true.
       // A healing-assisted import keeps the stall signal — only truly clean blocks reset it.
-      val newState = if (state.healingNodesFetchedThisBlock == 0)
-        state.notImportingBlocks().branchResolved().healingResolved()
-      else
-        state.notImportingBlocks().branchResolved()
+      val newState =
+        if (state.healingNodesFetchedThisBlock == 0)
+          state.notImportingBlocks().branchResolved().healingResolved()
+        else
+          state.notImportingBlocks().branchResolved()
       val behavior: Behavior = getBehavior(newBehavior, importType)
       if (newBehavior == Running) {
         self ! PickBlocks

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -88,7 +88,7 @@ class BlockImporter(
 
     case BlockFetcher.PickedBlocks(blocks) =>
       SignedTransaction.retrieveSendersInBackGround(blocks.toList.map(_.body))
-      importBlocks(blocks, DefaultBlockImport)(state)
+      importBlocks(blocks, DefaultBlockImport)(state.resetNodesFetched())
 
     case MinedBlock(block) if !state.importing =>
       importBlock(
@@ -109,7 +109,13 @@ class BlockImporter(
       )(state)
 
     case ImportDone(newBehavior, importType) =>
-      val newState = state.notImportingBlocks().branchResolved()
+      // B1: Only reset healingStallCount on a CLEAN import (no state node fetches required).
+      // Mirrors Besu WorldDownloadState.requestComplete(madeProgress): resets only when madeProgress==true.
+      // A healing-assisted import keeps the stall signal — only truly clean blocks reset it.
+      val newState = if (state.healingNodesFetchedThisBlock == 0)
+        state.notImportingBlocks().branchResolved().healingResolved()
+      else
+        state.notImportingBlocks().branchResolved()
       val behavior: Behavior = getBehavior(newBehavior, importType)
       if (newBehavior == Running) {
         self ! PickBlocks
@@ -135,18 +141,26 @@ class BlockImporter(
       state: ImporterState
   ): Receive = {
     case BlockFetcher.FetchedStateNode(nodeData) if nodeData.values.isEmpty =>
-      // StateNodeFetcher exhausted MaxStateNodeFetchRetries on this missing node — no current peer
-      // can serve it via SNAP GetTrieNodes (typical: pivot fell out of the 128-block serve window
-      // on every connected peer).
+      // StateNodeFetcher exhausted SNAP GetTrieNodes across all peers with no result.
+      // Two escalation paths:
+      //   (1) HealingImpossible: pivot state root pruned on all peers → restart SNAP (Besu pattern)
+      //   (2) RegularSyncStuck: repeated exhausts → SNAP re-sync escape valve
       val blockNum = blocksToRetry.head.number
       consecutiveExhausts += 1
       val missingHashStr = pendingStateNodeHash.map(ByteStringUtils.hash2string).getOrElse("<unknown>")
+      val newStallCount = state.healingStallCount + 1
 
-      if (consecutiveExhausts >= BlockImporter.StuckEscapeThreshold) {
-        // Multiple consecutive exhausts mean peers genuinely don't have our parent state and
-        // never will (we're far behind their snap-serve window). The only recovery is to re-pivot
-        // via SNAP. Reset our local counter so we don't re-fire if SyncController bounces us back
-        // to regular sync; the SnapFastEscapeHatch handles cycle limits.
+      if (newStallCount >= HealingImpossibleThreshold) {
+        log.error(
+          "Trie healing impossible for block {} after {} consecutive failures — " +
+            "GetTrieNodes returns empty from all peers (pivot state root pruned). Escalating to restart SNAP sync.",
+          blockNum,
+          newStallCount
+        )
+        supervisor ! ProgressProtocol.HealingImpossible
+        context.setReceiveTimeout(syncConfig.syncRetryInterval)
+        context.become(running(state.copy(healingStallCount = 0)))
+      } else if (consecutiveExhausts >= BlockImporter.StuckEscapeThreshold) {
         log.error(
           "Regular sync stuck on block {} after {} consecutive state-node exhausts (missing {}); requesting SNAP re-sync",
           blockNum,
@@ -156,11 +170,12 @@ class BlockImporter(
         consecutiveExhausts = 0
         pendingStateNodeHash = None
         supervisor ! SyncProtocol.RegularSyncStuck(blockNum, missingHashStr)
-        // Don't transition further — SyncController will PoisonPill regular sync.
       } else {
         log.error(
-          "State node recovery failed after max retries for block {} (consecutive exhausts: {}/{}) — backing off {}s before retry",
+          "State node recovery failed after max retries for block {} (stall {}/{}, exhausts {}/{}) — backing off {}s before retry",
           blockNum,
+          newStallCount,
+          HealingImpossibleThreshold,
           consecutiveExhausts,
           BlockImporter.StuckEscapeThreshold,
           5.minutes.toSeconds
@@ -170,9 +185,8 @@ class BlockImporter(
           "state node unrecoverable after max retries",
           shouldBlacklist = false
         )
-        // Don't self ! PickBlocks — that would immediately retry the same block.
         context.setReceiveTimeout(5.minutes)
-        context.become(running(state))
+        context.become(running(state.copy(healingStallCount = newStallCount)))
       }
 
     case BlockFetcher.FetchedStateNode(nodeData) =>
@@ -188,11 +202,11 @@ class BlockImporter(
       // and the data is the bytecode. EvmCodeStorage is keyed by codeHash, same as the fetch.
       try evmCodeStorage.put(hash, node).commit()
       catch { case _: Exception => () }
-      // Successful state-node delivery — reset stuck-counter so a later transient failure on a
-      // different block doesn't escalate to SNAP re-sync prematurely.
+      // Successful state-node delivery — reset stuck-counter so a later transient failure
+      // doesn't escalate prematurely. B1: Track that this block needed healing.
       consecutiveExhausts = 0
       pendingStateNodeHash = None
-      importBlocks(blocksToRetry, blockImportType)(state)
+      importBlocks(blocksToRetry, blockImportType)(state.nodesFetched())
 
     case ReceiveTimeout =>
       log.warning("Timed out waiting for missing state node for block {}, retrying import", blocksToRetry.head.number)
@@ -825,6 +839,11 @@ object BlockImporter {
   // 3 × 5-min backoff = ~15 minutes of bounded retry before invoking the escape valve.
   val StuckEscapeThreshold: Int = 3
 
+  // After this many consecutive trie-healing stalls (StateNodeFetcher returned empty from all peers),
+  // escalate HealingImpossible → SyncController → restart SNAP with a fresh current pivot.
+  // Besu: ~100 requestsWithoutProgress → StalledDownloadException → PivotSyncDownloader.handleFailure().
+  val HealingImpossibleThreshold: Int = 2
+
   // scalastyle:off parameter.number
   def props(
       fetcher: ActorRef,
@@ -891,7 +910,9 @@ object BlockImporter {
 
   case class ImporterState(
       importing: Boolean,
-      resolvingBranchFrom: Option[BigInt]
+      resolvingBranchFrom: Option[BigInt],
+      healingStallCount: Int = 0,
+      healingNodesFetchedThisBlock: Int = 0
   ) {
     def importingBlocks(): ImporterState = copy(importing = true)
 
@@ -902,6 +923,14 @@ object BlockImporter {
     def branchResolved(): ImporterState = copy(resolvingBranchFrom = None)
 
     def isResolvingBranch: Boolean = resolvingBranchFrom.isDefined
+
+    def healingStalled(): ImporterState = copy(healingStallCount = healingStallCount + 1)
+
+    def healingResolved(): ImporterState = copy(healingStallCount = 0)
+
+    def nodesFetched(): ImporterState = copy(healingNodesFetchedThisBlock = healingNodesFetchedThisBlock + 1)
+
+    def resetNodesFetched(): ImporterState = copy(healingNodesFetchedThisBlock = 0)
   }
 
   object ImporterState {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -130,15 +130,16 @@ class RegularSync(
       context.become(running(newState))
 
     case msg: SyncProtocol.RegularSyncStuck =>
-      // Forward escape-valve signal to SyncController (our parent). BlockImporter detects this
-      // condition and emits the message; we just relay it up so SyncController can re-trigger
-      // SNAP sync from a recent pivot.
       log.warning(
         "Regular sync stuck on block {} (missing {}); forwarding to SyncController for SNAP re-sync",
         msg.blockNumber,
         msg.missingHash
       )
       context.parent ! msg
+
+    case ProgressProtocol.HealingImpossible =>
+      log.error("Trie healing impossible — pivot state root pruned on all peers. Forwarding to SyncController to restart SNAP sync.")
+      context.parent ! SyncProtocol.HealingImpossible
   }
 
   override def supervisorStrategy: SupervisorStrategy = AllForOneStrategy()(SupervisorStrategy.defaultDecider)
@@ -208,5 +209,8 @@ object RegularSync {
     case class StartingFrom(blockNumber: BigInt) extends ProgressProtocol
     case class GotNewBlock(blockNumber: BigInt) extends ProgressProtocol
     case class ImportedBlock(blockNumber: BigInt, internally: Boolean) extends ProgressProtocol
+    // Sent by BlockImporter when trie healing is permanently stuck (pivot state root pruned on all peers).
+    // RegularSync forwards to SyncController which clears SnapSyncDone and restarts SNAP.
+    case object HealingImpossible extends ProgressProtocol
   }
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -138,7 +138,9 @@ class RegularSync(
       context.parent ! msg
 
     case ProgressProtocol.HealingImpossible =>
-      log.error("Trie healing impossible — pivot state root pruned on all peers. Forwarding to SyncController to restart SNAP sync.")
+      log.error(
+        "Trie healing impossible — pivot state root pruned on all peers. Forwarding to SyncController to restart SNAP sync."
+      )
       context.parent ! SyncProtocol.HealingImpossible
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
@@ -143,9 +143,9 @@ class StateNodeFetcher(
       case _ => Behaviors.unhandled
     }
 
-  /** Increment attempt counter and either schedule another request or signal exhaustion to the
-    * BlockImporter. Sending an empty FetchedStateNode triggers BlockImporter's 5-minute backoff
-    * handler so the resolvingMissingNode → import-fail → re-fetch loop can't spin indefinitely.
+  /** Increment attempt counter and either schedule another request or signal exhaustion to the BlockImporter. Sending
+    * an empty FetchedStateNode triggers BlockImporter's 5-minute backoff handler so the resolvingMissingNode →
+    * import-fail → re-fetch loop can't spin indefinitely.
     */
   private def retryOrExhaust(req: StateNodeRequester): Unit = {
     val nextAttempt = req.attempts + 1
@@ -173,10 +173,15 @@ class StateNodeFetcher(
 
         validatedNode match {
           case Left(err) =>
-            log.debug("State node validation failed with {}, excluding peer {} from next GetNodeData attempt", err.description, peer.id)
+            log.debug(
+              "State node validation failed with {}, excluding peer {} from next GetNodeData attempt",
+              err.description,
+              peer.id
+            )
             peersClient ! RecordNodeDataFailure(peer.id)
             peersClient ! BlacklistPeer(peer.id, err)
-            requester = Some(stateNodeRequester.copy(triedNodeDataPeers = stateNodeRequester.triedNodeDataPeers + peer.id))
+            requester =
+              Some(stateNodeRequester.copy(triedNodeDataPeers = stateNodeRequester.triedNodeDataPeers + peer.id))
             retryOrExhaust(stateNodeRequester)
             Behaviors.same[StateNodeFetcherCommand]
           case Right(node) =>
@@ -252,9 +257,9 @@ class StateNodeFetcher(
       }
       .getOrElse(Behaviors.same)
 
-  /** If the requester still has an unused fallback canonical root, swap it in as the primary
-    * stateRoot and clear the fallback slot (so we only switch once). Returns None when no
-    * fallback is available or it has already been consumed.
+  /** If the requester still has an unused fallback canonical root, swap it in as the primary stateRoot and clear the
+    * fallback slot (so we only switch once). Returns None when no fallback is available or it has already been
+    * consumed.
     */
   private def maybeSwitchToFallbackRoot(req: StateNodeRequester): Option[StateNodeRequester] =
     req.fallbackStateRoot
@@ -324,7 +329,8 @@ class StateNodeFetcher(
           // SNAP-capable peers use BONSAI storage (state diffs, not hash-keyed nodes) and cannot
           // serve GetNodeData. Besu gates SNAP serving on isBonsaiFormat() — all SNAP peers = BONSAI.
           val triedNodeData = requester.map(_.triedNodeDataPeers).getOrElse(Set.empty)
-          val nodeDataSelector = if (triedNodeData.isEmpty) BestNodeDataPeer else BestNodeDataPeerExcluding(triedNodeData)
+          val nodeDataSelector =
+            if (triedNodeData.isEmpty) BestNodeDataPeer else BestNodeDataPeerExcluding(triedNodeData)
           log.debug("Requesting missing state node via GetNodeData (tried {} peers)", triedNodeData.size)
           val resp = makeRequest(
             Request.create(GetNodeData(List(hash)), nodeDataSelector),

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
@@ -11,6 +11,7 @@ import org.apache.pekko.util.ByteString
 import cats.effect.unsafe.IORuntime
 import cats.syntax.either._
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
@@ -21,6 +22,7 @@ import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchCommand
 import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchedStateNode
 import com.chipprbots.ethereum.crypto.kec256
 import com.chipprbots.ethereum.network.Peer
+import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.p2p.Message
 import com.chipprbots.ethereum.network.p2p.messages.ETH63.GetNodeData
 import com.chipprbots.ethereum.network.p2p.messages.ETH63.NodeData
@@ -53,6 +55,19 @@ class StateNodeFetcher(
 
   private var requester: Option[StateNodeRequester] = None
 
+  // B5: Session-scoped stateless-peer set — peers that returned empty GetTrieNodes responses.
+  // Peers with pruned state roots cannot serve healing requests for the entire healing session.
+  // Cleared automatically when the actor is recreated (HealingImpossible → RegularSync restart).
+  // Mirrors go-ethereum eth/protocols/snap/sync.go:2929-2936 statelessPeers map.
+  private val statelessPeers = mutable.Set.empty[PeerId]
+
+  // Generation counter: incremented on each new FetchStateNode. Stale pipeToSelf callbacks
+  // from superseded requests carry the old generation and are silently dropped.
+  // Prevents request multiplication when BlockImporter sends a new FetchStateNode before
+  // the previous one's callbacks have resolved (Besu: single CompletableFuture chain,
+  // no concurrent requests possible).
+  private var requestGeneration: Int = 0
+
   override def onMessage(message: StateNodeFetcherCommand): Behavior[StateNodeFetcherCommand] =
     message match {
       case StateNodeFetcher.FetchStateNode(hash, sender, stateRoot, paths, _, isByteCode, fallbackRoot) =>
@@ -76,6 +91,7 @@ class StateNodeFetcher(
               paths.isDefined,
               fallbackRoot.isDefined
             )
+            requestGeneration += 1
             requester = Some(
               StateNodeRequester(hash, sender, stateRoot, paths, attempts = 0, isByteCode, fallbackRoot)
             )
@@ -94,15 +110,15 @@ class StateNodeFetcher(
         val values = rlpValues.items.collect { case RLPValue(bytes) => ByteString(bytes) }
         handleNodeDataValues(peer, values)
 
+      // SNAP ByteCodes response (for contract code recovery via GetByteCodes)
+      case AdaptedMessage(peer, ByteCodes(_, codes)) if requester.isDefined =>
+        log.info("Received SNAP ByteCodes response from peer {} with {} codes", peer, codes.size)
+        handleByteCodesValues(peer, codes)
+
       // SNAP TrieNodes response
       case AdaptedMessage(peer, TrieNodes(_, nodes)) if requester.isDefined =>
         log.info("Received SNAP TrieNodes response from peer {} with {} nodes", peer, nodes.size)
         handleTrieNodesValues(peer, nodes)
-
-      // SNAP ByteCodes response
-      case AdaptedMessage(peer, ByteCodes(_, codes)) if requester.isDefined =>
-        log.info("Received SNAP ByteCodes response from peer {} with {} codes", peer, codes.size)
-        handleByteCodesValues(peer, codes)
 
       case StateNodeFetcher.RetryStateNodeRequest =>
         // The peer request resolved to NoSuitablePeer / RequestFailed and FetchRequest piped this
@@ -127,9 +143,9 @@ class StateNodeFetcher(
       case _ => Behaviors.unhandled
     }
 
-  /** Increment attempt counter and either schedule another request or signal exhaustion to the BlockImporter. Sending
-    * an empty FetchedStateNode triggers BlockImporter's 5-minute backoff handler so the resolvingMissingNode →
-    * import-fail → re-fetch loop can't spin indefinitely.
+  /** Increment attempt counter and either schedule another request or signal exhaustion to the
+    * BlockImporter. Sending an empty FetchedStateNode triggers BlockImporter's 5-minute backoff
+    * handler so the resolvingMissingNode → import-fail → re-fetch loop can't spin indefinitely.
     */
   private def retryOrExhaust(req: StateNodeRequester): Unit = {
     val nextAttempt = req.attempts + 1
@@ -157,8 +173,10 @@ class StateNodeFetcher(
 
         validatedNode match {
           case Left(err) =>
-            log.debug("State node validation failed with {}", err.description)
+            log.debug("State node validation failed with {}, excluding peer {} from next GetNodeData attempt", err.description, peer.id)
+            peersClient ! RecordNodeDataFailure(peer.id)
             peersClient ! BlacklistPeer(peer.id, err)
+            requester = Some(stateNodeRequester.copy(triedNodeDataPeers = stateNodeRequester.triedNodeDataPeers + peer.id))
             retryOrExhaust(stateNodeRequester)
             Behaviors.same[StateNodeFetcherCommand]
           case Right(node) =>
@@ -190,6 +208,10 @@ class StateNodeFetcher(
               Behaviors.same[StateNodeFetcherCommand]
             case None =>
               log.warn("SNAP TrieNodes response was empty, retrying")
+              // B5: Add to session-scoped stateless set — peer cannot serve trie nodes for this state root.
+              // Mirrors go-ethereum sync.go:2929 `s.statelessPeers[peer.ID()] = struct{}{}`.
+              statelessPeers += peer.id
+              requester = Some(stateNodeRequester.copy(triedSnapPeers = stateNodeRequester.triedSnapPeers + peer.id))
               peersClient ! BlacklistPeer(peer.id, BlacklistReason.EmptyStateNodeResponse)
               retryOrExhaust(stateNodeRequester)
               Behaviors.same[StateNodeFetcherCommand]
@@ -230,9 +252,9 @@ class StateNodeFetcher(
       }
       .getOrElse(Behaviors.same)
 
-  /** If the requester still has an unused fallback canonical root, swap it in as the primary stateRoot and clear the
-    * fallback slot (so we only switch once). Returns None when no fallback is available or it has already been
-    * consumed.
+  /** If the requester still has an unused fallback canonical root, swap it in as the primary
+    * stateRoot and clear the fallback slot (so we only switch once). Returns None when no
+    * fallback is available or it has already been consumed.
     */
   private def maybeSwitchToFallbackRoot(req: StateNodeRequester): Option[StateNodeRequester] =
     req.fallbackStateRoot
@@ -249,6 +271,7 @@ class StateNodeFetcher(
           // requested codes — equivalent to a stateless response. Retry against another peer.
           log.warn("SNAP ByteCodes response was empty, retrying")
           peersClient ! BlacklistPeer(peer.id, BlacklistReason.EmptyStateNodeResponse)
+          requester = Some(stateNodeRequester.copy(triedSnapPeers = stateNodeRequester.triedSnapPeers + peer.id))
           retryOrExhaust(stateNodeRequester)
           Behaviors.same[StateNodeFetcherCommand]
         } else {
@@ -267,6 +290,7 @@ class StateNodeFetcher(
             case None =>
               log.warn("SNAP ByteCodes: got {} codes but none matched target codeHash, retrying", codes.size)
               peersClient ! BlacklistPeer(peer.id, BlacklistReason.WrongStateNodeResponse)
+              requester = Some(stateNodeRequester.copy(triedSnapPeers = stateNodeRequester.triedSnapPeers + peer.id))
               retryOrExhaust(stateNodeRequester)
               Behaviors.same[StateNodeFetcherCommand]
           }
@@ -296,10 +320,14 @@ class StateNodeFetcher(
           sendGetTrieNodes(root, pathGroups)
 
         case _ =>
-          // Fallback to GetNodeData (pre-ETH68 peers only)
-          log.debug("Requesting missing state node via GetNodeData (no SNAP paths available)")
+          // Fallback to GetNodeData — route to non-SNAP peers only.
+          // SNAP-capable peers use BONSAI storage (state diffs, not hash-keyed nodes) and cannot
+          // serve GetNodeData. Besu gates SNAP serving on isBonsaiFormat() — all SNAP peers = BONSAI.
+          val triedNodeData = requester.map(_.triedNodeDataPeers).getOrElse(Set.empty)
+          val nodeDataSelector = if (triedNodeData.isEmpty) BestNodeDataPeer else BestNodeDataPeerExcluding(triedNodeData)
+          log.debug("Requesting missing state node via GetNodeData (tried {} peers)", triedNodeData.size)
           val resp = makeRequest(
-            Request.create(GetNodeData(List(hash)), BestNodeDataPeer),
+            Request.create(GetNodeData(List(hash)), nodeDataSelector),
             StateNodeFetcher.RetryStateNodeRequest
           )
           context.pipeToSelf(resp.unsafeToFuture()) {
@@ -309,20 +337,21 @@ class StateNodeFetcher(
       }
     }
 
-  private def sendGetTrieNodes(root: ByteString, pathGroups: Seq[Seq[ByteString]]): Unit = {
-    log.info(
-      "Requesting missing state node via SNAP GetTrieNodes ({} path groups, root={})",
-      pathGroups.size,
-      root.take(4).toArray.map("%02x".format(_)).mkString
+  private def sendGetByteCodes(hash: ByteString): Unit = {
+    log.debug(
+      "Requesting missing contract bytecode via SNAP GetByteCodes (hash={})",
+      ByteStringUtils.hash2string(hash)
     )
-    val request = GetTrieNodes(
+    // B5: Union per-request tried peers with session-scoped stateless peers before peer selection
+    val triedSnap = requester.map(_.triedSnapPeers).getOrElse(Set.empty) ++ statelessPeers
+    val snapSelector = if (triedSnap.isEmpty) BestSnapPeer else BestSnapPeerExcluding(triedSnap)
+    val request = GetByteCodes(
       requestId = ETH66.nextRequestId,
-      rootHash = root,
-      paths = pathGroups,
+      hashes = Seq(hash),
       responseBytes = BigInt(512 * 1024)
     )
     val resp = makeRequest(
-      Request(request, BestSnapPeer, (msg: GetTrieNodes) => new GetTrieNodesEnc(msg)),
+      Request(request, snapSelector, (msg: GetByteCodes) => new GetByteCodesEnc(msg)),
       StateNodeFetcher.RetryStateNodeRequest
     )
     context.pipeToSelf(resp.unsafeToFuture()) {
@@ -331,23 +360,24 @@ class StateNodeFetcher(
     }
   }
 
-  /** Fetch a single contract bytecode by codeHash via SNAP GetByteCodes. Used when post-fast-sync regular sync hits a
-    * "Block has invalid gas used" error and findMissingContractCode identifies a missing bytecode. SNAP's GetByteCodes
-    * is served by every snap-capable peer regardless of their ETH version, so this works even when the entire peer set
-    * is ETH68+ (no GetNodeData).
-    */
-  private def sendGetByteCodes(codeHash: ByteString): Unit = {
-    log.info(
-      "Requesting missing bytecode via SNAP GetByteCodes (codeHash={})",
-      ByteStringUtils.hash2string(codeHash)
+  private def sendGetTrieNodes(root: ByteString, pathGroups: Seq[Seq[ByteString]]): Unit = {
+    // B5: Union per-request tried peers with session-scoped stateless peers before peer selection
+    val triedSnap = requester.map(_.triedSnapPeers).getOrElse(Set.empty) ++ statelessPeers
+    val snapSelector = if (triedSnap.isEmpty) BestSnapPeer else BestSnapPeerExcluding(triedSnap)
+    log.debug(
+      "Requesting missing state node via SNAP GetTrieNodes ({} path groups, root={}, excluding {} tried peers)",
+      pathGroups.size,
+      root.take(4).toArray.map("%02x".format(_)).mkString,
+      triedSnap.size
     )
-    val request = GetByteCodes(
+    val request = GetTrieNodes(
       requestId = ETH66.nextRequestId,
-      hashes = Seq(codeHash),
+      rootHash = root,
+      paths = pathGroups,
       responseBytes = BigInt(512 * 1024)
     )
     val resp = makeRequest(
-      Request(request, BestSnapPeer, (msg: GetByteCodes) => new GetByteCodesEnc(msg)),
+      Request(request, snapSelector, (msg: GetTrieNodes) => new GetTrieNodesEnc(msg)),
       StateNodeFetcher.RetryStateNodeRequest
     )
     context.pipeToSelf(resp.unsafeToFuture()) {
@@ -372,6 +402,12 @@ object StateNodeFetcher {
   // disconnect on every GetTrieNodes request).
   val MaxStateNodeFetchRetries: Int = 10
   val BackoffInterval: FiniteDuration = 5.seconds
+
+  // After this many consecutive empty SNAP TrieNodes responses from all peers, signal failure.
+  // ETH/68 removed GetNodeData — there is no fallback. Empty from all peers means the state root
+  // is pruned. BlockImporter escalates HealingImpossible after 2 such failures → restart SNAP.
+  // Besu: RetryingGetTrieNodeFromPeerTask.MAX_RETRIES = 4 across peers per request, then exception.
+  val SnapFallbackThreshold: Int = 5
 
   sealed trait StateNodeFetcherCommand
   final case class FetchStateNode(
@@ -398,6 +434,8 @@ object StateNodeFetcher {
       isByteCode: Boolean = false,
       // One-shot fallback root: cleared the moment we switch to it, so we only attempt the
       // root-swap once per recovery (no flip-flop between primary and fallback).
-      fallbackStateRoot: Option[ByteString] = None
+      fallbackStateRoot: Option[ByteString] = None,
+      triedSnapPeers: Set[PeerId] = Set.empty,
+      triedNodeDataPeers: Set[PeerId] = Set.empty
   )
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2098,15 +2098,22 @@ class SNAPSyncController(
               validationRetryCount += 1
 
               if (validationRetryCount > MaxValidationRetries) {
-                log.warning(
-                  s"Root node missing after $validationRetryCount validation attempts. " +
-                    s"Proceeding to regular sync — missing nodes will be fetched on-demand during block execution."
-                )
-                // Skip validation and proceed: mark SNAP done, start regular sync.
-                // With deferred merkleization, the root node was never built from flat data.
-                // Regular sync's StateNodeFetcher will retrieve it via GetTrieNodes when needed.
-                appStateStorage.snapSyncDone().commit()
-                context.parent ! Done
+                // Root node still missing after all retries — state trie is incomplete.
+                // RegularSync cannot recover this: eth/68 peers don't serve GetNodeData, and
+                // local Besu uses BONSAI storage (state diffs, not hash-keyed trie nodes).
+                // Restart SNAP with a fresh pivot rather than handing broken state to RegularSync.
+                val retryMsg = s"root node missing after $validationRetryCount validation retries"
+                if (recordCriticalFailure(retryMsg)) {
+                  log.error("Too many critical SNAP failures — falling back to fast sync")
+                  fallbackToFastSync()
+                } else {
+                  log.warning(
+                    s"Root node missing after $validationRetryCount validation attempts. " +
+                      s"Restarting SNAP sync with a fresh pivot to rebuild the state trie."
+                  )
+                  validationRetryCount = 0
+                  restartSnapSync(retryMsg)
+                }
               } else {
                 log.error(s"Root node is missing (retry attempt $validationRetryCount of $MaxValidationRetries)")
                 log.info("Retrying validation after brief delay...")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -127,6 +127,10 @@ class SNAPSyncController(
   private var healingRequestTask: Option[Cancellable] = None
   private var storageStagnationRefreshAttempted: Boolean = false
   private var trieWalkInProgress: Boolean = false
+  // Monotonic counter that tags every async walk future. Incremented whenever a new walk is
+  // started (startTrieWalk / triggerHealingForMissingNodes) or the pivot changes during healing.
+  // Messages from a prior epoch carry a stale generation and are discarded on arrival.
+  private var walkGeneration: Long = 0L
   private var healingRoundCount: Int = 0
   private var bootstrapCheckTask: Option[Cancellable] = None
   private var pivotBootstrapRetryTask: Option[Cancellable] = None
@@ -580,49 +584,88 @@ class SNAPSyncController(
         // A trie walk is already running — its result will determine next step
         log.info("Trie walk in progress, waiting for result...")
       } else {
-        // No walk in progress — start one to check for deeper missing nodes
-        startTrieWalk()
+        // ARCH-WALK-HEAL-INTERLEAVE: Start walk with coordinator alive (if still running) or
+        // create a fresh coordinator before the walk so inline discovery can run concurrently.
+        startStateHealingWithInterleave()
       }
 
-    case TrieWalkResult(missingNodes) if currentPhase == StateHealing =>
-      trieWalkInProgress = false
-      if (missingNodes.isEmpty) {
-        log.info("Trie walk found no missing nodes — healing complete after {} rounds!", healingRoundCount)
-        healingRoundCount = 0
-        // Commit final pivot root — deferred from refreshPivotInPlace() to prevent BUG-006.
-        // AppStateStorage now reflects the root that healing actually completed against.
-        pivotBlock.foreach(b => appStateStorage.putSnapSyncPivotBlock(b).commit())
-        stateRoot.foreach(r => appStateStorage.putSnapSyncStateRoot(r).commit())
-        progressMonitor.startPhase(StateValidation)
-        currentPhase = StateValidation
-        validateState()
-      } else {
-        // A2: Loop indefinitely until Pending==0 — mirrors go-ethereum sync.go:1400
-        // `for len(s.healer.trieTasks) > 0 || s.healer.scheduler.Pending() > 0` and
-        // Besu SnapWorldDownloadState.java:177-185 `allTasksCompleted()` loop with no round cap.
-        // Missing nodes are re-queued; peer scoring (B5) handles unresponsive peers.
-        healingRoundCount += 1
-        log.info(
-          s"Trie walk found ${missingNodes.size} missing nodes — queuing for healing (round $healingRoundCount)"
-        )
+    // Streaming batch from ongoing trie walk — forward immediately to coordinator for early healing
+    case TrieWalkBatch(gen, missingNodes) if currentPhase == StateHealing =>
+      if (gen != walkGeneration) {
+        log.debug(s"Discarding stale TrieWalkBatch (epoch $gen, current $walkGeneration)")
+      } else if (missingNodes.nonEmpty) {
+        log.info(s"Trie walk batch: ${missingNodes.size} missing nodes — queuing for healing")
         trieNodeHealingCoordinator.foreach { coordinator =>
           coordinator ! actors.Messages.QueueMissingNodes(missingNodes)
         }
-        // Schedule next overlapping trie walk — don't wait for healing to complete
-        scheduler.scheduleOnce(2.minutes) {
-          self ! ScheduledTrieWalk
-        }(ec)
+      }
+
+    // Streaming walk completed — all batches already sent via TrieWalkBatch
+    case TrieWalkComplete(gen, totalFound) if currentPhase == StateHealing =>
+      if (gen != walkGeneration) {
+        log.debug(s"Discarding stale TrieWalkComplete (epoch $gen, current $walkGeneration)")
+      } else {
+        trieWalkInProgress = false
+        if (totalFound == 0) {
+          log.info("Trie walk found no missing nodes — healing complete after {} rounds!", healingRoundCount)
+          healingRoundCount = 0
+          for (b <- pivotBlock; r <- stateRoot)
+            appStateStorage.putSnapSyncPivotBlock(b).and(appStateStorage.putSnapSyncStateRoot(r)).commit()
+          progressMonitor.startPhase(StateValidation)
+          currentPhase = StateValidation
+          validateState()
+        } else {
+          // A2: Loop indefinitely until Pending==0 — mirrors go-ethereum sync.go:1400
+          healingRoundCount += 1
+          log.info(
+            s"Trie walk complete: $totalFound missing nodes queued across batches (round $healingRoundCount)"
+          )
+          scheduler.scheduleOnce(2.minutes) {
+            self ! ScheduledTrieWalk
+          }(ec)
+        }
+      }
+
+    case TrieWalkResult(gen, missingNodes) if currentPhase == StateHealing =>
+      if (gen != walkGeneration) {
+        log.debug(s"Discarding stale TrieWalkResult (epoch $gen, current $walkGeneration)")
+      } else {
+        trieWalkInProgress = false
+        if (missingNodes.isEmpty) {
+          log.info("Trie walk found no missing nodes — healing complete after {} rounds!", healingRoundCount)
+          healingRoundCount = 0
+          for (b <- pivotBlock; r <- stateRoot)
+            appStateStorage.putSnapSyncPivotBlock(b).and(appStateStorage.putSnapSyncStateRoot(r)).commit()
+          progressMonitor.startPhase(StateValidation)
+          currentPhase = StateValidation
+          validateState()
+        } else {
+          healingRoundCount += 1
+          log.info(
+            s"Trie walk found ${missingNodes.size} missing nodes — queuing for healing (round $healingRoundCount)"
+          )
+          trieNodeHealingCoordinator.foreach { coordinator =>
+            coordinator ! actors.Messages.QueueMissingNodes(missingNodes)
+          }
+          scheduler.scheduleOnce(2.minutes) {
+            self ! ScheduledTrieWalk
+          }(ec)
+        }
       }
 
     case ScheduledTrieWalk if currentPhase == StateHealing =>
       startTrieWalk()
 
-    case TrieWalkFailed(error) if currentPhase == StateHealing =>
-      trieWalkInProgress = false
-      log.error(s"Trie walk failed: $error. Retrying after delay...")
-      scheduler.scheduleOnce(5.seconds) {
-        self ! ScheduledTrieWalk
-      }(ec)
+    case TrieWalkFailed(gen, error) if currentPhase == StateHealing =>
+      if (gen != walkGeneration) {
+        log.debug(s"Discarding stale TrieWalkFailed (epoch $gen, current $walkGeneration)")
+      } else {
+        trieWalkInProgress = false
+        log.error(s"Trie walk failed: $error. Retrying after delay...")
+        scheduler.scheduleOnce(5.seconds) {
+          self ! ScheduledTrieWalk
+        }(ec)
+      }
 
     case StateValidationComplete =>
       log.info("State validation complete. SNAP sync finished!")
@@ -1924,9 +1967,11 @@ class SNAPSyncController(
       super.aroundReceive(receive, msg)
   }
 
-  // Internal message for async trie walk result
-  private case class TrieWalkResult(missingNodes: Seq[(Seq[ByteString], ByteString)])
-  private case class TrieWalkFailed(error: String)
+  // Internal messages for async trie walk — tagged with walkGeneration to discard stale results
+  private case class TrieWalkResult(generation: Long, missingNodes: Seq[(Seq[ByteString], ByteString)])
+  private case class TrieWalkBatch(generation: Long, missingNodes: Seq[(Seq[ByteString], ByteString)])
+  private case class TrieWalkComplete(generation: Long, totalFound: Int)
+  private case class TrieWalkFailed(generation: Long, error: String)
   private case object ScheduledTrieWalk
 
   /** Start an async trie walk to discover missing nodes. Guards against concurrent walks. */
@@ -1934,6 +1979,8 @@ class SNAPSyncController(
     if (trieWalkInProgress) return
     if (currentPhase != StateHealing) return
     trieWalkInProgress = true
+    walkGeneration += 1
+    val thisGen = walkGeneration
     stateRoot.foreach { root =>
       log.info("Starting trie walk to discover missing nodes for healing...")
       val storage = getOrCreateMptStorage(pivotBlock.getOrElse(BigInt(0)))
@@ -1941,11 +1988,15 @@ class SNAPSyncController(
       scala.concurrent
         .Future {
           val validator = new StateValidator(storage)
-          validator.findMissingNodesWithPaths(root)
+          validator.findMissingNodesStreaming(
+            root,
+            batchSize = 500,
+            onBatch = { batch => selfRef ! TrieWalkBatch(thisGen, batch) }
+          )
         }(ec)
         .foreach {
-          case Right(missingNodes) => selfRef ! TrieWalkResult(missingNodes)
-          case Left(error)         => selfRef ! TrieWalkFailed(error)
+          case Right(totalFound) => selfRef ! TrieWalkComplete(thisGen, totalFound)
+          case Left(error)       => selfRef ! TrieWalkFailed(thisGen, error)
         }(ec)
     }
   }
@@ -1991,20 +2042,66 @@ class SNAPSyncController(
       }
 
       // Periodically send peer availability notifications
-      healingRequestTask = Some(
-        scheduler.scheduleWithFixedDelay(
-          0.seconds,
-          1.second,
-          self,
-          RequestTrieNodeHealing
-        )(ec, self)
-      )
+      startHealingRequestScheduler()
 
       progressMonitor.startPhase(StateHealing)
 
       // Run initial trie walk asynchronously to discover missing nodes
       startTrieWalk()
     }
+  }
+
+  private def startStateHealingWithInterleave(): Unit = {
+    if (trieNodeHealingCoordinator.isDefined) {
+      // Coordinator still running — just start the validation walk
+      startTrieWalk()
+    } else {
+      stateRoot match {
+        case Some(root) =>
+          val storage = getOrCreateMptStorage(pivotBlock.getOrElse(BigInt(0)))
+          trieNodeHealingCoordinator = Some(
+            context.actorOf(
+              actors.TrieNodeHealingCoordinator
+                .props(
+                  stateRoot = root,
+                  networkPeerManager = networkPeerManager,
+                  requestTracker = requestTracker,
+                  mptStorage = storage,
+                  batchSize = snapSyncConfig.healingBatchSize,
+                  snapSyncController = self,
+                  concurrency = snapSyncConfig.healingConcurrency
+                )
+                .withDispatcher("sync-dispatcher"),
+              s"trie-node-healing-coordinator-$coordinatorGeneration"
+            )
+          )
+          trieNodeHealingCoordinator.foreach { coordinator =>
+            coordinator ! actors.Messages.StartTrieNodeHealing(root)
+            coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(5)
+          }
+          startHealingRequestScheduler()
+          log.info(
+            s"[HEAL-INTERLEAVE] Healing coordinator created before walk — " +
+            s"root=${root.take(8).toHex}, generation=$coordinatorGeneration"
+          )
+          startTrieWalk()
+        case None =>
+          log.warning("[HEAL-INTERLEAVE] stateRoot is None — walking only (no coordinator created)")
+          startTrieWalk()
+      }
+    }
+  }
+
+  private def startHealingRequestScheduler(): Unit = {
+    healingRequestTask.foreach(_.cancel())
+    healingRequestTask = Some(
+      scheduler.scheduleWithFixedDelay(
+        0.seconds,
+        1.second,
+        self,
+        RequestTrieNodeHealing
+      )(ec, self)
+    )
   }
 
   // Internal message for periodic healing requests
@@ -2248,9 +2345,21 @@ class SNAPSyncController(
     // The backing storage was already created for the original pivot block number,
     // but since nodes are keyed by hash, they're valid for any root.
 
-    // Persist new pivot
-    appStateStorage.putSnapSyncPivotBlock(newPivotBlock).commit()
-    appStateStorage.putSnapSyncStateRoot(newStateRoot).commit()
+    // Any in-flight trie walk is now for the old root — invalidate it by bumping the
+    // generation counter. The walk future will complete and send a message tagged with
+    // the old generation, which the handler discards (D1 stale epoch fix).
+    if (trieWalkInProgress) {
+      log.info("Pivot refresh during trie walk — invalidating in-flight walk (stale epoch)")
+      walkGeneration += 1
+      trieWalkInProgress = false
+    }
+
+    // Persist new pivot — but NOT during healing: AppStateStorage is updated only when healing
+    // succeeds (trie walk finds 0 missing nodes). Mid-healing writes cause root mismatch (BUG-006):
+    // the new root is stored before all its nodes are healed, then validateState() sees a mismatch.
+    if (currentPhase != StateHealing) {
+      appStateStorage.putSnapSyncPivotBlock(newPivotBlock).and(appStateStorage.putSnapSyncStateRoot(newStateRoot)).commit()
+    }
     updateBestBlockForPivot(newPivotHeader, newPivotBlock)
     SNAPSyncMetrics.setPivotBlockNumber(newPivotBlock)
 
@@ -2330,6 +2439,9 @@ class SNAPSyncController(
     mptStorage = None
     currentPhase = Idle
     coordinatorGeneration += 1
+    // Invalidate any in-flight trie walk so its stale result is discarded on arrival
+    walkGeneration += 1
+    trieWalkInProgress = false
 
     // Reset progress counters so logs/ETA reflect the new attempt
     progressMonitor.reset()
@@ -2345,6 +2457,8 @@ class SNAPSyncController(
   private def triggerHealingForMissingNodes(missingNodes: Seq[ByteString]): Unit = {
     log.info(s"Validation found ${missingNodes.size} missing nodes — re-running trie walk with paths for healing")
     currentPhase = StateHealing
+    walkGeneration += 1
+    val thisGen = walkGeneration
     stateRoot.foreach { root =>
       val storage = getOrCreateMptStorage(pivotBlock.getOrElse(BigInt(0)))
       scala.concurrent
@@ -2353,8 +2467,8 @@ class SNAPSyncController(
           validator.findMissingNodesWithPaths(root)
         }(ec)
         .foreach {
-          case Right(nodes) => self ! TrieWalkResult(nodes)
-          case Left(error)  => self ! TrieWalkFailed(error)
+          case Right(nodes) => self ! TrieWalkResult(thisGen, nodes)
+          case Left(error)  => self ! TrieWalkFailed(thisGen, error)
         }(ec)
     }
   }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2059,7 +2059,7 @@ class SNAPSyncController(
     }
   }
 
-  private def startStateHealingWithInterleave(): Unit = {
+  private def startStateHealingWithInterleave(): Unit =
     if (trieNodeHealingCoordinator.isDefined) {
       // Coordinator still running — just start the validation walk
       startTrieWalk()
@@ -2090,7 +2090,7 @@ class SNAPSyncController(
           startHealingRequestScheduler()
           log.info(
             s"[HEAL-INTERLEAVE] Healing coordinator created before walk — " +
-            s"root=${root.take(8).toHex}, generation=$coordinatorGeneration"
+              s"root=${root.take(8).toHex}, generation=$coordinatorGeneration"
           )
           startTrieWalk()
         case None =>
@@ -2098,7 +2098,6 @@ class SNAPSyncController(
           startTrieWalk()
       }
     }
-  }
 
   private def startHealingRequestScheduler(): Unit = {
     healingRequestTask.foreach(_.cancel())
@@ -2366,7 +2365,10 @@ class SNAPSyncController(
     // succeeds (trie walk finds 0 missing nodes). Mid-healing writes cause root mismatch (BUG-006):
     // the new root is stored before all its nodes are healed, then validateState() sees a mismatch.
     if (currentPhase != StateHealing) {
-      appStateStorage.putSnapSyncPivotBlock(newPivotBlock).and(appStateStorage.putSnapSyncStateRoot(newStateRoot)).commit()
+      appStateStorage
+        .putSnapSyncPivotBlock(newPivotBlock)
+        .and(appStateStorage.putSnapSyncStateRoot(newStateRoot))
+        .commit()
     }
     updateBestBlockForPivot(newPivotHeader, newPivotBlock)
     SNAPSyncMetrics.setPivotBlockNumber(newPivotBlock)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -370,6 +370,14 @@ class SNAPSyncController(
       progressMonitor.setFinalizingTrie(false)
       log.info("Account range trie finalization complete")
 
+    case AccountTrieFinalizationFailed(error) =>
+      // Root mismatch: the trie we built doesn't hash to the pivot's state root.
+      // This means peers returned empty/wrong data (e.g., snapshot not ready).
+      // Restart with a fresh pivot rather than entering healing with corrupt state.
+      log.error(s"Account trie finalization failed ($error) — restarting SNAP sync with fresh pivot")
+      progressMonitor.setFinalizingTrie(false)
+      restartSnapSync(s"account trie finalization failed: $error")
+
     case ProgressBytecodesDownloaded(count) =>
       progressMonitor.incrementBytecodesDownloaded(count)
 
@@ -2877,6 +2885,7 @@ object SNAPSyncController {
   case object ProgressAccountsFinalizingTrie
   case object ProgressAccountsTrieFinalized
   final case class AccountTrieFinalized(finalizedRoot: ByteString)
+  final case class AccountTrieFinalizationFailed(error: String)
   final case class ProgressBytecodesDownloaded(count: Long)
   final case class ProgressStorageSlotsSynced(count: Long)
   final case class ProgressNodesHealed(count: Long)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -127,9 +127,7 @@ class SNAPSyncController(
   private var healingRequestTask: Option[Cancellable] = None
   private var storageStagnationRefreshAttempted: Boolean = false
   private var trieWalkInProgress: Boolean = false
-  private var consecutiveUnproductiveHealingRounds: Int = 0
-  private val maxUnproductiveHealingRounds: Int =
-    3 // After 3 rounds of finding same missing nodes with 0 healed, skip to validation
+  private var healingRoundCount: Int = 0
   private var bootstrapCheckTask: Option[Cancellable] = None
   private var pivotBootstrapRetryTask: Option[Cancellable] = None
   private var rateTrackerTuneTask: Option[Cancellable] = None
@@ -383,7 +381,6 @@ class SNAPSyncController(
 
     case ProgressNodesHealed(count) =>
       progressMonitor.incrementNodesHealed(count)
-      consecutiveUnproductiveHealingRounds = 0 // Reset — healing made progress
 
     case ProgressAccountEstimate(estimatedTotal) =>
       progressMonitor.updateEstimates(accounts = estimatedTotal)
@@ -590,36 +587,31 @@ class SNAPSyncController(
     case TrieWalkResult(missingNodes) if currentPhase == StateHealing =>
       trieWalkInProgress = false
       if (missingNodes.isEmpty) {
-        log.info("Trie walk found no missing nodes — healing complete!")
-        consecutiveUnproductiveHealingRounds = 0
+        log.info("Trie walk found no missing nodes — healing complete after {} rounds!", healingRoundCount)
+        healingRoundCount = 0
+        // Commit final pivot root — deferred from refreshPivotInPlace() to prevent BUG-006.
+        // AppStateStorage now reflects the root that healing actually completed against.
+        pivotBlock.foreach(b => appStateStorage.putSnapSyncPivotBlock(b).commit())
+        stateRoot.foreach(r => appStateStorage.putSnapSyncStateRoot(r).commit())
         progressMonitor.startPhase(StateValidation)
         currentPhase = StateValidation
         validateState()
       } else {
-        consecutiveUnproductiveHealingRounds += 1
-        if (consecutiveUnproductiveHealingRounds >= maxUnproductiveHealingRounds) {
-          log.warning(
-            s"Healing stagnation: ${missingNodes.size} missing nodes persist after " +
-              s"$consecutiveUnproductiveHealingRounds consecutive rounds with no progress. " +
-              s"Proceeding to validation — regular sync will recover missing nodes on-demand."
-          )
-          consecutiveUnproductiveHealingRounds = 0
-          progressMonitor.startPhase(StateValidation)
-          currentPhase = StateValidation
-          validateState()
-        } else {
-          log.info(
-            s"Trie walk found ${missingNodes.size} missing nodes — queuing for healing " +
-              s"(round $consecutiveUnproductiveHealingRounds/$maxUnproductiveHealingRounds)"
-          )
-          trieNodeHealingCoordinator.foreach { coordinator =>
-            coordinator ! actors.Messages.QueueMissingNodes(missingNodes)
-          }
-          // Schedule next overlapping trie walk — don't wait for healing to complete
-          scheduler.scheduleOnce(2.minutes) {
-            self ! ScheduledTrieWalk
-          }(ec)
+        // A2: Loop indefinitely until Pending==0 — mirrors go-ethereum sync.go:1400
+        // `for len(s.healer.trieTasks) > 0 || s.healer.scheduler.Pending() > 0` and
+        // Besu SnapWorldDownloadState.java:177-185 `allTasksCompleted()` loop with no round cap.
+        // Missing nodes are re-queued; peer scoring (B5) handles unresponsive peers.
+        healingRoundCount += 1
+        log.info(
+          s"Trie walk found ${missingNodes.size} missing nodes — queuing for healing (round $healingRoundCount)"
+        )
+        trieNodeHealingCoordinator.foreach { coordinator =>
+          coordinator ! actors.Messages.QueueMissingNodes(missingNodes)
         }
+        // Schedule next overlapping trie walk — don't wait for healing to complete
+        scheduler.scheduleOnce(2.minutes) {
+          self ! ScheduledTrieWalk
+        }(ec)
       }
 
     case ScheduledTrieWalk if currentPhase == StateHealing =>
@@ -2538,14 +2530,29 @@ class SNAPSyncController(
 
   /** Final SNAP sync completion — called when both state sync and chain download are done. */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
-    appStateStorage.snapSyncDone().commit()
-
     // Look up the pivot header so we can store a complete "best block" anchor.
     // RegularSync's BranchResolution needs: header, body, number→hash mapping,
     // ChainWeight, and BestBlockInfo (hash + number) to accept blocks that chain
     // from the pivot.
     blockchainReader.getBlockHeaderByNumber(pivot) match {
       case Some(pivotHeader) =>
+        // A5: Root match guard — snapStateRoot must equal pivotHeader.stateRoot before
+        // marking sync done. Mirrors Besu SnapWorldDownloadState.saveWorldState() implicit
+        // verification. If they diverge (BUG-008 class), restart SNAP rather than committing
+        // a broken state.
+        appStateStorage.getSnapSyncStateRoot().foreach { snapRoot =>
+          if (snapRoot != pivotHeader.stateRoot) {
+            log.error(
+              "SNAP finalization aborted: snapStateRoot={} != pivotHeader.stateRoot={}. " +
+                "State trie root mismatch — escalating to SyncController for SNAP restart.",
+              snapRoot.toHex,
+              pivotHeader.stateRoot.toHex
+            )
+            context.parent ! SyncProtocol.HealingImpossible
+            return
+          }
+        }
+
         val pivotHash = pivotHeader.hash
 
         // Store the full block (header + empty body) so getBlockByHash(pivotHash) returns
@@ -2573,6 +2580,12 @@ class SNAPSyncController(
             com.chipprbots.ethereum.domain.appstate.BlockInfo(pivotHash, pivot)
           )
           .commit()
+
+        // D4: snapSyncDone written AFTER pivot header and best-block info are stored.
+        // Pivot data is written first so a crash between writes leaves the node in a
+        // recoverable state (D3 startup gate detects SnapSyncDone=true with unreachable
+        // root and restarts SNAP). Mirrors Besu SnapSyncStatePersistenceManager ordering.
+        appStateStorage.snapSyncDone().commit()
 
         log.info(s"SNAP sync completed successfully at block $pivot (hash=${pivotHash.take(8).toHex})")
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
@@ -198,7 +198,7 @@ class StateValidator(mptStorage: MptStorage) {
 
     try {
       val rootNode = mptStorage.get(stateRoot.toArray)
-      walkAccountTrieBFS(rootNode, result)
+      walkAccountTrieDFS(rootNode, result)
       Right(result.toSeq)
     } catch {
       case _: MerklePatriciaTrie.MissingNodeException =>
@@ -210,18 +210,21 @@ class StateValidator(mptStorage: MptStorage) {
     }
   }
 
-  private def walkAccountTrieBFS(
+  private def walkAccountTrieDFS(
       rootNode: MptNode,
       result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
   ): Unit = {
     import com.chipprbots.ethereum.domain.Account.accountSerializer
 
-    // Queue items: (node, nibble-path-so-far)
-    val queue   = mutable.Queue[(MptNode, Array[Byte])]((rootNode, Array.empty))
+    // Use a stack (DFS) instead of a queue (BFS). DFS uses O(trie_depth) space —
+    // typically 8-9 levels for ETC mainnet — vs O(trie_width) for BFS which can
+    // accumulate millions of BranchNodes simultaneously (OOM on 85.9M account tries).
+    val stack   = mutable.ArrayDeque[(MptNode, Array[Byte])]()
     val visited = mutable.Set[ByteString]()
+    stack.prepend((rootNode, Array.emptyByteArray))
 
-    while (queue.nonEmpty) {
-      val (node, nibblePath) = queue.dequeue()
+    while (stack.nonEmpty) {
+      val (node, nibblePath) = stack.removeHead()
 
       node match {
         case NullNode => ()
@@ -230,12 +233,12 @@ class StateValidator(mptStorage: MptStorage) {
           try {
             val account = accountSerializer.fromBytes(leaf.value.toArray)
             if (account.storageRoot != com.chipprbots.ethereum.domain.Account.EmptyStorageRootHash) {
-              val fullNibblePath  = nibblePath ++ leaf.key.toArray
+              val fullNibblePath   = nibblePath ++ leaf.key.toArray
               val accountHashBytes = HexPrefix.nibblesToBytes(fullNibblePath)
               try {
                 val storageRoot = mptStorage.get(account.storageRoot.toArray)
-                // Each storage trie gets its own BFS + visited set (independent walk)
-                walkStorageTrieBFS(storageRoot, ByteString(accountHashBytes), result)
+                // Each storage trie gets its own DFS + visited set (independent walk)
+                walkStorageTrieDFS(storageRoot, ByteString(accountHashBytes), result)
               } catch {
                 case _: MerklePatriciaTrie.MissingNodeException =>
                   val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
@@ -248,29 +251,30 @@ class StateValidator(mptStorage: MptStorage) {
           val nodeHash = ByteString(ext.hash)
           if (!visited.contains(nodeHash)) {
             visited += nodeHash
-            queue.enqueue((ext.next, nibblePath ++ ext.sharedKey.toArray))
+            stack.prepend((ext.next, nibblePath ++ ext.sharedKey.toArray))
           }
 
         case branch: BranchNode =>
           val nodeHash = ByteString(branch.hash)
           if (!visited.contains(nodeHash)) {
             visited += nodeHash
-            for (i <- 0 until 16) {
+            // Push in reverse order so child 0 is processed first (consistent ordering)
+            for (i <- 15 to 0 by -1) {
               val child = branch.children(i)
               if (!child.isNull)
-                queue.enqueue((child, nibblePath :+ i.toByte))
+                stack.prepend((child, nibblePath :+ i.toByte))
             }
           }
 
         case hash: HashNode =>
           // Do NOT add hash.hash to visited here: decodeNode sets cachedHash = lookupKey,
-          // so the resolved node shares the same hash and will add itself when dequeued.
+          // so the resolved node shares the same hash and will add itself when popped.
           // Adding it here would cause the resolved node's branch/extension case to skip itself.
           val hashKey = ByteString(hash.hash)
           if (!visited.contains(hashKey)) {
             try {
               val resolvedNode = mptStorage.get(hash.hash)
-              queue.enqueue((resolvedNode, nibblePath))
+              stack.prepend((resolvedNode, nibblePath))
             } catch {
               case _: MerklePatriciaTrie.MissingNodeException =>
                 val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
@@ -281,16 +285,17 @@ class StateValidator(mptStorage: MptStorage) {
     }
   }
 
-  private def walkStorageTrieBFS(
+  private def walkStorageTrieDFS(
       rootNode: MptNode,
       accountHash: ByteString,
       result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
   ): Unit = {
-    val queue   = mutable.Queue[(MptNode, Array[Byte])]((rootNode, Array.empty))
+    val stack   = mutable.ArrayDeque[(MptNode, Array[Byte])]()
     val visited = mutable.Set[ByteString]()
+    stack.prepend((rootNode, Array.emptyByteArray))
 
-    while (queue.nonEmpty) {
-      val (node, nibblePath) = queue.dequeue()
+    while (stack.nonEmpty) {
+      val (node, nibblePath) = stack.removeHead()
 
       node match {
         case _: LeafNode | NullNode => ()
@@ -299,17 +304,17 @@ class StateValidator(mptStorage: MptStorage) {
           val nodeHash = ByteString(ext.hash)
           if (!visited.contains(nodeHash)) {
             visited += nodeHash
-            queue.enqueue((ext.next, nibblePath ++ ext.sharedKey.toArray))
+            stack.prepend((ext.next, nibblePath ++ ext.sharedKey.toArray))
           }
 
         case branch: BranchNode =>
           val nodeHash = ByteString(branch.hash)
           if (!visited.contains(nodeHash)) {
             visited += nodeHash
-            for (i <- 0 until 16) {
+            for (i <- 15 to 0 by -1) {
               val child = branch.children(i)
               if (!child.isNull)
-                queue.enqueue((child, nibblePath :+ i.toByte))
+                stack.prepend((child, nibblePath :+ i.toByte))
             }
           }
 
@@ -318,7 +323,7 @@ class StateValidator(mptStorage: MptStorage) {
           if (!visited.contains(hashKey)) {
             try {
               val resolvedNode = mptStorage.get(hash.hash)
-              queue.enqueue((resolvedNode, nibblePath))
+              stack.prepend((resolvedNode, nibblePath))
             } catch {
               case _: MerklePatriciaTrie.MissingNodeException =>
                 val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
@@ -210,9 +210,44 @@ class StateValidator(mptStorage: MptStorage) {
     }
   }
 
+  def findMissingNodesStreaming(
+      stateRoot: ByteString,
+      batchSize: Int,
+      onBatch: Seq[(Seq[ByteString], ByteString)] => Unit
+  ): Either[String, Int] = {
+    val result    = mutable.ArrayBuffer[(Seq[ByteString], ByteString)]()
+    var totalSent = 0
+
+    val flushIfFull: () => Unit = () => {
+      if (result.size >= batchSize) {
+        onBatch(result.toSeq)
+        totalSent += result.size
+        result.clear()
+      }
+    }
+
+    try {
+      val rootNode = mptStorage.get(stateRoot.toArray)
+      walkAccountTrieDFS(rootNode, result, flushIfFull)
+      if (result.nonEmpty) {
+        onBatch(result.toSeq)
+        totalSent += result.size
+      }
+      Right(totalSent)
+    } catch {
+      case _: MerklePatriciaTrie.MissingNodeException =>
+        val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+        onBatch(Seq((Seq(compactPath), stateRoot)))
+        Right(totalSent + 1)
+      case e: Exception =>
+        Left(s"Trie walk failed: ${e.getMessage}")
+    }
+  }
+
   private def walkAccountTrieDFS(
       rootNode: MptNode,
-      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
+      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)],
+      flushIfFull: () => Unit = () => ()
   ): Unit = {
     import com.chipprbots.ethereum.domain.Account.accountSerializer
 
@@ -238,11 +273,12 @@ class StateValidator(mptStorage: MptStorage) {
               try {
                 val storageRoot = mptStorage.get(account.storageRoot.toArray)
                 // Each storage trie gets its own DFS + visited set (independent walk)
-                walkStorageTrieDFS(storageRoot, ByteString(accountHashBytes), result)
+                walkStorageTrieDFS(storageRoot, ByteString(accountHashBytes), result, flushIfFull)
               } catch {
                 case _: MerklePatriciaTrie.MissingNodeException =>
                   val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
                   result += ((Seq(ByteString(accountHashBytes), compactPath), account.storageRoot))
+                  flushIfFull()
               }
             }
           } catch { case _: Exception => () }
@@ -279,6 +315,7 @@ class StateValidator(mptStorage: MptStorage) {
               case _: MerklePatriciaTrie.MissingNodeException =>
                 val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
                 result += ((Seq(compactPath), ByteString(hash.hash)))
+                flushIfFull()
             }
           }
       }
@@ -288,7 +325,8 @@ class StateValidator(mptStorage: MptStorage) {
   private def walkStorageTrieDFS(
       rootNode: MptNode,
       accountHash: ByteString,
-      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
+      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)],
+      flushIfFull: () => Unit = () => ()
   ): Unit = {
     val stack   = mutable.ArrayDeque[(MptNode, Array[Byte])]()
     val visited = mutable.Set[ByteString]()
@@ -328,6 +366,7 @@ class StateValidator(mptStorage: MptStorage) {
               case _: MerklePatriciaTrie.MissingNodeException =>
                 val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
                 result += ((Seq(accountHash, compactPath), ByteString(hash.hash)))
+                flushIfFull()
             }
           }
       }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
@@ -182,147 +182,150 @@ class StateValidator(mptStorage: MptStorage) {
   // Path-tracking trie walk for GetTrieNodes healing
   // ========================================
 
-  /** Find all missing trie nodes with GetTrieNodes-compatible pathsets. */
+  /** Find all missing trie nodes with GetTrieNodes-compatible pathsets.
+    *
+    * Uses iterative BFS queues instead of recursion to avoid StackOverflowError on
+    * large tries (ETC mainnet: ~90M accounts, trie depth up to 64 nibbles).
+    * Each storage trie is walked with its own visited set (independent BFS), matching
+    * the original per-storage-trie isolation.
+    *
+    * Mirrors Besu TrieNodeHealingRequest.getChildRequests() (java:94-125) and
+    * go-ethereum trie/sync.go:ProcessNode() (line 419-448): every retrieved node
+    * enqueues ALL hash-referenced children before moving on.
+    */
   def findMissingNodesWithPaths(stateRoot: ByteString): Either[String, Seq[(Seq[ByteString], ByteString)]] = {
     val result = mutable.ArrayBuffer[(Seq[ByteString], ByteString)]()
 
     try {
       val rootNode = mptStorage.get(stateRoot.toArray)
-      traverseAccountTrieWithPaths(rootNode, mptStorage, Array.empty[Byte], result, mutable.Set.empty)
+      walkAccountTrieBFS(rootNode, result)
       Right(result.toSeq)
     } catch {
-      case e: MerklePatriciaTrie.MissingNodeException =>
+      case _: MerklePatriciaTrie.MissingNodeException =>
         val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-        result += ((Seq(compactPath), e.hash))
+        result += ((Seq(compactPath), stateRoot))
         Right(result.toSeq)
       case e: Exception =>
         Left(s"Trie walk failed: ${e.getMessage}")
     }
   }
 
-  /** Walk the account trie, tracking nibble paths for missing nodes. Also checks storage tries. */
-  private def traverseAccountTrieWithPaths(
-      node: MptNode,
-      storage: MptStorage,
-      currentNibblePath: Array[Byte],
-      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)],
-      visited: mutable.Set[ByteString]
+  private def walkAccountTrieBFS(
+      rootNode: MptNode,
+      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
   ): Unit = {
     import com.chipprbots.ethereum.domain.Account.accountSerializer
 
-    node match {
-      case leaf: LeafNode =>
-        try {
-          val account = accountSerializer.fromBytes(leaf.value.toArray)
-          if (account.storageRoot != com.chipprbots.ethereum.domain.Account.EmptyStorageRootHash) {
-            val leafKeyNibbles = leaf.key.toArray
-            val fullNibblePath = currentNibblePath ++ leafKeyNibbles
-            val accountHashBytes = HexPrefix.nibblesToBytes(fullNibblePath)
+    // Queue items: (node, nibble-path-so-far)
+    val queue   = mutable.Queue[(MptNode, Array[Byte])]((rootNode, Array.empty))
+    val visited = mutable.Set[ByteString]()
 
-            try {
-              val storageRoot = storage.get(account.storageRoot.toArray)
-              traverseStorageTrieWithPaths(
-                storageRoot,
-                storage,
-                Array.empty[Byte],
-                ByteString(accountHashBytes),
-                result,
-                mutable.Set.empty
-              )
-            } catch {
-              case e: MerklePatriciaTrie.MissingNodeException =>
-                val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-                result += ((Seq(ByteString(accountHashBytes), compactPath), e.hash))
-            }
-          }
-        } catch {
-          case _: Exception => ()
-        }
+    while (queue.nonEmpty) {
+      val (node, nibblePath) = queue.dequeue()
 
-      case ext: ExtensionNode =>
-        val nodeHash = ByteString(ext.hash)
-        if (!visited.contains(nodeHash)) {
-          visited += nodeHash
-          val sharedKeyNibbles = ext.sharedKey.toArray
-          val newPath = currentNibblePath ++ sharedKeyNibbles
-          traverseAccountTrieWithPaths(ext.next, storage, newPath, result, visited)
-        }
+      node match {
+        case NullNode => ()
 
-      case branch: BranchNode =>
-        val nodeHash = ByteString(branch.hash)
-        if (!visited.contains(nodeHash)) {
-          visited += nodeHash
-          for (i <- 0 until 16) {
-            val child = branch.children(i)
-            if (!child.isNull) {
-              val newPath = currentNibblePath :+ i.toByte
-              traverseAccountTrieWithPaths(child, storage, newPath, result, visited)
-            }
-          }
-        }
-
-      case hash: HashNode =>
-        val hashKey = ByteString(hash.hash)
-        if (!visited.contains(hashKey)) {
+        case leaf: LeafNode =>
           try {
-            val resolvedNode = storage.get(hash.hash)
-            traverseAccountTrieWithPaths(resolvedNode, storage, currentNibblePath, result, visited)
-          } catch {
-            case _: MerklePatriciaTrie.MissingNodeException =>
-              val compactPath = ByteString(HexPrefix.encode(currentNibblePath, isLeaf = false))
-              result += ((Seq(compactPath), ByteString(hash.hash)))
-          }
-        }
+            val account = accountSerializer.fromBytes(leaf.value.toArray)
+            if (account.storageRoot != com.chipprbots.ethereum.domain.Account.EmptyStorageRootHash) {
+              val fullNibblePath  = nibblePath ++ leaf.key.toArray
+              val accountHashBytes = HexPrefix.nibblesToBytes(fullNibblePath)
+              try {
+                val storageRoot = mptStorage.get(account.storageRoot.toArray)
+                // Each storage trie gets its own BFS + visited set (independent walk)
+                walkStorageTrieBFS(storageRoot, ByteString(accountHashBytes), result)
+              } catch {
+                case _: MerklePatriciaTrie.MissingNodeException =>
+                  val compactPath = ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+                  result += ((Seq(ByteString(accountHashBytes), compactPath), account.storageRoot))
+              }
+            }
+          } catch { case _: Exception => () }
 
-      case NullNode => ()
+        case ext: ExtensionNode =>
+          val nodeHash = ByteString(ext.hash)
+          if (!visited.contains(nodeHash)) {
+            visited += nodeHash
+            queue.enqueue((ext.next, nibblePath ++ ext.sharedKey.toArray))
+          }
+
+        case branch: BranchNode =>
+          val nodeHash = ByteString(branch.hash)
+          if (!visited.contains(nodeHash)) {
+            visited += nodeHash
+            for (i <- 0 until 16) {
+              val child = branch.children(i)
+              if (!child.isNull)
+                queue.enqueue((child, nibblePath :+ i.toByte))
+            }
+          }
+
+        case hash: HashNode =>
+          // Do NOT add hash.hash to visited here: decodeNode sets cachedHash = lookupKey,
+          // so the resolved node shares the same hash and will add itself when dequeued.
+          // Adding it here would cause the resolved node's branch/extension case to skip itself.
+          val hashKey = ByteString(hash.hash)
+          if (!visited.contains(hashKey)) {
+            try {
+              val resolvedNode = mptStorage.get(hash.hash)
+              queue.enqueue((resolvedNode, nibblePath))
+            } catch {
+              case _: MerklePatriciaTrie.MissingNodeException =>
+                val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
+                result += ((Seq(compactPath), ByteString(hash.hash)))
+            }
+          }
+      }
     }
   }
 
-  /** Walk a storage trie, tracking nibble paths for missing nodes. */
-  private def traverseStorageTrieWithPaths(
-      node: MptNode,
-      storage: MptStorage,
-      currentNibblePath: Array[Byte],
+  private def walkStorageTrieBFS(
+      rootNode: MptNode,
       accountHash: ByteString,
-      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)],
-      visited: mutable.Set[ByteString]
-  ): Unit =
-    node match {
-      case _: LeafNode | NullNode => ()
+      result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)]
+  ): Unit = {
+    val queue   = mutable.Queue[(MptNode, Array[Byte])]((rootNode, Array.empty))
+    val visited = mutable.Set[ByteString]()
 
-      case ext: ExtensionNode =>
-        val nodeHash = ByteString(ext.hash)
-        if (!visited.contains(nodeHash)) {
-          visited += nodeHash
-          val sharedKeyNibbles = ext.sharedKey.toArray
-          val newPath = currentNibblePath ++ sharedKeyNibbles
-          traverseStorageTrieWithPaths(ext.next, storage, newPath, accountHash, result, visited)
-        }
+    while (queue.nonEmpty) {
+      val (node, nibblePath) = queue.dequeue()
 
-      case branch: BranchNode =>
-        val nodeHash = ByteString(branch.hash)
-        if (!visited.contains(nodeHash)) {
-          visited += nodeHash
-          for (i <- 0 until 16) {
-            val child = branch.children(i)
-            if (!child.isNull) {
-              val newPath = currentNibblePath :+ i.toByte
-              traverseStorageTrieWithPaths(child, storage, newPath, accountHash, result, visited)
+      node match {
+        case _: LeafNode | NullNode => ()
+
+        case ext: ExtensionNode =>
+          val nodeHash = ByteString(ext.hash)
+          if (!visited.contains(nodeHash)) {
+            visited += nodeHash
+            queue.enqueue((ext.next, nibblePath ++ ext.sharedKey.toArray))
+          }
+
+        case branch: BranchNode =>
+          val nodeHash = ByteString(branch.hash)
+          if (!visited.contains(nodeHash)) {
+            visited += nodeHash
+            for (i <- 0 until 16) {
+              val child = branch.children(i)
+              if (!child.isNull)
+                queue.enqueue((child, nibblePath :+ i.toByte))
             }
           }
-        }
 
-      case hash: HashNode =>
-        val hashKey = ByteString(hash.hash)
-        if (!visited.contains(hashKey)) {
-          try {
-            val resolvedNode = storage.get(hash.hash)
-            traverseStorageTrieWithPaths(resolvedNode, storage, currentNibblePath, accountHash, result, visited)
-          } catch {
-            case _: MerklePatriciaTrie.MissingNodeException =>
-              val compactPath = ByteString(HexPrefix.encode(currentNibblePath, isLeaf = false))
-              result += ((Seq(accountHash, compactPath), ByteString(hash.hash)))
+        case hash: HashNode =>
+          val hashKey = ByteString(hash.hash)
+          if (!visited.contains(hashKey)) {
+            try {
+              val resolvedNode = mptStorage.get(hash.hash)
+              queue.enqueue((resolvedNode, nibblePath))
+            } catch {
+              case _: MerklePatriciaTrie.MissingNodeException =>
+                val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
+                result += ((Seq(accountHash, compactPath), ByteString(hash.hash)))
+            }
           }
-        }
+      }
     }
+  }
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
@@ -184,14 +184,12 @@ class StateValidator(mptStorage: MptStorage) {
 
   /** Find all missing trie nodes with GetTrieNodes-compatible pathsets.
     *
-    * Uses iterative BFS queues instead of recursion to avoid StackOverflowError on
-    * large tries (ETC mainnet: ~90M accounts, trie depth up to 64 nibbles).
-    * Each storage trie is walked with its own visited set (independent BFS), matching
-    * the original per-storage-trie isolation.
+    * Uses iterative BFS queues instead of recursion to avoid StackOverflowError on large tries (ETC mainnet: ~90M
+    * accounts, trie depth up to 64 nibbles). Each storage trie is walked with its own visited set (independent BFS),
+    * matching the original per-storage-trie isolation.
     *
-    * Mirrors Besu TrieNodeHealingRequest.getChildRequests() (java:94-125) and
-    * go-ethereum trie/sync.go:ProcessNode() (line 419-448): every retrieved node
-    * enqueues ALL hash-referenced children before moving on.
+    * Mirrors Besu TrieNodeHealingRequest.getChildRequests() (java:94-125) and go-ethereum trie/sync.go:ProcessNode()
+    * (line 419-448): every retrieved node enqueues ALL hash-referenced children before moving on.
     */
   def findMissingNodesWithPaths(stateRoot: ByteString): Either[String, Seq[(Seq[ByteString], ByteString)]] = {
     val result = mutable.ArrayBuffer[(Seq[ByteString], ByteString)]()
@@ -215,16 +213,15 @@ class StateValidator(mptStorage: MptStorage) {
       batchSize: Int,
       onBatch: Seq[(Seq[ByteString], ByteString)] => Unit
   ): Either[String, Int] = {
-    val result    = mutable.ArrayBuffer[(Seq[ByteString], ByteString)]()
+    val result = mutable.ArrayBuffer[(Seq[ByteString], ByteString)]()
     var totalSent = 0
 
-    val flushIfFull: () => Unit = () => {
+    val flushIfFull: () => Unit = () =>
       if (result.size >= batchSize) {
         onBatch(result.toSeq)
         totalSent += result.size
         result.clear()
       }
-    }
 
     try {
       val rootNode = mptStorage.get(stateRoot.toArray)
@@ -254,7 +251,7 @@ class StateValidator(mptStorage: MptStorage) {
     // Use a stack (DFS) instead of a queue (BFS). DFS uses O(trie_depth) space —
     // typically 8-9 levels for ETC mainnet — vs O(trie_width) for BFS which can
     // accumulate millions of BranchNodes simultaneously (OOM on 85.9M account tries).
-    val stack   = mutable.ArrayDeque[(MptNode, Array[Byte])]()
+    val stack = mutable.ArrayDeque[(MptNode, Array[Byte])]()
     val visited = mutable.Set[ByteString]()
     stack.prepend((rootNode, Array.emptyByteArray))
 
@@ -268,7 +265,7 @@ class StateValidator(mptStorage: MptStorage) {
           try {
             val account = accountSerializer.fromBytes(leaf.value.toArray)
             if (account.storageRoot != com.chipprbots.ethereum.domain.Account.EmptyStorageRootHash) {
-              val fullNibblePath   = nibblePath ++ leaf.key.toArray
+              val fullNibblePath = nibblePath ++ leaf.key.toArray
               val accountHashBytes = HexPrefix.nibblesToBytes(fullNibblePath)
               try {
                 val storageRoot = mptStorage.get(account.storageRoot.toArray)
@@ -328,7 +325,7 @@ class StateValidator(mptStorage: MptStorage) {
       result: mutable.ArrayBuffer[(Seq[ByteString], ByteString)],
       flushIfFull: () => Unit = () => ()
   ): Unit = {
-    val stack   = mutable.ArrayDeque[(MptNode, Array[Byte])]()
+    val stack = mutable.ArrayDeque[(MptNode, Array[Byte])]()
     val visited = mutable.Set[ByteString]()
     stack.prepend((rootNode, Array.emptyByteArray))
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -544,12 +544,12 @@ class AccountRangeCoordinator(
 
     case TrieFlushComplete(Left(error)) =>
       log.error(s"Failed to finalize trie: $error")
-      snapSyncController ! SNAPSyncController.ProgressAccountsTrieFinalized
+      snapSyncController ! SNAPSyncController.AccountTrieFinalizationFailed(error)
       context.stop(self)
 
     case Status.Failure(ex) =>
       log.error(ex, s"Trie finalization failed with exception: ${ex.getMessage}")
-      snapSyncController ! SNAPSyncController.ProgressAccountsTrieFinalized
+      snapSyncController ! SNAPSyncController.AccountTrieFinalizationFailed(ex.getMessage)
       context.stop(self)
 
     case _: PeerAvailable =>

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -115,8 +115,8 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
 
   /** Clear the SNAP-sync-done flag. Used by the regular-sync stuck escape valve to force a SNAP re-sync from a recent
     * pivot when post-SNAP regular sync hits permanently-unfetchable state nodes (e.g., stuck many blocks behind
-    * canonical tip with no peer able to serve our parent stateRoot), or when healing completed prematurely
-    * (BUG-006 root mismatch recovery).
+    * canonical tip with no peer able to serve our parent stateRoot), or when healing completed prematurely (BUG-006
+    * root mismatch recovery).
     */
   def clearSnapSyncDone(): DataSourceBatchUpdate =
     remove(Keys.SnapSyncDone)

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -115,7 +115,8 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
 
   /** Clear the SNAP-sync-done flag. Used by the regular-sync stuck escape valve to force a SNAP re-sync from a recent
     * pivot when post-SNAP regular sync hits permanently-unfetchable state nodes (e.g., stuck many blocks behind
-    * canonical tip with no peer able to serve our parent stateRoot).
+    * canonical tip with no peer able to serve our parent stateRoot), or when healing completed prematurely
+    * (BUG-006 root mismatch recovery).
     */
   def clearSnapSyncDone(): DataSourceBatchUpdate =
     remove(Keys.SnapSyncDone)

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/MptStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/MptStorage.scala
@@ -44,8 +44,8 @@ class SerializingMptStorage(storage: NodesKeyValueStorage) extends MptStorage {
 }
 
 object MptStorage {
-  def collapseNode(node: Option[MptNode]): (Option[MptNode], List[(ByteString, Array[Byte])]) =
-    node.fold[(Option[MptNode], List[(ByteString, Array[Byte])])]((None, List.empty)) { n =>
+  def collapseNode(node: Option[MptNode]): (Option[MptNode], Seq[(ByteString, Array[Byte])]) =
+    node.fold[(Option[MptNode], Seq[(ByteString, Array[Byte])])]((None, Seq.empty)) { n =>
       val (hashNode, newNodes) = MptTraversals.collapseTrie(n)
       (Some(hashNode), newNodes)
     }

--- a/src/main/scala/com/chipprbots/ethereum/mpt/MptTraversals.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/MptTraversals.scala
@@ -13,11 +13,11 @@ import com.chipprbots.ethereum.rlp.rawDecode
 
 object MptTraversals {
 
-  def collapseTrie(node: MptNode): (HashNode, List[(ByteString, Array[Byte])]) = {
+  def collapseTrie(node: MptNode): (HashNode, Seq[(ByteString, Array[Byte])]) = {
     val nodeCapper = new NodeCapper(withUpdates = true)
     val nodeEncoded = encodeNode(node, Some(nodeCapper))
     val rootHash = ByteString(Node.hashFn(nodeEncoded))
-    (HashNode(rootHash.toArray[Byte]), (rootHash, nodeEncoded) :: nodeCapper.getNodesToUpdate)
+    (HashNode(rootHash.toArray[Byte]), (rootHash, nodeEncoded) +: nodeCapper.getNodesToUpdate)
   }
 
   def parseTrieIntoMemory(rootNode: MptNode, source: MptStorage): MptNode =

--- a/src/main/scala/com/chipprbots/ethereum/mpt/MptVisitors/RlpHashingVisitor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/MptVisitors/RlpHashingVisitor.scala
@@ -2,6 +2,8 @@ package com.chipprbots.ethereum.mpt.MptVisitors
 
 import org.apache.pekko.util.ByteString
 
+import scala.collection.mutable
+
 import com.chipprbots.ethereum.db.storage.NodeStorage.NodeEncoded
 import com.chipprbots.ethereum.db.storage.NodeStorage.NodeHash
 import com.chipprbots.ethereum.mpt.BranchNode
@@ -13,8 +15,10 @@ import com.chipprbots.ethereum.mpt.Node
 import com.chipprbots.ethereum.rlp.RLPEncodeable
 import com.chipprbots.ethereum.rlp.RLPValue
 
+// C1: ArrayBuffer instead of linked-list cons cells — contiguous storage reduces GC object count.
+// Mirrors go-ethereum triedb/hashdb/database.go: Cap() flushes oldest nodes when dirtiesSize > limit.
 class NodeCapper(withUpdates: Boolean) {
-  private var nodesToUpdate = List.empty[(NodeHash, NodeEncoded)]
+  private val nodesToUpdate = mutable.ArrayBuffer.empty[(NodeHash, NodeEncoded)]
 
   def capNode(nodeEncoded: RLPEncodeable, depth: Int): RLPEncodeable =
     if (depth > 0)
@@ -29,13 +33,13 @@ class NodeCapper(withUpdates: Boolean) {
     else {
       val hash = Node.hashFn(asArray)
       if (withUpdates) {
-        nodesToUpdate = (ByteString(hash), asArray) :: nodesToUpdate
+        nodesToUpdate += ((ByteString(hash), asArray))
       }
       RLPValue(hash)
     }
   }
 
-  def getNodesToUpdate: List[(NodeHash, NodeEncoded)] = nodesToUpdate
+  def getNodesToUpdate: Seq[(NodeHash, NodeEncoded)] = nodesToUpdate.toSeq
 }
 
 class RlpHashingVisitor(downstream: MptVisitor[RLPEncodeable], depth: Int, nodeCapper: NodeCapper)


### PR DESCRIPTION
## Summary

- **BFS→DFS trie walk (OOM prevention):** The account trie validator used BFS internally, accumulating all BranchNode children in a queue simultaneously. On ETC mainnet (85.9M accounts), this queue grows to millions of entries and causes OOM. Replace with DFS using an explicit stack — O(trie_depth ≈ 9) space instead of O(trie_width ≈ millions)
- **D1 — stale walk epoch guard:** When a pivot refresh happens during a trie walk, the in-flight walk completes and sends `TrieWalkResult` against the old root. Tag every walk message with a `walkGeneration` counter; discard results where `gen != walkGeneration`. Also introduces streaming `TrieWalkBatch` messages so healing can start processing nodes before the full walk completes
- **HealingImpossible signal chain (BUG-006 part 3):** When `GetTrieNodes` returns empty from all peers (pivot state root pruned), `StateNodeFetcher` signals `FetchedStateNode(empty)` → `BlockImporter` → `RegularSync` → `SyncController`. SyncController clears `SnapSyncDone` and restarts SNAP with a fresh current pivot. Mirrors Besu's `StalledDownloadException → PivotSyncDownloader.handleFailure()` and go-ethereum's `HasState(head.Root)` check
- **BUG-006 part 2 — restart SNAP on validation failure:** After a successful heal, `validateState()` re-walks the trie. If it finds mismatches (root changed mid-heal due to pivot refresh), restart SNAP rather than marking sync done with an inconsistent state
- **Restart SNAP on account trie root mismatch:** If `AccountRangeCoordinator` receives a proof that implies a different state root than the current pivot, restart SNAP with the correct root rather than continuing with a mismatched root

## Background — HealingImpossible

This mirrors two reference implementations:
- **Besu:** `StalledDownloadException` thrown in `SnapWorldStateDownloadProcess` → caught in `PivotSyncDownloader.handleFailure()` → clears pivot → re-enters SNAP with new pivot
- **go-ethereum:** After heal, `HasState(head.Root)` check in `sync.go:1400` — if false, re-enable SNAP sync

The ETC mainnet scenario: the node falls many thousands of blocks behind canonical tip. Every connected peer's snap-serve window (128 blocks) has moved past our pivot. `GetTrieNodes` returns empty from all peers. The only recovery is to re-pivot via SNAP.

## Changes

- **`StateValidator.scala`** — BFS→DFS in `walkAccountTrieDFS` + `walkStorageTrieDFS`; streaming `findMissingNodesStreaming`
- **`SNAPSyncController.scala`** — `walkGeneration` counter; `TrieWalkBatch` / `TrieWalkComplete` messages; `startStateHealingWithInterleave()`; deferred pivot writes until healing complete; account trie root mismatch handler
- **`StateNodeFetcher.scala`** — `statelessPeers` set; empty SNAP response escalation to `HealingImpossible` after `SnapFallbackThreshold = 5` consecutive empties
- **`BlockImporter.scala`** — `healingStallCount` + `HealingImpossibleThreshold`; coexists with existing `consecutiveExhausts` + `StuckEscapeThreshold` (dual-path escalation)
- **`RegularSync.scala`** — `HealingImpossible` handler forwards to `SyncController`
- **`SyncController.scala`** — `HealingImpossible` handler: circuit breaker with `healingRestartCount`; exponential backoff after `maxHealingRestarts`; also handles existing `RegularSyncStuck`
- **`SyncProtocol.scala`** — `HealingImpossible` message (coexists with `RegularSyncStuck`)

## Merge dependency

⚠️ **Merge after #1153 (fix/snap-pipeline-core) and #1154 (fix/regular-sync).** This PR touches `SNAPSyncController.scala`, `BlockImporter.scala`, and `RegularSync.scala` — all high-churn files that are also modified by those two PRs. Merging #1153 and #1154 first reduces the conflict surface here significantly. Recommended merge order: #1153 → #1154 → #1155.

## Test plan

- [x] `sbt compile` — clean
- [x] `sbt test` — all existing tests pass
- [ ] Inject a state with 10M+ accounts; verify trie walk completes without OOM
- [ ] Trigger a pivot refresh mid-walk; verify stale `TrieWalkResult` is discarded
- [ ] Simulate all peers returning empty `GetTrieNodes`; verify `HealingImpossible` → SNAP restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)