### PR TITLE
fix(etc): swap stale DNS discovery domain to all.classic.etcdisco.net — closes #1199

### DIFF
--- a/src/main/resources/conf/base/chains/etc-chain.conf
+++ b/src/main/resources/conf/base/chains/etc-chain.conf
@@ -204,7 +204,7 @@
   # EIP-1459 DNS-based peer discovery domains
   # Core-geth uses these to dynamically discover ETC mainnet peers via DNS TXT records (ENR tree)
   dns-discovery-domains = [
-    "all.classic.blockd.info"
+    "all.classic.etcdisco.net"
   ]
 
   # Set of initial nodes

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -126,7 +126,9 @@
     
     <!-- Peer discovery lifecycle (start/stop events only) -->
     <logger name="com.chipprbots.ethereum.network.discovery.PeerDiscoveryManager" level="INFO" />
-    
+    <logger name="com.chipprbots.ethereum.network.discovery.DnsDiscovery" level="INFO" />
+    <logger name="com.chipprbots.ethereum.network.discovery.DiscoveryConfig" level="INFO" />
+
     <!-- Sync status and lifecycle (high-level status only) -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.SyncController" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.fast.FastSync" level="INFO" />


### PR DESCRIPTION
## Summary

- Issue: #1199
- Closes #1199

The ETC mainnet DNS discovery domain `all.classic.blockd.info` has gone
stale — its ENR tree no longer surfaces live peers. Switching to the new
authoritative registry `all.classic.etcdisco.net` brings DNS bootstrap
back to life: **0 enodes → 296 enodes** in fresh-sync diagnostics.

## Verified live

Pre-fix on a freshly-wiped `fukuii-primary` running ETC mainnet (any sync
mode): peer pool surfaced 322 unique inbound STATUS messages, **zero**
with `forkId=0xbe46d57c` (the ETC mainnet identity fukuii itself sends).
SNAP/Fast bounced on bootstrap retry until the escape hatch fired and
regular sync wedged on `GetBlockHeaders` timeouts.

Post-fix on the same node:

```
2026-05-04 10:27:10 INFO  DiscoveryConfig$ - Resolving 1 DNS discovery domain(s): all.classic.etcdisco.net
2026-05-04 10:27:10 INFO  DnsDiscovery$    - DNS_DISCOVERY: Resolving peers from DNS tree: all.classic.etcdisco.net
2026-05-04 10:27:11 INFO  DnsDiscovery$    - DNS_DISCOVERY: Resolved 296 enode(s) from all.classic.etcdisco.net
2026-05-04 10:27:11 INFO  DiscoveryConfig$ - Bootstrap nodes: 324 total (30 config, 296 DNS)
```

The DNS query itself works equivalently from any vantage point:

```
$ dig +short TXT all.classic.etcdisco.net
"enrtree-root:v1 e=FHOHITYUEGTD2TTZ3GJ4S4N6YE l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=237 ..."
```

## Why the failure was silent

The same package-level filter that hides RLPx/discovery wire detail was
also hiding the discovery summary lines (`Resolved N enode(s)` and
`Bootstrap nodes: M total`). The lookup itself succeeded against the
stale domain (the TXT record at the old name still exists), so no WARN
fired. We saw zero diagnostics about a 0-yield resolution.

This PR adds two narrow logger overrides at INFO so that anyone adding a
new chain config or rotating bootnodes can immediately see the
DNS contribution at startup.

## Test plan

- [x] `dig +short TXT all.classic.etcdisco.net` returns `enrtree-root:v1`
- [x] Fresh container build with the updated config logs
      `Resolved 296 enode(s) from all.classic.etcdisco.net`
- [x] `Bootstrap nodes: 324 total (30 config, 296 DNS)` reflects DNS
      contribution
- [ ] Live: confirm `forkId=0xbe46d57c` peers connect within first few
      minutes of fresh sync (in progress on `fukuii-primary`)

## Out of scope

The `all.classic.blockd.info` legacy domain is left in place upstream;
this PR only updates fukuii's reference. If `etcdisco.net` itself ever
rotates, the same one-line pattern applies. A future task could add
both domains to the array (DNS discovery accepts a list) for resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
