### PR TITLE
[codex] fix SNAP forced storage completion handoff

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -84,6 +84,7 @@ class SNAPSyncController(
   // Concurrent phase completion tracking (all 3 coordinators run in parallel)
   private var bytecodePhaseComplete: Boolean = false
   private var storagePhaseComplete: Boolean = false
+  private var storagePhaseForceCompleted: Boolean = false
 
   private val progressMonitor = new SyncProgressMonitor(scheduler)
 
@@ -575,7 +576,17 @@ class SNAPSyncController(
 
     case StorageRangeSyncComplete if !storagePhaseComplete =>
       storagePhaseComplete = true
+      storagePhaseForceCompleted = false
       log.info(s"Storage range sync complete. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete")
+      checkAllDownloadsComplete()
+
+    case StorageRangeSyncForceCompleted if !storagePhaseComplete =>
+      storagePhaseComplete = true
+      storagePhaseForceCompleted = true
+      log.warning(
+        s"Storage range sync was force-completed. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete. " +
+          "SNAP will run healing/validation before regular sync handoff."
+      )
       checkAllDownloadsComplete()
 
     case HealingAllPeersStateless if currentPhase == StateHealing =>
@@ -751,7 +762,7 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
-      if (snapSyncConfig.deferredMerkleization) {
+      if (SNAPSyncController.shouldSkipHealingAfterDownloads(snapSyncConfig, storagePhaseForceCompleted)) {
         // With deferred merkleization, trie nodes were never constructed during download —
         // only flat storage was written. A trie walk would find the entire internal trie "missing",
         // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).
@@ -766,7 +777,14 @@ class SNAPSyncController(
         )
         completeSnapSync()
       } else {
-        log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
+        if (snapSyncConfig.deferredMerkleization && storagePhaseForceCompleted) {
+          log.warning(
+            "All state downloads reached terminal state, but storage was force-completed with deferred " +
+              "merkleization enabled. Starting healing instead of handing off a state with known holes."
+          )
+        } else {
+          log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
+        }
         currentPhase = StateHealing
         startStateHealing()
       }
@@ -1021,6 +1039,7 @@ class SNAPSyncController(
             accountsComplete = true
             bytecodePhaseComplete = false
             storagePhaseComplete = false
+            storagePhaseForceCompleted = false
 
             log.info(s"Recovery: resuming bytecodes + storage sync from pivot $pivot (drift=$drift blocks)")
 
@@ -1767,7 +1786,8 @@ class SNAPSyncController(
               initialMaxInFlightPerPeer =
                 0, // Defer storage dispatch during AccountRangeSync — prevents false pivot refreshes from stale-root timeouts
               initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
-              minResponseBytes = snapSyncConfig.storageMinResponseBytes
+              minResponseBytes = snapSyncConfig.storageMinResponseBytes,
+              deferredMerkleization = snapSyncConfig.deferredMerkleization
             )
             .withDispatcher("sync-dispatcher"),
           s"storage-range-coordinator-$coordinatorGeneration"
@@ -2309,6 +2329,7 @@ class SNAPSyncController(
     accountsComplete = false
     bytecodePhaseComplete = false
     storagePhaseComplete = false
+    storagePhaseForceCompleted = false
     appStateStorage.putSnapSyncAccountsComplete(false).commit()
     appStateStorage.putSnapSyncStorageFilePath("").commit()
 
@@ -2730,6 +2751,7 @@ object SNAPSyncController {
   case object AccountRangeSyncComplete
   case object ByteCodeSyncComplete
   case object StorageRangeSyncComplete
+  case object StorageRangeSyncForceCompleted
 
   /** Inline contract data dispatched from AccountRangeCoordinator after each account batch. Geth-aligned: bytecodes and
     * storage tasks are populated inline from processAccountResponse(), not queried after account download completes.
@@ -2762,6 +2784,12 @@ object SNAPSyncController {
   final case class ProgressNodesHealed(count: Long)
   final case class ProgressAccountEstimate(estimatedTotal: Long)
   final case class ProgressStorageContracts(completedContracts: Int, totalContracts: Int)
+
+  private[snap] def shouldSkipHealingAfterDownloads(
+      snapSyncConfig: SNAPSyncConfig,
+      storagePhaseForceCompleted: Boolean
+  ): Boolean =
+    snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted
 
   def props(
       blockchainReader: BlockchainReader,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -154,7 +154,7 @@ object Messages {
   case object NoMoreStorageTasks extends StorageRangeCoordinatorMessage
 
   /** Sent by SNAPSyncController when storage sync has stagnated and should promote to healing. Coordinator flushes
-    * deferred writes and reports StorageRangeSyncComplete.
+    * deferred writes and reports StorageRangeSyncForceCompleted so the controller cannot treat the handoff as clean.
     */
   case object ForceCompleteStorage extends StorageRangeCoordinatorMessage
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -725,7 +725,7 @@ class StorageRangeCoordinator(
       pendingAccountSlots.clear()
       totalBufferedSlots = 0
       log.info("Storage range sync force-completed (promoting to healing phase)")
-      snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
+      snapSyncController ! SNAPSyncController.StorageRangeSyncForceCompleted
 
     case StoragePivotRefreshed(newStateRoot) =>
       log.info(s"Storage pivot refreshed: ${stateRoot.take(4).toHex} -> ${newStateRoot.take(4).toHex}")

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -141,6 +141,7 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     val _ = AccountRangeSyncComplete
     val _ = ByteCodeSyncComplete
     val _ = StorageRangeSyncComplete
+    val _ = StorageRangeSyncForceCompleted
     val _ = StateHealingComplete
     val _ = StateValidationComplete
     val getProgress = GetProgress
@@ -153,6 +154,24 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     getProgress shouldBe GetProgress
     bootstrapComplete shouldBe BootstrapComplete
     fallback shouldBe FallbackToFastSync
+  }
+
+  it should "skip healing for clean deferred-merkleization downloads only" taggedAs UnitTest in {
+    val config = SNAPSyncConfig(deferredMerkleization = true)
+
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = config,
+      storagePhaseForceCompleted = false
+    ) shouldBe true
+  }
+
+  it should "run healing when storage was force-completed even with deferred merkleization" taggedAs UnitTest in {
+    val config = SNAPSyncConfig(deferredMerkleization = true)
+
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = config,
+      storagePhaseForceCompleted = true
+    ) shouldBe false
   }
 
   it should "have bootstrap message with target block" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -290,7 +290,7 @@ class StorageRangeCoordinatorSpec
     slots.foreach { case (slotHash, value) =>
       flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
     }
-    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncComplete)
+    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncForceCompleted)
 
     system.stop(coord)
   }


### PR DESCRIPTION
## Summary

This fixes the SNAP handoff path where storage stagnation force-completed the storage coordinator but the controller still treated the phase as a clean completion. With deferred merkleization enabled, that allowed SNAP to skip healing/validation and hand regular sync a pivot state with known holes.

Changes:
- Add `StorageRangeSyncForceCompleted` so forced storage completion is distinguishable from clean drain completion.
- Track forced storage completion in `SNAPSyncController` and prevent the deferred-merkleization skip when storage was force-completed.
- Keep the clean deferred-merkleization fast path intact for successful downloads.
- Pass `snapSyncConfig.deferredMerkleization` into the live storage coordinator creation path.
- Add regression coverage for the skip-healing decision and update the storage force-complete expectation.

## Validation

```bash
sbt "testOnly com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncControllerSpec com.chipprbots.ethereum.blockchain.sync.snap.actors.StorageRangeCoordinatorSpec"
```

Result: 27 tests passed.