### PR TITLE
fix(hive): disable discv4 in hive runs to unblock 'sync go-ethereum from fukuii' — refs #1192

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -116,6 +116,16 @@ FLAGS="$FLAGS -Dfukuii.network.server-address.interface=0.0.0.0"
 FLAGS="$FLAGS -Dfukuii.network.server-address.port=30303"
 FLAGS="$FLAGS -Dfukuii.network.discovery.interface=0.0.0.0"
 FLAGS="$FLAGS -Dfukuii.network.discovery.port=30303"
+# Workaround for `sync go-ethereum from fukuii` Hive gate: scalanet's discv4
+# packet decoder rejects every one of geth's UDP packets with
+# `PacketException: Failed to unpack message: Invalid hash` (~4 errors/sec for
+# the entire 60s test window). Without a PONG, geth's discovery state machine
+# never marks fukuii's bootnode alive and never TCP-dials it for RLPx — test
+# times out at head=0. Hive already supplies the bootnode via static-nodes.json
+# below (HIVE_BOOTNODE), so discovery isn't needed to find peers; disabling it
+# sidesteps the parser bug. Underlying scalanet hash-validation regression
+# tracked separately — restore discovery in hive runs once that is fixed.
+FLAGS="$FLAGS -Dfukuii.network.discovery.discovery-enabled=false"
 
 # Chain import — prefer /chain.rlp, otherwise concatenate /blocks/*.rlp (consensus sim).
 if [ -f "/chain.rlp" ]; then


### PR DESCRIPTION
## Summary

- Tracking issue: #1192
- Unblocks PR #1183 (`staging` → `main`) Hive sync gate

Adds `-Dfukuii.network.discovery.discovery-enabled=false` to `hive/fukuii/fukuii.sh`. **Hive runs only** — production builds are unaffected.

## The bug this works around

`sync go-ethereum from fukuii` is the only failing Hive sync test on PR #1183 (the other 17 pass; #1191 cleared the prior Nethermind-shaped failures). Fukuii logs **236 discv4 UDP packet decode errors** during the 60s test window:

```
ERROR DiscoveryNetwork - Error handling channel from /172.17.0.5:30303
  PacketException: Failed to unpack message: Invalid hash.
```

scalanet's `Packet.unpack()` rejects every one of geth's discv4 packets via `keccak256(signature || packet-type || packet-data)` mismatch. With no PONG, geth never marks the bootnode alive and never TCP-dials → test times out at head=0.

| Test | Discv4 errors / window | Outcome |
|---|---|---|
| sync nethermind from fukuii | 5 / 90s | PASS |
| **sync go-ethereum from fukuii** | **236 / 60s** | **FAIL** |

## Why disabling discv4 is safe for Hive

- Hive supplies the bootnode via `HIVE_BOOTNODE` env var, which the entrypoint already writes to `$DATADIR/static-nodes.json` (existing code path, lines 128–132).
- Static-nodes are dialed via direct TCP RLPx — no discv4 round-trip required.
- All 17 currently-passing tests already exercise the static-bootnode path; this PR doesn't change their flow, only stops fukuii from emitting/rejecting discv4 traffic.

## Test plan

- [x] `bash -n hive/fukuii/fukuii.sh` — syntax clean
- [ ] CI Hive sync re-runs against this branch — expect zero fukuii-gate failures
- [ ] `sync go-ethereum from fukuii` PASS
- [ ] `sync nethermind from fukuii` still PASS (regression check)
- [ ] All other 16 sync tests unchanged

## Out of scope

The underlying scalanet discv4 hash-validation regression (#1192) is not fixed by this PR. We restore discovery in hive runs once #1192 lands.

## Scope

- 1 file changed, 10 insertions
- No production-build impact (only `hive/fukuii/fukuii.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
