### PR TITLE
feat(snap): persist & resume background chain backfill across node restarts — closes #1169

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -232,7 +232,9 @@ class SyncController(
         s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
       )
       resetSnapFastCycleCount()
-      val regularSync = startRegularSync()
+      // SNAPSyncController already owns the live ChainDownloader child via its
+      // `completedWithBackfill` state — don't spawn a duplicate standalone resumer (#1169).
+      val regularSync = startRegularSync(resumeBackfill = false)
       context.watch(snapSync)
       context.become(runningRegularSyncWithBackfill(regularSync, snapSync))
 
@@ -761,7 +763,7 @@ class SyncController(
     context.become(runningSnapSync(snapSync))
   }
 
-  def startRegularSync(): ActorRef = {
+  def startRegularSync(resumeBackfill: Boolean = true): ActorRef = {
     syncGeneration += 1
     val peersClient =
       context.actorOf(
@@ -794,7 +796,89 @@ class SyncController(
     )
     regularSync ! SyncProtocol.Start
     context.become(runningRegularSync(regularSync))
+    // After SNAP completes, chain backfill (#1162) writes headers / bodies / receipts in the
+    // background. If the node was killed mid-backfill, persisted cursors (#1169) tell us how
+    // far it got — spawn a standalone ChainDownloader to finish the job alongside regular sync.
+    // Suppressed when called from the SnapSyncFinalized path: SNAPSyncController already owns
+    // the live backfill actor in that flow.
+    if (resumeBackfill) maybeStartBackfillResume(regularSync)
     regularSync
+  }
+
+  /** Spawn a standalone `ChainDownloader` to resume background chain backfill from persisted cursors. No-op when SNAP
+    * has not completed, when no `BackfillTarget` was persisted, or when all cursors have already reached the target.
+    * Issues #1162 (background backfill) + #1169 (resume across restarts).
+    */
+  private def maybeStartBackfillResume(regularSync: ActorRef): Unit =
+    if (appStateStorage.needsBackfillResume()) {
+      val target = appStateStorage.getBackfillTarget()
+      val headerCursor = appStateStorage.getBackfillBestHeader()
+      val bodyCursor = appStateStorage.getBackfillBestBody()
+      val receiptCursor = appStateStorage.getBackfillBestReceipt()
+      log.info(
+        "Resuming background chain backfill: target={}, header={}, body={}, receipt={}",
+        target,
+        headerCursor,
+        bodyCursor,
+        receiptCursor
+      )
+      val snapSyncConfig = loadSnapSyncConfig()
+      syncGeneration += 1
+      import com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader
+      val resumer = context.actorOf(
+        ChainDownloader
+          .props(
+            blockchainReader,
+            blockchainWriter,
+            appStateStorage,
+            networkPeerManager,
+            peerEventBus,
+            syncConfig,
+            scheduler,
+            snapSyncConfig.chainBackfillConcurrentRequests,
+            snapSyncConfig.chainDownloadTimeout
+          )
+          .withDispatcher("sync-dispatcher"),
+        s"backfill-resumer-$syncGeneration"
+      )
+      context.watch(resumer)
+      resumer ! ChainDownloader.Start(target)
+      context.become(runningRegularSyncWithStandaloneBackfill(regularSync, resumer))
+    }
+
+  /** Receive while regular sync runs alongside a standalone backfill resumer (#1169). Mirrors
+    * `runningRegularSyncWithBackfill` but for the post-restart case where we own the backfill actor directly instead of
+    * routing through a lingering `SNAPSyncController`.
+    */
+  def runningRegularSyncWithStandaloneBackfill(regularSync: ActorRef, resumer: ActorRef): Receive = {
+    case com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader.Done =>
+      log.info("Standalone chain backfill resume complete.")
+      context.unwatch(resumer)
+      resumer ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+
+    case progress: com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader.Progress =>
+      log.debug(
+        "Standalone backfill progress: headers={} bodies={} receipts={} target={}",
+        progress.headersDownloaded,
+        progress.bodiesDownloaded,
+        progress.receiptsDownloaded,
+        progress.targetBlock
+      )
+
+    case Terminated(actor) if actor == resumer =>
+      log.warning("Standalone backfill resumer died; chain backfill aborted (cursors persist for next restart).")
+      context.become(runningRegularSync(regularSync))
+
+    case msg if isRestartTrigger(msg) =>
+      log.info("Restart triggered while standalone backfill was running; poison-pilling backfill resumer first.")
+      context.unwatch(resumer)
+      resumer ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+      self ! msg // Re-deliver so the new state handles it.
+
+    case msg =>
+      runningRegularSync(regularSync).apply(msg)
   }
 
   def startRecovery(needBytecode: Boolean, needStorage: Boolean): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -17,6 +17,7 @@ import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.RequestFailed
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.ResponseReceived
+import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.domain.BlockBody
@@ -46,6 +47,7 @@ import com.chipprbots.ethereum.utils.Config.SyncConfig
 class ChainDownloader(
     blockchainReader: BlockchainReader,
     blockchainWriter: BlockchainWriter,
+    appStateStorage: AppStateStorage,
     val networkPeerManager: ActorRef,
     val peerEventBus: ActorRef,
     val blacklist: Blacklist,
@@ -97,6 +99,8 @@ class ChainDownloader(
   def idle: Receive = handlePeerListMessages.orElse {
     case Start(target) =>
       targetBlock = target
+      // Persist the target so a node restart mid-backfill can resume standalone (#1169).
+      appStateStorage.putBackfillTarget(target).commit()
       // Find where we left off (check what's already stored)
       bestHeaderNumber = findBestStoredHeader()
       log.info(
@@ -113,6 +117,7 @@ class ChainDownloader(
       // Re-start downloading if target was updated after completion (e.g. pivot refreshed from 0 to real block)
       if (newTarget > targetBlock && newTarget > bestHeaderNumber) {
         targetBlock = newTarget
+        appStateStorage.putBackfillTarget(newTarget).commit()
         bestHeaderNumber = findBestStoredHeader()
         log.info("Chain download restarted with new target: {}, resuming from header {}", newTarget, bestHeaderNumber)
         scheduleDispatch()
@@ -150,6 +155,7 @@ class ChainDownloader(
       if (newTarget > targetBlock) {
         log.info("Chain download target updated: {} -> {}", targetBlock, newTarget)
         targetBlock = newTarget
+        appStateStorage.putBackfillTarget(newTarget).commit()
       }
 
     case Stop =>
@@ -408,7 +414,9 @@ class ChainDownloader(
     while (!aborted && it.hasNext) {
       val header = it.next()
       if (prevHash.exists(_ == header.parentHash)) {
-        // Store header + chain weight
+        // Store header + chain weight, atomically advancing the backfill cursor in the same
+        // RocksDB write batch (#1169) so a crash mid-write never leaves the cursor ahead of
+        // the data on disk.
         val parentWeight = blockchainReader
           .getChainWeightByHash(header.parentHash)
           .getOrElse(ChainWeight.totalDifficultyOnly(0))
@@ -416,6 +424,7 @@ class ChainDownloader(
         blockchainWriter
           .storeBlockHeader(header)
           .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
+          .and(appStateStorage.putBackfillBestHeader(header.number))
           .commit()
 
         bodiesQueue :+= header.hash
@@ -449,11 +458,22 @@ class ChainDownloader(
       return
     }
 
-    // Store received bodies
+    // Store received bodies + atomically advance the body cursor (#1169).
     val received = requestedHashes.zip(bodies)
+    val highestBodyNumber = received
+      .flatMap { case (hash, _) => blockchainReader.getBlockHeaderByHash(hash).map(_.number) }
+      .maxOption
+      .getOrElse(BigInt(0))
+    val cursorUpdate =
+      if (highestBodyNumber > appStateStorage.getBackfillBestBody())
+        appStateStorage.putBackfillBestBody(highestBodyNumber)
+      else
+        appStateStorage.emptyBatchUpdate
+
     received
       .map { case (hash, body) => blockchainWriter.storeBlockBody(hash, body) }
       .reduce(_.and(_))
+      .and(cursorUpdate)
       .commit()
 
     bodiesDownloaded += received.size
@@ -497,9 +517,23 @@ class ChainDownloader(
           .map(_.toReceipt)
       }
 
-      // Store receipts
-      requestedHashes.zip(receiptsByBlock).foreach { case (hash, receipts) =>
-        blockchainWriter.storeReceipts(hash, receipts).commit()
+      // Store receipts. Atomically advance the receipt cursor (#1169) in the same batch as
+      // the highest-numbered receipt write, so a crash mid-write doesn't leave the cursor
+      // ahead of disk.
+      val receiptsByHash = requestedHashes.zip(receiptsByBlock)
+      val highestReceiptNumber = receiptsByHash
+        .flatMap { case (hash, _) => blockchainReader.getBlockHeaderByHash(hash).map(_.number) }
+        .maxOption
+        .getOrElse(BigInt(0))
+
+      receiptsByHash.zipWithIndex.foreach { case ((hash, receipts), idx) =>
+        val storeUpdate = blockchainWriter.storeReceipts(hash, receipts)
+        val withCursor =
+          if (idx == receiptsByHash.size - 1 && highestReceiptNumber > appStateStorage.getBackfillBestReceipt())
+            storeUpdate.and(appStateStorage.putBackfillBestReceipt(highestReceiptNumber))
+          else
+            storeUpdate
+        withCursor.commit()
       }
 
       receiptsDownloaded += receiptsByBlock.size
@@ -536,20 +570,34 @@ class ChainDownloader(
         receiptsDownloaded,
         targetBlock
       )
+      // Clear backfill cursors so the next startup doesn't try to resume a finished backfill (#1169).
+      appStateStorage.clearBackfillCursors().commit()
       dispatchTask.foreach(_.cancel())
       context.parent ! Done
       context.become(idle)
     }
 
   private def findBestStoredHeader(): BigInt = {
-    // Binary search for the highest stored header starting from genesis
-    // The chain may have been partially downloaded in a previous run
-    var low: BigInt = 0
-    var high: BigInt = targetBlock
-    var best: BigInt = 0
+    // Fast skip: trust the persisted cursor when its header is on disk (#1169).
+    // The cursor is updated atomically with each storeBlockHeader commit so it never
+    // overstates progress. We still validate by reading the header at the cursor —
+    // if the cursor was somehow corrupted (manual DB intervention, downgrade), fall
+    // back to the binary search.
+    val cursorHeader = appStateStorage.getBackfillBestHeader()
+    val (low0, best0) =
+      if (cursorHeader > 0 && blockchainReader.getBlockHeaderByNumber(cursorHeader).isDefined)
+        (cursorHeader + 1, cursorHeader)
+      else
+        (BigInt(0), BigInt(0))
 
-    // Quick check: if genesis+1 doesn't exist, start from 0
-    if (blockchainReader.getBlockHeaderByNumber(1).isEmpty) return 0
+    // Quick check: if genesis+1 doesn't exist, start from 0 (only meaningful for fresh runs).
+    if (best0 == 0 && blockchainReader.getBlockHeaderByNumber(1).isEmpty) return 0
+
+    // Binary search above the cursor for the highest stored header. With cursor-fast-skip
+    // this almost always finds `best == cursorHeader` after one probe.
+    var low: BigInt = low0
+    var high: BigInt = targetBlock
+    var best: BigInt = best0
 
     while (low <= high) {
       val mid = (low + high) / 2
@@ -561,18 +609,27 @@ class ChainDownloader(
       }
     }
 
-    // Also rebuild the body/receipt queues for headers we have but bodies/receipts we don't
+    // Rebuild the body/receipt queues for headers we have but bodies/receipts we don't.
+    // Use the body/receipt cursors as the floor so we don't re-walk every header — anything
+    // ≤ those cursors was committed atomically with its body/receipt write and is on disk.
+    val bodyFloor = appStateStorage.getBackfillBestBody()
+    val receiptFloor = appStateStorage.getBackfillBestReceipt()
+
     var i = best
     while (i >= 1) {
-      blockchainReader.getBlockHeaderByNumber(i) match {
-        case Some(header) =>
-          if (blockchainReader.getBlockBodyByHash(header.hash).isEmpty) {
-            bodiesQueue :+= header.hash
-          }
-          if (blockchainReader.getReceiptsByHash(header.hash).isEmpty) {
-            receiptsQueue :+= header.hash
-          }
-        case None => // shouldn't happen
+      val needsBodyCheck = i > bodyFloor
+      val needsReceiptCheck = i > receiptFloor
+      if (needsBodyCheck || needsReceiptCheck) {
+        blockchainReader.getBlockHeaderByNumber(i) match {
+          case Some(header) =>
+            if (needsBodyCheck && blockchainReader.getBlockBodyByHash(header.hash).isEmpty) {
+              bodiesQueue :+= header.hash
+            }
+            if (needsReceiptCheck && blockchainReader.getReceiptsByHash(header.hash).isEmpty) {
+              receiptsQueue :+= header.hash
+            }
+          case None => // shouldn't happen
+        }
       }
       i -= 1
     }
@@ -643,6 +700,7 @@ object ChainDownloader {
   def props(
       blockchainReader: BlockchainReader,
       blockchainWriter: BlockchainWriter,
+      appStateStorage: AppStateStorage,
       networkPeerManager: ActorRef,
       peerEventBus: ActorRef,
       syncConfig: SyncConfig,
@@ -654,6 +712,7 @@ object ChainDownloader {
       new ChainDownloader(
         blockchainReader,
         blockchainWriter,
+        appStateStorage,
         networkPeerManager,
         peerEventBus,
         CacheBasedBlacklist.empty(1000),

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2643,6 +2643,7 @@ class SNAPSyncController(
             .props(
               blockchainReader,
               blockchainWriter,
+              appStateStorage,
               networkPeerManager,
               peerEventBus,
               syncConfig,

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -303,6 +303,79 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
   /** Store the finalized account trie root hash from finalizeTrie(). */
   def putSnapSyncFinalizedRoot(root: ByteString): DataSourceBatchUpdate =
     put(Keys.SnapSyncFinalizedRoot, Hex.toHexString(root.toArray))
+
+  // ========================================
+  // Background chain backfill cursors (#1169)
+  // ========================================
+  //
+  // After SNAP completes, `ChainDownloader` continues to backfill genesis→pivot in the background
+  // (#1162). If the node is killed mid-backfill we want regular sync to come back up immediately
+  // and *also* resume backfill from where it stopped. These cursors give us:
+  //
+  //   1. A fast skip-to-current path on resume (no full binary search across the chain).
+  //   2. A predicate (`needsBackfillResume`) for `SyncController.start()` to decide whether to
+  //      spawn a standalone `ChainDownloader` alongside regular sync.
+  //
+  // Three separate cursors because `ChainDownloader` writes headers, bodies, and receipts on
+  // independent commit paths — they don't all advance in lockstep and must be tracked
+  // separately. Each cursor is updated atomically with its corresponding storage commit so a
+  // crash mid-write never leaves the cursor ahead of the data on disk.
+
+  /** Highest backfill target the node was working toward when it last saved progress. Set when `ChainDownloader`
+    * starts; cleared after `Done` so future startups don't spuriously resume.
+    */
+  def getBackfillTarget(): BigInt =
+    getBigInt(Keys.BackfillTarget)
+
+  def putBackfillTarget(target: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillTarget, target.toString)
+
+  /** Highest header number whose `storeBlockHeader` commit has succeeded. */
+  def getBackfillBestHeader(): BigInt =
+    getBigInt(Keys.BackfillBestHeader)
+
+  def putBackfillBestHeader(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestHeader, n.toString)
+
+  /** Highest block number whose `storeBlockBody` commit has succeeded. May lag the header cursor. */
+  def getBackfillBestBody(): BigInt =
+    getBigInt(Keys.BackfillBestBody)
+
+  def putBackfillBestBody(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestBody, n.toString)
+
+  /** Highest block number whose `storeReceipts` commit has succeeded. May lag the body cursor. */
+  def getBackfillBestReceipt(): BigInt =
+    getBigInt(Keys.BackfillBestReceipt)
+
+  def putBackfillBestReceipt(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestReceipt, n.toString)
+
+  /** Clear all backfill cursors + target. Called on `ChainDownloader.Done` so the next startup doesn't try to resume an
+    * already-completed backfill.
+    */
+  def clearBackfillCursors(): DataSourceBatchUpdate =
+    update(
+      toRemove = Seq(
+        Keys.BackfillTarget,
+        Keys.BackfillBestHeader,
+        Keys.BackfillBestBody,
+        Keys.BackfillBestReceipt
+      ),
+      toUpsert = Nil
+    )
+
+  /** True iff SNAP is done AND a backfill target was previously persisted AND any of the three cursors is below the
+    * target. `SyncController.start()` uses this to spawn a standalone `ChainDownloader` alongside regular sync.
+    */
+  def needsBackfillResume(): Boolean = {
+    if (!isSnapSyncDone()) return false
+    val target = getBackfillTarget()
+    if (target <= 0) return false
+    getBackfillBestHeader() < target ||
+    getBackfillBestBody() < target ||
+    getBackfillBestReceipt() < target
+  }
 }
 
 object AppStateStorage {
@@ -330,6 +403,10 @@ object AppStateStorage {
     val SnapSyncCodeHashesPath = "SnapSyncCodeHashesPath"
     val SnapSyncStorageFilePath = "SnapSyncStorageFilePath"
     val SnapSyncFinalizedRoot = "SnapSyncFinalizedRoot"
+    val BackfillTarget = "BackfillTarget"
+    val BackfillBestHeader = "BackfillBestHeader"
+    val BackfillBestBody = "BackfillBestBody"
+    val BackfillBestReceipt = "BackfillBestReceipt"
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.testing.Tags._
@@ -80,6 +82,87 @@ class ChainDownloaderSpec
     system.stop(downloader)
   }
 
+  // Issue #1169: persist a BackfillTarget at Start so that a node killed mid-backfill can
+  // resume standalone after restart.
+  it should "persist BackfillTarget on Start so a restart can resume backfill" taggedAs UnitTest in {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+
+    // findBestStoredHeader probes block 1; mock it as missing so the binary search falls
+    // through and returns 0 immediately, leaving the actor in `downloading` state.
+    (blockchainReader.getBlockHeaderByNumber _)
+      .expects(BigInt(1))
+      .returning(None)
+      .anyNumberOfTimes()
+
+    appStateStorage.getBackfillTarget() shouldBe BigInt(0)
+
+    val downloader = TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = 4
+      )
+    )
+
+    val target = BigInt(19_250_000)
+    downloader ! ChainDownloader.Start(target)
+
+    appStateStorage.getBackfillTarget() shouldBe target
+
+    system.stop(downloader)
+  }
+
+  // Issue #1169: an UpdateTarget message during the downloading phase persists the bumped
+  // target so a restart resumes against the latest target rather than a stale one.
+  it should "persist a bumped BackfillTarget on UpdateTarget" taggedAs UnitTest in {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+
+    (blockchainReader.getBlockHeaderByNumber _)
+      .expects(BigInt(1))
+      .returning(None)
+      .anyNumberOfTimes()
+
+    val downloader = TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = 4
+      )
+    )
+
+    downloader ! ChainDownloader.Start(BigInt(1000))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1000)
+
+    downloader ! ChainDownloader.UpdateTarget(BigInt(1500))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1500)
+
+    // A target lower than the current one is ignored.
+    downloader ! ChainDownloader.UpdateTarget(BigInt(1200))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1500)
+
+    system.stop(downloader)
+  }
+
   /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start` sent),
     * so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
     */
@@ -87,12 +170,14 @@ class ChainDownloaderSpec
     implicit val ec: ExecutionContext = system.dispatcher
     val blockchainReader = mock[BlockchainReader]
     val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
     val networkPeerManager = TestProbe()
     val peerEventBus = TestProbe()
     TestActorRef[ChainDownloader](
       ChainDownloader.props(
         blockchainReader = blockchainReader,
         blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
         networkPeerManager = networkPeerManager.ref,
         peerEventBus = peerEventBus.ref,
         syncConfig = defaultSyncConfig,

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/AppStateStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/AppStateStorageSpec.scala
@@ -214,6 +214,111 @@ class AppStateStorageSpec extends AnyWordSpec with ScalaCheckPropertyChecks with
       assert(storage.isSnapSyncInProgress())
       assert(!storage.isSnapSyncDone())
     }
+
+    // ========================================
+    // Backfill cursors (#1169)
+    // ========================================
+
+    "round-trip backfill target / header / body / receipt cursors" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+
+      // Empty storage — every getter returns 0.
+      assert(storage.getBackfillTarget() == 0)
+      assert(storage.getBackfillBestHeader() == 0)
+      assert(storage.getBackfillBestBody() == 0)
+      assert(storage.getBackfillBestReceipt() == 0)
+
+      storage
+        .putBackfillTarget(BigInt(19_250_000))
+        .and(storage.putBackfillBestHeader(BigInt(8_000_000)))
+        .and(storage.putBackfillBestBody(BigInt(7_500_000)))
+        .and(storage.putBackfillBestReceipt(BigInt(7_000_000)))
+        .commit()
+
+      assert(storage.getBackfillTarget() == BigInt(19_250_000))
+      assert(storage.getBackfillBestHeader() == BigInt(8_000_000))
+      assert(storage.getBackfillBestBody() == BigInt(7_500_000))
+      assert(storage.getBackfillBestReceipt() == BigInt(7_000_000))
+    }
+
+    "clearBackfillCursors removes all four backfill keys" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage
+        .putBackfillTarget(BigInt(100))
+        .and(storage.putBackfillBestHeader(BigInt(50)))
+        .and(storage.putBackfillBestBody(BigInt(40)))
+        .and(storage.putBackfillBestReceipt(BigInt(30)))
+        .commit()
+
+      storage.clearBackfillCursors().commit()
+
+      assert(storage.getBackfillTarget() == 0)
+      assert(storage.getBackfillBestHeader() == 0)
+      assert(storage.getBackfillBestBody() == 0)
+      assert(storage.getBackfillBestReceipt() == 0)
+    }
+
+    "needsBackfillResume — false when SNAP is not done" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      // Even with cursors set, no SNAP-done flag means no resume.
+      storage.putBackfillTarget(BigInt(100)).commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — false when no target was persisted" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — false when all cursors have reached target" taggedAs (
+      UnitTest,
+      DatabaseTest
+    ) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      val target = BigInt(1000)
+      storage
+        .putBackfillTarget(target)
+        .and(storage.putBackfillBestHeader(target))
+        .and(storage.putBackfillBestBody(target))
+        .and(storage.putBackfillBestReceipt(target))
+        .commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — true when any cursor lags target" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      val target = BigInt(1000)
+
+      // Header behind.
+      storage
+        .putBackfillTarget(target)
+        .and(storage.putBackfillBestHeader(BigInt(500)))
+        .and(storage.putBackfillBestBody(target))
+        .and(storage.putBackfillBestReceipt(target))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // Now header caught up but body behind.
+      storage
+        .putBackfillBestHeader(target)
+        .and(storage.putBackfillBestBody(BigInt(800)))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // Body caught up but receipt behind.
+      storage
+        .putBackfillBestBody(target)
+        .and(storage.putBackfillBestReceipt(BigInt(600)))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // All three caught up.
+      storage.putBackfillBestReceipt(target).commit()
+      assert(!storage.needsBackfillResume())
+    }
   }
 
   trait Fixtures {


### PR DESCRIPTION
## Summary

After SNAP completes, `ChainDownloader` (#1162) keeps writing
headers/bodies/receipts to backfill genesis→pivot in the background.
Killing the node mid-backfill used to mean backfill never auto-resumed
— regular sync continued from the pivot, but pre-pivot RPCs that were
"almost backfilled" stopped progressing.

This PR persists progress and wires a standalone resume path:

1. **Cursors in `AppStateStorage`** — `BackfillTarget`,
   `BackfillBestHeader`, `BackfillBestBody`, `BackfillBestReceipt`,
   plus `clearBackfillCursors()` and `needsBackfillResume()`.
2. **Atomic cursor advances in `ChainDownloader`** — each cursor is
   updated in the *same* `DataSourceBatchUpdate` as its corresponding
   `storeBlockHeader` / `storeBlockBody` / `storeReceipts` commit,
   so a crash mid-batch never leaves a cursor ahead of disk.
3. **Standalone resume path in `SyncController`** — after
   `startRegularSync()`, calls `maybeStartBackfillResume(regularSync)`;
   if `needsBackfillResume()` is true it spawns a `ChainDownloader`
   child, watches it, and transitions into a new
   `runningRegularSyncWithStandaloneBackfill` state. The
   `SnapSyncFinalized` path opts out (`resumeBackfill = false`) because
   `SNAPSyncController` already owns the live backfill actor in that
   flow.
4. **Lifecycle covered** — restart triggers poison-pill the resumer
   first; `Terminated` falls back gracefully (cursors persist for the
   next restart).

`findBestStoredHeader()` also uses the cursor as a fast-skip path on
restart: the binary search starts above it, and the body/receipt
queue rebuild only walks blocks above each cursor floor. Falls back
to the original full search when the cursor is corrupted/zero.

## Test plan

- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt 'testOnly com.chipprbots.ethereum.db.storage.AppStateStorageSpec'` — 28/28 (22 existing + 6 new)
- [x] `sbt 'testOnly com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloaderSpec'` — 7/7 (5 existing + 2 new)
- [x] `sbt 'testOnly com.chipprbots.ethereum.db.storage.* com.chipprbots.ethereum.blockchain.sync.snap.*'` — 215/215
- [ ] **Mordor**: kill node 50% through backfill, restart, observe
  backfill resumes from cursors and completes (the in-the-wild
  verification called out in the issue).

## New unit tests

**`AppStateStorageSpec` (6 new):**

1. Round-trip backfill target / header / body / receipt cursors —
   empty storage returns 0; a chained `.and(...).commit()` round-trips
   all four.
2. `clearBackfillCursors` removes all four backfill keys atomically.
3. `needsBackfillResume` — false when SNAP is not done.
4. `needsBackfillResume` — false when no target was persisted.
5. `needsBackfillResume` — false when all cursors have reached target.
6. `needsBackfillResume` — true when any cursor lags target (verifies
   each of the three cursors independently triggers the predicate).

**`ChainDownloaderSpec` (2 new):**

1. `Start(target)` persists `BackfillTarget` so a restart can resume.
2. `UpdateTarget(newTarget)` persists a higher target; lower targets
   are ignored (matches existing in-memory semantic).

## References

- Closes #1169
- Depends on #1162 (already merged)
- Pulls the persistence work that was deliberately scoped out of #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
