### PR TITLE
fix(snap): drain AccountRangeCoordinator.activeTasks on peer-disconnect / stall — closes #1184

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2975,6 +2975,11 @@ class SNAPSyncController(
         s"Account data preserved."
     )
     lastAccountProgressMs = System.currentTimeMillis()
+    // #1184: ask the coordinator to drain `activeTasks` BEFORE the pivot refresh so any
+    // leaked slots are re-queued and visible by the time the resulting `PivotRefreshed`
+    // message arrives. Coordinator-side defensive drains (PeerUnavailable / PivotRefreshed
+    // / CheckDispatchStalled) cover this independently; this is the explicit controller hook.
+    accountRangeCoordinator.foreach(_ ! actors.Messages.RecoverStalledAccountTasks)
     refreshPivotInPlace(s"account stall: $context")
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -1,6 +1,15 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props, SupervisorStrategy, OneForOneStrategy, Status}
+import org.apache.pekko.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  Cancellable,
+  Props,
+  SupervisorStrategy,
+  OneForOneStrategy,
+  Status
+}
 import org.apache.pekko.actor.SupervisorStrategy._
 import org.apache.pekko.util.ByteString
 
@@ -186,19 +195,80 @@ class AccountRangeCoordinator(
   // Priority queue: dequeue the task with the SMALLEST remaining keyspace first.
   // This focuses workers on nearly-complete ranges, ensuring at least some ranges
   // finish before peers stop responding (instead of spreading work evenly across all 16).
-  private val pendingTasks = mutable.PriorityQueue[AccountTask](remainingTasks: _*)(
+  private[actors] val pendingTasks = mutable.PriorityQueue[AccountTask](remainingTasks: _*)(
     Ordering.by[AccountTask, BigInt](_.remainingKeyspace).reverse
   )
-  private val activeTasks = mutable.Map[BigInt, (AccountTask, ActorRef, Peer)]() // requestId -> (task, worker, peer)
+  // requestId -> (task, worker, peer)
+  private[actors] val activeTasks = mutable.Map[BigInt, (AccountTask, ActorRef, Peer)]()
   private val completedTasks = mutable.ArrayBuffer[AccountTask]()
 
   // Worker pool
-  private val workers = mutable.ArrayBuffer[ActorRef]()
-  private val idleWorkers = mutable.LinkedHashSet.empty[ActorRef]
+  private[actors] val workers = mutable.ArrayBuffer[ActorRef]()
+  private[actors] val idleWorkers = mutable.LinkedHashSet.empty[ActorRef]
+
+  // #1184: dispatch-stalled detector — silent peers (no FIN/RST) leave activeTasks slots
+  // held forever; the worker→TaskFailed cascade depends on a response that never arrives.
+  // Track time-of-last-progress and fire `CheckDispatchStalled` periodically; when
+  // `activeTasks.nonEmpty && (now - lastDispatchOrResponseMs) > noActivityTimeoutMs`, drain.
+  // 90 s threshold fires before the controller's 180 s `Account stall detected` watchdog,
+  // so the coordinator self-heals without burning a pivot-refresh budget slot.
+  private[actors] var lastDispatchOrResponseMs: Long = System.currentTimeMillis()
+  private val noActivityTimeoutMs: Long = 90_000L
+  private val dispatchStallCheckInterval: FiniteDuration = 30.seconds
+  private var stallCheckTask: Option[Cancellable] = None
 
   /** Count in-flight requests for a given peer (pipelining support). */
   private def inFlightForPeer(peer: Peer): Int =
     activeTasks.values.count(_._3.id == peer.id)
+
+  /** Drain stale in-flight requests back to the pending queue (#1184). Sends `WorkerRequestCancelled` to each affected
+    * worker — the worker is responsible for cancelling its own `SNAPRequestTracker` entry and resetting `currentTask`,
+    * matching the existing contract on the `RequestTimeout` / `WorkerPeerDisconnected` paths.
+    *
+    *   - `PeerUnavailable` → `peerFilter = Some(peerId)`
+    *   - dispatch-stalled / pivot-refresh / `RecoverStalledAccountTasks` → `peerFilter = None`
+    *
+    * Mirrors `StorageRangeCoordinator.maybeRequestPivotRefresh` (~lines 167-187), extended with
+    * `WorkerRequestCancelled` notification because `AccountRangeWorker` (unlike storage workers) keeps per-request
+    * `currentTask` state. Without the cancel, the drained worker stays in `working` and would reject the next
+    * `FetchAccountRange` with `TaskFailed(0, "Worker busy")`.
+    *
+    * Idempotent: `activeTasks.remove` returns `None` for already-removed slots, so a late `TaskFailed` / `TaskComplete`
+    * arriving after a drain is a safe no-op via the existing `.foreach` pattern in `handleTaskComplete` /
+    * `handleTaskFailed`.
+    *
+    * Caller is responsible for resetting `lastDispatchOrResponseMs` if recovery should also reset the activity timer
+    * regardless of whether any slots were drained (e.g. `PivotRefreshed` and `RecoverStalledAccountTasks` always reset;
+    * `PeerUnavailable` only resets when something was drained).
+    *
+    * @return
+    *   number of slots drained
+    */
+  private def drainActiveTasks(reason: String, peerFilter: Option[String] = None): Int = {
+    val toDrain: Seq[(BigInt, AccountTask, ActorRef, Peer)] = activeTasks.toSeq.collect {
+      case (reqId, (task, worker, peer)) if peerFilter.forall(_ == peer.id.value) =>
+        (reqId, task, worker, peer)
+    }
+    if (toDrain.isEmpty) return 0
+    toDrain.foreach { case (reqId, task, worker, _) =>
+      // 1. Cancel the worker's local state FIRST so it leaves `working` and accepts the
+      //    next FetchAccountRange. The worker calls requestTracker.completeRequest itself,
+      //    matching the existing contract. Pekko preserves coordinator → worker message
+      //    ordering, so any subsequent FetchAccountRange to the same worker arrives strictly
+      //    after this cancellation has been processed.
+      worker ! WorkerRequestCancelled(reqId)
+      // 2. Re-queue the task. Do NOT increment requeueCount — drain is recovery, not a
+      //    per-task failure; bumping would prematurely trip MaxRequeuesPerTask.
+      task.pending = false
+      pendingTasks.enqueue(task)
+      // 3. Mark the worker idle in the coordinator's pool (idempotent).
+      markWorkerIdle(worker)
+      // 4. Remove the slot.
+      activeTasks.remove(reqId)
+    }
+    log.info(s"Re-queued ${toDrain.size} stale in-flight account requests ($reason)")
+    toDrain.size
+  }
 
   // Statistics
   private var accountsDownloaded: Long = 0
@@ -361,14 +431,22 @@ class AccountRangeCoordinator(
     } else {
       log.info(s"AccountRangeCoordinator starting with $concurrency workers")
     }
+    // #1184: schedule the periodic dispatch-stalled detector. Fires every 30 s; the
+    // 90 s `noActivityTimeoutMs` ensures we drain stuck slots before the controller's
+    // 180 s `Account stall detected` watchdog escalates to a pivot refresh.
+    import context.dispatcher
+    stallCheckTask = Some(
+      context.system.scheduler
+        .scheduleAtFixedRate(dispatchStallCheckInterval, dispatchStallCheckInterval, self, CheckDispatchStalled)
+    )
     // If all tasks were already completed, report completion immediately
     if (pendingTasks.isEmpty && activeTasks.isEmpty) {
-      import context.dispatcher
       context.system.scheduler.scheduleOnce(100.millis, self, CheckCompletion)
     }
   }
 
   override def postStop(): Unit = {
+    stallCheckTask.foreach(_.cancel())
     // Send final progress snapshot so controller can resume from saved positions on restart
     sendProgressSnapshot()
     // Close and delete temporary files.
@@ -425,11 +503,11 @@ class AccountRangeCoordinator(
       stateRoot = newStateRoot
       pivotWasRefreshed = true
 
-      // Update all pending tasks to use the new root
+      // #1184: drain unconditionally instead of relying on the worker → TaskFailed cascade
+      // that misses silent peers. Drain BEFORE re-applying the root so all drained tasks
+      // land in pendingTasks first, then pendingTasks.foreach re-tags them to the new root.
+      drainActiveTasks(s"pivot refresh to ${newStateRoot.take(4).toHex}")
       pendingTasks.foreach(_.rootHash = newStateRoot)
-      // Active tasks will fail with root mismatch and get re-queued;
-      // handleTaskFailed will re-enqueue them with the old root, but they'll be
-      // dispatched with the new root on their next attempt.
 
       // Clear stateless tracking — peers can serve the new root
       statelessPeers.clear()
@@ -441,6 +519,9 @@ class AccountRangeCoordinator(
       peerConsecutiveTimeouts.clear()
       // Note: do NOT reset consecutiveUnproductiveRefreshes here.
       // Only reset when we receive real account data (proof the new root is servable).
+
+      // #1184: always reset the activity timer — we're starting a fresh phase.
+      lastDispatchOrResponseMs = System.currentTimeMillis()
 
       // Resume dispatching with the fresh root
       tryRedispatchPendingTasks()
@@ -478,19 +559,45 @@ class AccountRangeCoordinator(
 
     case PeerUnavailable(peerId) =>
       // Peer disconnected — remove from available set, reset its timeout counter so network-level
-      // disconnects don't accumulate toward the stateless threshold. Then immediately cancel any
-      // in-flight request to this peer so workers return to idle without waiting for 30s timeout.
+      // disconnects don't accumulate toward the stateless threshold.
       // go-ethereum eth/protocols/snap/sync.go:1621 (revertRequests) and Besu
       // AbstractRetryingPeerTask.java:158 both treat disconnect as transient re-queue, not failure.
       knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
       peerConsecutiveTimeouts.remove(peerId)
       peerCooldownUntilMs.remove(peerId)
-      val inFlight = activeTasks.collect {
-        case (reqId, (_, worker, peer)) if peer.id.value == peerId => (reqId, worker)
-      }.toSeq
-      if (inFlight.nonEmpty) {
-        log.debug(s"Peer $peerId disconnected — cancelling ${inFlight.size} in-flight request(s)")
-        inFlight.foreach { case (_, worker) => worker ! WorkerPeerDisconnected(peerId) }
+      // #1184: drain the slots ourselves rather than relying on the worker → TaskFailed
+      // cascade. drainActiveTasks sends WorkerRequestCancelled to each affected worker so they
+      // leave `working` state cleanly and don't reject redispatch with TaskFailed(0, "Worker
+      // busy"). Subsumes the legacy WorkerPeerDisconnected flow.
+      val drained = drainActiveTasks(s"peer $peerId unavailable", Some(peerId))
+      if (drained > 0) {
+        lastDispatchOrResponseMs = System.currentTimeMillis()
+        tryRedispatchPendingTasks()
+      }
+
+    case RecoverStalledAccountTasks =>
+      // #1184: controller-side stall watchdog hook. The controller only sends this when it
+      // already thinks we're stuck, so reset the activity timer unconditionally to give us a
+      // fresh window before the next 180 s tick.
+      drainActiveTasks("controller-side stall recovery")
+      lastDispatchOrResponseMs = System.currentTimeMillis()
+      tryRedispatchPendingTasks()
+
+    case CheckDispatchStalled =>
+      val now = System.currentTimeMillis()
+      val stalled = activeTasks.nonEmpty && (now - lastDispatchOrResponseMs) > noActivityTimeoutMs
+      if (stalled) {
+        val idleSec = (now - lastDispatchOrResponseMs) / 1000
+        log.warning(
+          s"Account dispatch stalled: ${activeTasks.size} active, ${pendingTasks.size} pending, " +
+            s"no activity for ${idleSec}s. Draining stale slots."
+        )
+        drainActiveTasks(s"dispatch stalled (no activity ${idleSec}s)")
+        // Always reset — give dispatch a clean window so the detector doesn't re-fire on the
+        // next 30 s tick. If dispatch can't proceed (no eligible peers) we'll detect that
+        // next time anyway.
+        lastDispatchOrResponseMs = System.currentTimeMillis()
+        tryRedispatchPendingTasks()
       }
 
     case TaskComplete(requestId, result) =>
@@ -688,6 +795,8 @@ class AccountRangeCoordinator(
     val responseBytes = responseBytesTargetFor(peer)
 
     worker ! FetchAccountRange(task, peer, requestId, responseBytes)
+    // #1184: progress signal — used by CheckDispatchStalled.
+    lastDispatchOrResponseMs = System.currentTimeMillis()
   }
 
   // How many accounts to insert per chunk before yielding to the actor mailbox.
@@ -705,6 +814,8 @@ class AccountRangeCoordinator(
       result: Either[String, (Int, Seq[(ByteString, Account)], Seq[ByteString])]
   ): Unit =
     activeTasks.remove(requestId).foreach { case (task, worker, peer) =>
+      // #1184: progress signal — used by CheckDispatchStalled.
+      lastDispatchOrResponseMs = System.currentTimeMillis()
       markWorkerIdle(worker)
       result match {
         case Right((accountCount, accounts, proof)) =>
@@ -846,6 +957,8 @@ class AccountRangeCoordinator(
 
   private def handleTaskFailed(requestId: BigInt, reason: String): Unit =
     activeTasks.remove(requestId).foreach { case (task, worker, peer) =>
+      // #1184: progress signal — used by CheckDispatchStalled.
+      lastDispatchOrResponseMs = System.currentTimeMillis()
       markWorkerIdle(worker)
       // Only mark peer stateless if the task was using the CURRENT root.
       // After pivot refresh, in-flight requests with the OLD root will fail

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -44,39 +44,42 @@ class AccountRangeWorker(
 
   override def receive: Receive = idle
 
-  def idle: Receive = { case FetchAccountRange(task, peer, requestId, responseBytes) =>
-    log.debug(s"Fetching account range ${task.rangeString} from peer ${peer.id} (responseBytes=$responseBytes)")
+  def idle: Receive = {
+    case _: WorkerRequestCancelled => // #1184: idempotent — already idle, nothing to clear
+    case _: WorkerPeerDisconnected => // No current task, nothing to do
+    case FetchAccountRange(task, peer, requestId, responseBytes) =>
+      log.debug(s"Fetching account range ${task.rangeString} from peer ${peer.id} (responseBytes=$responseBytes)")
 
-    // Send request directly via network peer manager
-    // Create GetAccountRange message
-    val request = GetAccountRange(
-      requestId = requestId,
-      rootHash = task.rootHash,
-      startingHash = task.next,
-      limitHash = task.last,
-      responseBytes = responseBytes
-    )
+      // Send request directly via network peer manager
+      // Create GetAccountRange message
+      val request = GetAccountRange(
+        requestId = requestId,
+        rootHash = task.rootHash,
+        startingHash = task.next,
+        limitHash = task.last,
+        responseBytes = responseBytes
+      )
 
-    // Track the request with adaptive timeout from SNAPRequestTracker / PeerRateTracker
-    // (geth msgrate algorithm). Starts at ~12s for a fresh tracker, converges down as peers
-    // respond — slow peers get pruned faster instead of holding in-flight slots for a full 30s.
-    requestTracker.trackRequest(
-      requestId,
-      peer,
-      SNAPRequestTracker.RequestType.GetAccountRange
-    ) {
-      self ! RequestTimeout(requestId)
-    }
+      // Track the request with adaptive timeout from SNAPRequestTracker / PeerRateTracker
+      // (geth msgrate algorithm). Starts at ~12s for a fresh tracker, converges down as peers
+      // respond — slow peers get pruned faster instead of holding in-flight slots for a full 30s.
+      requestTracker.trackRequest(
+        requestId,
+        peer,
+        SNAPRequestTracker.RequestType.GetAccountRange
+      ) {
+        self ! RequestTimeout(requestId)
+      }
 
-    // Send message to peer
-    import com.chipprbots.ethereum.network.NetworkPeerManagerActor
-    import com.chipprbots.ethereum.network.p2p.messages.SNAP.GetAccountRange.GetAccountRangeEnc
-    import com.chipprbots.ethereum.network.p2p.MessageSerializable
-    val messageSerializable: MessageSerializable = new GetAccountRangeEnc(request)
-    networkPeerManager ! NetworkPeerManagerActor.SendMessage(messageSerializable, peer.id)
+      // Send message to peer
+      import com.chipprbots.ethereum.network.NetworkPeerManagerActor
+      import com.chipprbots.ethereum.network.p2p.messages.SNAP.GetAccountRange.GetAccountRangeEnc
+      import com.chipprbots.ethereum.network.p2p.MessageSerializable
+      val messageSerializable: MessageSerializable = new GetAccountRangeEnc(request)
+      networkPeerManager ! NetworkPeerManagerActor.SendMessage(messageSerializable, peer.id)
 
-    currentTask = Some((task, peer, requestId))
-    context.become(working)
+      currentTask = Some((task, peer, requestId))
+      context.become(working)
   }
 
   def working: Receive = {
@@ -155,6 +158,20 @@ class AccountRangeWorker(
           currentTask = None
           context.become(idle)
         case _ => // Different peer or no task; ignore
+      }
+
+    case WorkerRequestCancelled(reqId) =>
+      // #1184: coordinator drained `activeTasks` and is owning the re-queue itself —
+      // we just clear local state. Do NOT send TaskFailed (coordinator already re-queued).
+      // Match existing tracker-ownership contract: worker owns its tracker entry.
+      // Idempotent: SNAPRequestTracker.completeRequest is safe on already-removed ids.
+      currentTask match {
+        case Some((_, _, currentReqId)) if currentReqId == reqId =>
+          log.debug(s"Worker request $reqId cancelled by coordinator — clearing state")
+          requestTracker.completeRequest(reqId, 0)
+          currentTask = None
+          context.become(idle)
+        case _ => // Different reqId or no current task; ignore
       }
 
     case FetchAccountRange(task, peer, _, _) =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -64,6 +64,18 @@ object Messages {
     */
   case class PivotRefreshed(newStateRoot: ByteString) extends AccountRangeCoordinatorMessage
 
+  /** Sent by `SNAPSyncController`'s 180 s account-stall watchdog (#1184) to ask the `AccountRangeCoordinator` to drain
+    * `activeTasks` back to `pendingTasks` before the controller's `refreshPivotInPlace` runs. Coordinator-side
+    * defensive drains in `PeerUnavailable` / `PivotRefreshed` / `CheckDispatchStalled` cover this independently; this
+    * message is the explicit controller hook.
+    */
+  case object RecoverStalledAccountTasks extends AccountRangeCoordinatorMessage
+
+  /** Self-message — periodic check for `activeTasks.nonEmpty` + no-activity wedges (#1184). Scheduled from
+    * `AccountRangeCoordinator.preStart` at 30 s intervals via `scheduleAtFixedRate`; cancelled in `postStop`.
+    */
+  private[actors] case object CheckDispatchStalled extends AccountRangeCoordinatorMessage
+
   // Internal message for chunked account storage (avoids blocking the actor for minutes)
   private[actors] case class StoreAccountChunk(
       task: AccountTask,
@@ -83,6 +95,12 @@ object Messages {
   case class AccountRangeResponseMsg(response: AccountRange) extends AccountRangeWorkerMessage
   case class RequestTimeout(requestId: BigInt) extends AccountRangeWorkerMessage
   case class WorkerPeerDisconnected(peerId: String) extends AccountRangeWorkerMessage
+
+  /** Cancellation from coordinator after a `drainActiveTasks` operation (#1184). The worker cancels its own
+    * `SNAPRequestTracker` entry, clears `currentTask`, and returns to `idle` if the request id matches; no `TaskFailed`
+    * is sent back because the coordinator has already re-queued the task. Idempotent: a second cancel is a no-op.
+    */
+  case class WorkerRequestCancelled(requestId: BigInt) extends AccountRangeWorkerMessage
 
   // ========================================
   // ByteCode Messages

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.matchers.should.Matchers
 import com.chipprbots.ethereum.blockchain.sync.snap._
 import com.chipprbots.ethereum.crypto.kec256
 import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
+import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.testing.Tags._
 import com.chipprbots.ethereum.testing.{PeerTestHelpers, TestMptStorage}
 
@@ -376,5 +377,239 @@ class AccountRangeCoordinatorSpec
     // stops itself on this terminal path.
     controller.expectMsg(2.seconds, SNAPSyncController.AccountTrieFinalizationFailed("synthetic failure"))
     watcher.expectTerminated(coord, 2.seconds)
+  }
+
+  // ========================================
+  // activeTasks leak fix (#1184)
+  // ========================================
+
+  /** Seed an `activeTasks` slot with a `TestProbe` worker. Adds the probe to `workers` too, otherwise `markWorkerIdle`
+    * is a silent no-op (`workers.contains` guard) and the "is the worker reusable after drain?" assertion can't be
+    * made.
+    */
+  private def seedActiveTask(
+      coord: TestActorRef[AccountRangeCoordinator],
+      reqId: BigInt,
+      peer: Peer,
+      rootHash: ByteString = kec256(ByteString("active-tasks-test-root"))
+  ): (AccountTask, TestProbe) = {
+    val workerProbe = TestProbe()
+    val ua = coord.underlyingActor
+    val task = AccountTask(
+      next = ByteString(Array.fill[Byte](32)(0x00)),
+      last = ByteString(Array.fill[Byte](32)(0xff.toByte)),
+      rootHash = rootHash
+    )
+    task.pending = true
+    ua.workers += workerProbe.ref
+    ua.idleWorkers -= workerProbe.ref
+    ua.activeTasks.put(reqId, (task, workerProbe.ref, peer))
+    (task, workerProbe)
+  }
+
+  it should "drain activeTasks for a specific peer on PeerUnavailable (#1184)" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val pendingProbeA = TestProbe()
+    val pendingProbeB = TestProbe()
+    val peerA = PeerTestHelpers.createTestPeer("active-tasks-peerA", pendingProbeA.ref)
+    val peerB = PeerTestHelpers.createTestPeer("active-tasks-peerB", pendingProbeB.ref)
+
+    val (taskA1, workerA1) = seedActiveTask(coord, BigInt(101), peerA)
+    val (taskA2, workerA2) = seedActiveTask(coord, BigInt(102), peerA)
+    val (_, workerB1) = seedActiveTask(coord, BigInt(103), peerB)
+    val ua = coord.underlyingActor
+    val pendingBefore = ua.pendingTasks.size
+
+    coord ! Messages.PeerUnavailable(peerA.id.value)
+
+    // peerA's two slots drained; peerB's single slot untouched.
+    ua.activeTasks.size shouldBe 1
+    ua.activeTasks.contains(BigInt(103)) shouldBe true
+    ua.pendingTasks.size shouldBe (pendingBefore + 2)
+    taskA1.pending shouldBe false
+    taskA2.pending shouldBe false
+
+    // Drained workers received WorkerRequestCancelled (with their own reqId).
+    workerA1.expectMsg(2.seconds, Messages.WorkerRequestCancelled(BigInt(101)))
+    workerA2.expectMsg(2.seconds, Messages.WorkerRequestCancelled(BigInt(102)))
+    workerB1.expectNoMessage(300.millis)
+
+    // Drained workers are back in idleWorkers, ready for reuse.
+    ua.idleWorkers should contain(workerA1.ref)
+    ua.idleWorkers should contain(workerA2.ref)
+
+    system.stop(coord)
+  }
+
+  it should "drain all activeTasks on RecoverStalledAccountTasks and reset the activity timer" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("recover-stalled-peer", pendingProbe.ref)
+
+    val (_, w1) = seedActiveTask(coord, BigInt(201), peer)
+    val (_, w2) = seedActiveTask(coord, BigInt(202), peer)
+    val (_, w3) = seedActiveTask(coord, BigInt(203), peer)
+    val pendingBefore = ua.pendingTasks.size
+
+    // Mark the activity timer as stale so we can verify it gets reset.
+    ua.lastDispatchOrResponseMs = 1L
+    coord ! Messages.RecoverStalledAccountTasks
+
+    ua.activeTasks shouldBe empty
+    ua.pendingTasks.size shouldBe (pendingBefore + 3)
+    w1.expectMsgType[Messages.WorkerRequestCancelled](2.seconds)
+    w2.expectMsgType[Messages.WorkerRequestCancelled](2.seconds)
+    w3.expectMsgType[Messages.WorkerRequestCancelled](2.seconds)
+    ua.lastDispatchOrResponseMs should be > 1L
+
+    system.stop(coord)
+  }
+
+  it should "fire CheckDispatchStalled on activeTasks.nonEmpty + no activity (matches the observed wedge)" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("stalled-peer", pendingProbe.ref)
+
+    // Drain the queue so pendingTasks is empty (matches the observed `tasksPending=0,
+    // tasksActive=1` symptom that the earlier `pendingTasks.nonEmpty` requirement would
+    // have missed).
+    while (ua.pendingTasks.nonEmpty) ua.pendingTasks.dequeue()
+    val (_, worker) = seedActiveTask(coord, BigInt(301), peer)
+
+    // Force a stale activity timestamp (>90 s ago).
+    ua.lastDispatchOrResponseMs = System.currentTimeMillis() - 100_000L
+    val timestampBefore = ua.lastDispatchOrResponseMs
+
+    coord ! Messages.CheckDispatchStalled
+
+    ua.activeTasks shouldBe empty
+    ua.pendingTasks.size shouldBe 1
+    worker.expectMsg(2.seconds, Messages.WorkerRequestCancelled(BigInt(301)))
+    ua.lastDispatchOrResponseMs should be > timestampBefore
+
+    system.stop(coord)
+  }
+
+  it should "drain activeTasks AND re-tag pendingTasks rootHash on PivotRefreshed (#1184)" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("pivot-refresh-peer", pendingProbe.ref)
+    val oldRoot = kec256(ByteString("pivot-refresh-old-root"))
+    val newRoot = kec256(ByteString("pivot-refresh-new-root"))
+
+    val (taskA, _) = seedActiveTask(coord, BigInt(401), peer, rootHash = oldRoot)
+    val (taskB, _) = seedActiveTask(coord, BigInt(402), peer, rootHash = oldRoot)
+
+    coord ! Messages.PivotRefreshed(newRoot)
+
+    ua.activeTasks shouldBe empty
+    // Both drained tasks ended up in pendingTasks (with the rest of the initial task set).
+    val drainedRoots = Seq(taskA.rootHash, taskB.rootHash)
+    drainedRoots.foreach(_ shouldBe newRoot)
+    // All pendingTasks now carry the new root.
+    ua.pendingTasks.foreach(_.rootHash shouldBe newRoot)
+
+    system.stop(coord)
+  }
+
+  it should "treat a duplicate PeerUnavailable as a clean no-op" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("idempotent-peer", pendingProbe.ref)
+
+    seedActiveTask(coord, BigInt(501), peer)
+    seedActiveTask(coord, BigInt(502), peer)
+    seedActiveTask(coord, BigInt(503), peer)
+    val pendingBefore = ua.pendingTasks.size
+
+    coord ! Messages.PeerUnavailable(peer.id.value)
+    val pendingAfterFirst = ua.pendingTasks.size
+
+    coord ! Messages.PeerUnavailable(peer.id.value)
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds) // forces sequential processing
+
+    ua.pendingTasks.size shouldBe pendingAfterFirst
+    pendingAfterFirst shouldBe (pendingBefore + 3)
+
+    system.stop(coord)
+  }
+
+  it should "treat a late TaskFailed after drain as a no-op" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("late-taskfailed-peer", pendingProbe.ref)
+
+    seedActiveTask(coord, BigInt(601), peer)
+    val pendingBefore = ua.pendingTasks.size
+
+    coord ! Messages.PeerUnavailable(peer.id.value)
+    val pendingAfterDrain = ua.pendingTasks.size
+    pendingAfterDrain shouldBe (pendingBefore + 1)
+
+    // Late TaskFailed for the already-drained slot — handleTaskFailed's
+    // activeTasks.remove(...).foreach makes this a no-op.
+    coord ! Messages.TaskFailed(BigInt(601), "stale response")
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds) // forces sequential processing
+
+    ua.activeTasks shouldBe empty
+    ua.pendingTasks.size shouldBe pendingAfterDrain
+
+    system.stop(coord)
+  }
+
+  it should "redispatch through a drained worker without TaskFailed(0, \"Worker busy\") (#1184 worker-reuse race)" taggedAs UnitTest in {
+    // End-to-end test using REAL coordinator-created workers (not seeded probes) so the
+    // assertion observes actual network-send behaviour. Without WorkerRequestCancelled
+    // the redispatch step would drive the worker (still in `working` state) through
+    // line 162's "Worker is busy, cannot accept new task" branch and emit
+    // TaskFailed(0, "Worker busy") — the canonical leak-fix-incomplete signature.
+    val stateRoot = kec256(ByteString("worker-reuse-test-root"))
+    val networkPeerManager = TestProbe()
+    val peerProbeA = TestProbe()
+    val peerProbeB = TestProbe()
+    val peerA = PeerTestHelpers.createTestPeer("reuse-peerA", peerProbeA.ref)
+    val peerB = PeerTestHelpers.createTestPeer("reuse-peerB", peerProbeB.ref)
+
+    // Real coordinator (not the TestActorRef helper — we don't need underlyingActor here).
+    val syncController = TestProbe()
+    val coordinator = system.actorOf(
+      AccountRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        concurrency = 1, // exactly one worker so reuse is unambiguous
+        snapSyncController = syncController.ref
+      )
+    )
+
+    coordinator ! Messages.StartAccountRangeSync(stateRoot)
+    coordinator ! Messages.PeerAvailable(peerA)
+
+    // First dispatch: real worker → networkPeerManager receives a SendMessage.
+    networkPeerManager.expectMsgType[Any](3.seconds)
+
+    // Drain via PeerUnavailable. WorkerRequestCancelled goes to the worker (clears
+    // currentTask, become(idle)); coordinator re-queues the task.
+    coordinator ! Messages.PeerUnavailable(peerA.id.value)
+
+    // Second dispatch via a fresh peer. Without the worker-reuse fix, the still-busy worker
+    // would emit TaskFailed(0, "Worker busy") instead of dispatching. We assert that we DO
+    // see a second network send.
+    coordinator ! Messages.PeerAvailable(peerB)
+    networkPeerManager.expectMsgType[Any](3.seconds)
+
+    // Drain side: the syncController probe never sees a "Worker busy" failure escalation.
+    // (No specific message for that, but if the cancel had failed the redispatch path
+    // wouldn't have produced the second SendMessage above.)
+
+    system.stop(coordinator)
   }
 }


### PR DESCRIPTION
Closes #1184. **Should land before #1183** (staging → main) so main gets the fix.

## The leak

`AccountRangeCoordinator.activeTasks` could leak permanent in-flight
slots when the dispatching peer went silent without sending FIN/RST.
Live Mordor evidence (#1184): twice in one session the sync wedged at
`tasksPending=0, tasksActive≥1` with 9 SNAP peers available but no
work moving. The 180 s controller-side stall watchdog rolled the pivot
but never cleared the stale slots — 11 consecutive recoveries failed
to unstick a single leaked entry, exhausted the budget, fell to
FastSync (which on Mordor is wedged because peers don't speak
GetNodeData), and lost all SNAP-acquired accounts.

## Mechanism

Hybrid C+A fix that mirrors `StorageRangeCoordinator`'s existing
`dispatchStalled` re-queue pattern (lines 167–187), extended with
explicit worker-state cancellation because `AccountRangeWorker` keeps
per-request `currentTask` state — without that the drained worker
stays in `working` and rejects the next `FetchAccountRange` with
`TaskFailed(0, "Worker busy")`, producing a new intermittent stall
instead of fixing the original.

**`drainActiveTasks(reason, peerFilter)`** helper — sends
`WorkerRequestCancelled(reqId)` to each affected worker (worker owns
its tracker entry, matching the existing `RequestTimeout` /
`WorkerPeerDisconnected` contract), re-queues without bumping
`requeueCount`, marks the worker idle, removes the slot. Idempotent.

Wired into four insertion points:

| Insertion point | Trigger | Filter |
|---|---|---|
| `PeerUnavailable` | known peer disconnect | per-peer |
| `PivotRefreshed` | always (defensive — replaces the "active tasks will fail with root mismatch and get re-queued" comment that turned out unreliable) | full |
| `RecoverStalledAccountTasks` (new) | controller-side 180 s `Account stall detected` watchdog | full |
| `CheckDispatchStalled` (new self-message) | coordinator-side 30 s tick when `activeTasks.nonEmpty && idleFor > 90 s` | full |

**Detector keys on `activeTasks.nonEmpty` only** — the observed wedge
is `tasksPending=0, tasksActive=1`, so a `pendingTasks.nonEmpty`
requirement would have missed it.

**Activity-timer reset semantics** — explicit at every call site (not
inside the helper) so the "we just made progress" signal is local and
auditable: `dispatchNextTaskToWorker` / `handleTaskComplete` /
`handleTaskFailed` (existing progress); `PivotRefreshed` /
`RecoverStalledAccountTasks` / `CheckDispatchStalled` (always —
recovery); `PeerUnavailable` (only when drained).

## Tests

7 new tests in `AccountRangeCoordinatorSpec` (21 total in the spec; all
253 SNAP-related tests pass):

1. Per-peer drain on `PeerUnavailable` — peerA's slots drained,
   peerB's untouched, drained workers in `idleWorkers`.
2. `RecoverStalledAccountTasks` — full drain + activity timer reset.
3. `CheckDispatchStalled` matches the `tasksPending=0, tasksActive=1`
   wedge.
4. `PivotRefreshed` defensive drain + post-drain root re-tag.
5. Idempotent duplicate `PeerUnavailable`.
6. Late `TaskFailed` after drain is a no-op.
7. **Worker-reuse race with REAL workers** — drives a real coordinator
   through `PeerAvailable(A) → SendMessage → PeerUnavailable(A) →
   drain → PeerAvailable(B)`; asserts a second `SendMessage` fires
   (no `TaskFailed(0, "Worker busy")` rejection). The test that would
   catch a regression of "drain helper without
   `WorkerRequestCancelled`".

## Risk notes

- **Pekko ordering guarantee** — coordinator → worker
  `WorkerRequestCancelled` is sent before any subsequent
  `FetchAccountRange` to the same worker, so the worker leaves
  `working` before the next dispatch arrives.
- **Tracker ownership unchanged** — the worker (not the coordinator)
  cancels its own `SNAPRequestTracker` entry, matching existing
  `RequestTimeout` / `WorkerPeerDisconnected` contract.
- **`StoreAccountChunk` is not at risk** — `activeTasks.remove` fires
  in `handleTaskComplete` before the chunked storage loop starts, so
  long-running chunk processing can never look like a stall to
  `CheckDispatchStalled`.
- **`task.requeueCount` does NOT bump on drain** — drain is recovery,
  not a per-task failure, so it can't prematurely trip
  `MaxRequeuesPerTask`.

## Verification

- [x] `sbt 'testOnly *AccountRangeCoordinatorSpec'` — 21/21
- [x] `sbt 'testOnly com.chipprbots.ethereum.db.storage.*
  com.chipprbots.ethereum.blockchain.sync.snap.*
  com.chipprbots.ethereum.blockchain.sync.snap.actors.*'` — 253/253
- [x] `sbt scalafmtCheckAll`
- [ ] Live Mordor: wipe `fukuii-secondary` data, deploy from this PR,
  watch for the same `tasksActive=N, tasksPending=0` symptom. Under
  the fix the coordinator self-heals on the 30 s `CheckDispatchStalled`
  tick (90 s no-activity threshold) before the controller's 180 s
  watchdog fires. Either way: no `Account stall pivot-refresh budget
  exhausted`, no fall-through to FastSync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
