### PR TITLE
Merge develop → staging: SNAP sync hardening + perf wave (#1162, #1164–#1169)

### DIFF
--- a/src/main/resources/conf/base/pekko.conf
+++ b/src/main/resources/conf/base/pekko.conf
@@ -107,6 +107,20 @@ storage-writer-dispatcher {
   throughput = 1
 }
 
+# Dedicated single-thread dispatcher for TrieNodeHealingCoordinator's batched raw
+# node DB writes. Healing-heavy runs accumulate thousands of trie nodes per
+# second; the previous async flush ran on the actor's `context.dispatcher`
+# (sync-dispatcher), so a busy flush could starve every other sync actor.
+# Single thread because RocksDB compaction is single-threaded.
+healing-writer-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 1
+  }
+  throughput = 1
+}
+
 # DEBUGGING SETTING
 # Uncomment to enable non-standard mailbox for all actors
 # Mailbox will start logging actor path, when actor mailbox size will be bigger than `size-limit`

--- a/src/main/resources/conf/base/pekko.conf
+++ b/src/main/resources/conf/base/pekko.conf
@@ -75,6 +75,22 @@ engine-api-dispatcher {
   throughput = 5
 }
 
+# Dedicated bounded dispatcher for AccountRangeCoordinator's trie flush + finalisation
+# work. Periodic `flushTrieToStorage` collapses a large in-memory trie (RLP-encode +
+# Keccak-256 every node on the modified path) and writes a RocksDB batch — 50-200ms
+# bursts. `finalizeTrie` is the same pattern but on the entire accumulated tree (10+
+# minutes on mainnet). Pinning to a small thread pool keeps both off `sync-dispatcher`
+# so other sync actors don't stall, and bounds parallelism so concurrent flushes can't
+# squeeze the global pool.
+account-trie-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 2
+  }
+  throughput = 1
+}
+
 # Dedicated single-thread dispatcher for off-actor flat-slot RocksDB commits
 # during SNAP storage sync. ~95% of contracts hit the small-contract path; the
 # StorageRangeCoordinator used to call `flatSlotStorage.putSlotsBatch(...).commit()`

--- a/src/main/resources/conf/base/pekko.conf
+++ b/src/main/resources/conf/base/pekko.conf
@@ -75,6 +75,22 @@ engine-api-dispatcher {
   throughput = 5
 }
 
+# Dedicated single-thread dispatcher for off-actor flat-slot RocksDB commits
+# during SNAP storage sync. ~95% of contracts hit the small-contract path; the
+# StorageRangeCoordinator used to call `flatSlotStorage.putSlotsBatch(...).commit()`
+# synchronously on the actor mailbox for every one of them, producing a commit
+# storm. The coordinator now aggregates small-contract writes in memory and
+# hands them off here in batches. Single thread because RocksDB compaction is
+# single-threaded anyway and we want to preserve write ordering.
+storage-writer-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 1
+  }
+  throughput = 1
+}
+
 # DEBUGGING SETTING
 # Uncomment to enable non-standard mailbox for all actors
 # Mailbox will start logging actor path, when actor mailbox size will be bigger than `size-limit`

--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -116,6 +116,10 @@ sync {
     # for chain download — no need to reserve slots for SNAP protocol requests.
     # With 50 bodies/request, 16 concurrent = 800 bodies in-flight ≈ 4-5x speedup.
     chain-download-boosted-concurrent-requests = 16
+    # Concurrency budget for chain backfill once SNAP state is finalised and regular sync has
+    # taken over (#1162). Backfill yields peer slots to regular sync — kept at the same low
+    # value as the SNAP-era cap so historical block download trails politely behind forward sync.
+    chain-backfill-concurrent-requests = 2
     # Timeout for chain download ETH protocol requests (seconds).
     # Much shorter than SNAP sync timeout (45s) to avoid holding peers "busy" for too long.
     # If a peer can't respond in 10s it's likely overloaded — release it quickly.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -6,6 +6,7 @@ import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.actor.PoisonPill
 import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Scheduler
+import org.apache.pekko.actor.Terminated
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -226,9 +227,21 @@ class SyncController(
 
       context.become(runningPivotHeaderBootstrap(peersClient, headerBootstrap, targetBlock, snapSync))
 
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.SnapSyncFinalized(pivot) =>
+      log.info(
+        s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
+      )
+      resetSnapFastCycleCount()
+      val regularSync = startRegularSync()
+      context.watch(snapSync)
+      context.become(runningRegularSyncWithBackfill(regularSync, snapSync))
+
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
+      // Defensive fallback: with the post-#1162 handshake, SnapSyncFinalized always precedes Done,
+      // so this branch should not normally be reached. If it is (e.g., unexpected message ordering),
+      // treat as a legacy "SNAP done" signal.
       snapSync ! PoisonPill
-      log.info("SNAP sync completed, transitioning to regular sync")
+      log.info("SNAP sync completed (legacy Done path), transitioning to regular sync")
       resetSnapFastCycleCount()
       startRegularSync()
 
@@ -277,6 +290,46 @@ class SyncController(
       case msg =>
         regularSync.forward(msg)
     }
+  }
+
+  /** Receive used between `SnapSyncFinalized` and `Done` from the lingering SNAPSyncController.
+    *
+    * Regular sync is the primary owner of peer slots; SNAP backfill runs at low priority in the background. This
+    * Receive lets `SNAPSyncController.Done` arrive (so we can poison-pill the SNAP actor) and intercepts restart paths
+    * so the lingering backfill actor is cleaned up before a new sync mode takes over. Everything else is delegated to
+    * `runningRegularSync(regularSync)`.
+    */
+  def runningRegularSyncWithBackfill(regularSync: ActorRef, snapSync: ActorRef): Receive = {
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
+      log.info("SNAP background backfill complete; shutting down SNAPSyncController.")
+      context.unwatch(snapSync)
+      snapSync ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+
+    case Terminated(actor) if actor == snapSync =>
+      log.warning("SNAPSyncController died while regular sync was running; chain backfill aborted.")
+      context.become(runningRegularSync(regularSync))
+
+    case msg if isRestartTrigger(msg) =>
+      log.info("Restart triggered while SNAP backfill was running; poison-pilling SNAP backfill actor first.")
+      context.unwatch(snapSync)
+      snapSync ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+      self ! msg // Re-deliver so the new state handles it.
+
+    case msg =>
+      runningRegularSync(regularSync).apply(msg)
+  }
+
+  /** Restart-style messages that mean the current sync strategy is being abandoned. Used by
+    * `runningRegularSyncWithBackfill` to detect when it must terminate the lingering backfill actor before delegating.
+    */
+  private def isRestartTrigger(msg: Any): Boolean = msg match {
+    case SyncProtocol.ResetFastSync       => true
+    case SyncProtocol.RestartFastSync     => true
+    case RestartFastSyncNow               => true
+    case _: SyncProtocol.RegularSyncStuck => true
+    case _                                => false
   }
 
   def runningRegularSyncBootstrap(
@@ -393,6 +446,18 @@ class SyncController(
       if (!checkSnapFastEscapeHatch()) {
         startFastSync()
       }
+
+    case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.SnapSyncFinalized(pivot) =>
+      log.info(
+        s"Received SnapSyncFinalized(pivot=$pivot) during pivot header bootstrap. Stopping bootstrap and transitioning to regular sync."
+      )
+      headerBootstrap ! PoisonPill
+      peersClient ! PoisonPill
+      // SNAP finalised mid-bootstrap is an exceptional path; tear down the SNAP actor cleanly
+      // (no chain-backfill watch, since the bootstrap state is already racy).
+      originalSnapSyncRef ! PoisonPill
+      resetSnapFastCycleCount()
+      startRegularSync()
 
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.Done =>
       log.info(
@@ -696,7 +761,7 @@ class SyncController(
     context.become(runningSnapSync(snapSync))
   }
 
-  def startRegularSync(): Unit = {
+  def startRegularSync(): ActorRef = {
     syncGeneration += 1
     val peersClient =
       context.actorOf(
@@ -729,6 +794,7 @@ class SyncController(
     )
     regularSync ! SyncProtocol.Start
     context.become(runningRegularSync(regularSync))
+    regularSync
   }
 
   def startRecovery(needBytecode: Boolean, needStorage: Boolean): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -232,7 +232,9 @@ class SyncController(
         s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
       )
       resetSnapFastCycleCount()
-      val regularSync = startRegularSync()
+      // SNAPSyncController already owns the live ChainDownloader child via its
+      // `completedWithBackfill` state — don't spawn a duplicate standalone resumer (#1169).
+      val regularSync = startRegularSync(resumeBackfill = false)
       context.watch(snapSync)
       context.become(runningRegularSyncWithBackfill(regularSync, snapSync))
 
@@ -761,7 +763,7 @@ class SyncController(
     context.become(runningSnapSync(snapSync))
   }
 
-  def startRegularSync(): ActorRef = {
+  def startRegularSync(resumeBackfill: Boolean = true): ActorRef = {
     syncGeneration += 1
     val peersClient =
       context.actorOf(
@@ -794,7 +796,89 @@ class SyncController(
     )
     regularSync ! SyncProtocol.Start
     context.become(runningRegularSync(regularSync))
+    // After SNAP completes, chain backfill (#1162) writes headers / bodies / receipts in the
+    // background. If the node was killed mid-backfill, persisted cursors (#1169) tell us how
+    // far it got — spawn a standalone ChainDownloader to finish the job alongside regular sync.
+    // Suppressed when called from the SnapSyncFinalized path: SNAPSyncController already owns
+    // the live backfill actor in that flow.
+    if (resumeBackfill) maybeStartBackfillResume(regularSync)
     regularSync
+  }
+
+  /** Spawn a standalone `ChainDownloader` to resume background chain backfill from persisted cursors. No-op when SNAP
+    * has not completed, when no `BackfillTarget` was persisted, or when all cursors have already reached the target.
+    * Issues #1162 (background backfill) + #1169 (resume across restarts).
+    */
+  private def maybeStartBackfillResume(regularSync: ActorRef): Unit =
+    if (appStateStorage.needsBackfillResume()) {
+      val target = appStateStorage.getBackfillTarget()
+      val headerCursor = appStateStorage.getBackfillBestHeader()
+      val bodyCursor = appStateStorage.getBackfillBestBody()
+      val receiptCursor = appStateStorage.getBackfillBestReceipt()
+      log.info(
+        "Resuming background chain backfill: target={}, header={}, body={}, receipt={}",
+        target,
+        headerCursor,
+        bodyCursor,
+        receiptCursor
+      )
+      val snapSyncConfig = loadSnapSyncConfig()
+      syncGeneration += 1
+      import com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader
+      val resumer = context.actorOf(
+        ChainDownloader
+          .props(
+            blockchainReader,
+            blockchainWriter,
+            appStateStorage,
+            networkPeerManager,
+            peerEventBus,
+            syncConfig,
+            scheduler,
+            snapSyncConfig.chainBackfillConcurrentRequests,
+            snapSyncConfig.chainDownloadTimeout
+          )
+          .withDispatcher("sync-dispatcher"),
+        s"backfill-resumer-$syncGeneration"
+      )
+      context.watch(resumer)
+      resumer ! ChainDownloader.Start(target)
+      context.become(runningRegularSyncWithStandaloneBackfill(regularSync, resumer))
+    }
+
+  /** Receive while regular sync runs alongside a standalone backfill resumer (#1169). Mirrors
+    * `runningRegularSyncWithBackfill` but for the post-restart case where we own the backfill actor directly instead of
+    * routing through a lingering `SNAPSyncController`.
+    */
+  def runningRegularSyncWithStandaloneBackfill(regularSync: ActorRef, resumer: ActorRef): Receive = {
+    case com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader.Done =>
+      log.info("Standalone chain backfill resume complete.")
+      context.unwatch(resumer)
+      resumer ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+
+    case progress: com.chipprbots.ethereum.blockchain.sync.snap.ChainDownloader.Progress =>
+      log.debug(
+        "Standalone backfill progress: headers={} bodies={} receipts={} target={}",
+        progress.headersDownloaded,
+        progress.bodiesDownloaded,
+        progress.receiptsDownloaded,
+        progress.targetBlock
+      )
+
+    case Terminated(actor) if actor == resumer =>
+      log.warning("Standalone backfill resumer died; chain backfill aborted (cursors persist for next restart).")
+      context.become(runningRegularSync(regularSync))
+
+    case msg if isRestartTrigger(msg) =>
+      log.info("Restart triggered while standalone backfill was running; poison-pilling backfill resumer first.")
+      context.unwatch(resumer)
+      resumer ! PoisonPill
+      context.become(runningRegularSync(regularSync))
+      self ! msg // Re-deliver so the new state handles it.
+
+    case msg =>
+      runningRegularSync(regularSync).apply(msg)
   }
 
   def startRecovery(needBytecode: Boolean, needStorage: Boolean): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -17,6 +17,7 @@ import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.RequestFailed
 import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.ResponseReceived
+import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.domain.BlockBody
@@ -46,6 +47,7 @@ import com.chipprbots.ethereum.utils.Config.SyncConfig
 class ChainDownloader(
     blockchainReader: BlockchainReader,
     blockchainWriter: BlockchainWriter,
+    appStateStorage: AppStateStorage,
     val networkPeerManager: ActorRef,
     val peerEventBus: ActorRef,
     val blacklist: Blacklist,
@@ -97,6 +99,8 @@ class ChainDownloader(
   def idle: Receive = handlePeerListMessages.orElse {
     case Start(target) =>
       targetBlock = target
+      // Persist the target so a node restart mid-backfill can resume standalone (#1169).
+      appStateStorage.putBackfillTarget(target).commit()
       // Find where we left off (check what's already stored)
       bestHeaderNumber = findBestStoredHeader()
       log.info(
@@ -113,6 +117,7 @@ class ChainDownloader(
       // Re-start downloading if target was updated after completion (e.g. pivot refreshed from 0 to real block)
       if (newTarget > targetBlock && newTarget > bestHeaderNumber) {
         targetBlock = newTarget
+        appStateStorage.putBackfillTarget(newTarget).commit()
         bestHeaderNumber = findBestStoredHeader()
         log.info("Chain download restarted with new target: {}, resuming from header {}", newTarget, bestHeaderNumber)
         scheduleDispatch()
@@ -150,6 +155,7 @@ class ChainDownloader(
       if (newTarget > targetBlock) {
         log.info("Chain download target updated: {} -> {}", targetBlock, newTarget)
         targetBlock = newTarget
+        appStateStorage.putBackfillTarget(newTarget).commit()
       }
 
     case Stop =>
@@ -408,7 +414,9 @@ class ChainDownloader(
     while (!aborted && it.hasNext) {
       val header = it.next()
       if (prevHash.exists(_ == header.parentHash)) {
-        // Store header + chain weight
+        // Store header + chain weight, atomically advancing the backfill cursor in the same
+        // RocksDB write batch (#1169) so a crash mid-write never leaves the cursor ahead of
+        // the data on disk.
         val parentWeight = blockchainReader
           .getChainWeightByHash(header.parentHash)
           .getOrElse(ChainWeight.totalDifficultyOnly(0))
@@ -416,6 +424,7 @@ class ChainDownloader(
         blockchainWriter
           .storeBlockHeader(header)
           .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
+          .and(appStateStorage.putBackfillBestHeader(header.number))
           .commit()
 
         bodiesQueue :+= header.hash
@@ -449,11 +458,22 @@ class ChainDownloader(
       return
     }
 
-    // Store received bodies
+    // Store received bodies + atomically advance the body cursor (#1169).
     val received = requestedHashes.zip(bodies)
+    val highestBodyNumber = received
+      .flatMap { case (hash, _) => blockchainReader.getBlockHeaderByHash(hash).map(_.number) }
+      .maxOption
+      .getOrElse(BigInt(0))
+    val cursorUpdate =
+      if (highestBodyNumber > appStateStorage.getBackfillBestBody())
+        appStateStorage.putBackfillBestBody(highestBodyNumber)
+      else
+        appStateStorage.emptyBatchUpdate
+
     received
       .map { case (hash, body) => blockchainWriter.storeBlockBody(hash, body) }
       .reduce(_.and(_))
+      .and(cursorUpdate)
       .commit()
 
     bodiesDownloaded += received.size
@@ -497,9 +517,23 @@ class ChainDownloader(
           .map(_.toReceipt)
       }
 
-      // Store receipts
-      requestedHashes.zip(receiptsByBlock).foreach { case (hash, receipts) =>
-        blockchainWriter.storeReceipts(hash, receipts).commit()
+      // Store receipts. Atomically advance the receipt cursor (#1169) in the same batch as
+      // the highest-numbered receipt write, so a crash mid-write doesn't leave the cursor
+      // ahead of disk.
+      val receiptsByHash = requestedHashes.zip(receiptsByBlock)
+      val highestReceiptNumber = receiptsByHash
+        .flatMap { case (hash, _) => blockchainReader.getBlockHeaderByHash(hash).map(_.number) }
+        .maxOption
+        .getOrElse(BigInt(0))
+
+      receiptsByHash.zipWithIndex.foreach { case ((hash, receipts), idx) =>
+        val storeUpdate = blockchainWriter.storeReceipts(hash, receipts)
+        val withCursor =
+          if (idx == receiptsByHash.size - 1 && highestReceiptNumber > appStateStorage.getBackfillBestReceipt())
+            storeUpdate.and(appStateStorage.putBackfillBestReceipt(highestReceiptNumber))
+          else
+            storeUpdate
+        withCursor.commit()
       }
 
       receiptsDownloaded += receiptsByBlock.size
@@ -536,20 +570,34 @@ class ChainDownloader(
         receiptsDownloaded,
         targetBlock
       )
+      // Clear backfill cursors so the next startup doesn't try to resume a finished backfill (#1169).
+      appStateStorage.clearBackfillCursors().commit()
       dispatchTask.foreach(_.cancel())
       context.parent ! Done
       context.become(idle)
     }
 
   private def findBestStoredHeader(): BigInt = {
-    // Binary search for the highest stored header starting from genesis
-    // The chain may have been partially downloaded in a previous run
-    var low: BigInt = 0
-    var high: BigInt = targetBlock
-    var best: BigInt = 0
+    // Fast skip: trust the persisted cursor when its header is on disk (#1169).
+    // The cursor is updated atomically with each storeBlockHeader commit so it never
+    // overstates progress. We still validate by reading the header at the cursor —
+    // if the cursor was somehow corrupted (manual DB intervention, downgrade), fall
+    // back to the binary search.
+    val cursorHeader = appStateStorage.getBackfillBestHeader()
+    val (low0, best0) =
+      if (cursorHeader > 0 && blockchainReader.getBlockHeaderByNumber(cursorHeader).isDefined)
+        (cursorHeader + 1, cursorHeader)
+      else
+        (BigInt(0), BigInt(0))
 
-    // Quick check: if genesis+1 doesn't exist, start from 0
-    if (blockchainReader.getBlockHeaderByNumber(1).isEmpty) return 0
+    // Quick check: if genesis+1 doesn't exist, start from 0 (only meaningful for fresh runs).
+    if (best0 == 0 && blockchainReader.getBlockHeaderByNumber(1).isEmpty) return 0
+
+    // Binary search above the cursor for the highest stored header. With cursor-fast-skip
+    // this almost always finds `best == cursorHeader` after one probe.
+    var low: BigInt = low0
+    var high: BigInt = targetBlock
+    var best: BigInt = best0
 
     while (low <= high) {
       val mid = (low + high) / 2
@@ -561,18 +609,27 @@ class ChainDownloader(
       }
     }
 
-    // Also rebuild the body/receipt queues for headers we have but bodies/receipts we don't
+    // Rebuild the body/receipt queues for headers we have but bodies/receipts we don't.
+    // Use the body/receipt cursors as the floor so we don't re-walk every header — anything
+    // ≤ those cursors was committed atomically with its body/receipt write and is on disk.
+    val bodyFloor = appStateStorage.getBackfillBestBody()
+    val receiptFloor = appStateStorage.getBackfillBestReceipt()
+
     var i = best
     while (i >= 1) {
-      blockchainReader.getBlockHeaderByNumber(i) match {
-        case Some(header) =>
-          if (blockchainReader.getBlockBodyByHash(header.hash).isEmpty) {
-            bodiesQueue :+= header.hash
-          }
-          if (blockchainReader.getReceiptsByHash(header.hash).isEmpty) {
-            receiptsQueue :+= header.hash
-          }
-        case None => // shouldn't happen
+      val needsBodyCheck = i > bodyFloor
+      val needsReceiptCheck = i > receiptFloor
+      if (needsBodyCheck || needsReceiptCheck) {
+        blockchainReader.getBlockHeaderByNumber(i) match {
+          case Some(header) =>
+            if (needsBodyCheck && blockchainReader.getBlockBodyByHash(header.hash).isEmpty) {
+              bodiesQueue :+= header.hash
+            }
+            if (needsReceiptCheck && blockchainReader.getReceiptsByHash(header.hash).isEmpty) {
+              receiptsQueue :+= header.hash
+            }
+          case None => // shouldn't happen
+        }
       }
       i -= 1
     }
@@ -643,6 +700,7 @@ object ChainDownloader {
   def props(
       blockchainReader: BlockchainReader,
       blockchainWriter: BlockchainWriter,
+      appStateStorage: AppStateStorage,
       networkPeerManager: ActorRef,
       peerEventBus: ActorRef,
       syncConfig: SyncConfig,
@@ -654,6 +712,7 @@ object ChainDownloader {
       new ChainDownloader(
         blockchainReader,
         blockchainWriter,
+        appStateStorage,
         networkPeerManager,
         peerEventBus,
         CacheBasedBlacklist.empty(1000),

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -85,6 +85,10 @@ class ChainDownloader(
   // Concurrency — starts conservative during SNAP state sync, boosted after state completes
   private var maxConcurrentRequests: Int = initialMaxConcurrentRequests
 
+  // Visible to tests in the same package: lets ChainDownloaderSpec assert YieldToRegularSync clamping
+  // without relying on log-output scraping or reflection.
+  private[snap] def currentMaxConcurrentRequests: Int = maxConcurrentRequests
+
   // Dispatch timer
   private var dispatchTask: Option[org.apache.pekko.actor.Cancellable] = None
 
@@ -117,6 +121,9 @@ class ChainDownloader(
 
     case BoostConcurrency(n) =>
       boostConcurrency(n)
+
+    case YieldToRegularSync(n) =>
+      yieldToRegularSync(n)
 
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
@@ -158,6 +165,9 @@ class ChainDownloader(
     case BoostConcurrency(n) =>
       boostConcurrency(n)
       dispatchRequests() // Immediately use the new slots
+
+    case YieldToRegularSync(n) =>
+      yieldToRegularSync(n)
 
     case GetProgress =>
       sender() ! Progress(headersDownloaded, bodiesDownloaded, receiptsDownloaded, targetBlock)
@@ -578,6 +588,25 @@ class ChainDownloader(
     scheduleDispatch(200.millis)
   }
 
+  private def yieldToRegularSync(n: Int): Unit = {
+    // Clamp to >=1: zero would wedge dispatch (inFlightCount >= maxConcurrentRequests is immediately
+    // true), preventing any new work from starting and stranding the parent waiting for ChainDownloader.Done
+    // forever. If the operator wants no backfill, they should disable it via chain-download-enabled=false.
+    val clamped = math.max(n, 1)
+    val prev = maxConcurrentRequests
+    maxConcurrentRequests = clamped
+    if (clamped != n) {
+      log.warning("YieldToRegularSync({}) clamped to {} to prevent dispatch wedge", n, clamped)
+    }
+    log.info(
+      "Chain download yielding to regular sync: {} -> {} concurrent requests (background backfill)",
+      prev,
+      clamped
+    )
+    // Slow the dispatch tick so backfill doesn't fight regular sync for the actor mailbox or peers.
+    scheduleDispatch(2.seconds)
+  }
+
   private def scheduleDispatch(interval: FiniteDuration = 2.seconds): Unit = {
     dispatchTask.foreach(_.cancel())
     dispatchTask = Some(
@@ -599,6 +628,9 @@ object ChainDownloader {
   case object Stop
   case object Done
   case class BoostConcurrency(maxConcurrent: Int)
+  // Sent when SNAP state is finalised and regular sync is taking over. Backfill drops to a smaller
+  // concurrency budget so it competes politely for peer slots. Mirrors `BoostConcurrency` but downward.
+  case class YieldToRegularSync(maxConcurrent: Int)
   case object GetProgress
   case class Progress(
       headersDownloaded: BigInt,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -84,6 +84,7 @@ class SNAPSyncController(
   // Concurrent phase completion tracking (all 3 coordinators run in parallel)
   private var bytecodePhaseComplete: Boolean = false
   private var storagePhaseComplete: Boolean = false
+  private var storagePhaseForceCompleted: Boolean = false
 
   private val progressMonitor = new SyncProgressMonitor(scheduler)
 
@@ -575,7 +576,17 @@ class SNAPSyncController(
 
     case StorageRangeSyncComplete if !storagePhaseComplete =>
       storagePhaseComplete = true
+      storagePhaseForceCompleted = false
       log.info(s"Storage range sync complete. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete")
+      checkAllDownloadsComplete()
+
+    case StorageRangeSyncForceCompleted if !storagePhaseComplete =>
+      storagePhaseComplete = true
+      storagePhaseForceCompleted = true
+      log.warning(
+        s"Storage range sync was force-completed. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete. " +
+          "SNAP will run healing/validation before regular sync handoff."
+      )
       checkAllDownloadsComplete()
 
     case HealingAllPeersStateless if currentPhase == StateHealing =>
@@ -751,7 +762,7 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
-      if (snapSyncConfig.deferredMerkleization) {
+      if (SNAPSyncController.shouldSkipHealingAfterDownloads(snapSyncConfig, storagePhaseForceCompleted)) {
         // With deferred merkleization, trie nodes were never constructed during download —
         // only flat storage was written. A trie walk would find the entire internal trie "missing",
         // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).
@@ -766,7 +777,14 @@ class SNAPSyncController(
         )
         completeSnapSync()
       } else {
-        log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
+        if (snapSyncConfig.deferredMerkleization && storagePhaseForceCompleted) {
+          log.warning(
+            "All state downloads reached terminal state, but storage was force-completed with deferred " +
+              "merkleization enabled. Starting healing instead of handing off a state with known holes."
+          )
+        } else {
+          log.info("All state downloads complete (accounts + bytecodes + storage). Starting healing...")
+        }
         currentPhase = StateHealing
         startStateHealing()
       }
@@ -1021,6 +1039,7 @@ class SNAPSyncController(
             accountsComplete = true
             bytecodePhaseComplete = false
             storagePhaseComplete = false
+            storagePhaseForceCompleted = false
 
             log.info(s"Recovery: resuming bytecodes + storage sync from pivot $pivot (drift=$drift blocks)")
 
@@ -1767,7 +1786,8 @@ class SNAPSyncController(
               initialMaxInFlightPerPeer =
                 0, // Defer storage dispatch during AccountRangeSync — prevents false pivot refreshes from stale-root timeouts
               initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
-              minResponseBytes = snapSyncConfig.storageMinResponseBytes
+              minResponseBytes = snapSyncConfig.storageMinResponseBytes,
+              deferredMerkleization = snapSyncConfig.deferredMerkleization
             )
             .withDispatcher("sync-dispatcher"),
           s"storage-range-coordinator-$coordinatorGeneration"
@@ -2309,6 +2329,7 @@ class SNAPSyncController(
     accountsComplete = false
     bytecodePhaseComplete = false
     storagePhaseComplete = false
+    storagePhaseForceCompleted = false
     appStateStorage.putSnapSyncAccountsComplete(false).commit()
     appStateStorage.putSnapSyncStorageFilePath("").commit()
 
@@ -2730,6 +2751,7 @@ object SNAPSyncController {
   case object AccountRangeSyncComplete
   case object ByteCodeSyncComplete
   case object StorageRangeSyncComplete
+  case object StorageRangeSyncForceCompleted
 
   /** Inline contract data dispatched from AccountRangeCoordinator after each account batch. Geth-aligned: bytecodes and
     * storage tasks are populated inline from processAccountResponse(), not queried after account download completes.
@@ -2762,6 +2784,12 @@ object SNAPSyncController {
   final case class ProgressNodesHealed(count: Long)
   final case class ProgressAccountEstimate(estimatedTotal: Long)
   final case class ProgressStorageContracts(completedContracts: Int, totalContracts: Int)
+
+  private[snap] def shouldSkipHealingAfterDownloads(
+      snapSyncConfig: SNAPSyncConfig,
+      storagePhaseForceCompleted: Boolean
+  ): Boolean =
+    snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted
 
   def props(
       blockchainReader: BlockchainReader,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2643,6 +2643,7 @@ class SNAPSyncController(
             .props(
               blockchainReader,
               blockchainWriter,
+              appStateStorage,
               networkPeerManager,
               peerEventBus,
               syncConfig,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -216,7 +216,15 @@ class SNAPSyncController(
   }
 
   override def postStop(): Unit = {
-    // Cancel all scheduled tasks
+    stopSnapOnlySchedules()
+    log.info("SNAP Sync Controller stopped")
+  }
+
+  /** Cancel every SNAP-only scheduled task. Idempotent — Cancellables tolerate double-cancel. Called both at the
+    * lifecycle transition into `completedWithBackfill` (so eviction/tickers don't keep running while regular sync owns
+    * the peer pool) and at `postStop()`.
+    */
+  private def stopSnapOnlySchedules(): Unit = {
     accountRangeRequestTask.foreach(_.cancel())
     bytecodeRequestTask.foreach(_.cancel())
     storageRangeRequestTask.foreach(_.cancel())
@@ -229,8 +237,24 @@ class SNAPSyncController(
     snapPeerEvictionTask.foreach(_.cancel())
     rateTrackerTuneTask.foreach(_.cancel())
     progressMonitor.stopPeriodicLogging()
+  }
 
-    log.info("SNAP Sync Controller stopped")
+  /** Stop the SNAP state-sync child coordinators (account/bytecode/storage/healing) and clear their references. They do
+    * not self-stop on completion, so when `SNAPSyncController` is kept alive past `finalizeSnapSync()` for background
+    * chain backfill (#1162), failing to stop them retains completed task buffers, worker actors, and rate trackers for
+    * the entire backfill window. The previous `PoisonPill` to the parent used to clean these up implicitly.
+    *
+    * `chainDownloader` is NOT stopped here — it keeps running in `completedWithBackfill`.
+    */
+  private def stopStateSyncChildren(): Unit = {
+    accountRangeCoordinator.foreach(context.stop)
+    accountRangeCoordinator = None
+    bytecodeCoordinator.foreach(context.stop)
+    bytecodeCoordinator = None
+    storageRangeCoordinator.foreach(context.stop)
+    storageRangeCoordinator = None
+    trieNodeHealingCoordinator.foreach(context.stop)
+    trieNodeHealingCoordinator = None
   }
 
   override def receive: Receive = idle
@@ -2461,38 +2485,24 @@ class SNAPSyncController(
     refreshPivotInPlace(s"account stall: $context")
   }
 
+  /** State sync + healing + validation finished — anchor the pivot and hand off to regular sync immediately.
+    *
+    * Historical chain backfill (genesis → pivot) is decoupled: we do not block here waiting for it. Instead,
+    * `finalizeSnapSync()` emits `SnapSyncFinalized(pivot)` to the parent (which starts RegularSync) and either:
+    *   - emits `Done` immediately if backfill is disabled or already complete, or
+    *   - keeps the controller alive in `completedWithBackfill` so it can forward `ChainDownloader.Progress` /
+    *     `ChainDownloader.Done` to the parent without blocking forward sync.
+    *
+    * Closes #1162.
+    */
   private def completeSnapSync(): Unit =
-    pivotBlock.foreach { pivot =>
-      if (snapSyncConfig.deferredMerkleization) {
-        // With deferred merkleization, don't wait for chain download to finish.
-        // Downloading 24M+ block headers/bodies/receipts from genesis takes days and
-        // blocks the node from syncing new blocks. Regular sync will handle chain data
-        // from the pivot forward. Historical chain data can be backfilled later.
-        log.info(
-          "Deferred merkleization enabled — skipping chain download wait. " +
-            "Finalizing SNAP sync immediately to start regular sync from pivot."
-        )
-        // Stop the chain downloader — regular sync handles blocks from pivot onward
-        chainDownloader.foreach(context.stop)
-        chainDownloader = None
-        finalizeSnapSync(pivot)
-      } else if (!chainDownloadComplete && chainDownloader.isDefined) {
-        // Chain download is still running — boost its concurrency and wait
-        log.info("SNAP state sync complete, boosting chain download concurrency and waiting for completion...")
-        chainDownloader.foreach(
-          _ ! ChainDownloader.BoostConcurrency(
-            snapSyncConfig.chainDownloadBoostedConcurrentRequests
-          )
-        )
-        currentPhase = ChainDownloadCompletion
-        progressMonitor.startPhase(ChainDownloadCompletion)
-        context.become(waitingForChainDownload)
-      } else {
-        finalizeSnapSync(pivot)
-      }
-    }
+    pivotBlock.foreach(finalizeSnapSync)
 
-  /** Final SNAP sync completion — called when both state sync and chain download are done. */
+  /** Anchor the pivot, mark SNAP state done, and hand off to the parent. Always emits `SnapSyncFinalized(pivot)`. Emits
+    * `Done` either immediately (no backfill in flight) or later from `completedWithBackfill` after
+    * `ChainDownloader.Done` arrives. SNAP-only schedules are cancelled before the handoff so eviction tickers and
+    * stagnation checks don't keep firing while regular sync owns the peer pool.
+    */
   private def finalizeSnapSync(pivot: BigInt): Unit = {
     appStateStorage.snapSyncDone().commit()
 
@@ -2538,32 +2548,67 @@ class SNAPSyncController(
         appStateStorage.putBestBlockNumber(pivot).commit()
     }
 
-    // Stop chain downloader if still running
-    chainDownloader.foreach(context.stop)
-    chainDownloader = None
-
     progressMonitor.complete()
     log.info(progressMonitor.currentProgress.toString)
+    currentPhase = Completed
 
-    context.become(completed)
-    context.parent ! Done
+    // Cancel SNAP-only schedules before handing off so eviction tickers / stagnation checks stop
+    // affecting peers while regular sync runs. Stop state-sync child coordinators too — they don't
+    // self-stop on completion and would otherwise retain completed task buffers and worker actors
+    // for the full background-backfill window. The chain downloader child is intentionally NOT stopped.
+    stopSnapOnlySchedules()
+    stopStateSyncChildren()
+
+    // Phase 1 of the handshake: tell the parent that pivot/state is anchored. Parent starts RegularSync.
+    context.parent ! SnapSyncFinalized(pivot)
+
+    val backfillStillRunning =
+      snapSyncConfig.chainDownloadEnabled && chainDownloader.isDefined && !chainDownloadComplete
+
+    if (backfillStillRunning) {
+      log.info(
+        s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
+      )
+      // Yield peer slots to regular sync — backfill keeps a small budget.
+      chainDownloader.foreach(
+        _ ! ChainDownloader.YieldToRegularSync(snapSyncConfig.chainBackfillConcurrentRequests)
+      )
+      context.become(completedWithBackfill)
+    } else {
+      // No backfill in flight — emit Done immediately. Parent poison-pills this actor.
+      chainDownloader.foreach(context.stop)
+      chainDownloader = None
+      context.become(completed)
+      context.parent ! Done
+    }
   }
 
-  /** Waiting for parallel chain download to finish after SNAP state sync completed. */
-  def waitingForChainDownload: Receive = handlePeerListMessagesWithRateTracking.orElse {
-    case ChainDownloader.Done =>
-      log.info("Parallel chain download complete. Finalizing SNAP sync.")
-      chainDownloadComplete = true
-      pivotBlock.foreach(finalizeSnapSync)
-
+  /** Receive after SNAP state is finalised but `ChainDownloader` is still backfilling history.
+    *
+    * Minimal surface — only what `ChainDownloader` and status RPCs need. SNAP-protocol responses, peer-list messages,
+    * and stagnation checks are no longer relevant; everything else is silently dropped. The actor's sole remaining job
+    * is to propagate `ChainDownloader.Done` to the parent so it can poison-pill us.
+    */
+  def completedWithBackfill: Receive = {
     case ChainDownloader.Progress(h, b, r, t) =>
       progressMonitor.updateChainProgress(h, b, r, t)
 
+    case ChainDownloader.Done =>
+      log.info("Background chain backfill complete; SNAPSyncController shutting down.")
+      chainDownloadComplete = true
+      chainDownloader.foreach(context.stop)
+      chainDownloader = None
+      context.become(completed)
+      context.parent ! Done
+
     case SyncProtocol.GetStatus =>
-      sender() ! currentSyncStatus
+      sender() ! SyncProtocol.Status.SyncDone
 
     case GetProgress =>
       sender() ! progressMonitor.currentProgress
+
+    case _ =>
+    // Stale SNAP messages, leaked tickers, and other noise are silently dropped.
   }
 
   private def startChainDownloader(): Unit = {
@@ -2667,6 +2712,12 @@ object SNAPSyncController {
 
   case object Start
   case object Done
+  // Two-phase handshake with SyncController:
+  //   1. SnapSyncFinalized(pivot) — pivot/state anchored, regular sync can start.
+  //      SyncController starts RegularSync but does NOT poison-pill SNAPSyncController.
+  //   2. Done — backfill complete (or absent/disabled). SyncController poison-pills SNAPSyncController.
+  // Sender always emits the same shape: Finalized first, then Done either immediately or after backfill.
+  final case class SnapSyncFinalized(pivot: BigInt)
   case object FallbackToFastSync // Signal to fallback to fast sync due to repeated failures
   case class StartRegularSyncBootstrap(targetBlock: BigInt) // Request bootstrap from SyncController
   final case class BootstrapComplete(
@@ -2775,6 +2826,9 @@ case class SNAPSyncConfig(
     chainDownloadEnabled: Boolean = true,
     chainDownloadMaxConcurrentRequests: Int = 2,
     chainDownloadBoostedConcurrentRequests: Int = 16,
+    // Concurrency budget for chain backfill once SNAP state is finalised and regular sync has started.
+    // Smaller than `chainDownloadMaxConcurrentRequests` so backfill yields peer slots to regular sync.
+    chainBackfillConcurrentRequests: Int = 2,
     chainDownloadTimeout: FiniteDuration = 10.seconds,
     minSnapPeers: Int = 3,
     snapPeerEvictionInterval: FiniteDuration = 15.seconds,
@@ -2856,6 +2910,10 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("chain-download-boosted-concurrent-requests"))
           snapConfig.getInt("chain-download-boosted-concurrent-requests")
         else 16,
+      chainBackfillConcurrentRequests =
+        if (snapConfig.hasPath("chain-backfill-concurrent-requests"))
+          snapConfig.getInt("chain-backfill-concurrent-requests")
+        else 2,
       chainDownloadTimeout =
         if (snapConfig.hasPath("chain-download-timeout"))
           snapConfig.getDuration("chain-download-timeout").toMillis.millis

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -8,7 +8,7 @@ import java.io.{BufferedOutputStream, FileOutputStream, RandomAccessFile}
 import java.nio.file.{Files, Path}
 
 import scala.collection.mutable
-import scala.concurrent.{Future, blocking}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
@@ -59,7 +59,8 @@ class AccountRangeCoordinator(
     initialMaxInFlightPerPeer: Int = 5,
     trieFlushThreshold: Int = 50000,
     initialResponseBytesConfig: Int = 524288,
-    minResponseBytesConfig: Int = 102400
+    minResponseBytesConfig: Int = 102400,
+    accountTrieEcOverride: Option[ExecutionContext] = None
 ) extends Actor
     with ActorLogging {
 
@@ -311,8 +312,22 @@ class AccountRangeCoordinator(
   // bottleneck (50-200ms per flush × 5 concurrent responses = constant blocking).
   private var accountsSinceLastFlush: Long = 0
 
-  // Internal message for async trie finalization result — carries the finalized root hash
-  private case class TrieFlushComplete(result: Either[String, ByteString])
+  // Dedicated dispatcher for trie flush + finalisation. Tests inject their own
+  // `ExecutionContext`; production looks up `account-trie-dispatcher` from `pekko.conf`.
+  // Both `flushTrieToStorage` (50-200ms bursts) and `finalizeTrie` (10+ minutes on
+  // mainnet) run here so they don't tie up `sync-dispatcher` or the global pool.
+  private val accountTrieEc: ExecutionContext =
+    accountTrieEcOverride.getOrElse(context.system.dispatchers.lookup("account-trie-dispatcher"))
+
+  // Generation token. Bumped at every fresh async flush spawn, on `PivotRefreshed`,
+  // and at finalisation. Async result messages carry the generation they were spawned
+  // under and are ignored if it no longer matches — defensive guard so a stale
+  // completion (e.g., from before a state transition) can't apply against the wrong
+  // assumption. Mirrors the validateState() async pattern (PR #1163).
+  // Package-private so unit tests can verify generation behaviour.
+  private[actors] var trieFlushGeneration: Long = 0L
+
+  import AccountRangeCoordinator.{TrieFlushAsyncComplete, TrieFlushAsyncFailed, TrieFlushComplete}
 
   // Deferred-write storage wrapper: makes updateNodesInStorage() a no-op during bulk insertion,
   // keeping all trie nodes in memory. This avoids the per-put collapse (RLP encode + Keccak-256 hash)
@@ -499,24 +514,34 @@ class AccountRangeCoordinator(
         // Switch to finalizing state so no message can touch the trie during flush
         context.become(finalizing)
 
-        // Run the expensive flush (O(n*log(n)) trie collapse + RocksDB write) on a
-        // separate thread to avoid blocking the Pekko dispatcher for 10+ minutes.
+        // Run the expensive flush (O(n*log(n)) trie collapse + RocksDB write) on the
+        // dedicated `account-trie-dispatcher` so it can't squeeze the global pool or
+        // sync-dispatcher. Generation token added defensively (mirrors PR #1163).
+        trieFlushGeneration += 1
+        val gen = trieFlushGeneration
         val selfRef = self
         Future {
           blocking(finalizeTrie())
-        }(scala.concurrent.ExecutionContext.global)
+        }(accountTrieEc)
           .onComplete {
-            case Success(result) => selfRef ! TrieFlushComplete(result)
+            case Success(result) => selfRef ! TrieFlushComplete(gen, result)
             case Failure(ex)     => selfRef ! Status.Failure(ex)
           }(context.dispatcher)
       }
   }
 
   /** Receive state during async trie finalization. The in-memory trie is being collapsed and written to RocksDB on a
-    * background thread. No message should touch stateTrie or deferredStorage during this phase.
+    * background thread. No message should touch stateTrie or deferredStorage during this phase. Package-private so
+    * tests can `become(finalizing)` directly without driving the heavy finalisation work.
     */
-  private def finalizing: Receive = {
-    case TrieFlushComplete(Right(finalizedRoot)) =>
+  private[actors] def finalizing: Receive = {
+    // Stale-generation drop. A completion arriving for a generation that's been bumped
+    // since spawn (e.g., the actor restarted finalisation) is silently ignored — data
+    // is on disk either way, and the in-flight Future can't be cancelled.
+    case TrieFlushComplete(gen, _) if gen != trieFlushGeneration =>
+      log.debug(s"Dropping stale TrieFlushComplete (gen=$gen, current=$trieFlushGeneration)")
+
+    case TrieFlushComplete(_, Right(finalizedRoot)) =>
       log.info(
         "State trie finalized successfully with root {}",
         finalizedRoot.take(8).toArray.map("%02x".format(_)).mkString
@@ -525,7 +550,7 @@ class AccountRangeCoordinator(
       snapSyncController ! SNAPSyncController.ProgressAccountsTrieFinalized
       context.stop(self)
 
-    case TrieFlushComplete(Left(error)) =>
+    case TrieFlushComplete(_, Left(error)) =>
       log.error(s"Failed to finalize trie: $error")
       snapSyncController ! SNAPSyncController.ProgressAccountsTrieFinalized
       context.stop(self)
@@ -844,18 +869,8 @@ class AccountRangeCoordinator(
         // Yield to actor mailbox - other messages (PeerAvailable, responses) process before next chunk
         self ! StoreAccountChunk(task, rest, totalCount, newStored, isTaskRangeComplete)
       } else {
-        // Threshold-based flush: only flush to RocksDB when accumulated nodes exceed threshold.
-        // With pipelining, per-response flushing (50-200ms each) blocks the coordinator
-        // and becomes the throughput bottleneck. Threshold-based flushing amortizes the cost.
-        accountsSinceLastFlush += totalCount
-        if (accountsSinceLastFlush >= trieFlushThreshold) {
-          flushTrieToStorage()
-          accountsSinceLastFlush = 0
-        }
-        log.debug(
-          s"Stored all $totalCount accounts in-memory ($accountsDownloaded total, ${accountsSinceLastFlush} since last flush)"
-        )
-
+        // Mark task done / re-enqueue BEFORE potentially spawning async flush — so the
+        // task tracking is up to date by the time we re-enter `receive` after flushing.
         if (isTaskRangeComplete) {
           task.done = true
           completedTasks += task
@@ -870,8 +885,21 @@ class AccountRangeCoordinator(
           pendingTasks.enqueue(task)
         }
 
-        // Check if all tasks are complete
-        self ! CheckCompletion
+        // Threshold-based flush: only flush to RocksDB when accumulated nodes exceed threshold.
+        // With pipelining, per-response flushing (50-200ms each) blocks the coordinator
+        // and becomes the throughput bottleneck. Threshold-based flushing amortizes the cost.
+        accountsSinceLastFlush += totalCount
+        if (accountsSinceLastFlush >= trieFlushThreshold) {
+          accountsSinceLastFlush = 0
+          spawnFlushTrieAsync()
+          // CheckCompletion is sent from the flush completion handler.
+        } else {
+          log.debug(
+            s"Stored all $totalCount accounts in-memory ($accountsDownloaded total, ${accountsSinceLastFlush} since last flush)"
+          )
+          // Check if all tasks are complete
+          self ! CheckCompletion
+        }
       }
     } catch {
       case e: Exception =>
@@ -886,6 +914,9 @@ class AccountRangeCoordinator(
   /** Flush all in-memory trie nodes to RocksDB in a single batch. This collapses the entire in-memory trie (RLP-encode
     * + Keccak-256 hash all nodes), then writes everything to RocksDB via one WriteBatch. After flush, the trie is
     * rebuilt from the persisted root hash so old in-memory nodes can be garbage collected.
+    *
+    * Used directly only from `finalizeTrie` (where the actor is in `finalizing` and no concurrent puts can race).
+    * Periodic flushes during account download go through `spawnFlushTrieAsync`.
     */
   private def flushTrieToStorage(): Unit =
     deferredStorage.flush().foreach { rootHash =>
@@ -893,6 +924,68 @@ class AccountRangeCoordinator(
       stateTrie = MerklePatriciaTrie[ByteString, Account](rootHash, deferredStorage)
       log.info(s"Flushed trie to storage, root=${rootHash.take(8).map("%02x".format(_)).mkString}...")
     }
+
+  /** Async variant of `flushTrieToStorage` for the periodic-flush path. Switches the actor to the `flushing` receive
+    * state (so no message touches `stateTrie` or `deferredStorage` during the flush), spawns the collapse + RocksDB
+    * write on `account-trie-dispatcher`, then returns to the normal receive on completion. Generation-tagged so a stale
+    * completion (from before a state transition) is dropped.
+    */
+  private def spawnFlushTrieAsync(): Unit = {
+    trieFlushGeneration += 1
+    val gen = trieFlushGeneration
+    context.become(flushing)
+
+    val selfRef = self
+    val storage = deferredStorage
+    Future {
+      blocking {
+        val startMs = System.currentTimeMillis()
+        val rootHash = storage.flush().map(rh => ByteString(rh))
+        val elapsedMs = System.currentTimeMillis() - startMs
+        (rootHash, elapsedMs)
+      }
+    }(accountTrieEc).onComplete {
+      case Success((root, elapsedMs)) =>
+        selfRef ! TrieFlushAsyncComplete(gen, root, elapsedMs)
+      case Failure(ex) =>
+        selfRef ! TrieFlushAsyncFailed(gen, ex.getMessage)
+    }(context.dispatcher)
+  }
+
+  /** Receive state during async periodic trie flush. The flush is collapsing the in-memory trie + writing to RocksDB on
+    * `account-trie-dispatcher`; no message should touch `stateTrie` or `deferredStorage` until it completes. Other
+    * messages (peer availability, AccountRange responses, store-chunk continuations) stay in the mailbox and process in
+    * order once the flush returns to the normal receive. Package-private so tests can drive stale-completion paths.
+    */
+  private[actors] def flushing: Receive = {
+    // Stale-generation drop — happens only if generation got bumped while a flush
+    // was in flight (e.g., transition into finalisation). Data is durable either way.
+    case TrieFlushAsyncComplete(gen, _, _) if gen != trieFlushGeneration =>
+      log.debug(s"Dropping stale TrieFlushAsyncComplete (gen=$gen, current=$trieFlushGeneration)")
+      context.become(receive)
+      self ! CheckCompletion
+
+    case TrieFlushAsyncFailed(gen, _) if gen != trieFlushGeneration =>
+      log.debug(s"Dropping stale TrieFlushAsyncFailed (gen=$gen, current=$trieFlushGeneration)")
+      context.become(receive)
+      self ! CheckCompletion
+
+    case TrieFlushAsyncComplete(_, persistedRoot, elapsedMs) =>
+      persistedRoot.foreach { rootHash =>
+        import com.chipprbots.ethereum.mpt.byteStringSerializer
+        stateTrie = MerklePatriciaTrie[ByteString, Account](rootHash.toArray, deferredStorage)
+        log.info(
+          s"Flushed trie to storage in ${elapsedMs}ms, root=${rootHash.take(8).map("%02x".format(_)).mkString}..."
+        )
+      }
+      context.become(receive)
+      self ! CheckCompletion
+
+    case TrieFlushAsyncFailed(_, error) =>
+      log.error(s"Async trie flush failed: $error. Continuing with in-memory trie; healing will recover.")
+      context.become(receive)
+      self ! CheckCompletion
+  }
 
   /** Identify contract accounts (those with non-empty code hash)
     *
@@ -1104,6 +1197,24 @@ class AccountRangeCoordinator(
 }
 
 object AccountRangeCoordinator {
+
+  /** Async trie-finalisation result. `generation` matches the value of `trieFlushGeneration` at spawn time so stale
+    * completions (after a state transition / restart) can be dropped without applying against the wrong assumption.
+    */
+  private[actors] case class TrieFlushComplete(generation: Long, result: Either[String, ByteString])
+
+  /** Async periodic flush completed. `persistedRoot` is the root hash returned by `deferredStorage.flush()` — used to
+    * rebuild `stateTrie` so old in-memory nodes can be garbage collected.
+    */
+  private[actors] case class TrieFlushAsyncComplete(
+      generation: Long,
+      persistedRoot: Option[ByteString],
+      elapsedMs: Long
+  )
+
+  /** Async periodic flush failed. Healing phase will recover any missing nodes. */
+  private[actors] case class TrieFlushAsyncFailed(generation: Long, error: String)
+
   def props(
       stateRoot: ByteString,
       networkPeerManager: ActorRef,
@@ -1115,7 +1226,8 @@ object AccountRangeCoordinator {
       initialMaxInFlightPerPeer: Int = 5,
       trieFlushThreshold: Int = 50000,
       initialResponseBytes: Int = 524288,
-      minResponseBytes: Int = 102400
+      minResponseBytes: Int = 102400,
+      accountTrieEcOverride: Option[ExecutionContext] = None
   ): Props =
     Props(
       new AccountRangeCoordinator(
@@ -1129,7 +1241,8 @@ object AccountRangeCoordinator {
         initialMaxInFlightPerPeer,
         trieFlushThreshold,
         initialResponseBytes,
-        minResponseBytes
+        minResponseBytes,
+        accountTrieEcOverride
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -2,8 +2,6 @@ package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
 
-import scala.concurrent.duration._
-
 import com.chipprbots.ethereum.blockchain.sync.snap._
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.p2p.messages.SNAP._
@@ -59,12 +57,13 @@ class AccountRangeWorker(
       responseBytes = responseBytes
     )
 
-    // Track the request with timeout
+    // Track the request with adaptive timeout from SNAPRequestTracker / PeerRateTracker
+    // (geth msgrate algorithm). Starts at ~12s for a fresh tracker, converges down as peers
+    // respond — slow peers get pruned faster instead of holding in-flight slots for a full 30s.
     requestTracker.trackRequest(
       requestId,
       peer,
-      SNAPRequestTracker.RequestType.GetAccountRange,
-      timeout = 30.seconds
+      SNAPRequestTracker.RequestType.GetAccountRange
     ) {
       self ! RequestTimeout(requestId)
     }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -110,6 +110,9 @@ class ByteCodeCoordinator(
   // Statistics
   private var bytecodesDownloaded: Long = 0
   private var bytesDownloaded: Long = 0
+  // #1164: number of bytecode hashes abandoned via ForceCompleteByteCodes. Surfaced in postStop()
+  // diagnostics so operators can correlate force-completes with later BytecodeRecoveryActor activity.
+  private var bytecodesAbandoned: Long = 0
 
   // ByteCodes request tuning (Nethermind-style): use a per-peer dynamic byte budget, clamped hard to 2 MiB.
   // We send many hashes and rely on the peer-side `responseBytes` soft limit to bound work.
@@ -148,7 +151,10 @@ class ByteCodeCoordinator(
     log.info("ByteCodeCoordinator starting")
 
   override def postStop(): Unit =
-    log.info(s"ByteCodeCoordinator stopped. Downloaded $bytecodesDownloaded bytecodes")
+    log.info(
+      s"ByteCodeCoordinator stopped. Downloaded $bytecodesDownloaded bytecodes" +
+        (if (bytecodesAbandoned > 0) s", abandoned $bytecodesAbandoned via force-complete" else "")
+    )
 
   override val supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1.minute) { case _: Exception =>
@@ -243,6 +249,29 @@ class ByteCodeCoordinator(
 
     case ByteCodeCheckCompletion =>
       checkCompletion()
+
+    case ForceCompleteByteCodes =>
+      // #1164: When bytecode sync stagnates (e.g., a small set of code hashes no peer can serve),
+      // the existing completion check is unreachable because pendingTasks doesn't drain. Mirrors
+      // StorageRangeCoordinator.ForceCompleteStorage. Missing bytecodes can be recovered post-SNAP
+      // via BytecodeRecoveryActor.
+      val abandonedPending = pendingTasks.size
+      val abandonedActive = activeTasks.size
+      val abandonedTotal = abandonedPending + abandonedActive
+      log.warning(
+        s"Force-completing bytecode sync: $bytecodesDownloaded bytecodes downloaded, " +
+          s"abandoning $abandonedTotal remaining tasks ($abandonedPending pending, $abandonedActive active). " +
+          "Missing bytecodes will be recovered post-SNAP via BytecodeRecoveryActor if needed."
+      )
+      bytecodesAbandoned += abandonedTotal
+      pendingTasks.clear()
+      // Mark workers idle so they don't keep dispatching; drop active task tracking.
+      activeTasks.values.foreach(active => markWorkerIdle(active.worker))
+      activeTasks.clear()
+      // Set the sentinel so any late `checkCompletion()` calls also pass cleanly.
+      noMoreTasksExpected = true
+      log.info("Bytecode sync force-completed (promoting to healing/recovery phase)")
+      snapSyncController ! SNAPSyncController.ByteCodeSyncComplete
 
     case ByteCodeGetProgress =>
       val total = completedTasks.size + activeTasks.size + pendingTasks.size

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeWorker.scala
@@ -2,8 +2,6 @@ package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props, Stash}
 
-import scala.concurrent.duration._
-
 import com.chipprbots.ethereum.blockchain.sync.snap._
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
@@ -42,12 +40,13 @@ class ByteCodeWorker(
       responseBytes = maxResponseSize
     )
 
-    // Track request with timeout
+    // Track request with adaptive timeout from SNAPRequestTracker / PeerRateTracker.
+    // Starts at ~12s for a fresh tracker; converges down as peers respond so slow peers
+    // get pruned faster instead of holding in-flight slots for a full 30s.
     requestTracker.trackRequest(
       requestId,
       peer,
-      SNAPRequestTracker.RequestType.GetByteCodes,
-      timeout = 30.seconds
+      SNAPRequestTracker.RequestType.GetByteCodes
     ) {
       self ! ByteCodeRequestTimeout(requestId)
     }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -154,7 +154,7 @@ object Messages {
   case object NoMoreStorageTasks extends StorageRangeCoordinatorMessage
 
   /** Sent by SNAPSyncController when storage sync has stagnated and should promote to healing. Coordinator flushes
-    * deferred writes and reports StorageRangeSyncComplete.
+    * deferred writes and reports StorageRangeSyncForceCompleted so the controller cannot treat the handoff as clean.
     */
   case object ForceCompleteStorage extends StorageRangeCoordinatorMessage
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -107,6 +107,13 @@ object Messages {
   case object ByteCodeGetProgress extends ByteCodeCoordinatorMessage
   case object ByteCodeCheckCompletion extends ByteCodeCoordinatorMessage
 
+  /** Sent by SNAPSyncController when bytecode sync has stagnated and must be force-completed (#1164). Coordinator
+    * abandons remaining pending/active tasks (with an accounting counter), drains the queue, and reports
+    * `ByteCodeSyncComplete`. Mirrors `ForceCompleteStorage`. Missing bytecodes can be recovered post-SNAP via
+    * `BytecodeRecoveryActor`.
+    */
+  case object ForceCompleteByteCodes extends ByteCodeCoordinatorMessage
+
   sealed trait ByteCodeWorkerMessage
   case class FetchByteCodes(task: ByteCodeTask, peer: Peer) extends ByteCodeWorkerMessage
   case class ByteCodeWorkerFetchTask(task: ByteCodeTask, peer: Peer, requestId: BigInt, maxResponseSize: BigInt)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -176,6 +176,23 @@ object Messages {
       forStateRoot: ByteString
   ) extends StorageRangeCoordinatorMessage
 
+  /** An aggregated flat-slot batch (small-contract writes) finished committing on the storage-writer dispatcher.
+    * `forStateRoot` lets the coordinator drop completion messages from a generation that has since been superseded by a
+    * pivot refresh. The data has already been persisted; the message is just bookkeeping.
+    */
+  private[actors] case class FlatBatchFlushComplete(
+      forStateRoot: ByteString,
+      entryCount: Int,
+      elapsedMs: Long
+  ) extends StorageRangeCoordinatorMessage
+
+  /** Aggregated flat-slot batch failed to commit. Healing phase is expected to re-fetch the missing slots. */
+  private[actors] case class FlatBatchFlushFailed(
+      forStateRoot: ByteString,
+      entryCount: Int,
+      error: String
+  ) extends StorageRangeCoordinatorMessage
+
   // ========================================
   // TrieNodeHealing Messages
   // ========================================

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -725,7 +725,7 @@ class StorageRangeCoordinator(
       pendingAccountSlots.clear()
       totalBufferedSlots = 0
       log.info("Storage range sync force-completed (promoting to healing phase)")
-      snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
+      snapSyncController ! SNAPSyncController.StorageRangeSyncForceCompleted
 
     case StoragePivotRefreshed(newStateRoot) =>
       log.info(s"Storage pivot refreshed: ${stateRoot.take(4).toHex} -> ${newStateRoot.take(4).toHex}")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -5,10 +5,12 @@ import org.apache.pekko.actor.SupervisorStrategy._
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.math.Ordered.orderingToOrdered
 
 import com.chipprbots.ethereum.blockchain.sync.snap._
+import com.chipprbots.ethereum.db.dataSource.DataSourceBatchUpdate
 import com.chipprbots.ethereum.db.storage.{DeferredWriteMptStorage, FlatSlotStorage, MptStorage}
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
@@ -53,7 +55,9 @@ class StorageRangeCoordinator(
     initialMaxInFlightPerPeer: Int = 5,
     configInitialResponseBytes: Int = 1048576,
     configMinResponseBytes: Int = 131072,
-    deferredMerkleization: Boolean = true
+    deferredMerkleization: Boolean = true,
+    flatBatchEntryThreshold: Int = 1000,
+    flatBatchEcOverride: Option[ExecutionContext] = None
 ) extends Actor
     with ActorLogging {
 
@@ -346,6 +350,37 @@ class StorageRangeCoordinator(
     */
   private val smallContractThreshold = 1024
 
+  // ========================================
+  // Aggregated flat-slot writes (small-contract path)
+  // ========================================
+  //
+  // ~95% of ETC contracts hit the small-contract path. Doing a synchronous
+  // RocksDB commit per contract on the actor mailbox produces a commit storm
+  // and starves the coordinator's other work. Instead, accumulate completed
+  // small contracts here and flush them off-thread in batches.
+  //
+  // Stale flushes after a pivot refresh are tagged with the state root they
+  // were aggregated under and dropped at the completion-message handler — the
+  // data is still written (writes are idempotent and any account that
+  // legitimately needs different slot values at a later root will be re-fetched
+  // and overwrite), the bookkeeping just doesn't double-count.
+
+  /** Pending (accountHash, sortedSlots) pairs awaiting flush. Package-private for unit tests. */
+  private[actors] val pendingFlatBatchAccounts =
+    mutable.ArrayBuffer.empty[(ByteString, Seq[(ByteString, ByteString)])]
+
+  /** Total slot entries currently buffered in `pendingFlatBatchAccounts`. Package-private for unit tests. */
+  private[actors] var pendingFlatBatchEntries: Int = 0
+
+  /** Number of in-flight async flat-batch flushes — used to gate completion. Package-private for unit tests. */
+  private[actors] var inFlightFlatBatches: Int = 0
+
+  /** Dedicated dispatcher for flat-batch RocksDB commits. Tests can inject their own ExecutionContext to keep timing
+    * deterministic; production looks up `storage-writer-dispatcher` from the actor system.
+    */
+  private val flatBatchEc: ExecutionContext =
+    flatBatchEcOverride.getOrElse(context.system.dispatchers.lookup("storage-writer-dispatcher"))
+
   /** Bounded thread pool for trie construction — controls RocksDB write pressure. Using 3 threads avoids overwhelming
     * the single-threaded RocksDB compaction while still enabling parallel trie builds. Unbounded Futures on
     * sync-dispatcher caused thread starvation under heavy load.
@@ -361,18 +396,59 @@ class StorageRangeCoordinator(
     )
   private val trieBuilderEc = scala.concurrent.ExecutionContext.fromExecutorService(trieBuilderPool)
 
-  /** Write only to flat storage for small contracts — skip MPT construction. Called synchronously from the actor for
-    * accounts that arrived in a single response with fewer slots than smallContractThreshold. These are ~95% of ETC
-    * contracts. The MPT will be built lazily from flat data during healing or post-sync Merkleization.
+  /** Buffer a small-contract's slots into the aggregated flat-batch accumulator. The actual RocksDB commit is deferred
+    * to `flushPendingFlatBatch()` — called once the accumulator hits `flatBatchEntryThreshold` or at completion — and
+    * runs on `storage-writer-dispatcher` so it doesn't block the coordinator mailbox. ~95% of ETC contracts go through
+    * this path; an inline commit per contract was a hidden RocksDB bottleneck.
     */
-  private def writeSmallContractFlatOnly(
+  private[actors] def writeSmallContractFlatOnly(
       accountHash: ByteString,
       slots: mutable.ArrayBuffer[(ByteString, ByteString)]
   ): Unit = {
-    val sorted = slots.sortBy(_._1)(ByteStringOrdering)
-    flatSlotStorage.putSlotsBatch(accountHash, sorted.toSeq).commit()
+    val sorted = slots.sortBy(_._1)(ByteStringOrdering).toSeq
+    pendingFlatBatchAccounts += ((accountHash, sorted))
+    pendingFlatBatchEntries += sorted.size
     pendingAccountSlots.remove(accountHash)
     totalBufferedSlots -= slots.size
+    if (pendingFlatBatchEntries >= flatBatchEntryThreshold) {
+      flushPendingFlatBatch()
+    }
+  }
+
+  /** Hand the current accumulator off to the storage-writer dispatcher and reset it. The Future builds the combined
+    * `DataSourceBatchUpdate` and commits it in one RocksDB write batch, then notifies the actor with
+    * `FlatBatchFlushComplete` (or `FlatBatchFlushFailed`). The completion message carries `forStateRoot` so the actor
+    * can drop bookkeeping for batches that pre-date a pivot refresh.
+    */
+  private def flushPendingFlatBatch(): Unit = {
+    if (pendingFlatBatchAccounts.isEmpty) return
+    val batchAccounts = pendingFlatBatchAccounts.toList // immutable snapshot
+    val entries = pendingFlatBatchEntries
+    val forStateRoot = stateRoot
+    pendingFlatBatchAccounts.clear()
+    pendingFlatBatchEntries = 0
+    inFlightFlatBatches += 1
+
+    val selfRef = self
+    val storage = flatSlotStorage // capture for Future
+    val ec = flatBatchEc
+    import scala.concurrent.{Future, blocking}
+    Future {
+      blocking {
+        val startMs = System.currentTimeMillis()
+        var combined: DataSourceBatchUpdate = storage.emptyBatchUpdate
+        batchAccounts.foreach { case (accountHash, slots) =>
+          combined = combined.and(storage.putSlotsBatch(accountHash, slots))
+        }
+        combined.commit()
+        System.currentTimeMillis() - startMs
+      }
+    }(ec).onComplete {
+      case scala.util.Success(elapsedMs) =>
+        selfRef ! FlatBatchFlushComplete(forStateRoot, entries, elapsedMs)
+      case scala.util.Failure(e) =>
+        selfRef ! FlatBatchFlushFailed(forStateRoot, entries, e.getMessage)
+    }(ec)
   }
 
   /** Build tries for a batch of complete accounts on a background thread. Sorts slots by key for better trie locality,
@@ -495,6 +571,23 @@ class StorageRangeCoordinator(
 
   /** Shut down the trie builder thread pool when the actor stops. */
   override def postStop(): Unit = {
+    // Best-effort: flush any tail of accumulated small-contract slots synchronously
+    // here so we don't lose data when the actor terminates (force-complete, restart).
+    if (pendingFlatBatchAccounts.nonEmpty) {
+      try {
+        var combined: DataSourceBatchUpdate = flatSlotStorage.emptyBatchUpdate
+        pendingFlatBatchAccounts.foreach { case (accountHash, slots) =>
+          combined = combined.and(flatSlotStorage.putSlotsBatch(accountHash, slots))
+        }
+        combined.commit()
+        log.info(s"postStop: flushed final ${pendingFlatBatchEntries} flat slot entries")
+      } catch {
+        case e: Exception =>
+          log.error(s"postStop: failed to flush final flat batch: ${e.getMessage}")
+      }
+      pendingFlatBatchAccounts.clear()
+      pendingFlatBatchEntries = 0
+    }
     trieBuilderPool.shutdown()
     super.postStop()
   }
@@ -586,6 +679,10 @@ class StorageRangeCoordinator(
       ) {
         flushAllPendingTrieBuilds()
       }
+      // Drain the flat-batch accumulator once no more downloads are coming.
+      if (noMoreTasksExpected && tasks.isEmpty && activeTasks.isEmpty) {
+        flushPendingFlatBatch()
+      }
       if (isComplete) {
         log.info("Storage range sync complete!")
         snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
@@ -605,6 +702,7 @@ class StorageRangeCoordinator(
       // Trigger final trie builds if all downloads are done
       if (tasks.isEmpty && activeTasks.isEmpty) {
         flushAllPendingTrieBuilds()
+        flushPendingFlatBatch()
       }
       if (isComplete) {
         log.info("Storage range sync complete!")
@@ -621,6 +719,8 @@ class StorageRangeCoordinator(
       )
       // Build tries for any fully-downloaded accounts before force-completing
       flushAllPendingTrieBuilds()
+      // Hand off any small-contract slots that are still in the accumulator.
+      flushPendingFlatBatch()
       // Discard partially-downloaded accounts (continuations won't arrive)
       pendingAccountSlots.clear()
       totalBufferedSlots = 0
@@ -629,6 +729,13 @@ class StorageRangeCoordinator(
 
     case StoragePivotRefreshed(newStateRoot) =>
       log.info(s"Storage pivot refreshed: ${stateRoot.take(4).toHex} -> ${newStateRoot.take(4).toHex}")
+
+      // Flush before mutating `stateRoot` so the off-actor commit is tagged with the OLD root.
+      // The completion message will then arrive when `stateRoot` is the NEW root, take the stale
+      // branch in the handler, and emit the "bookkeeping ignored, data on disk" debug line. Done
+      // before the buffer-clears below so we don't have to coordinate the order with `pendingFlatBatchAccounts`.
+      flushPendingFlatBatch()
+
       stateRoot = newStateRoot
 
       // Cancel all in-flight requests: their responses are for the old root and will
@@ -727,6 +834,28 @@ class StorageRangeCoordinator(
           pendingAccountSlots.remove(hash)
         }
       }
+      self ! StorageCheckCompletion
+
+    case FlatBatchFlushComplete(forStateRoot, entryCount, elapsedMs) =>
+      inFlightFlatBatches = (inFlightFlatBatches - 1).max(0)
+      if (forStateRoot != stateRoot) {
+        log.debug(
+          s"Flat batch flush completed for stale root ${forStateRoot.take(4).toHex} " +
+            s"($entryCount entries) — bookkeeping ignored, data on disk"
+        )
+      } else {
+        val rate = if (elapsedMs > 0) entryCount * 1000L / elapsedMs else entryCount.toLong
+        log.debug(s"Flat batch flushed: $entryCount slots in ${elapsedMs}ms ($rate slots/s)")
+      }
+      // A drained flush may have unblocked completion (NoMore + empty queues).
+      self ! StorageCheckCompletion
+
+    case FlatBatchFlushFailed(forStateRoot, entryCount, error) =>
+      inFlightFlatBatches = (inFlightFlatBatches - 1).max(0)
+      log.error(
+        s"Flat batch flush failed for $entryCount slots " +
+          s"(root ${forStateRoot.take(4).toHex}): $error. Healing phase will recover."
+      )
       self ! StorageCheckCompletion
   }
 
@@ -1096,7 +1225,8 @@ class StorageRangeCoordinator(
 
   private def isComplete: Boolean =
     noMoreTasksExpected && tasks.isEmpty && activeTasks.isEmpty &&
-      accountsReadyForBuild.isEmpty && accountsInTrieConstruction.isEmpty && pendingAccountSlots.isEmpty
+      accountsReadyForBuild.isEmpty && accountsInTrieConstruction.isEmpty && pendingAccountSlots.isEmpty &&
+      pendingFlatBatchAccounts.isEmpty && inFlightFlatBatches == 0
 
   /** Update contract completion counts and send progress to controller. */
   private def updateContractProgress(): Unit = {
@@ -1137,7 +1267,9 @@ object StorageRangeCoordinator {
       initialMaxInFlightPerPeer: Int = 5,
       initialResponseBytes: Int = 1048576,
       minResponseBytes: Int = 131072,
-      deferredMerkleization: Boolean = true
+      deferredMerkleization: Boolean = true,
+      flatBatchEntryThreshold: Int = 1000,
+      flatBatchEcOverride: Option[ExecutionContext] = None
   ): Props =
     Props(
       new StorageRangeCoordinator(
@@ -1153,7 +1285,9 @@ object StorageRangeCoordinator {
         initialMaxInFlightPerPeer,
         configInitialResponseBytes = initialResponseBytes,
         configMinResponseBytes = minResponseBytes,
-        deferredMerkleization = deferredMerkleization
+        deferredMerkleization = deferredMerkleization,
+        flatBatchEntryThreshold = flatBatchEntryThreshold,
+        flatBatchEcOverride = flatBatchEcOverride
       )
     )
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -6,6 +6,7 @@ import org.apache.pekko.util.ByteString
 import org.bouncycastle.util.encoders.Hex
 
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import com.chipprbots.ethereum.blockchain.sync.snap._
@@ -31,17 +32,27 @@ class TrieNodeHealingCoordinator(
     mptStorage: MptStorage,
     batchSize: Int,
     snapSyncController: ActorRef,
-    concurrency: Int
+    concurrency: Int,
+    healingWriterEcOverride: Option[ExecutionContext] = None
 ) extends Actor
     with ActorLogging {
 
   import Messages._
 
-  // Task management — each task has a pathset (for GetTrieNodes) and a hash (for verification)
+  // Task management — each task has a pathset (for GetTrieNodes) and a hash (for verification).
+  // ArrayDeque (circular buffer) gives O(1) amortized head/tail operations. The previous
+  // immutable `Seq` did O(n) on every `:+` and head-drop — quadratic at healing scale.
   private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0)
-  private var pendingTasks: Seq[HealingEntry] = Seq.empty
+  private val pendingTasks: mutable.ArrayDeque[HealingEntry] = mutable.ArrayDeque.empty
   private var completedTaskCount: Int = 0
   private var abandonedTaskCount: Int = 0
+
+  /** Dedicated dispatcher for the batched raw-node RocksDB flush. Tests inject their own EC; production looks up
+    * `healing-writer-dispatcher` from the actor system. Keeps the blocking write off `sync-dispatcher` so other sync
+    * actors don't stall during healing-heavy bursts.
+    */
+  private val healingWriterEc: ExecutionContext =
+    healingWriterEcOverride.getOrElse(context.system.dispatchers.lookup("healing-writer-dispatcher"))
 
   // Per-task retry limit: after this many timeouts/failures, skip the task.
   // At ~6s per timeout cycle, 20 retries = ~2 minutes of trying per node.
@@ -173,7 +184,9 @@ class TrieNodeHealingCoordinator(
       log.info(s"Flushed $count healed nodes to disk (total: $totalNodesHealed)")
     }
 
-  /** Async flush — copies buffer, clears it, writes on background thread. */
+  /** Async flush — copies buffer, clears it, writes on the dedicated `healing-writer-dispatcher` so the blocking
+    * RocksDB write doesn't compete with sync actors on `sync-dispatcher`.
+    */
   private def flushRawNodesAsync(): Unit =
     if (rawNodeBuffer.nonEmpty && !flushing) {
       flushing = true
@@ -181,13 +194,14 @@ class TrieNodeHealingCoordinator(
       rawNodeBuffer.clear()
       import scala.concurrent.{Future, blocking}
       val selfRef = self
+      val ec = healingWriterEc
       Future {
         blocking {
           mptStorage.storeRawNodes(nodes)
           mptStorage.persist()
           nodes.size
         }
-      }(context.dispatcher).foreach(n => selfRef ! FlushComplete(n))(context.dispatcher)
+      }(ec).foreach(n => selfRef ! FlushComplete(n))(ec)
     }
 
   override def preStart(): Unit =
@@ -229,7 +243,7 @@ class TrieNodeHealingCoordinator(
       )
       stateRoot = newStateRoot
       flushRawNodesSync() // Flush any buffered nodes before clearing state
-      pendingTasks = Seq.empty // Will be re-populated by trie walk from controller
+      pendingTasks.clear() // Will be re-populated by trie walk from controller
       pendingHashSet.clear()
       statelessPeers.clear()
       peerCooldownUntilMs.clear()
@@ -292,7 +306,7 @@ class TrieNodeHealingCoordinator(
         HealingEntry(pathset = pathset, hash = hash)
     }
     val deduped = pathsAndHashes.size - entries.size
-    pendingTasks = pendingTasks ++ entries
+    pendingTasks ++= entries
     val dedupStr = if (deduped > 0) s" ($deduped duplicates filtered)" else ""
     log.info(s"Queued ${entries.size} nodes for healing$dedupStr. Total pending: ${pendingTasks.size}")
   }
@@ -356,8 +370,9 @@ class TrieNodeHealingCoordinator(
     }
 
     val effectiveBatch = effectiveBatchSize
-    val batch = pendingTasks.take(effectiveBatch)
-    pendingTasks = pendingTasks.drop(effectiveBatch)
+    val takeCount = effectiveBatch.min(pendingTasks.size)
+    val batch: Seq[HealingEntry] = pendingTasks.iterator.take(takeCount).toSeq
+    pendingTasks.dropInPlace(takeCount)
     // Remove dispatched hashes from dedup set (they'll be re-added if re-queued on failure)
     batch.foreach(e => pendingHashSet -= e.hash)
 
@@ -428,14 +443,14 @@ class TrieNodeHealingCoordinator(
             s"got ${Hex.toHexString(nodeHash.take(4).toArray)}"
         )
         // Re-queue this task for retry
-        pendingTasks = pendingTasks :+ task
+        pendingTasks += task
       }
     }
 
     // Re-queue unmatched tasks (server returned fewer nodes than requested)
     val unmatchedTasks = tasksForRequest.drop(nodes.size)
     unmatchedTasks.foreach { task =>
-      pendingTasks = pendingTasks :+ task
+      pendingTasks += task
     }
 
     completedTaskCount += healedCount
@@ -514,7 +529,7 @@ class TrieNodeHealingCoordinator(
             s"(regular sync will fetch on-demand)"
         )
       } else {
-        pendingTasks = pendingTasks :+ updated
+        pendingTasks += updated
         requeued += 1
       }
     }
@@ -536,7 +551,7 @@ class TrieNodeHealingCoordinator(
           s"Regular sync will fetch missing nodes on-demand via GetTrieNodes."
       )
       abandonedTaskCount += pendingCount
-      pendingTasks = Seq.empty
+      pendingTasks.clear()
       pendingHashSet.clear()
     }
 
@@ -585,7 +600,8 @@ object TrieNodeHealingCoordinator {
       mptStorage: MptStorage,
       batchSize: Int,
       snapSyncController: ActorRef,
-      concurrency: Int = 16
+      concurrency: Int = 16,
+      healingWriterEcOverride: Option[ExecutionContext] = None
   ): Props =
     Props(
       new TrieNodeHealingCoordinator(
@@ -595,7 +611,8 @@ object TrieNodeHealingCoordinator {
         mptStorage,
         batchSize,
         snapSyncController,
-        concurrency
+        concurrency,
+        healingWriterEcOverride
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -303,6 +303,79 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
   /** Store the finalized account trie root hash from finalizeTrie(). */
   def putSnapSyncFinalizedRoot(root: ByteString): DataSourceBatchUpdate =
     put(Keys.SnapSyncFinalizedRoot, Hex.toHexString(root.toArray))
+
+  // ========================================
+  // Background chain backfill cursors (#1169)
+  // ========================================
+  //
+  // After SNAP completes, `ChainDownloader` continues to backfill genesis→pivot in the background
+  // (#1162). If the node is killed mid-backfill we want regular sync to come back up immediately
+  // and *also* resume backfill from where it stopped. These cursors give us:
+  //
+  //   1. A fast skip-to-current path on resume (no full binary search across the chain).
+  //   2. A predicate (`needsBackfillResume`) for `SyncController.start()` to decide whether to
+  //      spawn a standalone `ChainDownloader` alongside regular sync.
+  //
+  // Three separate cursors because `ChainDownloader` writes headers, bodies, and receipts on
+  // independent commit paths — they don't all advance in lockstep and must be tracked
+  // separately. Each cursor is updated atomically with its corresponding storage commit so a
+  // crash mid-write never leaves the cursor ahead of the data on disk.
+
+  /** Highest backfill target the node was working toward when it last saved progress. Set when `ChainDownloader`
+    * starts; cleared after `Done` so future startups don't spuriously resume.
+    */
+  def getBackfillTarget(): BigInt =
+    getBigInt(Keys.BackfillTarget)
+
+  def putBackfillTarget(target: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillTarget, target.toString)
+
+  /** Highest header number whose `storeBlockHeader` commit has succeeded. */
+  def getBackfillBestHeader(): BigInt =
+    getBigInt(Keys.BackfillBestHeader)
+
+  def putBackfillBestHeader(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestHeader, n.toString)
+
+  /** Highest block number whose `storeBlockBody` commit has succeeded. May lag the header cursor. */
+  def getBackfillBestBody(): BigInt =
+    getBigInt(Keys.BackfillBestBody)
+
+  def putBackfillBestBody(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestBody, n.toString)
+
+  /** Highest block number whose `storeReceipts` commit has succeeded. May lag the body cursor. */
+  def getBackfillBestReceipt(): BigInt =
+    getBigInt(Keys.BackfillBestReceipt)
+
+  def putBackfillBestReceipt(n: BigInt): DataSourceBatchUpdate =
+    put(Keys.BackfillBestReceipt, n.toString)
+
+  /** Clear all backfill cursors + target. Called on `ChainDownloader.Done` so the next startup doesn't try to resume an
+    * already-completed backfill.
+    */
+  def clearBackfillCursors(): DataSourceBatchUpdate =
+    update(
+      toRemove = Seq(
+        Keys.BackfillTarget,
+        Keys.BackfillBestHeader,
+        Keys.BackfillBestBody,
+        Keys.BackfillBestReceipt
+      ),
+      toUpsert = Nil
+    )
+
+  /** True iff SNAP is done AND a backfill target was previously persisted AND any of the three cursors is below the
+    * target. `SyncController.start()` uses this to spawn a standalone `ChainDownloader` alongside regular sync.
+    */
+  def needsBackfillResume(): Boolean = {
+    if (!isSnapSyncDone()) return false
+    val target = getBackfillTarget()
+    if (target <= 0) return false
+    getBackfillBestHeader() < target ||
+    getBackfillBestBody() < target ||
+    getBackfillBestReceipt() < target
+  }
 }
 
 object AppStateStorage {
@@ -330,6 +403,10 @@ object AppStateStorage {
     val SnapSyncCodeHashesPath = "SnapSyncCodeHashesPath"
     val SnapSyncStorageFilePath = "SnapSyncStorageFilePath"
     val SnapSyncFinalizedRoot = "SnapSyncFinalizedRoot"
+    val BackfillTarget = "BackfillTarget"
+    val BackfillBestHeader = "BackfillBestHeader"
+    val BackfillBestBody = "BackfillBestBody"
+    val BackfillBestReceipt = "BackfillBestReceipt"
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -1,0 +1,104 @@
+package com.chipprbots.ethereum.blockchain.sync.snap
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActorRef
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+
+import scala.concurrent.ExecutionContext
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.BlockchainWriter
+import com.chipprbots.ethereum.testing.Tags._
+
+class ChainDownloaderSpec
+    extends TestKit(ActorSystem("ChainDownloaderSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockFactory
+    with TestSyncConfig {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  // Regression for #1162: chain backfill keeps running in the background after SNAPSyncController
+  // emits SnapSyncFinalized, but at lower priority. ChainDownloader needs a `YieldToRegularSync(n)`
+  // message that mirrors `BoostConcurrency(n)` but downward — the SNAP controller sends it in
+  // finalizeSnapSync() so backfill yields peer slots to forward sync.
+  "ChainDownloader.YieldToRegularSync" should "carry the new concurrency budget" taggedAs UnitTest in {
+    ChainDownloader.YieldToRegularSync(7).maxConcurrent shouldBe 7
+  }
+
+  it should "be a distinct message type from BoostConcurrency" taggedAs UnitTest in {
+    val yielded: Any = ChainDownloader.YieldToRegularSync(7)
+    val boosted: Any = ChainDownloader.BoostConcurrency(7)
+    (yielded should not).equal(boosted)
+  }
+
+  // Behavioural test: the downloader's dispatch loop wedges if `maxConcurrentRequests` ever drops to
+  // zero (the slot check `inFlightCount >= maxConcurrentRequests` would be true forever), stranding
+  // the parent `SNAPSyncController` waiting for `ChainDownloader.Done` indefinitely. Clamp to >=1.
+  "ChainDownloader" should "clamp YieldToRegularSync(0) to 1 to prevent dispatch wedge" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 16)
+
+    downloader ! ChainDownloader.YieldToRegularSync(0)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 1
+
+    downloader ! ChainDownloader.YieldToRegularSync(5)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 5
+
+    system.stop(downloader)
+  }
+
+  it should "honour YieldToRegularSync(n) for any n >= 1" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 16)
+
+    downloader ! ChainDownloader.YieldToRegularSync(2)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 2
+
+    downloader ! ChainDownloader.YieldToRegularSync(1)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 1
+
+    system.stop(downloader)
+  }
+
+  it should "still apply YieldToRegularSync after BoostConcurrency (downward)" taggedAs UnitTest in {
+    val downloader = newDownloader(initialMaxConcurrentRequests = 2)
+
+    downloader ! ChainDownloader.BoostConcurrency(16)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 16
+
+    downloader ! ChainDownloader.YieldToRegularSync(2)
+    downloader.underlyingActor.currentMaxConcurrentRequests shouldBe 2
+
+    system.stop(downloader)
+  }
+
+  /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start` sent),
+    * so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
+    */
+  private def newDownloader(initialMaxConcurrentRequests: Int): TestActorRef[ChainDownloader] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+    TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = initialMaxConcurrentRequests
+      )
+    )
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.testing.Tags._
@@ -80,6 +82,87 @@ class ChainDownloaderSpec
     system.stop(downloader)
   }
 
+  // Issue #1169: persist a BackfillTarget at Start so that a node killed mid-backfill can
+  // resume standalone after restart.
+  it should "persist BackfillTarget on Start so a restart can resume backfill" taggedAs UnitTest in {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+
+    // findBestStoredHeader probes block 1; mock it as missing so the binary search falls
+    // through and returns 0 immediately, leaving the actor in `downloading` state.
+    (blockchainReader.getBlockHeaderByNumber _)
+      .expects(BigInt(1))
+      .returning(None)
+      .anyNumberOfTimes()
+
+    appStateStorage.getBackfillTarget() shouldBe BigInt(0)
+
+    val downloader = TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = 4
+      )
+    )
+
+    val target = BigInt(19_250_000)
+    downloader ! ChainDownloader.Start(target)
+
+    appStateStorage.getBackfillTarget() shouldBe target
+
+    system.stop(downloader)
+  }
+
+  // Issue #1169: an UpdateTarget message during the downloading phase persists the bumped
+  // target so a restart resumes against the latest target rather than a stale one.
+  it should "persist a bumped BackfillTarget on UpdateTarget" taggedAs UnitTest in {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+
+    (blockchainReader.getBlockHeaderByNumber _)
+      .expects(BigInt(1))
+      .returning(None)
+      .anyNumberOfTimes()
+
+    val downloader = TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = 4
+      )
+    )
+
+    downloader ! ChainDownloader.Start(BigInt(1000))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1000)
+
+    downloader ! ChainDownloader.UpdateTarget(BigInt(1500))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1500)
+
+    // A target lower than the current one is ignored.
+    downloader ! ChainDownloader.UpdateTarget(BigInt(1200))
+    appStateStorage.getBackfillTarget() shouldBe BigInt(1500)
+
+    system.stop(downloader)
+  }
+
   /** Spawn a ChainDownloader for unit-level message-handling tests. The downloader stays in `idle` (no `Start` sent),
     * so the in-flight queues remain empty and we don't need real blockchain or peer infrastructure.
     */
@@ -87,12 +170,14 @@ class ChainDownloaderSpec
     implicit val ec: ExecutionContext = system.dispatcher
     val blockchainReader = mock[BlockchainReader]
     val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
     val networkPeerManager = TestProbe()
     val peerEventBus = TestProbe()
     TestActorRef[ChainDownloader](
       ChainDownloader.props(
         blockchainReader = blockchainReader,
         blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
         networkPeerManager = networkPeerManager.ref,
         peerEventBus = peerEventBus.ref,
         syncConfig = defaultSyncConfig,

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTrackerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTrackerSpec.scala
@@ -266,4 +266,66 @@ class SNAPRequestTrackerSpec
     tracker.isPending(id2) shouldBe false
     tracker.isPending(id3) shouldBe true
   }
+
+  // ========================================
+  // Adaptive timeout via PeerRateTracker (issue #1168)
+  // ========================================
+
+  it should "default to the rate-tracker adaptive timeout when no explicit timeout is supplied" taggedAs UnitTest in {
+    // Fresh tracker: medianRTT = RttMinEstimateMs (2000ms), confidence = 0.5
+    // Formula: min(60s, 3 × medianRTT / confidence) = min(60s, 12000ms) = 12s.
+    val tracker = new SNAPRequestTracker()
+    val adaptive = tracker.rateTracker.targetTimeout()
+    adaptive shouldBe 12.seconds
+  }
+
+  it should "stay capped at PeerRateTracker.TtlLimitMs (60s) regardless of confidence drift" taggedAs UnitTest in {
+    val tracker = new SNAPRequestTracker()
+    // Even with confidence near the floor and minimum medianRTT, the upper bound is hard-capped.
+    // Drive confidence as low as possible by adding many peers (detune is multiplicative).
+    val testProbe = TestProbe()
+    (1 to 100).foreach(i => tracker.rateTracker.addPeer(s"peer-$i"))
+    val capped = tracker.rateTracker.targetTimeout()
+    capped should be <= 60.seconds
+  }
+
+  it should "fire the timeout callback for an unresponsive peer within the adaptive window" taggedAs UnitTest in {
+    // We can't wait the full 12s in a unit test, so we cover the firing-mechanism with a tiny
+    // explicit override. The wiring proof — that `trackRequest` without an explicit timeout
+    // *would* select the adaptive value — is covered by the previous test.
+    val tracker = new SNAPRequestTracker()
+    val testProbe = TestProbe()
+    val peer = createTestPeer("slow-peer", testProbe.ref)
+
+    var timeoutCalled = false
+    val requestId = tracker.generateRequestId()
+    tracker.trackRequest(requestId, peer, SNAPRequestTracker.RequestType.GetAccountRange, timeout = 50.millis) {
+      timeoutCalled = true
+    }
+
+    awaitCond(timeoutCalled, max = 500.millis)
+    tracker.isPending(requestId) shouldBe false
+  }
+
+  it should "shorten targetTimeout after fast responses tune the rate tracker" taggedAs UnitTest in {
+    // A fast-responding peer shifts medianRTT down toward its actual RTT, then `tune()` updates
+    // the EMA — confirming that adaptive timeout *can* be shorter than the initial 12s.
+    val tracker = new SNAPRequestTracker()
+    val initial = tracker.rateTracker.targetTimeout()
+
+    // Simulate fast responses: 4 peers each delivering 100 items in 50ms.
+    (1 to 4).foreach { i =>
+      val peerId = s"fast-peer-$i"
+      tracker.rateTracker.addPeer(peerId)
+      tracker.rateTracker.update(peerId, PeerRateTracker.MsgGetAccountRange, elapsedMs = 50L, items = 100)
+    }
+    // Bump confidence toward 1.0 and let the EMA migrate medianRTT downward.
+    (1 to 20).foreach(_ => tracker.rateTracker.tune())
+
+    val converged = tracker.rateTracker.targetTimeout()
+    // Converged timeout should be no larger than the initial — the rate tracker is allowed
+    // to keep it at the floor, but it must never grow beyond the starting estimate when peers
+    // are demonstrably faster than the default.
+    converged should be <= initial
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -141,6 +141,7 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     val _ = AccountRangeSyncComplete
     val _ = ByteCodeSyncComplete
     val _ = StorageRangeSyncComplete
+    val _ = StorageRangeSyncForceCompleted
     val _ = StateHealingComplete
     val _ = StateValidationComplete
     val getProgress = GetProgress
@@ -153,6 +154,24 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     getProgress shouldBe GetProgress
     bootstrapComplete shouldBe BootstrapComplete
     fallback shouldBe FallbackToFastSync
+  }
+
+  it should "skip healing for clean deferred-merkleization downloads only" taggedAs UnitTest in {
+    val config = SNAPSyncConfig(deferredMerkleization = true)
+
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = config,
+      storagePhaseForceCompleted = false
+    ) shouldBe true
+  }
+
+  it should "run healing when storage was force-completed even with deferred merkleization" taggedAs UnitTest in {
+    val config = SNAPSyncConfig(deferredMerkleization = true)
+
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = config,
+      storagePhaseForceCompleted = true
+    ) shouldBe false
   }
 
   it should "have bootstrap message with target block" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -42,6 +42,29 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     config.maxSnapSyncFailures should be > 0
   }
 
+  // Regression for #1162: chain backfill is decoupled from SNAP completion. The new
+  // `chainBackfillConcurrentRequests` budget controls how many in-flight ETH requests background
+  // backfill is allowed once regular sync has taken over. Default must be small (yield to regular sync).
+  it should "default chainBackfillConcurrentRequests to a small value (yield to regular sync)" taggedAs UnitTest in {
+    val config = SNAPSyncConfig()
+    config.chainBackfillConcurrentRequests should be > 0
+    config.chainBackfillConcurrentRequests should be <= config.chainDownloadBoostedConcurrentRequests
+  }
+
+  // Regression for #1162: SNAPSyncController emits a two-phase handshake — SnapSyncFinalized first,
+  // then Done either immediately or later. SnapSyncFinalized must carry the pivot block number
+  // so SyncController has the context it needs when starting regular sync.
+  "SNAPSyncController.SnapSyncFinalized" should "carry the pivot block number" taggedAs UnitTest in {
+    val msg = SNAPSyncController.SnapSyncFinalized(BigInt(12345))
+    msg.pivot shouldBe BigInt(12345)
+  }
+
+  it should "be distinct from Done" taggedAs UnitTest in {
+    val finalized: Any = SNAPSyncController.SnapSyncFinalized(BigInt(0))
+    val done: Any = SNAPSyncController.Done
+    (finalized should not).equal(done)
+  }
+
   "SyncProgress" should "format progress string correctly" taggedAs UnitTest in {
     import SNAPSyncController._
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -1,7 +1,7 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.{TestKit, TestProbe, ImplicitSender}
+import org.apache.pekko.actor.{ActorSystem, Status}
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe, ImplicitSender}
 import org.apache.pekko.util.ByteString
 
 import scala.concurrent.duration._
@@ -213,5 +213,127 @@ class AccountRangeCoordinatorSpec
     progress.progress should be >= 0.0
     progress.progress should be <= 1.0
     progress.elapsedTimeMs should be >= 0L
+  }
+
+  // ========================================
+  // Async trie flush + finalisation generation guard (issue #1166)
+  // ========================================
+
+  /** Helper: build a TestActorRef so tests can poke `underlyingActor` state directly and inject `system.dispatcher` as
+    * the trie EC for deterministic timing.
+    */
+  private def newCoordinator(
+      stateRoot: ByteString = kec256(ByteString("trie-async-test-root")),
+      controller: TestProbe = TestProbe()
+  ): TestActorRef[AccountRangeCoordinator] =
+    TestActorRef[AccountRangeCoordinator](
+      AccountRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        concurrency = 4,
+        snapSyncController = controller.ref,
+        accountTrieEcOverride = Some(system.dispatcher)
+      )
+    )
+
+  it should "construct successfully when an account-trie EC override is supplied" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    coord should not be null
+    coord.underlyingActor.trieFlushGeneration shouldBe 0L
+    system.stop(coord)
+  }
+
+  it should "drop a stale TrieFlushComplete (finalisation) silently — no controller messages" taggedAs UnitTest in {
+    val controller = TestProbe()
+    val coord = newCoordinator(controller = controller)
+
+    // Force the actor into the `finalizing` receive without actually running the heavy work.
+    // We simulate post-spawn state: bump the generation and capture it, then bump again so an
+    // arriving TrieFlushComplete with the captured generation looks stale.
+    coord.underlyingActor.trieFlushGeneration = 7L
+    coord.underlyingActor.context.become(coord.underlyingActor.finalizing)
+
+    val staleGen = 5L
+
+    coord ! AccountRangeCoordinator.TrieFlushComplete(staleGen, Right(ByteString("would-be-root")))
+
+    // Stale → controller hears nothing.
+    controller.expectNoMessage(300.millis)
+    coord.underlyingActor.trieFlushGeneration shouldBe 7L
+
+    system.stop(coord)
+  }
+
+  it should "honour a current-generation TrieFlushComplete and notify the controller" taggedAs UnitTest in {
+    val controller = TestProbe()
+    val coord = newCoordinator(controller = controller)
+
+    coord.underlyingActor.trieFlushGeneration = 3L
+    coord.underlyingActor.context.become(coord.underlyingActor.finalizing)
+
+    val rootHash = ByteString(Array.fill[Byte](32)(0x42))
+    coord ! AccountRangeCoordinator.TrieFlushComplete(3L, Right(rootHash))
+
+    controller.expectMsg(2.seconds, SNAPSyncController.AccountTrieFinalized(rootHash))
+    controller.expectMsg(2.seconds, SNAPSyncController.ProgressAccountsTrieFinalized)
+  }
+
+  it should "drop a stale TrieFlushAsyncComplete (periodic flush) and return to normal receive" taggedAs UnitTest in {
+    val controller = TestProbe()
+    val coord = newCoordinator(controller = controller)
+
+    coord.underlyingActor.trieFlushGeneration = 4L
+    coord.underlyingActor.context.become(coord.underlyingActor.flushing)
+
+    val staleGen = 2L
+
+    coord ! AccountRangeCoordinator.TrieFlushAsyncComplete(staleGen, persistedRoot = None, elapsedMs = 5L)
+
+    // The handler self-sends CheckCompletion, which can produce a ProgressAccountEstimate when
+    // tasks exist — for a fresh coordinator with empty tasks no message is emitted.
+    controller.expectNoMessage(300.millis)
+
+    // After dropping the stale completion the actor must be back on the normal receive,
+    // i.e. ready to handle a regular query.
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    system.stop(coord)
+  }
+
+  it should "drop a stale TrieFlushAsyncFailed and return to normal receive" taggedAs UnitTest in {
+    val controller = TestProbe()
+    val coord = newCoordinator(controller = controller)
+
+    coord.underlyingActor.trieFlushGeneration = 9L
+    coord.underlyingActor.context.become(coord.underlyingActor.flushing)
+
+    coord ! AccountRangeCoordinator.TrieFlushAsyncFailed(generation = 8L, error = "stale failure")
+
+    controller.expectNoMessage(300.millis)
+
+    // Confirm we left `flushing` and are back on normal receive.
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    system.stop(coord)
+  }
+
+  it should "ignore Status.Failure during finalisation by stopping the actor" taggedAs UnitTest in {
+    val controller = TestProbe()
+    val coord = newCoordinator(controller = controller)
+
+    coord.underlyingActor.trieFlushGeneration = 1L
+    coord.underlyingActor.context.become(coord.underlyingActor.finalizing)
+
+    val watcher = TestProbe()
+    watcher.watch(coord)
+
+    coord ! Status.Failure(new RuntimeException("synthetic failure"))
+
+    controller.expectMsg(2.seconds, SNAPSyncController.ProgressAccountsTrieFinalized)
+    watcher.expectTerminated(coord, 2.seconds)
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
@@ -390,4 +390,59 @@ class ByteCodeCoordinatorSpec
     coordinator ! Messages.ByteCodePeerAvailable(peer)
     networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
   }
+
+  // #1164: ForceCompleteByteCodes drains pending+active tasks and reports completion. Without this, a small set of
+  // unservable code hashes could hold the bytecode phase open indefinitely (the existing completion check requires
+  // `pendingTasks.isEmpty && activeTasks.isEmpty` and there's no per-task failure cap).
+  it should "force-complete bytecode sync, abandoning pending tasks (#1164)" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Queue a non-trivial set of bytecode hashes. No peer is registered, so they'll sit in pendingTasks
+    // forever — modelling the wedged state where peers can't serve a small unservable subset.
+    val codeHashes = (1 to 10).map(i => kec256(ByteString(s"code$i")))
+    coordinator ! Messages.StartByteCodeSync(codeHashes)
+    coordinator ! Messages.NoMoreByteCodeTasks
+
+    // Without the force-complete, ByteCodeCheckCompletion stays blocked because pendingTasks is non-empty.
+    coordinator ! Messages.ByteCodeCheckCompletion
+    snapSyncController.expectNoMessage(200.millis)
+
+    // Force-complete drains the queue and signals the parent.
+    coordinator ! Messages.ForceCompleteByteCodes
+    snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
+  }
+
+  it should "handle ForceCompleteByteCodes when queues are already empty" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Empty queue + ForceCompleteByteCodes: should still emit ByteCodeSyncComplete (idempotent terminal state).
+    coordinator ! Messages.ForceCompleteByteCodes
+    snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -290,7 +290,7 @@ class StorageRangeCoordinatorSpec
     slots.foreach { case (slotHash, value) =>
       flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
     }
-    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncComplete)
+    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncForceCompleted)
 
     system.stop(coord)
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -1,9 +1,10 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.{TestKit, TestProbe, ImplicitSender}
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe, ImplicitSender}
 import org.apache.pekko.util.ByteString
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 import org.scalatest.BeforeAndAfterAll
@@ -169,5 +170,187 @@ class StorageRangeCoordinatorSpec
     // Coordinator should still be operational
     coordinator ! Messages.StorageGetProgress
     expectMsgType[Any](3.seconds)
+  }
+
+  // ========================================
+  // Flat-batch aggregator (issue #1165)
+  // ========================================
+
+  /** Helper: build a TestActorRef with the override EC and small threshold so flat-batch behaviour is observable
+    * without spinning up the storage-writer-dispatcher.
+    */
+  private def newCoordWithFlatBatch(
+      flatSlotStorage: FlatSlotStorage,
+      threshold: Int,
+      stateRootArg: ByteString = kec256(ByteString("flat-batch-test-root"))
+  ): (TestActorRef[StorageRangeCoordinator], TestProbe) = {
+    val controller = TestProbe()
+    val ref = TestActorRef[StorageRangeCoordinator](
+      StorageRangeCoordinator.props(
+        stateRoot = stateRootArg,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        flatSlotStorage = flatSlotStorage,
+        maxAccountsPerBatch = 8,
+        maxInFlightRequests = 8,
+        requestTimeout = 30.seconds,
+        snapSyncController = controller.ref,
+        flatBatchEntryThreshold = threshold,
+        flatBatchEcOverride = Some(system.dispatcher)
+      )
+    )
+    (ref, controller)
+  }
+
+  /** Helper: synthesize an account-hash + slots payload of `slotsPerAccount` entries. */
+  private def fakeContract(
+      seed: Int,
+      slotsPerAccount: Int
+  ): (ByteString, mutable.ArrayBuffer[(ByteString, ByteString)]) = {
+    val accountHash = kec256(ByteString(s"acct-$seed"))
+    val slots = mutable.ArrayBuffer.empty[(ByteString, ByteString)]
+    var i = 0
+    while (i < slotsPerAccount) {
+      val slotHash = kec256(ByteString(s"slot-$seed-$i"))
+      val slotValue = ByteString(s"value-$seed-$i".getBytes)
+      slots += ((slotHash, slotValue))
+      i += 1
+    }
+    (accountHash, slots)
+  }
+
+  it should "buffer small-contract slots in the accumulator without immediate commit" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 100)
+
+    val (accountHash, slots) = fakeContract(seed = 1, slotsPerAccount = 3)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 3
+    coord.underlyingActor.pendingFlatBatchAccounts.size shouldBe 1
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+
+    // Nothing was committed — FlatSlotStorage is still empty for our keys.
+    flatSlots.getSlot(accountHash, slots.head._1) shouldBe None
+
+    system.stop(coord)
+  }
+
+  it should "flush exactly once when the threshold is crossed and persist all buffered slots" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 5)
+
+    // Three contracts, 2 slots each = 6 total slots, crossing the 5-entry threshold.
+    val contracts = (1 to 3).map(i => fakeContract(seed = i, slotsPerAccount = 2))
+    contracts.foreach { case (h, s) => coord.underlyingActor.writeSmallContractFlatOnly(h, s) }
+
+    // Flush is async on system.dispatcher; the 1-s deadline is generous.
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+
+    // After flush, all 6 slots are durable.
+    contracts.foreach { case (accountHash, slots) =>
+      slots.foreach { case (slotHash, value) =>
+        flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+      }
+    }
+
+    // Accumulator was reset.
+    coord.underlyingActor.pendingFlatBatchAccounts shouldBe empty
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 0
+
+    system.stop(coord)
+  }
+
+  it should "not trigger a flush when accumulator stays below threshold" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    val (accountHash, slots) = fakeContract(seed = 42, slotsPerAccount = 50)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 50
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+    flatSlots.getSlot(accountHash, slots.head._1) shouldBe None
+
+    system.stop(coord)
+  }
+
+  it should "flush remaining accumulator on ForceCompleteStorage" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, controller) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    val (accountHash, slots) = fakeContract(seed = 99, slotsPerAccount = 4)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 4
+
+    coord ! Messages.ForceCompleteStorage
+
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+    slots.foreach { case (slotHash, value) =>
+      flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+    }
+    controller.expectMsg(3.seconds, SNAPSyncController.StorageRangeSyncComplete)
+
+    system.stop(coord)
+  }
+
+  it should "drop bookkeeping for FlatBatchFlushComplete from a stale state root" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    coord.underlyingActor.inFlightFlatBatches = 1
+    val staleRoot = kec256(ByteString("a-stale-root"))
+
+    coord ! Messages.FlatBatchFlushComplete(staleRoot, entryCount = 7, elapsedMs = 5L)
+
+    coord.underlyingActor.inFlightFlatBatches shouldBe 0
+
+    system.stop(coord)
+  }
+
+  it should "flush the accumulator before mutating stateRoot on StoragePivotRefreshed" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val oldRoot = kec256(ByteString("old-root"))
+    val newRoot = kec256(ByteString("new-root"))
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000, stateRootArg = oldRoot)
+
+    // Buffer some data while stateRoot == oldRoot.
+    val (accountHash, slots) = fakeContract(seed = 7, slotsPerAccount = 4)
+    coord.underlyingActor.writeSmallContractFlatOnly(accountHash, slots)
+    coord.underlyingActor.pendingFlatBatchEntries shouldBe 4
+
+    // Pivot refresh: must commit the accumulator THEN advance the root.
+    coord ! Messages.StoragePivotRefreshed(newRoot)
+
+    awaitAssert(coord.underlyingActor.inFlightFlatBatches shouldBe 0, max = 1.second)
+
+    // Data made it to disk despite the pivot refresh.
+    slots.foreach { case (slotHash, value) =>
+      flatSlots.getSlot(accountHash, slotHash) shouldBe Some(value)
+    }
+    coord.underlyingActor.pendingFlatBatchAccounts shouldBe empty
+
+    system.stop(coord)
+  }
+
+  it should "decrement in-flight count on FlatBatchFlushFailed and stay operational" taggedAs UnitTest in {
+    val flatSlots = new FlatSlotStorage(EphemDataSource())
+    val (coord, _) = newCoordWithFlatBatch(flatSlots, threshold = 1000)
+
+    coord.underlyingActor.inFlightFlatBatches = 2
+
+    coord ! Messages.FlatBatchFlushFailed(
+      forStateRoot = kec256(ByteString("flat-batch-test-root")),
+      entryCount = 11,
+      error = "synthetic write failure"
+    )
+
+    coord.underlyingActor.inFlightFlatBatches shouldBe 1
+
+    coord ! Messages.StorageGetProgress
+    expectMsgType[Any](3.seconds)
+
+    system.stop(coord)
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
@@ -15,6 +15,8 @@ import com.chipprbots.ethereum.crypto.kec256
 import com.chipprbots.ethereum.testing.Tags._
 import com.chipprbots.ethereum.testing.{PeerTestHelpers, TestMptStorage}
 
+import java.nio.ByteBuffer
+
 class TrieNodeHealingCoordinatorSpec
     extends TestKit(ActorSystem("TrieNodeHealingCoordinatorSpec"))
     with ImplicitSender
@@ -183,5 +185,109 @@ class TrieNodeHealingCoordinatorSpec
     // Coordinator should still be operational
     coordinator ! Messages.HealingGetProgress
     expectMsgType[Any](3.seconds)
+  }
+
+  // ========================================
+  // pendingTasks ArrayDeque + dispatcher (issue #1167)
+  // ========================================
+
+  /** Synthesize a unique (pathset, hash) so the dedup set doesn't drop our nodes. */
+  private def fakeHashedNode(seed: Int): (Seq[ByteString], ByteString) = {
+    val hash = kec256(ByteString(s"healing-node-$seed"))
+    // pathset is a Seq[ByteString]; for queueing we just need something distinct.
+    val path = ByteString(ByteBuffer.allocate(4).putInt(seed).array())
+    (Seq(path), hash)
+  }
+
+  it should "absorb a large QueueMissingNodes payload without timing out" taggedAs UnitTest in {
+    // The previous immutable-Seq pendingTasks was O(n) per `:+`. Queueing 50,000 nodes via
+    // appendAll on the new ArrayDeque is O(n) total instead of O(n²).
+    val stateRoot = kec256(ByteString("deque-load-test-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        batchSize = 64,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(system.dispatcher)
+      )
+    )
+
+    val nodeCount = 50000
+    val nodes = (1 to nodeCount).map(fakeHashedNode)
+
+    coordinator ! Messages.StartTrieNodeHealing(stateRoot)
+    val queueStart = System.nanoTime()
+    coordinator ! Messages.QueueMissingNodes(nodes)
+    coordinator ! Messages.HealingGetProgress
+
+    val stats = expectMsgType[HealingStatistics](5.seconds)
+    val elapsedMs = (System.nanoTime() - queueStart) / 1000000L
+
+    stats.pendingTasks shouldBe nodeCount
+    // Loose ceiling — main signal is that this ran in linear time (O(n²) at this size
+    // would take many seconds even on a fast box). Tighten if it ever flakes.
+    elapsedMs should be < 5000L
+  }
+
+  it should "drain pending tasks in FIFO order across many small QueueMissingNodes calls" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("deque-fifo-test-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(system.dispatcher)
+      )
+    )
+
+    coordinator ! Messages.StartTrieNodeHealing(stateRoot)
+
+    // Three batches; total 750 nodes queued in O(n) time.
+    val batches = Seq.tabulate(3)(g => (g * 250 until (g + 1) * 250).map(fakeHashedNode))
+    batches.foreach(b => coordinator ! Messages.QueueMissingNodes(b))
+
+    coordinator ! Messages.HealingGetProgress
+    val stats = expectMsgType[HealingStatistics](3.seconds)
+    stats.pendingTasks shouldBe 750
+  }
+
+  it should "construct successfully when a healing-writer EC override is supplied" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("ec-override-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(system.dispatcher)
+      )
+    )
+
+    coordinator should not be null
+    coordinator ! Messages.HealingGetProgress
+    expectMsgType[HealingStatistics](2.seconds)
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/AppStateStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/AppStateStorageSpec.scala
@@ -214,6 +214,111 @@ class AppStateStorageSpec extends AnyWordSpec with ScalaCheckPropertyChecks with
       assert(storage.isSnapSyncInProgress())
       assert(!storage.isSnapSyncDone())
     }
+
+    // ========================================
+    // Backfill cursors (#1169)
+    // ========================================
+
+    "round-trip backfill target / header / body / receipt cursors" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+
+      // Empty storage — every getter returns 0.
+      assert(storage.getBackfillTarget() == 0)
+      assert(storage.getBackfillBestHeader() == 0)
+      assert(storage.getBackfillBestBody() == 0)
+      assert(storage.getBackfillBestReceipt() == 0)
+
+      storage
+        .putBackfillTarget(BigInt(19_250_000))
+        .and(storage.putBackfillBestHeader(BigInt(8_000_000)))
+        .and(storage.putBackfillBestBody(BigInt(7_500_000)))
+        .and(storage.putBackfillBestReceipt(BigInt(7_000_000)))
+        .commit()
+
+      assert(storage.getBackfillTarget() == BigInt(19_250_000))
+      assert(storage.getBackfillBestHeader() == BigInt(8_000_000))
+      assert(storage.getBackfillBestBody() == BigInt(7_500_000))
+      assert(storage.getBackfillBestReceipt() == BigInt(7_000_000))
+    }
+
+    "clearBackfillCursors removes all four backfill keys" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage
+        .putBackfillTarget(BigInt(100))
+        .and(storage.putBackfillBestHeader(BigInt(50)))
+        .and(storage.putBackfillBestBody(BigInt(40)))
+        .and(storage.putBackfillBestReceipt(BigInt(30)))
+        .commit()
+
+      storage.clearBackfillCursors().commit()
+
+      assert(storage.getBackfillTarget() == 0)
+      assert(storage.getBackfillBestHeader() == 0)
+      assert(storage.getBackfillBestBody() == 0)
+      assert(storage.getBackfillBestReceipt() == 0)
+    }
+
+    "needsBackfillResume — false when SNAP is not done" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      // Even with cursors set, no SNAP-done flag means no resume.
+      storage.putBackfillTarget(BigInt(100)).commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — false when no target was persisted" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — false when all cursors have reached target" taggedAs (
+      UnitTest,
+      DatabaseTest
+    ) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      val target = BigInt(1000)
+      storage
+        .putBackfillTarget(target)
+        .and(storage.putBackfillBestHeader(target))
+        .and(storage.putBackfillBestBody(target))
+        .and(storage.putBackfillBestReceipt(target))
+        .commit()
+      assert(!storage.needsBackfillResume())
+    }
+
+    "needsBackfillResume — true when any cursor lags target" taggedAs (UnitTest, DatabaseTest) in new Fixtures {
+      val storage = newAppStateStorage()
+      storage.snapSyncDone().commit()
+      val target = BigInt(1000)
+
+      // Header behind.
+      storage
+        .putBackfillTarget(target)
+        .and(storage.putBackfillBestHeader(BigInt(500)))
+        .and(storage.putBackfillBestBody(target))
+        .and(storage.putBackfillBestReceipt(target))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // Now header caught up but body behind.
+      storage
+        .putBackfillBestHeader(target)
+        .and(storage.putBackfillBestBody(BigInt(800)))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // Body caught up but receipt behind.
+      storage
+        .putBackfillBestBody(target)
+        .and(storage.putBackfillBestReceipt(BigInt(600)))
+        .commit()
+      assert(storage.needsBackfillResume())
+
+      // All three caught up.
+      storage.putBackfillBestReceipt(target).commit()
+      assert(!storage.needsBackfillResume())
+    }
   }
 
   trait Fixtures {

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.11"
+(ThisBuild / version) := "0.2.12"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.12"
+(ThisBuild / version) := "0.2.13"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.15"
+(ThisBuild / version) := "0.2.16"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.16"
+(ThisBuild / version) := "0.2.17"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.10"
+(ThisBuild / version) := "0.2.11"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.14"
+(ThisBuild / version) := "0.2.15"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.17"
+(ThisBuild / version) := "0.2.18"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.9"
+(ThisBuild / version) := "0.2.10"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.2.13"
+(ThisBuild / version) := "0.2.14"


### PR DESCRIPTION
## Summary

Promote the recent SNAP-sync hardening + perf wave from `develop` to
`staging`. 17 commits ahead, 8 substantive (rest are auto version
bumps).

## Highlights

| PR | Issue | What |
|---|---|---|
| #1171 | #1162 | `perf(snap)`: defer chain backfill to background — start regular sync as soon as state is validated |
| #1172 | #1164 | `fix(snap)`: `ForceCompleteByteCodes` drains pendingTasks |
| #1173 | #1165 | `perf(snap)`: batch flat-slot writes off `StorageRangeCoordinator` actor |
| #1174 | #1166 | `perf(snap)`: isolate `AccountRangeCoordinator` trie flush + finalisation onto a dedicated dispatcher |
| #1175 | #1167 | `perf(snap)`: healing `pendingTasks` ArrayDeque + dedicated DB-flush dispatcher |
| #1176 |     | `[codex] fix`: SNAP forced storage completion handoff |
| #1177 | #1168 | `perf(snap)`: drop hardcoded 30s timeout in account/bytecode workers (use `SNAPRequestTracker` adaptive) |
| #1179 | #1169 | `feat(snap)`: persist & resume background chain backfill across node restarts |

Plus auto-version bumps from `0.2.10` through `0.2.18`.

## What's not changing

- No consensus-critical or EVM-layer changes.
- No protocol / wire-format changes.
- All deltas live under `blockchain/sync/snap/**` plus a few touchpoints
  in `AppStateStorage` (added cursors), `pekko.conf` (new dedicated
  dispatchers), and `SyncController` (resume-backfill plumbing).

## Risk profile

- Largely additive: new dispatchers, new cursors, new opt-in
  parameters with safe defaults. No destructive changes to persisted
  data formats.
- Each PR landed independently with focused unit tests (~20 net new
  tests on top of the existing suites; full SNAP test coverage stays
  green after each).

## Test plan

- [x] Each underlying PR landed `develop` green (CI).
- [ ] Run staging deployment smoke (Mordor + ETC mainnet bring-up
  through Barad-dûr).
- [ ] **Mordor SNAP run** end-to-end against this staging tip — the
  combined effect of #1165–#1169 should land below the 2026-04-23
  ~334 slots/s storage-phase baseline, with no regressions in account
  / healing / chain-backfill phases.
- [ ] Kill-and-resume drill (#1169): kill the node 50% through
  background backfill, restart, observe backfill resume from
  persisted cursors and complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
