### PR TITLE
perf(snap): demote peers with disabled snapshot trees from AccountRange queries — closes #1197

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -84,19 +84,38 @@ class AccountRangeCoordinator(
   private var maxInFlightPerPeer: Int = initialMaxInFlightPerPeer
 
   // Stateless peer tracking: peers that return "Missing proof for empty account range"
-  // are unable to serve the current state root. Unlike the previous exponential cooldown,
-  // this is a binary classification: either a peer can serve the root or it can't.
-  // When ALL known peers become stateless, we request a pivot refresh from the controller.
-  private val statelessPeers = mutable.Set[com.chipprbots.ethereum.network.PeerId]()
+  // OR consecutive timeouts are unable to serve the current state root. Cleared on
+  // PivotRefreshed because the new root may be inside the peer's serve window.
+  // `private[actors]` so AccountRangeCoordinatorSpec can drive the state via TestActorRef.
+  private[actors] val statelessPeers = mutable.Set[com.chipprbots.ethereum.network.PeerId]()
+  // Snapless peer tracking (#1197): peers whose SNAP handler returns
+  // `AccountRangePacket{Accounts: nil, Proof: nil}` indicating `chain.Snapshots()` is
+  // structurally unavailable (typical core-geth `--syncmode full` configuration on ETC
+  // mainnet — see project_eth68_snap_research memory). The peer's snapshot won't
+  // materialize this session, so this set survives PivotRefreshed (root-independent).
+  // Bytecode + trie-node healing coordinators are unaffected — those code paths use
+  // direct DB lookups that don't depend on the snapshot tree.
+  private[actors] val snaplessPeers = mutable.Set[com.chipprbots.ethereum.network.PeerId]()
   private var pivotRefreshRequested = false
   private var pivotWasRefreshed = false
 
   private def isPeerStateless(peer: Peer): Boolean =
     statelessPeers.contains(peer.id)
 
+  private def isPeerSnapless(peer: Peer): Boolean =
+    snaplessPeers.contains(peer.id)
+
   private def markPeerStateless(peer: Peer, reason: String): Unit = {
-    val shouldMark = if (reason.contains("Missing proof for empty account range")) {
-      // Peer explicitly returned empty response — immediately stateless
+    val isEmptyProofSignal = reason.contains("Missing proof for empty account range")
+    val shouldMark = if (isEmptyProofSignal) {
+      // Peer explicitly returned empty response — immediately stateless AND snapless.
+      // The empty-with-empty signal means `chain.Snapshots()` is unavailable on this
+      // peer for any root, not just the current one (#1197).
+      snaplessPeers.add(peer.id)
+      log.info(
+        s"Peer ${peer.id.value} marked SNAPLESS (no snapshot tree) — will skip for " +
+          s"GetAccountRange this session. Bytecode/healing remain available."
+      )
       true
     } else if (reason.contains("Request timeout")) {
       // Peer timed out — track consecutive timeouts.
@@ -127,9 +146,26 @@ class AccountRangeCoordinator(
 
   private def maybeRequestPivotRefresh(): Unit = {
     if (pivotRefreshRequested) return
-    // If all known peers are stateless, the root has aged out of the serve window
-    val allStateless = knownAvailablePeers.nonEmpty &&
-      knownAvailablePeers.forall(p => statelessPeers.contains(p.id))
+    // Snapless peers (no snapshot tree at all) cannot be rescued by a pivot refresh — the
+    // refresh would just yield another empty response from the same peer at the new root.
+    // Compute "all stateless" against the *non-snapless* subset only (#1197).
+    val nonSnapless = knownAvailablePeers.filterNot(p => snaplessPeers.contains(p.id))
+    if (nonSnapless.isEmpty && knownAvailablePeers.nonEmpty) {
+      // Every peer in the pool is snapless. Pivot refresh won't help; the SNAP-range
+      // download is structurally blocked. Log once per snapless-saturation event so an
+      // operator can pivot to fast-sync or wait for a new peer mix.
+      log.warning(
+        s"All ${knownAvailablePeers.size} known peers are SNAPLESS (no snapshot tree). " +
+          "SNAP-range download cannot make progress on this peer pool. Bytecode and " +
+          "trie-node healing remain functional. Consider switching to do-snap-sync=false " +
+          "if this persists."
+      )
+      return
+    }
+    // If all NON-snapless peers are stateless, the current root has aged out of the
+    // serve window — pivot refresh might rescue them.
+    val allStateless = nonSnapless.nonEmpty &&
+      nonSnapless.forall(p => statelessPeers.contains(p.id))
     if (!allStateless) return
 
     // Exponential backoff: don't hammer the controller with rapid refresh requests
@@ -327,7 +363,7 @@ class AccountRangeCoordinator(
     * peer avoids peer flooding.
     */
   private def activePeerCount: Int =
-    knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerCoolingDown(p)).max(1)
+    knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerSnapless(p) && !isPeerCoolingDown(p)).max(1)
 
   // Per-peer adaptive byte budgeting (ported from StorageRangeCoordinator).
   // Geth's snap handler supports up to 2MB responses. Starting at 512KB and probing upward
@@ -509,7 +545,10 @@ class AccountRangeCoordinator(
       drainActiveTasks(s"pivot refresh to ${newStateRoot.take(4).toHex}")
       pendingTasks.foreach(_.rootHash = newStateRoot)
 
-      // Clear stateless tracking — peers can serve the new root
+      // Clear stateless tracking — peers can serve the new root.
+      // NOTE: snaplessPeers is INTENTIONALLY NOT cleared here (#1197). A peer with no
+      // snapshot tree won't grow one across a pivot refresh; clearing would just put
+      // them back in dispatch rotation to immediately re-classify and waste a cycle.
       statelessPeers.clear()
       pivotRefreshRequested = false
 
@@ -542,6 +581,8 @@ class AccountRangeCoordinator(
       knownAvailablePeers += peer
       if (isPeerStateless(peer)) {
         log.debug(s"Ignoring PeerAvailable(${peer.id.value}) - peer is stateless for current root")
+      } else if (isPeerSnapless(peer)) {
+        log.debug(s"Ignoring PeerAvailable(${peer.id.value}) - peer is snapless (no snapshot tree)")
       } else if (isPeerCoolingDown(peer)) {
         log.debug(s"Ignoring PeerAvailable(${peer.id.value}) - peer is cooling down")
       } else if (pendingTasks.isEmpty) {
@@ -1018,6 +1059,7 @@ class AccountRangeCoordinator(
     if (pendingTasks.isEmpty) return
     val eligiblePeers = knownAvailablePeers
       .filterNot(isPeerStateless)
+      .filterNot(isPeerSnapless)
       .filterNot(isPeerCoolingDown)
       .toList
     if (eligiblePeers.isEmpty) return

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -612,4 +612,127 @@ class AccountRangeCoordinatorSpec
 
     system.stop(coordinator)
   }
+
+  // ── Snapless peer demotion (refs #1197) ──
+  // ETC mainnet peers running core-geth with `--syncmode full` advertise snap/1 but
+  // their handler returns AccountRangePacket{Accounts:nil, Proof:nil} for every
+  // GetAccountRange because `chain.Snapshots()` is unavailable. Today's
+  // markPeerStateless adds the peer to statelessPeers, but PivotRefreshed clears that
+  // set — so on every pivot refresh the peer cycles back into dispatch, returns
+  // empty again, and the wedge repeats every ~2 minutes. The fix introduces a
+  // separate `snaplessPeers` set that survives PivotRefreshed because the peer's
+  // snapshot won't materialise mid-session.
+
+  it should "mark a peer SNAPLESS on 'Missing proof for empty account range' (#1197)" taggedAs UnitTest in {
+    // handleTaskFailed only calls markPeerStateless when the task's rootHash matches
+    // the coordinator's current stateRoot (otherwise it's a stale-root failure from a
+    // pre-pivot-refresh request, which doesn't reflect on the peer's snapshot state).
+    // Match the coordinator's default newCoordinator() stateRoot so the path is exercised.
+    val stateRoot = kec256(ByteString("trie-async-test-root"))
+    val coord = newCoordinator(stateRoot = stateRoot)
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("snapless-peer", pendingProbe.ref)
+
+    seedActiveTask(coord, BigInt(701), peer, rootHash = stateRoot)
+
+    // Drive the empty-with-empty failure path through the public coordinator API.
+    coord ! Messages.TaskFailed(BigInt(701), "Missing proof for empty account range")
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds) // sequential barrier
+
+    ua.statelessPeers should contain(peer.id)
+    ua.snaplessPeers should contain(peer.id)
+
+    system.stop(coord)
+  }
+
+  it should "leave snaplessPeers untouched on PivotRefreshed (#1197)" taggedAs UnitTest in {
+    val coord = newCoordinator()
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("snapless-pivot-peer", pendingProbe.ref)
+
+    // Seed both sets directly (the coordinator-internal effect of an empty-proof failure).
+    ua.statelessPeers.add(peer.id)
+    ua.snaplessPeers.add(peer.id)
+
+    coord ! Messages.PivotRefreshed(kec256(ByteString("post-refresh-root")))
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    // statelessPeers is for stale-root failures and clears on PivotRefreshed.
+    ua.statelessPeers shouldBe empty
+    // snaplessPeers tracks structural snapshot absence; survives so the peer doesn't
+    // go back into dispatch and immediately re-classify.
+    ua.snaplessPeers should contain(peer.id)
+
+    system.stop(coord)
+  }
+
+  it should "NOT classify a peer as SNAPLESS on Request timeout failures (#1197)" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("trie-async-test-root"))
+    val coord = newCoordinator(stateRoot = stateRoot)
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("timeout-only-peer", pendingProbe.ref)
+
+    // Drive 3 consecutive timeouts for one peer (consecutiveTimeoutThreshold default = 3).
+    seedActiveTask(coord, BigInt(801), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(801), "Request timeout")
+    seedActiveTask(coord, BigInt(802), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(802), "Request timeout")
+    seedActiveTask(coord, BigInt(803), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(803), "Request timeout")
+
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    // After 3 timeouts the peer is stateless (transient root-aging signal) but NOT
+    // snapless — timeout doesn't mean the snapshot tree is missing.
+    ua.statelessPeers should contain(peer.id)
+    ua.snaplessPeers should not contain peer.id
+
+    system.stop(coord)
+  }
+
+  it should "filter snapless peers from PeerAvailable dispatch (#1197)" taggedAs UnitTest in {
+    // The coordinator routes all peer requests through a single networkPeerManager —
+    // verify dispatch by inspecting its mailbox for SendMessage envelopes addressed to
+    // each peer id, rather than per-peer probes.
+    import com.chipprbots.ethereum.network.NetworkPeerManagerActor.SendMessage
+
+    val stateRoot = kec256(ByteString("snapless-dispatch-root"))
+    val networkPeerManager = TestProbe()
+    val syncController = TestProbe()
+    val peerProbeA = TestProbe()
+    val peerProbeB = TestProbe()
+    val peerA = PeerTestHelpers.createTestPeer("snapless-dispatch-a", peerProbeA.ref)
+    val peerB = PeerTestHelpers.createTestPeer("snapless-dispatch-b", peerProbeB.ref)
+
+    val coord = TestActorRef[AccountRangeCoordinator](
+      AccountRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        concurrency = 1, // exactly one initial task → one dispatch
+        snapSyncController = syncController.ref
+      )
+    )
+
+    // Pre-seed peerA as snapless before announcing it. peerB is a normal fresh peer.
+    coord.underlyingActor.snaplessPeers.add(peerA.id)
+
+    coord ! Messages.StartAccountRangeSync(stateRoot)
+    coord ! Messages.PeerAvailable(peerA)
+    coord ! Messages.PeerAvailable(peerB)
+
+    // The dispatch should reach peerB only. We expect at least one SendMessage on the
+    // shared networkPeerManager probe, and its `peerId` must be peerB's, not peerA's.
+    val sent = networkPeerManager.expectMsgType[SendMessage](3.seconds)
+    sent.peerId.value shouldBe peerB.id.value
+
+    system.stop(coord)
+  }
 }


### PR DESCRIPTION
## Summary

- Issue: #1197
- Closes #1197

ETC mainnet SNAP sync was wedging every ~2 minutes in a recurring cycle. Root cause
verified against current core-geth source (v1.12.22, `eth/protocols/snap/handler.go`):
peers running `--syncmode full` → `SnapshotCache=0` silently emit
`AccountRangePacket{Accounts: nil, Proof: nil}` for every `GetAccountRange` (the
handler comment is literal: *"Send back anything accumulated (or empty in case of
errors)"*). fukuii's existing handling cycled them back into rotation on every pivot
refresh, recreating the wedge.

## The fix in one line

Split the existing `statelessPeers` set into **stateless** (cleared on `PivotRefreshed`,
existing behavior — for stale-root failures) and **snapless** (NEW, survives pivot
refresh — for the empty-with-empty signal that means "this peer has no snapshot tree
at all"). Filter `snaplessPeers` out of dispatch alongside `statelessPeers`.

## Failure mode taxonomy

| Failure | Cause | Recoverable across pivot refresh? | Set |
|---|---|---|---|
| `Request timeout` | Current root aged out of peer's serve window | **Yes** (new root may be in window) | `statelessPeers` (cleared) |
| `Proof root mismatch` | Same | **Yes** | `statelessPeers` (cleared) |
| **`Missing proof for empty account range`** | **Peer has no snapshot tree** | **No** (snapshot won't materialize) | `statelessPeers` ∪ **`snaplessPeers`** (preserved) |

## Why ETC mainnet specifically

| Network | Peer pool | Effect |
|---|---|---|
| Mordor | Mostly other fukuii instances + ETH/68 peers, default config has snapshots | Empty-with-empty rare → existing per-pivot statelessPeers handles it |
| **ETC mainnet** | Dominated by **core-geth `--syncmode full`** (`SnapshotCache=0`) | Empty-with-empty is the **norm** → wedge cycle dominates |

## Implementation

`AccountRangeCoordinator.scala` (+44 lines / −9):
- Add `snaplessPeers` set + `isPeerSnapless` predicate (line 96-101)
- Extend `markPeerStateless` to add to BOTH sets when reason matches (line 110-119)
- Update `maybeRequestPivotRefresh` to compute "all stateless" against the
  non-snapless subset; log warning + skip refresh when all peers snapless (line 154-180)
- Update three dispatch filter sites: `activePeerCount`, `PeerAvailable` handler,
  `tryRedispatchPendingTasks`
- Annotate `PivotRefreshed.statelessPeers.clear()` to make snapless preservation explicit

`AccountRangeCoordinatorSpec.scala` (+123 lines): 4 new logic-model tests:
1. Empty-proof failure → both `statelessPeers` and `snaplessPeers` populated
2. `PivotRefreshed` → `statelessPeers` cleared, `snaplessPeers` preserved
3. `Request timeout` × 3 → `statelessPeers` populated, `snaplessPeers` NOT populated
4. Snapless peer announced via `PeerAvailable` → no dispatch; non-snapless peer dispatched

## Out of scope (deliberate)

- **`StorageRangeCoordinator` mirror.** Storage's empty signal is structurally
  ambiguous (proof-of-absence on a small contract vs. snapless). Existing
  `consecutiveUnproductiveRefreshes` + post-refresh-cooldown handle the storage
  wedge differently. If storage stalls become a confirmed problem on ETC mainnet
  post-merge of this PR, that would be a follow-up issue.
- **`ByteCodeCoordinator` / `TrieNodeHealingCoordinator`.** Independent peer-state
  tracking; the whole point is to keep snapless peers usable for these queries.
  Confirmed in code review — no shared state between coordinators.

## Test plan

- [x] 4 new tests in `AccountRangeCoordinatorSpec` — all green
- [x] `sbt 'testOnly *AccountRangeCoordinatorSpec'` — **25/25 green** (was 21)
- [x] `sbt 'testOnly *.snap.*'` — **230/230 green**
- [x] `sbt scalafmtCheckAll` — clean
- [ ] Live ETC mainnet:
  - Look for new log line: `Peer X marked SNAPLESS (no snapshot tree)` within
    first few minutes of account download
  - Wedge frequency should drop from "every ~2 min" to ideally none — peer pool
    converges on snapshot-bearing minority
  - If pool is ~100% snapless, look for the new "All N known peers are SNAPLESS"
    warning instead of an infinite refresh loop

## Reference

Memory note (`project_eth68_snap_research.md` updated separately) has the full
core-geth handler analysis. The verified handler code in v1.12.22:

```go
case msg.Code == GetAccountRangeMsg:
    accounts, proofs := ServiceGetAccountRangeQuery(backend.Chain(), &req)
    return p2p.Send(peer.rw, AccountRangeMsg, &AccountRangePacket{
        ID: req.ID, Accounts: accounts, Proof: proofs,  // ← empty when Snapshots() unavailable
    })

func ServiceGetAccountRangeQuery(...) {
    // Retrieve the requested state and bail out if non existent
    tr, err := trie.New(trie.StateTrieID(req.Root), chain.TrieDB())
    if err != nil { return nil, nil }
    it, err := chain.Snapshots().AccountIterator(req.Root, req.Origin)  // ← here
    if err != nil { return nil, nil }
    ...
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
