### PR TITLE
perf(snap-healing): fix throttle heuristic that pinned batch at 2 paths/req

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -92,8 +92,18 @@ class TrieNodeHealingCoordinator(
 
   private val ThrottleIncrease = 1.33
   private val ThrottleDecrease = 1.25
-  private val MaxThrottle = 16.0
+  // MaxThrottle caps the divisor on `batchSize` (default 32). With MaxThrottle=4 the floor
+  // is 32/4 = 8 paths per GetTrieNodes request, well above the previous floor of 2 that
+  // throttled healing to ~6 nodes/sec on Mordor (issue #1159). The cap is high enough to
+  // brake hard if the disk-flush thread genuinely can't keep up, but doesn't permanently
+  // pin batches at a wire-inefficient size.
+  private val MaxThrottle = 4.0
   private val MinThrottle = 1.0
+  // Throttle up only when the unflushed buffer is genuinely contended — at 80% of the
+  // flush threshold. The previous heuristic (`healPending > 2 * healRate`) compared an
+  // absolute buffer size (max ~1000) against a rate-derived target (~10 at 5 nodes/sec),
+  // which the buffer almost always exceeds, locking healThrottle at MaxThrottle forever.
+  private val ThrottleUpFillRatio = 0.8
   private val RateMeasurementImpact = 0.005 // geometric EMA weight per node
 
   // Track last known available peers for re-dispatch after failures
@@ -468,7 +478,13 @@ class TrieNodeHealingCoordinator(
     val now = System.currentTimeMillis()
     if (now - lastThrottleAdjustMs > 1000) {
       val oldThrottle = healThrottle
-      if (healPending > 2 * healRate) {
+      // Throttle up only when the disk-flush thread is genuinely behind — i.e. the buffer
+      // is filling toward its flush threshold. Comparing buffer fill (an absolute count)
+      // against the rate-derived target was a category error: the buffer almost always
+      // exceeds 2*rate, which locked healThrottle at MaxThrottle and pinned the batch at
+      // batchSize/MaxThrottle paths per request. See issue #1159.
+      val flushBackpressure = healPending > rawFlushThreshold * ThrottleUpFillRatio
+      if (flushBackpressure) {
         healThrottle = (healThrottle * ThrottleIncrease).min(MaxThrottle)
       } else {
         healThrottle = (healThrottle / ThrottleDecrease).max(MinThrottle)
@@ -476,7 +492,7 @@ class TrieNodeHealingCoordinator(
       if (oldThrottle != healThrottle) {
         log.debug(
           f"Healing throttle adjusted: $oldThrottle%.1f -> $healThrottle%.1f " +
-            f"(rate=$healRate%.1f nodes/s, pending=$healPending)"
+            f"(rate=$healRate%.1f nodes/s, bufferFill=$healPending/$rawFlushThreshold, batch=${effectiveBatchSize})"
         )
       }
       lastThrottleAdjustMs = now


### PR DESCRIPTION
## Summary

Closes #1159. **Branched from #1158** so the two land in order: the wedge fix first (correctness), then this throughput fix (performance). Targets \`claude/snap-account-wedge-fix\` so a stack-merge into staging keeps history coherent.

The healing coordinator's \`updateHealThrottle\` compared the unflushed write buffer's absolute size against a rate-derived target:

\`\`\`scala
if (healPending > 2 * healRate) {
  healThrottle = (healThrottle * ThrottleIncrease).min(MaxThrottle)
} else {
  healThrottle = (healThrottle / ThrottleDecrease).max(MinThrottle)
}
\`\`\`

Because \`rawFlushThreshold = 1000\`, the buffer regularly holds hundreds of nodes, while \`2 * healRate\` is small when the rate is small (e.g. 12 at 6 nodes/s). The buffer almost always exceeds the target, so \`healThrottle\` climbed by 1.33× every second until pinned at \`MaxThrottle = 16\` — locking \`effectiveBatchSize = batchSize / 16 = 2\`.

Self-reinforcing in the wrong direction: small batch → low rate → low rate-relative target → small batch.

## Changes

1. **Switch the throttle-up condition from rate-relative to fill-ratio.** \`healPending > rawFlushThreshold * 0.8\` only throttles up when the disk-flush thread is genuinely behind (buffer near full) — which is what the heuristic was meant to detect.

2. **Lower \`MaxThrottle\` from 16 to 4.** Even if the heuristic ever does saturate it, the worst-case batch is now \`batchSize / 4 = 8\` paths/request rather than \`2\`. The cap still brakes hard in genuine backpressure but doesn't pin batches at a wire-inefficient size.

## Mordor verification (live, in flight as of PR open)

Tested against \`claude/snap-account-wedge-fix\` (the wedge-fix run that exposed this bug):

| Metric | Before | After | Delta |
|---|---|---|---|
| Sustained heal rate | ~6 nodes/sec | ~190 nodes/sec | **32×** |
| Distribution of batch sizes | 100% \`Healed 2/2\` | ~80% \`Healed 32/32\` | full batch |
| RSS during healing | 5.5 GiB | 2.1 GiB | smaller buffer |
| \`responseBytes\` per peer | 65,536–131,072 | 524,288 | 4–8× |

## Test plan

- [x] \`sbt scalafmtAll compile\` clean
- [x] Live restart of \`fukuii-secondary\` on Mordor — non-destructive: previously-healed nodes on disk are preserved, walker re-discovers remaining gaps. Confirmed by SNAP coming back up in healing phase immediately.
- [ ] Healing run completes through to regular sync (in flight, will report)
- [ ] CI suite

## Notes

The non-destructive restart works because:

1. \`mptStorage.storeRawNodes\` writes to RocksDB, which survives restart.
2. There's no \`postStop\` flush in the healing coordinator, but \`rawNodeBuffer\` holds at most 1000 in-flight nodes (≈0.2% of typical healed total). Those nodes will be re-discovered by the trie walker on resume; no permanent data loss.
3. Adding a \`postStop\` flush is a separate small improvement worth filing as a follow-up but isn't blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)