### PR TITLE
perf(snap): defer chain backfill to background — closes #1162

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -116,6 +116,10 @@ sync {
     # for chain download — no need to reserve slots for SNAP protocol requests.
     # With 50 bodies/request, 16 concurrent = 800 bodies in-flight ≈ 4-5x speedup.
     chain-download-boosted-concurrent-requests = 16
+    # Concurrency budget for chain backfill once SNAP state is finalised and regular sync has
+    # taken over (#1162). Backfill yields peer slots to regular sync — kept at the same low
+    # value as the SNAP-era cap so historical block download trails politely behind forward sync.
+    chain-backfill-concurrent-requests = 2
     # Timeout for chain download ETH protocol requests (seconds).
     # Much shorter than SNAP sync timeout (45s) to avoid holding peers "busy" for too long.
     # If a peer can't respond in 10s it's likely overloaded — release it quickly.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -6,6 +6,7 @@ import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.actor.PoisonPill
 import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Scheduler
+import org.apache.pekko.actor.Terminated
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -226,9 +227,21 @@ class SyncController(
 
       context.become(runningPivotHeaderBootstrap(peersClient, headerBootstrap, targetBlock, snapSync))
 
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.SnapSyncFinalized(pivot) =>
+      log.info(
+        s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
+      )
+      resetSnapFastCycleCount()
+      val regularSync = startRegularSync()
+      context.watch(snapSync)
+      context.become(runningRegularSyncWithBackfill(regularSync, snapSync))
+
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
+      // Defensive fallback: with the post-#1162 handshake, SnapSyncFinalized always precedes Done,
+      // so this branch should not normally be reached. If it is (e.g., unexpected message ordering),
+      // treat as a legacy "SNAP done" signal.
       snapSync ! PoisonPill
-      log.info("SNAP sync completed, transitioning to regular sync")
+      log.info("SNAP sync completed (legacy Done path), transitioning to regular sync")
       resetSnapFastCycleCount()
       startRegularSync()
 
@@ -277,6 +290,46 @@ class SyncController(
       case msg =>
         regularSync.forward(msg)
     }
+  }
+
+  /** Receive used between `SnapSyncFinalized` and `Done` from the lingering SNAPSyncController.
+    *
+    * Regular sync is the primary owner of peer slots; SNAP backfill runs at low priority in the background. This
+    * Receive lets `SNAPSyncController.Done` arrive (so we can poison-pill the SNAP actor) and intercepts restart paths
+    * so the lingering backfill actor is cleaned up before a new sync mode takes over. Everything else is delegated to
+    * `runningRegularSync(regularSync)`.
+    */
+  def runningRegularSyncWithBackfill(regularSync: ActorRef, snapSync: ActorRef): Receive = {
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
+      log.info("SNAP background backfill complete; shutting down SNAPSyncController.")
+      context.unwatch(snapSync)
+      snapSync ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+
+    case Terminated(actor) if actor == snapSync =>
+      log.warning("SNAPSyncController died while regular sync was running; chain backfill aborted.")
+      context.become(runningRegularSync(regularSync))
+
+    case msg if isRestartTrigger(msg) =>
+      log.info("Restart triggered while SNAP backfill was running; poison-pilling SNAP backfill actor first.")
+      context.unwatch(snapSync)
+      snapSync ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+      self ! msg // Re-deliver so the new state handles it.
+
+    case msg =>
+      runningRegularSync(regularSync).apply(msg)
+  }
+
+  /** Restart-style messages that mean the current sync strategy is being abandoned. Used by
+    * `runningRegularSyncWithBackfill` to detect when it must terminate the lingering backfill actor before delegating.
+    */
+  private def isRestartTrigger(msg: Any): Boolean = msg match {
+    case SyncProtocol.ResetFastSync       => true
+    case SyncProtocol.RestartFastSync     => true
+    case RestartFastSyncNow               => true
+    case _: SyncProtocol.RegularSyncStuck => true
+    case _                                => false
   }
 
   def runningRegularSyncBootstrap(
@@ -393,6 +446,18 @@ class SyncController(
       if (!checkSnapFastEscapeHatch()) {
         startFastSync()
       }
+
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.SnapSyncFinalized(pivot) =>
+      log.info(
+        s"Received SnapSyncFinalized(pivot=$pivot) during pivot header bootstrap. Stopping bootstrap and transitioning to regular sync."
+      )
+      headerBootstrap ! PoisonPill
+      peersClient ! PoisonPill
+      // SNAP finalised mid-bootstrap is an exceptional path; tear down the SNAP actor cleanly
+      // (no chain-backfill watch, since the bootstrap state is already racy).
+      originalSnapSyncRef ! PoisonPill
+      resetSnapFastCycleCount()
+      startRegularSync()
 
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
       log.info(
@@ -696,7 +761,7 @@ class SyncController(
     context.become(runningSnapSync(snapSync))
   }
 
-  def startRegularSync(): Unit = {
+  def startRegularSync(): ActorRef = {
     syncGeneration += 1
     val peersClient =
       context.actorOf(
@@ -729,6 +794,7 @@ class SyncController(
     )
     regularSync ! SyncProtocol.Start
     context.become(runningRegularSync(regularSync))
+    regularSync
   }
 
   def startRecovery(needBytecode: Boolean, needStorage: Boolean): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -118,6 +118,9 @@ class ChainDownloader(
     case BoostConcurrency(n) =>
       boostConcurrency(n)
 
+    case YieldToRegularSync(n) =>
+      yieldToRegularSync(n)
+
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
   }
@@ -158,6 +161,9 @@ class ChainDownloader(
     case BoostConcurrency(n) =>
       boostConcurrency(n)
       dispatchRequests() // Immediately use the new slots
+
+    case YieldToRegularSync(n) =>
+      yieldToRegularSync(n)
 
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
@@ -578,6 +584,14 @@ class ChainDownloader(
     scheduleDispatch(200.millis)
   }
 
+  private def yieldToRegularSync(n: Int): Unit = {
+    val prev = maxConcurrentRequests
+    maxConcurrentRequests = n
+    log.info("Chain download yielding to regular sync: {} -> {} concurrent requests (background backfill)", prev, n)
+    // Slow the dispatch tick so backfill doesn't fight regular sync for the actor mailbox or peers.
+    scheduleDispatch(2.seconds)
+  }
+
   private def scheduleDispatch(interval: FiniteDuration = 2.seconds): Unit = {
     dispatchTask.foreach(_.cancel())
     dispatchTask = Some(
@@ -599,6 +613,9 @@ object ChainDownloader {
   case object Stop
   case object Done
   case class BoostConcurrency(maxConcurrent: Int)
+  // Sent when SNAP state is finalised and regular sync is taking over. Backfill drops to a smaller
+  // concurrency budget so it competes politely for peer slots. Mirrors `BoostConcurrency` but downward.
+  case class YieldToRegularSync(maxConcurrent: Int)
   case object GetProgress
   case class Progress(
       headersDownloaded: BigInt,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -85,6 +85,10 @@ class ChainDownloader(
   // Concurrency — starts conservative during SNAP state sync, boosted after state completes
   private var maxConcurrentRequests: Int = initialMaxConcurrentRequests
 
+  // Visible to tests in the same package: lets ChainDownloaderSpec assert YieldToRegularSync clamping
+  // without relying on log-output scraping or reflection.
+  private[snap] def currentMaxConcurrentRequests: Int = maxConcurrentRequests
+
   // Dispatch timer
   private var dispatchTask: Option[org.apache.pekko.actor.Cancellable] = None
 
@@ -585,9 +589,20 @@ class ChainDownloader(
   }
 
   private def yieldToRegularSync(n: Int): Unit = {
+    // Clamp to >=1: zero would wedge dispatch (inFlightCount >= maxConcurrentRequests is immediately
+    // true), preventing any new work from starting and stranding the parent waiting for ChainDownloader.Done
+    // forever. If the operator wants no backfill, they should disable it via chain-download-enabled=false.
+    val clamped = math.max(n, 1)
     val prev = maxConcurrentRequests
-    maxConcurrentRequests = n
-    log.info("Chain download yielding to regular sync: {} -> {} concurrent requests (background backfill)", prev, n)
+    maxConcurrentRequests = clamped
+    if (clamped != n) {
+      log.warning("YieldToRegularSync({}) clamped to {} to prevent dispatch wedge", n, clamped)
+    }
+    log.info(
+      "Chain download yielding to regular sync: {} -> {} concurrent requests (background backfill)",
+      prev,
+      clamped
+    )
     // Slow the dispatch tick so backfill doesn't fight regular sync for the actor mailbox or peers.
     scheduleDispatch(2.seconds)
   }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -239,6 +239,24 @@ class SNAPSyncController(
     progressMonitor.stopPeriodicLogging()
   }
 
+  /** Stop the SNAP state-sync child coordinators (account/bytecode/storage/healing) and clear their references. They do
+    * not self-stop on completion, so when `SNAPSyncController` is kept alive past `finalizeSnapSync()` for background
+    * chain backfill (#1162), failing to stop them retains completed task buffers, worker actors, and rate trackers for
+    * the entire backfill window. The previous `PoisonPill` to the parent used to clean these up implicitly.
+    *
+    * `chainDownloader` is NOT stopped here — it keeps running in `completedWithBackfill`.
+    */
+  private def stopStateSyncChildren(): Unit = {
+    accountRangeCoordinator.foreach(context.stop)
+    accountRangeCoordinator = None
+    bytecodeCoordinator.foreach(context.stop)
+    bytecodeCoordinator = None
+    storageRangeCoordinator.foreach(context.stop)
+    storageRangeCoordinator = None
+    trieNodeHealingCoordinator.foreach(context.stop)
+    trieNodeHealingCoordinator = None
+  }
+
   override def receive: Receive = idle
 
   def idle: Receive = {
@@ -2535,8 +2553,11 @@ class SNAPSyncController(
     currentPhase = Completed
 
     // Cancel SNAP-only schedules before handing off so eviction tickers / stagnation checks stop
-    // affecting peers while regular sync runs. The chain downloader child is intentionally NOT stopped.
+    // affecting peers while regular sync runs. Stop state-sync child coordinators too — they don't
+    // self-stop on completion and would otherwise retain completed task buffers and worker actors
+    // for the full background-backfill window. The chain downloader child is intentionally NOT stopped.
     stopSnapOnlySchedules()
+    stopStateSyncChildren()
 
     // Phase 1 of the handshake: tell the parent that pivot/state is anchored. Parent starts RegularSync.
     context.parent ! SnapSyncFinalized(pivot)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -216,7 +216,15 @@ class SNAPSyncController(
   }
 
   override def postStop(): Unit = {
-    // Cancel all scheduled tasks
+    stopSnapOnlySchedules()
+    log.info("SNAP Sync Controller stopped")
+  }
+
+  /** Cancel every SNAP-only scheduled task. Idempotent — Cancellables tolerate double-cancel. Called both at the
+    * lifecycle transition into `completedWithBackfill` (so eviction/tickers don't keep running while regular sync owns
+    * the peer pool) and at `postStop()`.
+    */
+  private def stopSnapOnlySchedules(): Unit = {
     accountRangeRequestTask.foreach(_.cancel())
     bytecodeRequestTask.foreach(_.cancel())
     storageRangeRequestTask.foreach(_.cancel())
@@ -229,8 +237,6 @@ class SNAPSyncController(
     snapPeerEvictionTask.foreach(_.cancel())
     rateTrackerTuneTask.foreach(_.cancel())
     progressMonitor.stopPeriodicLogging()
-
-    log.info("SNAP Sync Controller stopped")
   }
 
   override def receive: Receive = idle
@@ -2461,38 +2467,24 @@ class SNAPSyncController(
     refreshPivotInPlace(s"account stall: $context")
   }
 
+  /** State sync + healing + validation finished — anchor the pivot and hand off to regular sync immediately.
+    *
+    * Historical chain backfill (genesis → pivot) is decoupled: we do not block here waiting for it. Instead,
+    * `finalizeSnapSync()` emits `SnapSyncFinalized(pivot)` to the parent (which starts RegularSync) and either:
+    *   - emits `Done` immediately if backfill is disabled or already complete, or
+    *   - keeps the controller alive in `completedWithBackfill` so it can forward `ChainDownloader.Progress` /
+    *     `ChainDownloader.Done` to the parent without blocking forward sync.
+    *
+    * Closes #1162.
+    */
   private def completeSnapSync(): Unit =
-    pivotBlock.foreach { pivot =>
-      if (snapSyncConfig.deferredMerkleization) {
-        // With deferred merkleization, don't wait for chain download to finish.
-        // Downloading 24M+ block headers/bodies/receipts from genesis takes days and
-        // blocks the node from syncing new blocks. Regular sync will handle chain data
-        // from the pivot forward. Historical chain data can be backfilled later.
-        log.info(
-          "Deferred merkleization enabled — skipping chain download wait. " +
-            "Finalizing SNAP sync immediately to start regular sync from pivot."
-        )
-        // Stop the chain downloader — regular sync handles blocks from pivot onward
-        chainDownloader.foreach(context.stop)
-        chainDownloader = None
-        finalizeSnapSync(pivot)
-      } else if (!chainDownloadComplete && chainDownloader.isDefined) {
-        // Chain download is still running — boost its concurrency and wait
-        log.info("SNAP state sync complete, boosting chain download concurrency and waiting for completion...")
-        chainDownloader.foreach(
-          _ ! ChainDownloader.BoostConcurrency(
-            snapSyncConfig.chainDownloadBoostedConcurrentRequests
-          )
-        )
-        currentPhase = ChainDownloadCompletion
-        progressMonitor.startPhase(ChainDownloadCompletion)
-        context.become(waitingForChainDownload)
-      } else {
-        finalizeSnapSync(pivot)
-      }
-    }
+    pivotBlock.foreach(finalizeSnapSync)
 
-  /** Final SNAP sync completion — called when both state sync and chain download are done. */
+  /** Anchor the pivot, mark SNAP state done, and hand off to the parent. Always emits `SnapSyncFinalized(pivot)`. Emits
+    * `Done` either immediately (no backfill in flight) or later from `completedWithBackfill` after
+    * `ChainDownloader.Done` arrives. SNAP-only schedules are cancelled before the handoff so eviction tickers and
+    * stagnation checks don't keep firing while regular sync owns the peer pool.
+    */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
     appStateStorage.snapSyncDone().commit()
 
@@ -2538,32 +2530,64 @@ class SNAPSyncController(
         appStateStorage.putBestBlockNumber(pivot).commit()
     }
 
-    // Stop chain downloader if still running
-    chainDownloader.foreach(context.stop)
-    chainDownloader = None
-
     progressMonitor.complete()
     log.info(progressMonitor.currentProgress.toString)
+    currentPhase = Completed
 
-    context.become(completed)
-    context.parent ! Done
+    // Cancel SNAP-only schedules before handing off so eviction tickers / stagnation checks stop
+    // affecting peers while regular sync runs. The chain downloader child is intentionally NOT stopped.
+    stopSnapOnlySchedules()
+
+    // Phase 1 of the handshake: tell the parent that pivot/state is anchored. Parent starts RegularSync.
+    context.parent ! SnapSyncFinalized(pivot)
+
+    val backfillStillRunning =
+      snapSyncConfig.chainDownloadEnabled && chainDownloader.isDefined && !chainDownloadComplete
+
+    if (backfillStillRunning) {
+      log.info(
+        s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
+      )
+      // Yield peer slots to regular sync — backfill keeps a small budget.
+      chainDownloader.foreach(
+        _ ! ChainDownloader.YieldToRegularSync(snapSyncConfig.chainBackfillConcurrentRequests)
+      )
+      context.become(completedWithBackfill)
+    } else {
+      // No backfill in flight — emit Done immediately. Parent poison-pills this actor.
+      chainDownloader.foreach(context.stop)
+      chainDownloader = None
+      context.become(completed)
+      context.parent ! Done
+    }
   }
 
-  /** Waiting for parallel chain download to finish after SNAP state sync completed. */
-  def waitingForChainDownload: Receive = handlePeerListMessagesWithRateTracking.orElse {
-    case ChainDownloader.Done =>
-      log.info("Parallel chain download complete. Finalizing SNAP sync.")
-      chainDownloadComplete = true
-      pivotBlock.foreach(finalizeSnapSync)
-
+  /** Receive after SNAP state is finalised but `ChainDownloader` is still backfilling history.
+    *
+    * Minimal surface — only what `ChainDownloader` and status RPCs need. SNAP-protocol responses, peer-list messages,
+    * and stagnation checks are no longer relevant; everything else is silently dropped. The actor's sole remaining job
+    * is to propagate `ChainDownloader.Done` to the parent so it can poison-pill us.
+    */
+  def completedWithBackfill: Receive = {
     case ChainDownloader.Progress(h, b, r, t) =>
       progressMonitor.updateChainProgress(h, b, r, t)
 
+    case ChainDownloader.Done =>
+      log.info("Background chain backfill complete; SNAPSyncController shutting down.")
+      chainDownloadComplete = true
+      chainDownloader.foreach(context.stop)
+      chainDownloader = None
+      context.become(completed)
+      context.parent ! Done
+
     case SyncProtocol.GetStatus =>
-      sender() ! currentSyncStatus
+      sender() ! SyncProtocol.Status.SyncDone
 
     case GetProgress =>
       sender() ! progressMonitor.currentProgress
+
+    case _ =>
+    // Stale SNAP messages, leaked tickers, and other noise are silently dropped.
   }
 
   private def startChainDownloader(): Unit = {
@@ -2667,6 +2691,12 @@ object SNAPSyncController {
 
   case object Start
   case object Done
+  // Two-phase handshake with SyncController:
+  //   1. SnapSyncFinalized(pivot) — pivot/state anchored, regular sync can start.
+  //      SyncController starts RegularSync but does NOT poison-pill SNAPSyncController.
+  //   2. Done — backfill complete (or absent/disabled). SyncController poison-pills SNAPSyncController.
+  // Sender always emits the same shape: Finalized first, then Done either immediately or after backfill.
+  final case class SnapSyncFinalized(pivot: BigInt)
   case object FallbackToFastSync // Signal to fallback to fast sync due to repeated failures
   case class StartRegularSyncBootstrap(targetBlock: BigInt) // Request bootstrap from SyncController
   final case class BootstrapComplete(
@@ -2775,6 +2805,9 @@ case class SNAPSyncConfig(
     chainDownloadEnabled: Boolean = true,
     chainDownloadMaxConcurrentRequests: Int = 2,
     chainDownloadBoostedConcurrentRequests: Int = 16,
+    // Concurrency budget for chain backfill once SNAP state is finalised and regular sync has started.
+    // Smaller than `chainDownloadMaxConcurrentRequests` so backfill yields peer slots to regular sync.
+    chainBackfillConcurrentRequests: Int = 2,
     chainDownloadTimeout: FiniteDuration = 10.seconds,
     minSnapPeers: Int = 3,
     snapPeerEvictionInterval: FiniteDuration = 15.seconds,
@@ -2856,6 +2889,10 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("chain-download-boosted-concurrent-requests"))
           snapConfig.getInt("chain-download-boosted-concurrent-requests")
         else 16,
+      chainBackfillConcurrentRequests =
+        if (snapConfig.hasPath("chain-backfill-concurrent-requests"))
+          snapConfig.getInt("chain-backfill-concurrent-requests")
+        else 2,
       chainDownloadTimeout =
         if (snapConfig.hasPath("chain-download-timeout"))
           snapConfig.getDuration("chain-download-timeout").toMillis.millis

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -1,0 +1,24 @@
+package com.chipprbots.ethereum.blockchain.sync.snap
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.testing.Tags._
+
+class ChainDownloaderSpec extends AnyFlatSpec with Matchers {
+
+  // Regression for #1162: chain backfill keeps running in the background after SNAPSyncController
+  // emits SnapSyncFinalized, but at lower priority. ChainDownloader needs a `YieldToRegularSync(n)`
+  // message that mirrors `BoostConcurrency(n)` but downward — the SNAP controller sends it in
+  // finalizeSnapSync() so backfill yields peer slots to forward sync.
+  "ChainDownloader.YieldToRegularSync" should "carry the new concurrency budget" taggedAs UnitTest in {
+    ChainDownloader.YieldToRegularSync(7).maxConcurrent shouldBe 7
+    ChainDownloader.YieldToRegularSync(0).maxConcurrent shouldBe 0
+  }
+
+  it should "be a distinct message type from BoostConcurrency" taggedAs UnitTest in {
+    val yielded: Any = ChainDownloader.YieldToRegularSync(7)
+    val boosted: Any = ChainDownloader.BoostConcurrency(7)
+    (yielded should not).equal(boosted)
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -80,8 +80,8 @@ class ChainDownloaderSpec
     system.stop(downloader)
   }
 
-  /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start`
-    * sent), so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
+  /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start` sent),
+    * so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
     */
   private def newDownloader(initialMaxConcurrentRequests: Int): TestActorRef[ChainDownloader] = {
     implicit val ec: ExecutionContext = system.dispatcher

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -1,11 +1,31 @@
 package com.chipprbots.ethereum.blockchain.sync.snap
 
-import org.scalatest.flatspec.AnyFlatSpec
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActorRef
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+
+import scala.concurrent.ExecutionContext
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.testing.Tags._
 
-class ChainDownloaderSpec extends AnyFlatSpec with Matchers {
+class ChainDownloaderSpec
+    extends TestKit(ActorSystem("ChainDownloaderSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockFactory
+    with TestSyncConfig {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   // Regression for #1162: chain backfill keeps running in the background after SNAPSyncController
   // emits SnapSyncFinalized, but at lower priority. ChainDownloader needs a `YieldToRegularSync(n)`
@@ -13,12 +33,72 @@ class ChainDownloaderSpec extends AnyFlatSpec with Matchers {
   // finalizeSnapSync() so backfill yields peer slots to forward sync.
   "ChainDownloader.YieldToRegularSync" should "carry the new concurrency budget" taggedAs UnitTest in {
     ChainDownloader.YieldToRegularSync(7).maxConcurrent shouldBe 7
-    ChainDownloader.YieldToRegularSync(0).maxConcurrent shouldBe 0
   }
 
   it should "be a distinct message type from BoostConcurrency" taggedAs UnitTest in {
     val yielded: Any = ChainDownloader.YieldToRegularSync(7)
     val boosted: Any = ChainDownloader.BoostConcurrency(7)
     (yielded should not).equal(boosted)
+  }
+
+  // Behavioural test: the downloader's dispatch loop wedges if `maxConcurrentRequests` ever drops to
+  // zero (the slot check `inFlightCount >= maxConcurrentRequests` would be true forever), stranding
+  // the parent `SNAPSyncController` waiting for `ChainDownloader.Done` indefinitely. Clamp to >=1.
+  "ChainDownloader" should "clamp YieldToRegularSync(0) to 1 to prevent dispatch wedge" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 16)
+
+    downloader ! ChainDownloader.YieldToRegularSync(0)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 1
+
+    downloader ! ChainDownloader.YieldToRegularSync(5)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 5
+
+    system.stop(downloader)
+  }
+
+  it should "honour YieldToRegularSync(n) for any n >= 1" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 16)
+
+    downloader ! ChainDownloader.YieldToRegularSync(2)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 2
+
+    downloader ! ChainDownloader.YieldToRegularSync(1)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 1
+
+    system.stop(downloader)
+  }
+
+  it should "still apply YieldToRegularSync after BoostConcurrency (downward)" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 2)
+
+    downloader ! ChainDownloader.BoostConcurrency(16)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 16
+
+    downloader ! ChainDownloader.YieldToRegularSync(2)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 2
+
+    system.stop(downloader)
+  }
+
+  /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start`
+    * sent), so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
+    */
+  private def newDownloader(initialMaxConcurrentRequests: Int): TestActorRef[ChainDownloader] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+    TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = initialMaxConcurrentRequests
+      )
+    )
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -42,6 +42,29 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     config.maxSnapSyncFailures should be > 0
   }
 
+  // Regression for #1162: chain backfill is decoupled from SNAP completion. The new
+  // `chainBackfillConcurrentRequests` budget controls how many in-flight ETH requests background
+  // backfill is allowed once regular sync has taken over. Default must be small (yield to regular sync).
+  it should "default chainBackfillConcurrentRequests to a small value (yield to regular sync)" taggedAs UnitTest in {
+    val config = SNAPSyncConfig()
+    config.chainBackfillConcurrentRequests should be > 0
+    config.chainBackfillConcurrentRequests should be <= config.chainDownloadBoostedConcurrentRequests
+  }
+
+  // Regression for #1162: SNAPSyncController emits a two-phase handshake — SnapSyncFinalized first,
+  // then Done either immediately or later. SnapSyncFinalized must carry the pivot block number
+  // so SyncController has the context it needs when starting regular sync.
+  "SNAPSyncController.SnapSyncFinalized" should "carry the pivot block number" taggedAs UnitTest in {
+    val msg = SNAPSyncController.SnapSyncFinalized(BigInt(12345))
+    msg.pivot shouldBe BigInt(12345)
+  }
+
+  it should "be distinct from Done" taggedAs UnitTest in {
+    val finalized: Any = SNAPSyncController.SnapSyncFinalized(BigInt(0))
+    val done: Any = SNAPSyncController.Done
+    (finalized should not).equal(done)
+  }
+
   "SyncProgress" should "format progress string correctly" taggedAs UnitTest in {
     import SNAPSyncController._
 


### PR DESCRIPTION
## Summary

- **Closes #1162** — historical chain download no longer blocks SNAP completion.
- After state + healing + validation, `SNAPSyncController` now emits `SnapSyncFinalized(pivot)`, regular sync starts immediately, and `ChainDownloader` keeps running in the background at lower priority.
- Two-phase handshake (`SnapSyncFinalized` → `Done`) replaces the single `Done` signal so `SyncController` knows when to start regular sync vs. when to poison-pill the SNAP actor.
- New `ChainDownloader.YieldToRegularSync(n)` mirrors `BoostConcurrency(n)` but downward — backfill drops to `chain-backfill-concurrent-requests = 2` so it competes politely for peer slots. Clamped to `max(n, 1)` so a zero never wedges dispatch.
- SNAP-only schedules (peer eviction, stagnation checks, request tickers) cancelled via `stopSnapOnlySchedules()` before the handshake fires.
- **State-sync child coordinators are also stopped** via `stopStateSyncChildren()` (account/bytecode/storage/healing). The previous `PoisonPill` cascade from controller→children was load-bearing; without it those actors would retain completed task buffers and workers for the full backfill window.
- `SyncController.runningRegularSyncWithBackfill` watches the lingering SNAP actor and intercepts restart paths so the backfill is cleaned up before any sync-mode change.

## What's NOT in this PR

- **Persistence/resume of partial backfill across restarts** (tracked as #1169). `ChainDownloader` writes header/body/receipts via `BlockchainWriter` and a single header cursor is insufficient.
- **New `BackgroundChainBackfill` progress-monitor phase** — would need `SyncProgressMonitor` + `SNAPSyncMetrics` changes; deferred to keep the diff focused.
- **Re-parenting `ChainDownloader` to `SyncController`** (tracked as #1170, exploratory).
- **`deferred-merkleization` flag rename** — separate decoupling.
- **Removing dead `chainDownloadBoostedConcurrentRequests` config + `ChainDownloadCompletion` phase** — harmless residue, will tidy in a follow-up.

## Plan

`/home/dontpanic/.claude/plans/findings-1-highest-impact-kind-snowglobe.md` (local).

## Follow-on issues (across audit phases)

#1164 #1165 #1166 #1167 #1168 #1169 #1170 — all linked back to #1162.

## Test plan

- [x] `sbt compile` — clean.
- [x] `sbt scalafmtAll` — clean.
- [x] `sbt "testOnly *SNAPSyncControllerSpec *ChainDownloaderSpec"` — 18 tests pass; data-class regressions plus actor-level clamp behaviour for `YieldToRegularSync`.
- [ ] `sbt test` full suite (CI).
- [ ] **Mordor SNAP run on Cirith Ungol.** Expect `SnapSyncFinalized` log line and forward-sync progress within ~50 min of state finalisation, **without** blocking on chain download. Compare against 2026-04-23 baseline (59m26s end-to-end).
- [ ] **`chain-download-enabled = false` smoke.** Should match today's behaviour: `SnapSyncFinalized` and `Done` emitted back-to-back.
- [ ] **Restart-during-backfill regression.** While backfill is running and regular sync is alive, force a `RegularSyncStuck`. Confirm the lingering SNAP actor is poison-pilled before the new SNAP cycle.

> **Not a pass criterion in this PR:** mid-backfill node restart resuming backfill from cursor. By design, killing the node mid-backfill drops backfill on the floor — pre-pivot history above the highwater stays missing until #1169 lands.

## Behavioural test gap (acknowledged)

The added unit tests cover message data-class shapes and the
ChainDownloader actor's clamp path. Full behavioural coverage of
`SnapSyncFinalized→Done` ordering, regular-sync-start-while-backfill, and
restart-trigger cleanup of the backfill actor would require driving
`SNAPSyncController` and `SyncController` through their state machines —
heavy actor harness. Mordor on-network verification is the gold-standard
regression test for those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)