### PR TITLE
fix(snap): ForceCompleteByteCodes drains pendingTasks — closes #1164

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -110,6 +110,9 @@ class ByteCodeCoordinator(
   // Statistics
   private var bytecodesDownloaded: Long = 0
   private var bytesDownloaded: Long = 0
+  // #1164: number of bytecode hashes abandoned via ForceCompleteByteCodes. Surfaced in postStop()
+  // diagnostics so operators can correlate force-completes with later BytecodeRecoveryActor activity.
+  private var bytecodesAbandoned: Long = 0
 
   // ByteCodes request tuning (Nethermind-style): use a per-peer dynamic byte budget, clamped hard to 2 MiB.
   // We send many hashes and rely on the peer-side `responseBytes` soft limit to bound work.
@@ -148,7 +151,10 @@ class ByteCodeCoordinator(
     log.info("ByteCodeCoordinator starting")
 
   override def postStop(): Unit =
-    log.info(s"ByteCodeCoordinator stopped. Downloaded $bytecodesDownloaded bytecodes")
+    log.info(
+      s"ByteCodeCoordinator stopped. Downloaded $bytecodesDownloaded bytecodes" +
+        (if (bytecodesAbandoned > 0) s", abandoned $bytecodesAbandoned via force-complete" else "")
+    )
 
   override val supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1.minute) { case _: Exception =>
@@ -243,6 +249,29 @@ class ByteCodeCoordinator(
 
     case ByteCodeCheckCompletion =>
       checkCompletion()
+
+    case ForceCompleteByteCodes =>
+      // #1164: When bytecode sync stagnates (e.g., a small set of code hashes no peer can serve),
+      // the existing completion check is unreachable because pendingTasks doesn't drain. Mirrors
+      // StorageRangeCoordinator.ForceCompleteStorage. Missing bytecodes can be recovered post-SNAP
+      // via BytecodeRecoveryActor.
+      val abandonedPending = pendingTasks.size
+      val abandonedActive = activeTasks.size
+      val abandonedTotal = abandonedPending + abandonedActive
+      log.warning(
+        s"Force-completing bytecode sync: $bytecodesDownloaded bytecodes downloaded, " +
+          s"abandoning $abandonedTotal remaining tasks ($abandonedPending pending, $abandonedActive active). " +
+          "Missing bytecodes will be recovered post-SNAP via BytecodeRecoveryActor if needed."
+      )
+      bytecodesAbandoned += abandonedTotal
+      pendingTasks.clear()
+      // Mark workers idle so they don't keep dispatching; drop active task tracking.
+      activeTasks.values.foreach(active => markWorkerIdle(active.worker))
+      activeTasks.clear()
+      // Set the sentinel so any late `checkCompletion()` calls also pass cleanly.
+      noMoreTasksExpected = true
+      log.info("Bytecode sync force-completed (promoting to healing/recovery phase)")
+      snapSyncController ! SNAPSyncController.ByteCodeSyncComplete
 
     case ByteCodeGetProgress =>
       val total = completedTasks.size + activeTasks.size + pendingTasks.size

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -107,6 +107,13 @@ object Messages {
   case object ByteCodeGetProgress extends ByteCodeCoordinatorMessage
   case object ByteCodeCheckCompletion extends ByteCodeCoordinatorMessage
 
+  /** Sent by SNAPSyncController when bytecode sync has stagnated and must be force-completed (#1164). Coordinator
+    * abandons remaining pending/active tasks (with an accounting counter), drains the queue, and reports
+    * `ByteCodeSyncComplete`. Mirrors `ForceCompleteStorage`. Missing bytecodes can be recovered post-SNAP via
+    * `BytecodeRecoveryActor`.
+    */
+  case object ForceCompleteByteCodes extends ByteCodeCoordinatorMessage
+
   sealed trait ByteCodeWorkerMessage
   case class FetchByteCodes(task: ByteCodeTask, peer: Peer) extends ByteCodeWorkerMessage
   case class ByteCodeWorkerFetchTask(task: ByteCodeTask, peer: Peer, requestId: BigInt, maxResponseSize: BigInt)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
@@ -390,4 +390,59 @@ class ByteCodeCoordinatorSpec
     coordinator ! Messages.ByteCodePeerAvailable(peer)
     networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
   }
+
+  // #1164: ForceCompleteByteCodes drains pending+active tasks and reports completion. Without this, a small set of
+  // unservable code hashes could hold the bytecode phase open indefinitely (the existing completion check requires
+  // `pendingTasks.isEmpty && activeTasks.isEmpty` and there's no per-task failure cap).
+  it should "force-complete bytecode sync, abandoning pending tasks (#1164)" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Queue a non-trivial set of bytecode hashes. No peer is registered, so they'll sit in pendingTasks
+    // forever — modelling the wedged state where peers can't serve a small unservable subset.
+    val codeHashes = (1 to 10).map(i => kec256(ByteString(s"code$i")))
+    coordinator ! Messages.StartByteCodeSync(codeHashes)
+    coordinator ! Messages.NoMoreByteCodeTasks
+
+    // Without the force-complete, ByteCodeCheckCompletion stays blocked because pendingTasks is non-empty.
+    coordinator ! Messages.ByteCodeCheckCompletion
+    snapSyncController.expectNoMessage(200.millis)
+
+    // Force-complete drains the queue and signals the parent.
+    coordinator ! Messages.ForceCompleteByteCodes
+    snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
+  }
+
+  it should "handle ForceCompleteByteCodes when queues are already empty" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Empty queue + ForceCompleteByteCodes: should still emit ByteCodeSyncComplete (idempotent terminal state).
+    coordinator ! Messages.ForceCompleteByteCodes
+    snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
+  }
 }


### PR DESCRIPTION
## Summary

- **Closes #1164** — bytecode phase no longer wedges when a small set of code hashes is unservable.
- New `ForceCompleteByteCodes` message + handler mirrors the existing `ForceCompleteStorage` escape valve.
- Drains `pendingTasks` + `activeTasks`, marks workers idle, sets `noMoreTasksExpected = true`, sends `ByteCodeSyncComplete` to the parent.
- New `bytecodesAbandoned` counter is logged in `postStop()` so operators can correlate force-completes with later `BytecodeRecoveryActor` activity.

## Why this is needed

`ByteCodeCoordinator` has no per-task failure cap. The existing per-hash cap (`maxFailuresPerHash = 10`, ByteCodeCoordinator.scala:85) only fires when a peer responded with *some* bytecodes but not all — partial-hit responses. If every peer always times out or refuses outright, the failure counter never increments and tasks sit in `pendingTasks` forever. After `NoMoreByteCodeTasks` arrives, the completion check `noMoreTasksExpected && pendingTasks.isEmpty && activeTasks.isEmpty` is unreachable.

`ForceCompleteByteCodes` is the equivalent escape valve to `ForceCompleteStorage` (StorageRangeCoordinator.scala:614). Missing bytecodes are recoverable post-SNAP via `BytecodeRecoveryActor`, so abandoning is safe as long as we record what was dropped.

## What's NOT in this PR

- **Stagnation watchdog in `SNAPSyncController` to actually fire `ForceCompleteByteCodes`** — the existing per-coordinator stagnation path (`maybeRestartIfStorageStagnant`) is the model, but adding a bytecode equivalent is its own scope. Operators / SyncController callers can drive force-complete from whichever path they prefer first.

## Test plan

- [x] `sbt "testOnly *ByteCodeCoordinatorSpec"` — 12 tests pass (2 new):
  - `should force-complete bytecode sync, abandoning pending tasks (#1164)` — non-empty pending queue stays wedged on `ByteCodeCheckCompletion` (proving the pre-fix bug); `ForceCompleteByteCodes` then triggers `ByteCodeSyncComplete`.
  - `should handle ForceCompleteByteCodes when queues are already empty` — idempotent terminal-state behaviour.
- [x] `sbt scalafmtCheckAll` — clean.
- [ ] `sbt test` full suite (CI).

## Related

- Follow-on to #1162 (parent issue with the audit findings).
- Other follow-ons: #1165 #1166 #1167 #1168 #1169 #1170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)