### PR TITLE
fix(snap): wire IncrementalContractData → bytecodesEstimatedTotal so the dashboard reads %, not 5239500%

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -118,6 +118,13 @@ class SNAPSyncController(
   private var validationInProgress: Boolean = false
   private var validationGeneration: Long = 0L
 
+  // Running total of unique codeHashes streamed in via `IncrementalContractData`. Used to set
+  // `progressMonitor.estimatedTotalBytecodes` so the SNAP-sync dashboard's
+  // `100 * downloaded / clamp_min(estimated_total, 1)` formula has a real denominator. Without
+  // this, `estimated_total` stays at 0, the formula divides by 1 (the clamp floor), and the
+  // dashboard reads `5,239,500%` for a normal in-flight bytecodes count.
+  private var bytecodesEstimatedTotal: Long = 0L
+
   // Retry counter for bootstrap-to-SNAP transition (exponential backoff: 2s→60s cap, max 10 retries)
   private var bootstrapRetryCount: Int = 0
   private val BootstrapRetryBaseDelay = 2.seconds
@@ -563,6 +570,11 @@ class SNAPSyncController(
     case IncrementalContractData(codeHashes, storageTasks) =>
       if (codeHashes.nonEmpty) {
         bytecodeCoordinator.foreach(_ ! actors.Messages.AddByteCodeTasks(codeHashes))
+        // Accumulate the running total of unique codeHashes for the dashboard. `codeHashes` is
+        // already deduplicated upstream (Bloom filter in AccountRangeCoordinator), so summing
+        // batch sizes gives the unique total.
+        bytecodesEstimatedTotal += codeHashes.size
+        progressMonitor.updateEstimates(bytecodes = bytecodesEstimatedTotal)
       }
       if (storageTasks.nonEmpty) {
         storageRangeCoordinator.foreach(_ ! actors.Messages.AddStorageTasks(storageTasks))
@@ -2773,6 +2785,9 @@ class SNAPSyncController(
     bytecodePhaseComplete = false
     storagePhaseComplete = false
     storagePhaseForceCompleted = false
+    // Reset bytecode-estimate counter so it stays in sync with progressMonitor.reset()
+    // (called below). IncrementalContractData will repopulate as accounts are re-identified.
+    bytecodesEstimatedTotal = 0L
     appStateStorage
       .putSnapSyncAccountsComplete(false)
       .and(appStateStorage.putSnapSyncStorageComplete(false))

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SyncProgressMonitorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SyncProgressMonitorSpec.scala
@@ -1,0 +1,74 @@
+package com.chipprbots.ethereum.blockchain.sync.snap
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestKit
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.testing.Tags._
+
+class SyncProgressMonitorSpec
+    extends TestKit(ActorSystem("SyncProgressMonitorSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit =
+    TestKit.shutdownActorSystem(system)
+
+  // Regression for #1184 follow-up: SNAPSyncController never called
+  // `updateEstimates(bytecodes = N)`, so `estimatedTotalBytecodes` stayed at 0 and the dashboard's
+  // `100 * downloaded / clamp_min(estimated_total, 1)` formula divided by the clamp floor (1),
+  // producing readings like `5,239,500%` for normal in-flight bytecode counts. The fix is in
+  // `SNAPSyncController.IncrementalContractData` (accumulates `bytecodesEstimatedTotal` and
+  // calls `progressMonitor.updateEstimates(bytecodes = total)`); this test locks the
+  // `SyncProgressMonitor` side of that contract so a future refactor can't silently revert it.
+  "SyncProgressMonitor.updateEstimates" should
+    "set estimatedTotalBytecodes from the bytecodes argument" taggedAs UnitTest in {
+      val monitor = new SyncProgressMonitor(system.scheduler)
+
+      monitor.currentProgress.estimatedTotalBytecodes shouldBe 0L
+      monitor.updateEstimates(bytecodes = 12_500L)
+      monitor.currentProgress.estimatedTotalBytecodes shouldBe 12_500L
+    }
+
+  it should "honour the running-total contract: a larger update overrides the previous estimate" taggedAs UnitTest in {
+    val monitor = new SyncProgressMonitor(system.scheduler)
+
+    monitor.updateEstimates(bytecodes = 1_000L)
+    monitor.currentProgress.estimatedTotalBytecodes shouldBe 1_000L
+
+    // SNAPSyncController accumulates `bytecodesEstimatedTotal += codeHashes.size` per
+    // `IncrementalContractData` and pushes the new total — so the monitor must accept
+    // monotonically increasing replacements.
+    monitor.updateEstimates(bytecodes = 5_000L)
+    monitor.currentProgress.estimatedTotalBytecodes shouldBe 5_000L
+  }
+
+  it should "ignore a zero-or-negative update so callers can pass `accounts = 0` while updating bytecodes" taggedAs UnitTest in {
+    val monitor = new SyncProgressMonitor(system.scheduler)
+
+    monitor.updateEstimates(accounts = 7_000L, bytecodes = 0L, slots = 0L)
+    monitor.updateEstimates(bytecodes = 3_000L)
+
+    monitor.currentProgress.estimatedTotalAccounts shouldBe 7_000L
+    monitor.currentProgress.estimatedTotalBytecodes shouldBe 3_000L
+    monitor.currentProgress.estimatedTotalSlots shouldBe 0L
+  }
+
+  it should "produce a non-divide-by-clamp ratio after a real bytecode estimate is set" taggedAs UnitTest in {
+    // The dashboard formula is `100 * downloaded / clamp_min(estimated, 1)`. Before the fix,
+    // `estimated` was 0 → clamp_min picks 1 → `100 * 52395 / 1 = 5,239,500`. After the fix the
+    // estimate is real, so the percentage stays sane.
+    val monitor = new SyncProgressMonitor(system.scheduler)
+    monitor.updateEstimates(bytecodes = 100_000L)
+    monitor.incrementBytecodesDownloaded(52_395L)
+
+    val progress = monitor.currentProgress
+    val percentDouble = 100.0 * progress.bytecodesDownloaded / math.max(progress.estimatedTotalBytecodes, 1L)
+
+    percentDouble shouldBe 52.395 +- 0.01
+  }
+}


### PR DESCRIPTION
## Symptom

Grafana SNAP-sync dashboard "Bytecodes Progress" panel showed
`5,239,500%` for the in-flight bytecode count. Cosmetic only — sync
logic is unaffected — but unreadable.

## Cause

The dashboard query is:

```promql
100 * app_snapsync_bytecodes_downloaded_gauge
    / clamp_min(app_snapsync_bytecodes_estimated_total_gauge, 1)
```

`bytecodes_estimated_total_gauge` is set from
`SyncProgress.estimatedTotalBytecodes`, which is fed by
`progressMonitor.updateEstimates(bytecodes = …)`. **Nothing in
`SNAPSyncController` ever called that.** Accounts and storage slots
both wire through `updateEstimates`, but bytecodes were missed.
Estimate stayed at `0` → `clamp_min(0, 1) = 1` → dashboard read
`100 * 52,395 / 1 = 5,239,500`.

## Fix

`SNAPSyncController.IncrementalContractData` now accumulates a running
unique-codeHashes total and pushes it to the progress monitor.
`AccountRangeCoordinator` already deduplicates upstream via a Bloom
filter, so summing per-batch sizes gives the cumulative unique total.
Reset on `restartSnapSync` to mirror `progressMonitor.reset()`
semantics.

## Tests

New `SyncProgressMonitorSpec` (4 tests):

- `updateEstimates(bytecodes = N)` sets `estimatedTotalBytecodes`.
- Larger updates override smaller (running-total semantics).
- Zero update is a no-op so callers can pass `accounts = 0,
  bytecodes = N` without clobbering the account estimate.
- The dashboard formula now produces `52.395%` (sane) once a real
  estimate is set, vs. `5,239,500%` previously.

## Deployment

No urgency on the running Mordor SNAP — the bug is purely the
dashboard reading, sync logic is unchanged. Next regular deploy picks
this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
