### PR TITLE
perf(snap): batch flat-slot writes off StorageRangeCoordinator — closes #1165

### DIFF
--- a/src/main/resources/conf/base/pekko.conf
+++ b/src/main/resources/conf/base/pekko.conf
@@ -75,6 +75,22 @@ engine-api-dispatcher {
   throughput = 5
 }
 
+# Dedicated single-thread dispatcher for off-actor flat-slot RocksDB commits
+# during SNAP storage sync. ~95% of contracts hit the small-contract path; the
+# StorageRangeCoordinator used to call `flatSlotStorage.putSlotsBatch(...).commit()`
+# synchronously on the actor mailbox for every one of them, producing a commit
+# storm. The coordinator now aggregates small-contract writes in memory and
+# hands them off here in batches. Single thread because RocksDB compaction is
+# single-threaded anyway and we want to preserve write ordering.
+storage-writer-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 1
+  }
+  throughput = 1
+}
+
 # DEBUGGING SETTING
 # Uncomment to enable non-standard mailbox for all actors
 # Mailbox will start logging actor path, when actor mailbox size will be bigger than `size-limit`

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -176,6 +176,23 @@ object Messages {
       forStateRoot: ByteString
   ) extends StorageRangeCoordinatorMessage
 
+  /** An aggregated flat-slot batch (small-contract writes) finished committing on the storage-writer dispatcher.
+    * `forStateRoot` lets the coordinator drop completion messages from a generation that has since been superseded by a
+    * pivot refresh. The data has already been persisted; the message is just bookkeeping.
+    */
+  private[actors] case class FlatBatchFlushComplete(
+      forStateRoot: ByteString,
+      entryCount: Int,
+      elapsedMs: Long
+  ) extends StorageRangeCoordinatorMessage
+
+  /** Aggregated flat-slot batch failed to commit. Healing phase is expected to re-fetch the missing slots. */
+  private[actors] case class FlatBatchFlushFailed(
+      forStateRoot: ByteString,
+      entryCount: Int,
+      error: String
+  ) extends StorageRangeCoordinatorMessage
+
   // ========================================
   // TrieNodeHealing Messages
   // ========================================

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -5,10 +5,12 @@ import org.apache.pekko.actor.SupervisorStrategy._
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.math.Ordered.orderingToOrdered
 
 import com.chipprbots.ethereum.blockchain.sync.snap._
+import com.chipprbots.ethereum.db.dataSource.DataSourceBatchUpdate
 import com.chipprbots.ethereum.db.storage.{DeferredWriteMptStorage, FlatSlotStorage, MptStorage}
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
@@ -53,7 +55,9 @@ class StorageRangeCoordinator(
     initialMaxInFlightPerPeer: Int = 5,
     configInitialResponseBytes: Int = 1048576,
     configMinResponseBytes: Int = 131072,
-    deferredMerkleization: Boolean = true
+    deferredMerkleization: Boolean = true,
+    flatBatchEntryThreshold: Int = 1000,
+    flatBatchEcOverride: Option[ExecutionContext] = None
 ) extends Actor
     with ActorLogging {
 
@@ -346,6 +350,37 @@ class StorageRangeCoordinator(
     */
   private val smallContractThreshold = 1024
 
+  // ========================================
+  // Aggregated flat-slot writes (small-contract path)
+  // ========================================
+  //
+  // ~95% of ETC contracts hit the small-contract path. Doing a synchronous
+  // RocksDB commit per contract on the actor mailbox produces a commit storm
+  // and starves the coordinator's other work. Instead, accumulate completed
+  // small contracts here and flush them off-thread in batches.
+  //
+  // Stale flushes after a pivot refresh are tagged with the state root they
+  // were aggregated under and dropped at the completion-message handler — the
+  // data is still written (writes are idempotent and any account that
+  // legitimately needs different slot values at a later root will be re-fetched
+  // and overwrite), the bookkeeping just doesn't double-count.
+
+  /** Pending (accountHash, sortedSlots) pairs awaiting flush. Package-private for unit tests. */
+  private[actors] val pendingFlatBatchAccounts =
+    mutable.ArrayBuffer.empty[(ByteString, Seq[(ByteString, ByteString)])]
+
+  /** Total slot entries currently buffered in `pendingFlatBatchAccounts`. Package-private for unit tests. */
+  private[actors] var pendingFlatBatchEntries: Int = 0
+
+  /** Number of in-flight async flat-batch flushes — used to gate completion. Package-private for unit tests. */
+  private[actors] var inFlightFlatBatches: Int = 0
+
+  /** Dedicated dispatcher for flat-batch RocksDB commits. Tests can inject their own ExecutionContext to keep timing
+    * deterministic; production looks up `storage-writer-dispatcher` from the actor system.
+    */
+  private val flatBatchEc: ExecutionContext =
+    flatBatchEcOverride.getOrElse(context.system.dispatchers.lookup("storage-writer-dispatcher"))
+
   /** Bounded thread pool for trie construction — controls RocksDB write pressure. Using 3 threads avoids overwhelming
     * the single-threaded RocksDB compaction while still enabling parallel trie builds. Unbounded Futures on
     * sync-dispatcher caused thread starvation under heavy load.
@@ -361,18 +396,59 @@ class StorageRangeCoordinator(
     )
   private val trieBuilderEc = scala.concurrent.ExecutionContext.fromExecutorService(trieBuilderPool)
 
-  /** Write only to flat storage for small contracts — skip MPT construction. Called synchronously from the actor for
-    * accounts that arrived in a single response with fewer slots than smallContractThreshold. These are ~95% of ETC
-    * contracts. The MPT will be built lazily from flat data during healing or post-sync Merkleization.
+  /** Buffer a small-contract's slots into the aggregated flat-batch accumulator. The actual RocksDB commit is deferred
+    * to `flushPendingFlatBatch()` — called once the accumulator hits `flatBatchEntryThreshold` or at completion — and
+    * runs on `storage-writer-dispatcher` so it doesn't block the coordinator mailbox. ~95% of ETC contracts go through
+    * this path; an inline commit per contract was a hidden RocksDB bottleneck.
     */
-  private def writeSmallContractFlatOnly(
+  private[actors] def writeSmallContractFlatOnly(
       accountHash: ByteString,
       slots: mutable.ArrayBuffer[(ByteString, ByteString)]
   ): Unit = {
-    val sorted = slots.sortBy(_._1)(ByteStringOrdering)
-    flatSlotStorage.putSlotsBatch(accountHash, sorted.toSeq).commit()
+    val sorted = slots.sortBy(_._1)(ByteStringOrdering).toSeq
+    pendingFlatBatchAccounts += ((accountHash, sorted))
+    pendingFlatBatchEntries += sorted.size
     pendingAccountSlots.remove(accountHash)
     totalBufferedSlots -= slots.size
+    if (pendingFlatBatchEntries >= flatBatchEntryThreshold) {
+      flushPendingFlatBatch()
+    }
+  }
+
+  /** Hand the current accumulator off to the storage-writer dispatcher and reset it. The Future builds the combined
+    * `DataSourceBatchUpdate` and commits it in one RocksDB write batch, then notifies the actor with
+    * `FlatBatchFlushComplete` (or `FlatBatchFlushFailed`). The completion message carries `forStateRoot` so the actor
+    * can drop bookkeeping for batches that pre-date a pivot refresh.
+    */
+  private def flushPendingFlatBatch(): Unit = {
+    if (pendingFlatBatchAccounts.isEmpty) return
+    val batchAccounts = pendingFlatBatchAccounts.toList // immutable snapshot
+    val entries = pendingFlatBatchEntries
+    val forStateRoot = stateRoot
+    pendingFlatBatchAccounts.clear()
+    pendingFlatBatchEntries = 0
+    inFlightFlatBatches += 1
+
+    val selfRef = self
+    val storage = flatSlotStorage // capture for Future
+    val ec = flatBatchEc
+    import scala.concurrent.{Future, blocking}
+    Future {
+      blocking {
+        val startMs = System.currentTimeMillis()
+        var combined: DataSourceBatchUpdate = storage.emptyBatchUpdate
+        batchAccounts.foreach { case (accountHash, slots) =>
+          combined = combined.and(storage.putSlotsBatch(accountHash, slots))
+        }
+        combined.commit()
+        System.currentTimeMillis() - startMs
+      }
+    }(ec).onComplete {
+      case scala.util.Success(elapsedMs) =>
+        selfRef ! FlatBatchFlushComplete(forStateRoot, entries, elapsedMs)
+      case scala.util.Failure(e) =>
+        selfRef ! FlatBatchFlushFailed(forStateRoot, entries, e.getMessage)
+    }(ec)
   }
 
   /** Build tries for a batch of complete accounts on a background thread. Sorts slots by key for better trie locality,
@@ -495,6 +571,23 @@ class StorageRangeCoordinator(
 
   /** Shut down the trie builder thread pool when the actor stops. */
   override def postStop(): Unit = {
+    // Best-effort: flush any tail of accumulated small-contract slots synchronously
+    // here so we don't lose data when the actor terminates (force-complete, restart).
+    if (pendingFlatBatchAccounts.nonEmpty) {
+      try {
+        var combined: DataSourceBatchUpdate = flatSlotStorage.emptyBatchUpdate
+        pendingFlatBatchAccounts.foreach { case (accountHash, slots) =>
+          combined = combined.and(flatSlotStorage.putSlotsBatch(accountHash, slots))
+        }
+        combined.commit()
+        log.info(s"postStop: flushed final ${pendingFlatBatchEntries} flat slot entries")
+      } catch {
+        case e: Exception =>
+          log.error(s"postStop: failed to flush final flat batch: ${e.getMessage}")
+      }
+      pendingFlatBatchAccounts.clear()
+      pendingFlatBatchEntries = 0
+    }
     trieBuilderPool.shutdown()
     super.postStop()
   }
@@ -586,6 +679,10 @@ class StorageRangeCoordinator(
       ) {
         flushAllPendingTrieBuilds()
       }
+      // Drain the flat-batch accumulator once no more downloads are coming.
+      if (noMoreTasksExpected && tasks.isEmpty && activeTasks.isEmpty) {
+        flushPendingFlatBatch()
+      }
       if (isComplete) {
         log.info("Storage range sync complete!")
         snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
@@ -605,6 +702,7 @@ class StorageRangeCoordinator(
       // Trigger final trie builds if all downloads are done
       if (tasks.isEmpty && activeTasks.isEmpty) {
         flushAllPendingTrieBuilds()
+        flushPendingFlatBatch()
       }
       if (isComplete) {
         log.info("Storage range sync complete!")
@@ -621,6 +719,8 @@ class StorageRangeCoordinator(
       )
       // Build tries for any fully-downloaded accounts before force-completing
       flushAllPendingTrieBuilds()
+      // Hand off any small-contract slots that are still in the accumulator.
+      flushPendingFlatBatch()
       // Discard partially-downloaded accounts (continuations won't arrive)
       pendingAccountSlots.clear()
       totalBufferedSlots = 0
@@ -629,6 +729,13 @@ class StorageRangeCoordinator(
 
     case StoragePivotRefreshed(newStateRoot) =>
       log.info(s"Storage pivot refreshed: ${stateRoot.take(4).toHex} -> ${newStateRoot.take(4).toHex}")
+
+      // Flush before mutating `stateRoot` so the off-actor commit is tagged with the OLD root.
+      // The completion message will then arrive when `stateRoot` is the NEW root, take the stale
+      // branch in the handler, and emit the "bookkeeping ignored, data on disk" debug line. Done
+      // before the buffer-clears below so we don't have to coordinate the order with `pendingFlatBatchAccounts`.
+      flushPendingFlatBatch()
+
       stateRoot = newStateRoot
 
       // Cancel all in-flight requests: their responses are for the old root and will
@@ -727,6 +834,28 @@ class StorageRangeCoordinator(
           pendingAccountSlots.remove(hash)
         }
       }
+      self ! StorageCheckCompletion
+
+    case FlatBatchFlushComplete(forStateRoot, entryCount, elapsedMs) =>
+      inFlightFlatBatches = (inFlightFlatBatches - 1).max(0)
+      if (forStateRoot != stateRoot) {
+        log.debug(
+          s"Flat batch flush completed for stale root ${forStateRoot.take(4).toHex} " +
+            s"($entryCount entries) — bookkeeping ignored, data on disk"
+        )
+      } else {
+        val rate = if (elapsedMs > 0) entryCount * 1000L / elapsedMs else entryCount.toLong
+        log.debug(s"Flat batch flushed: $entryCount slots in ${elapsedMs}ms ($rate slots/s)")
+      }
+      // A drained flush may have unblocked completion (NoMore + empty queues).
+      self ! StorageCheckCompletion
+
+    case FlatBatchFlushFailed(forStateRoot, entryCount, error) =>
+      inFlightFlatBatches = (inFlightFlatBatches - 1).max(0)
+      log.error(
+        s"Flat batch flush failed for $entryCount slots " +
+          s"(root ${forStateRoot.take(4).toHex}): $error. Healing phase will recover."
+      )
       self ! StorageCheckCompletion
   }
 
@@ -1096,7 +1225,8 @@ class StorageRangeCoordinator(
 
   private def isComplete: Boolean =
     noMoreTasksExpected && tasks.isEmpty && activeTasks.isEmpty &&
-      accountsReadyForBuild.isEmpty && accountsInTrieConstruction.isEmpty && pendingAccountSlots.isEmpty
+      accountsReadyForBuild.isEmpty && accountsInTrieConstruction.isEmpty && pendingAccountSlots.isEmpty &&
+      pendingFlatBatchAccounts.isEmpty && inFlightFlatBatches == 0
 
   /** Update contract completion counts and send progress to controller. */
   private def updateContractProgress(): Unit = {
@@ -1137,7 +1267,9 @@ object StorageRangeCoordinator {
       initialMaxInFlightPerPeer: Int = 5,
       initialResponseBytes: Int = 1048576,
       minResponseBytes: Int = 131072,
-      deferredMerkleization: Boolean = true
+      deferredMerkleization: Boolean = true,
+      flatBatchEntryThreshold: Int = 1000,
+      flatBatchEcOverride: Option[ExecutionContext] = None
   ): Props =
     Props(
       new StorageRangeCoordinator(
@@ -1153,7 +1285,9 @@ object StorageRangeCoordinator {
         initialMaxInFlightPerPeer,
         configInitialResponseBytes = initialResponseBytes,
         configMinResponseBytes = minResponseBytes,
-        deferredMerkleization = deferredMerkleization
+        deferredMerkleization = deferredMerkleization,
+        flatBatchEntryThreshold = flatBatchEntryThreshold,
+        flatBatchEcOverride = flatBatchEcOverride
       )
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -1,9 +1,10 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.{TestKit, TestProbe, ImplicitSender}
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe, ImplicitSender}
 import org.apache.pekko.util.ByteString
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 import org.scalatest.BeforeAndAfterAll
@@ -169,5 +170,187 @@ class StorageRangeCoordinatorSpec
     // Coordinator should still be operational
     coordinator ! Messages.StorageGetProgress
     expectMsgType[Any](3.seconds)
+  }
+
+  // ========================================
+  // Flat-batch aggregator (issue #1165)
+  // ========================================
+
+  /** Helper: build a TestActorRef with the override EC and small threshold so flat-batch behaviour is observable
+    * without spinning up the storage-writer-dispatcher.
+    */
+  private def newCoordWithFlatBatch(
+      flatSlotStorage: FlatSlotStorage,
+      threshold: Int,
+      stateRootArg: ByteString = kec256(ByteString("flat-batch-test-root"))
+  ): (TestActorRef[StorageRangeCoordinator], TestProbe) = {
+    val controller = TestProbe()
+    val ref = TestActorRef[StorageRangeCoordinator](
+      StorageRangeCoordinator.props(
+        stateRoot = stateRootArg,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        flatSlotStorage = flatSlotStorage,
+        maxAccountsPerBatch = 8,
+        maxInFlightRequests = 8,
+        requestTimeout = 30.seconds,
+        snapSyncController = controller.ref,
+        flatBatchEntryThreshold = threshold,
+        flatBatchEcOverride = Some(system.dispatcher)
+      )
+    )
+    (ref, controller)
+  }
+
+  /** Helper: synthesize an account-hash + slots payload of `slotsPerAccount` entries. */
+  private def fakeContract(
+      seed: Int,
+      slotsPerAccount: Int
+  ): (ByteString, mutable.ArrayBuffer[(ByteString, ByteString)]) = {
+    val accountHash = kec256(ByteString(s"acct-$seed"))
+    val slots = mutable.ArrayBuffer.empty[(ByteString, ByteString)]
+    var i = 0
+    while (i < slotsPerAccount) {
+      val slotHash = kec256(ByteString(s"slot-$seed-$i"))
+      val slotValue = ByteString(s"value-$seed-$i".getBytes)
+      slots += ((slotHash, slotValue))
+      i += 1
+    }
+    (accountHash, slots)
+  }
+
+  it should "buffer small-contract slots in the accumulator without immediate commit" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 100)
+
+    val (accountHash, slots) = fakeContract(seed = 1, slotsPerAccount = 3)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 3
+    coord.underlyingActor.pendingFlatBatchAccounts.size shouldBe 1
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+
+    // Nothing was committed — FlatSlotStorage is still empty for our keys.
+    flatSlots.getSlot(accountHash, slots.head._1) shouldBe None
+
+    system.stop(coord)
+  }
+
+  it should "flush exactly once when the threshold is crossed and persist all buffered slots" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 5)
+
+    // Three contracts, 2 slots each = 6 total slots, crossing the 5-entry threshold.
+    val contracts = (1 to 3).map(i => fakeContract(seed = i, slotsPerAccount = 2))
+    contracts.foreach { case (h, s) => coord.underlyingActor.writeSmallContractFlatOnly(h, s) }
+
+    // Flush is async on system.dispatcher; the 1-s deadline is generous.
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+
+    // After flush, all 6 slots are durable.
+    contracts.foreach { case (accountHash, slots) =>
+      slots.foreach { case (slotHash, value) =>
+        flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+      }
+    }
+
+    // Accumulator was reset.
+    coord.underlyingActor.pendingFlatBatchAccounts shouldBe empty
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 0
+
+    system.stop(coord)
+  }
+
+  it should "not trigger a flush when accumulator stays below threshold" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    val (accountHash, slots) = fakeContract(seed = 42, slotsPerAccount = 50)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 50
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+    flatSlots.getSlot(accountHash, slots.head._1) shouldBe None
+
+    system.stop(coord)
+  }
+
+  it should "flush remaining accumulator on ForceCompleteStorage" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, controller) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    val (accountHash, slots) = fakeContract(seed = 99, slotsPerAccount = 4)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 4
+
+    coord ! Messages.ForceCompleteStorage
+
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+    slots.foreach { case (slotHash, value) =>
+      flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+    }
+    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncComplete)
+
+    system.stop(coord)
+  }
+
+  it should "drop bookkeeping for FlatBatchFlushComplete from a stale state root" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    coord.underlyingActor.inFlightFlatBatches = 1
+    val staleRoot = kec256(ByteString("a-stale-root"))
+
+    coord ! Messages.FlatBatchFlushComplete(staleRoot, entryCount = 7, elapsedMs = 5L)
+
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+
+    system.stop(coord)
+  }
+
+  it should "flush the accumulator before mutating stateRoot on StoragePivotRefreshed" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val oldRoot = kec256(ByteString("old-root"))
+    val newRoot = kec256(ByteString("new-root"))
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000, stateRootArg = oldRoot)
+
+    // Buffer some data while stateRoot == oldRoot.
+    val (accountHash, slots) = fakeContract(seed = 7, slotsPerAccount = 4)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 4
+
+    // Pivot refresh: must commit the accumulator THEN advance the root.
+    coord ! Messages.StoragePivotRefreshed(newRoot)
+
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+
+    // Data made it to disk despite the pivot refresh.
+    slots.foreach { case (slotHash, value) =>
+      flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+    }
+    coord.underlyingActor.pendingFlatBatchAccounts shouldBe empty
+
+    system.stop(coord)
+  }
+
+  it should "decrement in-flight count on FlatBatchFlushFailed and stay operational" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    coord.underlyingActor.inFlightFlatBatches = 2
+
+    coord ! Messages.FlatBatchFlushFailed(
+      forStateRoot = kec256(ByteString("flat-batch-test-root")),
+      entryCount = 11,
+      error = "synthetic write failure"
+    )
+
+    coord.underlyingActor.inFlightFlatBatches shouldBe 1
+
+    coord ! Messages.StorageGetProgress
+    expectMsgType[Any](3.seconds)
+
+    system.stop(coord)
   }
 }


### PR DESCRIPTION
## Summary

- Moves the small-contract flat-slot RocksDB commits off the
  `StorageRangeCoordinator` mailbox. ~95% of ETC contracts hit
  `writeSmallContractFlatOnly`, which was committing one batch per
  contract synchronously — a hidden write storm that starved the
  coordinator's other work and serialised against the actor thread.
- Mirrors PR #1163's async-Future pattern: in-memory accumulator,
  threshold-triggered flush, off-actor commit on a dedicated
  `storage-writer-dispatcher`, generation token via `forStateRoot`.
- Constructor-injectable threshold + dispatcher so unit tests stay
  deterministic without spinning up the production dispatcher.

## What changed

| File | Change |
|---|---|
| `StorageRangeCoordinator.scala` | Aggregator state + `flushPendingFlatBatch()` + `FlatBatchFlush{Complete,Failed}` handlers + drain points (`NoMoreStorageTasks`, `ForceCompleteStorage`, `StoragePivotRefreshed`, `postStop`) + `isComplete` gate. |
| `Messages.scala` | `FlatBatchFlushComplete` / `FlatBatchFlushFailed` (`private[actors]`). |
| `pekko.conf` | New `storage-writer-dispatcher` (single-thread). |
| `StorageRangeCoordinatorSpec.scala` | 7 new unit tests. |

Default threshold is `1000` slots ≈ 64 KB at 64 B/slot.

## Drain points

- `StorageCheckCompletion` / `NoMoreStorageTasks` flush the partial
  accumulator before reporting complete.
- `ForceCompleteStorage` flushes before signalling
  `StorageRangeSyncComplete`.
- `StoragePivotRefreshed` flushes **before** mutating `stateRoot`, so
  the off-actor commit is tagged with the OLD root and the handler
  takes the stale-bookkeeping branch ("data on disk, ignored
  bookkeeping") correctly.
- `postStop()` flushes synchronously as a last-resort safety net.

`isComplete` now also requires `pendingFlatBatchAccounts.isEmpty && inFlightFlatBatches == 0`.

## Test plan

- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt 'testOnly com.chipprbots.ethereum.blockchain.sync.snap.actors.StorageRangeCoordinatorSpec'` — 12/12 (5 existing + 7 new)
- [x] `sbt 'testOnly com.chipprbots.ethereum.blockchain.sync.snap.* com.chipprbots.ethereum.blockchain.sync.snap.actors.*'` — 90/90
- [ ] Mordor SNAP run — compare storage-phase wall-clock and small-contract throughput against the 2026-04-23 baseline (~334 slots/s avg)

## New unit tests

1. `should buffer small-contract slots in the accumulator without immediate commit` — write below threshold; FlatSlotStorage stays empty.
2. `should flush exactly once when the threshold is crossed and persist all buffered slots` — three contracts × 2 slots crosses threshold=5; all 6 slots durable; accumulator reset.
3. `should not trigger a flush when accumulator stays below threshold` — 50 slots, threshold=1000, no commit.
4. `should flush remaining accumulator on ForceCompleteStorage` — drain on force-complete; controller receives `StorageRangeSyncComplete`.
5. `should drop bookkeeping for FlatBatchFlushComplete from a stale state root` — counter decrements, no error.
6. `should flush the accumulator before mutating stateRoot on StoragePivotRefreshed` — order check; data persists despite refresh.
7. `should decrement in-flight count on FlatBatchFlushFailed and stay operational` — failure path.

## References

- Closes #1165
- Pattern follows #1163 (`spawnAccountValidation` on `snap-validation-dispatcher`)
- Independent of #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
