### PR TITLE
fix(eth/69): align STATUS wire format with EIP-7642 (6 fields) — closes #1194

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69.scala
@@ -12,14 +12,20 @@ import com.chipprbots.ethereum.utils.ByteUtils
 /** ETH/69 protocol (EIP-7642) — restructured Status, simplified receipts, BlockRangeUpdate.
   *
   * Key changes from ETH/68:
-  *   - Status message: removes totalDifficulty, reorders fields, adds earliestBlock/latestBlock
+  *   - Status message: removes totalDifficulty, reorders fields. Per EIP-7642 the wire layout is `[version, networkId,
+  *     genesis, forkId, latestBlock, latestBlockHash]` — exactly 6 fields. The `earliestBlock` info is conveyed by the
+  *     separate BlockRangeUpdate message (0x11).
   *   - Receipt encoding: removes bloom filter, uses flat RLP list with explicit tx-type field
   *   - New BlockRangeUpdate (0x11) notification message
   *   - All other messages (GetBlockHeaders, BlockHeaders, etc.) unchanged from ETH/68
   */
 object ETH69 {
 
-  /** ETH/69 Status message. RLP: [version, networkId, genesis, forkId, earliestBlock, latestBlock, latestBlockHash]
+  /** ETH/69 Status message.
+    *
+    * Wire format per EIP-7642: `[version, networkId, genesis, forkId, latestBlock, latestBlockHash]` — 6 fields. The
+    * `earliestBlock` field on this case class is convenience-only (set by `BlockRangeUpdate` later in the session) and
+    * is NOT serialized in the STATUS frame.
     */
   case class Status(
       protocolVersion: Int,
@@ -45,12 +51,14 @@ object ETH69 {
         with RLPSerializable {
       override def code: Int = Codes.StatusCode
       import msg._
+      // EIP-7642 wire layout: 6 fields. earliestBlock is intentionally omitted —
+      // it travels via the BlockRangeUpdate (0x11) message instead. Sending 7 fields
+      // here is a fukuii-only legacy and breaks interop with core-geth/besu (#1194).
       override def toRLPEncodable: RLPEncodeable = RLPList(
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(protocolVersion)),
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(networkId)),
         RLPValue(genesisHash.toArray[Byte]),
         forkId.toRLPEncodable,
-        RLPValue(ByteUtils.bigIntToUnsignedByteArray(earliestBlock)),
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(latestBlock)),
         RLPValue(latestBlockHash.toArray[Byte])
       )
@@ -59,7 +67,37 @@ object ETH69 {
     implicit class StatusDec(val bytes: Array[Byte]) extends AnyVal {
       import com.chipprbots.ethereum.forkid.ForkId._
 
+      /** Decode an ETH/69 STATUS frame.
+        *
+        * Tolerant of two shapes for backward compatibility during the rollout:
+        *   1. EIP-7642 spec (6 fields): `[version, networkId, genesis, forkId, latest, latestHash]` 2. Legacy fukuii
+        *      pre-#1194 (7 fields): `[version, networkId, genesis, forkId, earliest, latest, latestHash]` — used by
+        *      older fukuii nodes. Decoded with `earliestBlock` set to its wire value; new fukuii nodes never emit this
+        *      shape.
+        *
+        * The 6-field path sets `earliestBlock = 0` because the field is not on the wire. Once the network is
+        * unanimously on the spec shape, the 7-field branch can be removed.
+        */
       def toETH69Status: Status = rawDecode(bytes) match {
+        // 6-field EIP-7642 spec shape — what core-geth, besu, reth, and post-#1194 fukuii send.
+        case RLPList(
+              RLPValue(protocolVersionBytes),
+              RLPValue(networkIdBytes),
+              RLPValue(genesisHashBytes),
+              forkIdRlp: RLPList,
+              RLPValue(latestBlockBytes),
+              RLPValue(latestBlockHashBytes)
+            ) =>
+          Status(
+            protocolVersion = ByteUtils.bytesToBigInt(protocolVersionBytes).toInt,
+            networkId = ByteUtils.bytesToBigInt(networkIdBytes).toLong,
+            genesisHash = ByteString(genesisHashBytes),
+            forkId = decode[ForkId](forkIdRlp),
+            earliestBlock = BigInt(0),
+            latestBlock = ByteUtils.bytesToBigInt(latestBlockBytes),
+            latestBlockHash = ByteString(latestBlockHashBytes)
+          )
+        // 7-field legacy fukuii shape — kept for backward compat with pre-#1194 nodes.
         case RLPList(
               RLPValue(protocolVersionBytes),
               RLPValue(networkIdBytes),

--- a/src/test/scala/com/chipprbots/ethereum/network/ETH69TDSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/ETH69TDSpec.scala
@@ -184,4 +184,87 @@ class ETH69TDSpec extends AnyFlatSpec with Matchers {
     peerInfo.chainWeight.totalDifficulty shouldBe wireTD
     peerInfo.chainWeight.totalDifficulty should be > BigInt(100_000_000L) // clearly not a block number
   }
+
+  // -------------------------------------------------------------------------
+  // EIP-7642 STATUS wire format (#1194)
+  //
+  // Pre-fix: fukuii's ETH/69 STATUS encoded 7 fields with an extra `earliestBlock`
+  // not in the spec. Real-world peers (core-geth/besu running EIP-7642) send 6
+  // fields and fukuii rejected every one with `Cannot decode ETH69.Status`.
+  // Symptom on ETC mainnet: no peer pool, sync wedged. Mordor was unaffected
+  // because its peer pool was dominated by other fukuii instances + ETH/68.
+  //
+  // The fix:
+  //   1. Encoder emits 6 fields per EIP-7642 (no earliestBlock — that info is
+  //      conveyed via the separate BlockRangeUpdate message 0x11).
+  //   2. Decoder accepts both the 6-field spec shape AND the 7-field legacy
+  //      fukuii shape during the transition (so old fukuii peers still work).
+  // -------------------------------------------------------------------------
+
+  it should "encode ETH/69 STATUS as 6 fields per EIP-7642 (no earliestBlock on the wire)" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
+    import com.chipprbots.ethereum.rlp.{RLPList, RLPValue, rawDecode}
+
+    val status = eth69Status(latestBlockNr, latestHash)
+    val encoded: Array[Byte] = new StatusEnc(status).toBytes
+    val decoded = rawDecode(encoded)
+
+    decoded shouldBe a[RLPList]
+    val fields = decoded.asInstanceOf[RLPList].items.toList
+    fields should have size 6 // EIP-7642 spec — NOT 7
+  }
+
+  it should "round-trip through the spec-compliant 6-field wire format" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
+
+    val original = eth69Status(latestBlockNr, latestHash)
+    val encoded: Array[Byte] = new StatusEnc(original).toBytes
+    val decoded = encoded.toETH69Status
+
+    decoded.protocolVersion shouldBe original.protocolVersion
+    decoded.networkId shouldBe original.networkId
+    decoded.genesisHash shouldBe original.genesisHash
+    decoded.forkId shouldBe original.forkId
+    decoded.latestBlock shouldBe original.latestBlock
+    decoded.latestBlockHash shouldBe original.latestBlockHash
+    // earliestBlock is not on the spec wire — decoder defaults to 0.
+    decoded.earliestBlock shouldBe BigInt(0)
+  }
+
+  it should "decode legacy 7-field fukuii STATUS shape (backward compat with pre-#1194 peers)" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
+    import com.chipprbots.ethereum.rlp.{RLPList, RLPValue, encode}
+    import com.chipprbots.ethereum.utils.ByteUtils
+    import com.chipprbots.ethereum.forkid.ForkId._
+
+    // Hand-build the 7-field legacy shape used by fukuii pre-fix.
+    val legacyEarliest = BigInt(42)
+    val legacyRlp = RLPList(
+      RLPValue(ByteUtils.bigIntToUnsignedByteArray(BigInt(Capability.ETH69.version))),
+      RLPValue(ByteUtils.bigIntToUnsignedByteArray(BigInt(1))),
+      RLPValue(genesisHash.toArray[Byte]),
+      dummyForkId.toRLPEncodable,
+      RLPValue(ByteUtils.bigIntToUnsignedByteArray(legacyEarliest)),
+      RLPValue(ByteUtils.bigIntToUnsignedByteArray(latestBlockNr)),
+      RLPValue(latestHash.toArray[Byte])
+    )
+    val legacyBytes: Array[Byte] = encode(legacyRlp)
+
+    val decoded = legacyBytes.toETH69Status
+
+    decoded.networkId shouldBe 1L
+    decoded.latestBlock shouldBe latestBlockNr
+    decoded.latestBlockHash shouldBe latestHash
+    // The 7-field branch DOES preserve earliestBlock from the wire.
+    decoded.earliestBlock shouldBe legacyEarliest
+  }
+
+  it should "reject malformed STATUS payloads with the canonical error message" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
+    import com.chipprbots.ethereum.rlp.{RLPList, RLPValue, encode}
+
+    val garbage: Array[Byte] = encode(RLPList(RLPValue(Array[Byte](0x01)), RLPValue(Array[Byte](0x02))))
+    val ex = intercept[RuntimeException](garbage.toETH69Status)
+    ex.getMessage should include("Cannot decode ETH69.Status")
+  }
 }


### PR DESCRIPTION
## Summary

- Tracking issue: #1194
- Closes #1194
- Unblocks ETC mainnet SNAP sync from `chipprbots/fukuii:latest`

Fukuii's `ETH69.Status` was encoding/decoding **7 RLP fields** with an extra `earliestBlock` slot that is **not** in the EIP-7642 specification.

| Format | Fields | Wire layout |
|---|---|---|
| Fukuii (pre-fix) | **7** | `[version, networkId, genesis, forkId, earliestBlock, latestBlock, latestHash]` |
| EIP-7642 spec | **6** | `[version, networkId, genesis, forkId, latestBlock, latestHash]` |

The `earliestBlock` info is conveyed by the separate `BlockRangeUpdate` message (0x11), which fukuii already implements correctly.

## The bug this fixes

Fresh ETC mainnet SNAP sync wedges after ~25 minutes. Every ETH/69 peer (core-geth, besu) is rejected on STATUS exchange:

```
WARN [RLPxConnectionHandler] - DECODE_ERROR: Cannot decode ETH69.Status from:
  RLPList(Queue(RLPValue(45), RLPValue(0c4eb6), RLPValue(01),
    RLPValue(25b75436b8...), RLPValue(b5f7f912443c...),
    RLPList(Queue(RLPValue(12380625), RLPValue()))))
```

That's a 6-field payload from a spec-compliant peer; fukuii's pattern match expects 7. The pool of compatible ETH/68 peers was too small to sustain SNAP dispatch — pivot-refresh ask-timed-out from peer-pool exhaustion.

## Why Mordor was unaffected but ETC mainnet wedges

| Network | Peer pool | Effect |
|---|---|---|
| **Mordor** | Mostly other fukuii instances + ETH/68 clients | 7-field shape interops with itself; ETH/68 peers don't hit the ETH/69 decoder |
| **ETC mainnet** | Dominated by **core-geth** (canonical EIP-7642 ETH/69) | Every ETH/69 peer rejected on STATUS exchange |

## Fix

1. **Encoder** — emit 6 fields per EIP-7642 (drop `earliestBlock` from the wire).
2. **Decoder** — tolerant of both shapes during rollout:
   - 6-field spec (core-geth, besu, reth, post-fix fukuii) → `earliestBlock = 0`
   - 7-field legacy fukuii → `earliestBlock` preserved from wire (back-compat)
3. The case-class field stays for API consistency; the value comes from `BlockRangeUpdate` later in the session.
4. **No change** to `BlockRangeUpdate` — already correct.

## Test plan

- [x] 4 new tests in `ETH69TDSpec`:
  - encoded shape has exactly 6 RLP fields
  - round-trip preserves all on-wire fields
  - legacy 7-field decode still works (back-compat)
  - malformed payload throws canonical error
- [x] `sbt 'testOnly *ETH69TDSpec'` — 15/15 green (was 11, +4 new)
- [x] `sbt 'testOnly com.chipprbots.ethereum.network.*'` — 412/412 green
- [x] `sbt scalafmtCheckAll` — clean
- [ ] Live: rebuild image, re-run ETC mainnet SNAP from scratch on `fukuii-primary`. Expect ETH/69 peers (core-geth) to STATUS-exchange cleanly and account download to make progress.
- [ ] Mordor SNAP regression check (back-compat decode path covers any pre-fix fukuii peer).

## Scope

- 2 files changed (+124 / −3)
- No production data migration required
- Backward compatible during the rollout window via the tolerant decoder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
