### PR TITLE
fix(sepolia): complete EIP-2124 fork-chain + DNS + canonical bootnodes — closes #1202

### DIFF
--- a/ops/barad-dur/sepolia/docker-compose.yml
+++ b/ops/barad-dur/sepolia/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       - ./fukuii-conf:/app/conf:ro
       - ./jwt.hex:/app/jwt/jwt.hex:ro
       - ./fukuii-conf/static-nodes.json:/app/data/static-nodes.json:ro
+    # Override the image's ENTRYPOINT (which hardcodes the versioned JAR path —
+    # frozen at 0.1.240 from the original image build) so we use the unversioned
+    # symlink instead. Mirrors the pattern in the primary docker-compose.yml.
+    entrypoint: ["java"]
     command:
       - "-Xmx4g"
       - "-Xms2g"

--- a/ops/barad-dur/sepolia/fukuii-conf/sepolia.conf
+++ b/ops/barad-dur/sepolia/fukuii-conf/sepolia.conf
@@ -16,11 +16,21 @@ fukuii {
   }
 
   sync {
-    # CL-driven mode — blocks arrive via Engine API, not peer sync
-    do-fast-sync = false
-    do-snap-sync = false
+    # SNAP first — get state up to a recent pivot from peers (Sepolia has many
+    # snapshot-bearing geth/besu/nethermind nodes). After SNAP finishes, the CL
+    # drives ongoing block import via Engine API (newPayload + forkchoice).
+    do-fast-sync = true
+    do-snap-sync = true
+
+    # Sepolia has a healthy peer pool, but we keep this loose so a single SNAP-capable
+    # peer is enough to bootstrap a pivot — header-validation catches a bad pivot
+    # at execution time. Same approach used on ETC mainnet.
+    min-peers-to-choose-pivot-block = 1
+    use-bootstrap-checkpoints = true
+
     peer-response-timeout = 90.seconds
     blacklist-duration = 60.seconds
+    critical-blacklist-duration = 30.minutes
   }
 
   network {

--- a/src/main/resources/conf/base/chains/sepolia-chain.conf
+++ b/src/main/resources/conf/base/chains/sepolia-chain.conf
@@ -6,8 +6,24 @@
 
   terminal-total-difficulty = "17000000000000000"
 
+  # Sepolia fork timestamps (verified against go-ethereum master 2026-05-04).
+  # Without these, ForkIdValidator's checkSuperset rejects current chain-head
+  # peers (forkId=0x268956b6) as ErrLocalIncompatibleOrStale — only genesis-only
+  # bootnodes whose forkHash trivially matches our pre-Shanghai checksum get
+  # forkAccepted=true. Real Sepolia peers as of 2026-05 are post-Osaka
+  # (Oct 2025); the full schedule must be in our checksum list to recognize
+  # them as a known future-fork.
   shanghai-timestamp = 1677557088
   cancun-timestamp = 1706655072
+  prague-timestamp = 1741159776
+  osaka-timestamp = 1760427360
+  bpo1-timestamp = 1761017184
+  bpo2-timestamp = 1761607008
+
+  # Sepolia post-Merge net-split block (EIP-3675 / go-ethereum's MergeNetsplitBlock).
+  # Required in the EIP-2124 fork-id checksum chain — without it, our hash for
+  # post-Shanghai onwards is off by one CRC32 round.
+  merge-netsplit-block-number = "1735371"
 
   sync {
     do-fast-sync = false
@@ -66,14 +82,25 @@
   gas-tie-breaker = false
   eth-compatible-storage = true
 
-  # Official Sepolia bootnodes from go-ethereum
+  # EIP-1459 DNS-based peer discovery domains
+  # all.sepolia.ethdisco.net is the upstream-maintained ENR tree for Sepolia testnet —
+  # mirrors the geth bootnode list with live ENR records. Adds discovery-driven peer
+  # population on top of the static bootstrap-nodes below.
+  dns-discovery-domains = [
+    "all.sepolia.ethdisco.net"
+  ]
+
+  # Official Sepolia bootnodes from go-ethereum master (verified 2026-05-04).
+  # The previous list contained at least two corrupted enode public keys (notably
+  # `571` and `f8f8f8` repeating patterns) that caused signature-verification failure
+  # at handshake — peers would TCP-accept then drop us. Besu uses the same upstream list.
+  # Source: https://github.com/ethereum/go-ethereum/blob/master/params/bootnodes.go
   bootstrap-nodes = [
-    "enode://4e5e92199ee224a01932a377160aa432f31d0b351f84ab413a8e0a42f4f36476f8fb1cbe914af0d9aef0d51571571571571571571571571571571571571571571@138.197.51.181:30303",
-    "enode://ec66ddcf1a974950bd4c782789a7e04f8aa7c00f17d48e498f24c30bbe99f6b3e4ad7bf8f8f8d8a5e2b1ab5d3c0e2c9a96cf4c7d4e4f9a4e8b3b3f4f4e4c3a2b@51.141.78.53:30303",
-    "enode://9246d00bc8fd1742e5ad2428b80fc4dc45d786283e05ef6edbd9002cbc335d40998b9b4b81da0f63b4e29e10dc0cf927b68d91f39a8f9b7e5a93dab5f87e4b8e@18.168.182.86:30303",
-    "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303",
-    "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303",
-    "enode://31fcc46ef88f8732aa2e24f0991ad5eb324a6e81d424e0aba16a3373e01a3c2ac3fe08bf374ce5a4d1175dbf4651fb79a4561d8680781c4e3e058883c2b94712@150.136.179.25:36544"
+    "enode://4e5e92199ee224a01932a377160aa432f31d0b351f84ab413a8e0a42f4f36476f8fb1cbe914af0d9aef0d51665c214cf653c651c4bbd9d5550a934f241f1682b@138.197.51.181:30303", # sepolia-bootnode-1-nyc3
+    "enode://143e11fb766781d22d92a2e33f8f104cddae4411a122295ed1fdb6638de96a6ce65f5b7c964ba3763bba27961738fef7d3ecc739268f3e5e771fb4c87b6234ba@146.190.1.103:30303", # sepolia-bootnode-1-sfo3
+    "enode://8b61dc2d06c3f96fddcbebb0efb29d60d3598650275dc469c22229d3e5620369b0d3dedafd929835fe7f489618f19f456fe7c0df572bf2d914a9f4e006f783a9@170.64.250.88:30303", # sepolia-bootnode-1-syd1
+    "enode://10d62eff032205fcef19497f35ca8477bea0eadfff6d769a147e895d8b2b8f8ae6341630c645c30f5df6e67547c03494ced3d9c5764e8622a26587b083b028e8@139.59.49.206:30303", # sepolia-bootnode-1-blr1
+    "enode://9e9492e2e8836114cc75f5b929784f4f46c324ad01daf87d956f98b3b6c5fcba95524d6e5cf9861dc96a2c8a171ea7105bb554a197455058de185fa870970c7c@138.68.123.152:30303"  # sepolia-bootnode-1-ams3
   ]
 
   mess {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -159,7 +159,7 @@
     <logger name="com.chipprbots.ethereum.network" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerActor" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerManagerActor" level="ERROR" />
-    <logger name="com.chipprbots.ethereum.network.NetworkPeerManagerActor" level="ERROR" />
+    <logger name="com.chipprbots.ethereum.network.NetworkPeerManagerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.ServerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.KnownNodesManager" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerScoringManager" level="ERROR" />

--- a/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
+++ b/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
@@ -66,7 +66,10 @@ object ForkId {
     List(
       config.forkTimestamps.shanghaiTimestamp.map(BigInt(_)),
       config.forkTimestamps.cancunTimestamp.map(BigInt(_)),
-      config.forkTimestamps.pragueTimestamp.map(BigInt(_))
+      config.forkTimestamps.pragueTimestamp.map(BigInt(_)),
+      config.forkTimestamps.osakaTimestamp.map(BigInt(_)),
+      config.forkTimestamps.bpo1Timestamp.map(BigInt(_)),
+      config.forkTimestamps.bpo2Timestamp.map(BigInt(_))
     ).flatten.filterNot(_ == 0).distinct.sorted
 
   implicit class ForkIdEnc(forkId: ForkId) extends RLPSerializable {

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -193,12 +193,16 @@ class NetworkPeerManagerActor(
           s"latestBlock=${peerInfo.remoteStatus.latestBlock.getOrElse("?")} TD=${peerInfo.remoteStatus.chainWeight.totalDifficulty} (ETH/69, TD from local DB or block-number proxy)"
         else
           s"TD=${peerInfo.remoteStatus.chainWeight.totalDifficulty}"
-      log.debug(
-        "PEER_HANDSHAKE_SUCCESS: Peer {} handshake successful. Capability: {}, BestHash: {}, ChainInfo: {}",
-        peer.id,
-        peerInfo.remoteStatus.capability,
-        ByteStringUtils.hash2string(peerInfo.remoteStatus.bestHash),
-        chainInfoDisplay
+      // INFO-level so operators can see real chain affiliation (networkId, forkId, height,
+      // forkAccepted) of every peer that completes handshake. Critical for diagnosing
+      // bootstrap failures where most inbound peers are wrong-chain DHT noise — the
+      // INBOUND_CAP_OFFSETS log only proves capability negotiation, not chain membership.
+      log.info(
+        s"PEER_HANDSHAKE_SUCCESS: Peer ${peer.id} cap=${peerInfo.remoteStatus.capability} " +
+          s"networkId=${peerInfo.remoteStatus.networkId} " +
+          s"bestHash=${ByteStringUtils.hash2string(peerInfo.remoteStatus.bestHash)} " +
+          s"$chainInfoDisplay forkAccepted=${peerInfo.forkAccepted} " +
+          s"supportsSnap=${peerInfo.remoteStatus.supportsSnap}"
       )
       peerEventBusActor ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
       peerEventBusActor ! Subscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peer.id)))

--- a/src/main/scala/com/chipprbots/ethereum/utils/BlockchainConfig.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/BlockchainConfig.scala
@@ -30,7 +30,9 @@ case class ForkTimestamps(
     shanghaiTimestamp: Option[Long] = None,
     cancunTimestamp: Option[Long] = None,
     pragueTimestamp: Option[Long] = None,
-    osakaTimestamp: Option[Long] = None
+    osakaTimestamp: Option[Long] = None,
+    bpo1Timestamp: Option[Long] = None,
+    bpo2Timestamp: Option[Long] = None
 )
 
 case class BlockchainConfig(
@@ -98,7 +100,12 @@ case class ForkBlockNumbers(
     berlinBlockNumber: BigInt,
     mystiqueBlockNumber: BigInt,
     spiralBlockNumber: BigInt,
-    olympiaBlockNumber: BigInt
+    olympiaBlockNumber: BigInt,
+    // EIP-3675 / Sepolia post-Merge net-split block (1735371). Block-based fork that
+    // must be in the EIP-2124 fork-id checksum chain — go-ethereum's params/config.go
+    // lists this for Sepolia. Without it, our forkId hashes for Shanghai+ are off by
+    // one CRC32 round and ForkIdValidator.checkSuperset rejects all chain-head peers.
+    mergeNetsplitBlockNumber: BigInt = Long.MaxValue
 ) {
   def all: List[BigInt] = this.productIterator.toList.collect { case i: BigInt =>
     i
@@ -130,7 +137,8 @@ object ForkBlockNumbers {
     berlinBlockNumber = Long.MaxValue,
     mystiqueBlockNumber = Long.MaxValue,
     spiralBlockNumber = Long.MaxValue,
-    olympiaBlockNumber = Long.MaxValue
+    olympiaBlockNumber = Long.MaxValue,
+    mergeNetsplitBlockNumber = Long.MaxValue
   )
 }
 
@@ -205,6 +213,8 @@ object BlockchainConfig {
     val spiralBlockNumber: BigInt = BigInt(blockchainConfig.getString("spiral-block-number"))
     val olympiaBlockNumber: BigInt =
       Try(BigInt(blockchainConfig.getString("olympia-block-number"))).getOrElse(BigInt(Long.MaxValue))
+    val mergeNetsplitBlockNumber: BigInt =
+      Try(BigInt(blockchainConfig.getString("merge-netsplit-block-number"))).getOrElse(BigInt(Long.MaxValue))
 
     val treasuryAddress: Address =
       Try(Address(blockchainConfig.getString("treasury-address"))).getOrElse(Address(0))
@@ -219,7 +229,9 @@ object BlockchainConfig {
       shanghaiTimestamp = Try(blockchainConfig.getLong("shanghai-timestamp")).toOption,
       cancunTimestamp = Try(blockchainConfig.getLong("cancun-timestamp")).toOption,
       pragueTimestamp = Try(blockchainConfig.getLong("prague-timestamp")).toOption,
-      osakaTimestamp = Try(blockchainConfig.getLong("osaka-timestamp")).toOption
+      osakaTimestamp = Try(blockchainConfig.getLong("osaka-timestamp")).toOption,
+      bpo1Timestamp = Try(blockchainConfig.getLong("bpo1-timestamp")).toOption,
+      bpo2Timestamp = Try(blockchainConfig.getLong("bpo2-timestamp")).toOption
     )
 
     val messConfig: MESSConfig = Try {
@@ -258,7 +270,8 @@ object BlockchainConfig {
         berlinBlockNumber = berlinBlockNumber,
         mystiqueBlockNumber = mystiqueBlockNumber,
         spiralBlockNumber = spiralBlockNumber,
-        olympiaBlockNumber = olympiaBlockNumber
+        olympiaBlockNumber = olympiaBlockNumber,
+        mergeNetsplitBlockNumber = mergeNetsplitBlockNumber
       ),
       maxCodeSize = maxCodeSize,
       customGenesisFileOpt = customGenesisFileOpt,


### PR DESCRIPTION
## Summary

- Issue: #1202
- Closes #1202
- Follow-up issue: #1201 (PivotHeaderBootstrap "no header returned")

Fixes the EIP-2124 fork-id checksum chain for Sepolia and a handful of
co-blockers that prevented chain-head peers from being usable. With this
patch, real Sepolia chain-head peers (forkId=`0x268956b6`) finally pass
`ForkIdValidator.checkSuperset` and SNAP pivot selection succeeds against
the live chain head.

## Root cause

`ForkIdValidator.checkSuperset` only accepts a peer ahead of us if their
forkHash is one of our **future-fork checksums**. fukuii's Sepolia chain
config was missing five contributions to that chain:

| Fork | What was wrong |
|---|---|
| `MergeNetsplitBlock` (block 1735371) | not represented in `ForkBlockNumbers` |
| `osakaTimestamp` | already on `BlockchainConfig`, not in `ForkId.gatherTimestampForks` |
| `bpo1Timestamp` / `bpo2Timestamp` | no fields existed |
| `sepolia-chain.conf` | only had Shanghai + Cancun timestamps populated |

Verified checksum chain (matches go-ethereum's params/config.go for Sepolia):

```
genesis        → 0xfe3366e7
+mergeNetsplit (block 1735371)  → 0xb96cbd13
+shanghai      (ts 1677557088)  → 0xf7f9bc08
+cancun        (ts 1706655072)  → 0x88cf81d9   ← matches observed peer forkId
+prague        (ts 1741159776)  → 0xed88b5fd   ← matches observed peer forkId
+osaka         (ts 1760427360)  → 0xe2ae4999
+bpo1          (ts 1761017184)  → 0x56078a1e
+bpo2          (ts 1761607008)  → 0x268956b6   ← matches headline chain-head forkId
```

## Discoverability fixes (paired with the chain-config fix)

This issue was effectively invisible operationally before today, because:

1. `PEER_HANDSHAKE_SUCCESS` was DEBUG-level → invisible
2. `NetworkPeerManagerActor` logger was ERROR → suppressed everything
3. Sepolia DNS discovery domain was unconfigured → tiny peer pool
4. Two of six `bootstrap-nodes` had **corrupted enode public keys** (`571`
   and `f8f8f8` repeating patterns) → peers TCP-accepted then dropped us
   during RLPx auth, masking the deeper fork-chain issue

## Changes

### Code
- `ForkBlockNumbers`: add `mergeNetsplitBlockNumber` field (defaults
  `Long.MaxValue`)
- `ForkTimestamps`: add `bpo1Timestamp` + `bpo2Timestamp` fields
- `ForkId.gatherTimestampForks`: include osaka + bpo1 + bpo2 in the checksum
  chain
- `BlockchainConfig.fromRawConfig`: read `merge-netsplit-block-number` and
  `bpo1-timestamp` / `bpo2-timestamp` from HOCON
- `NetworkPeerManagerActor`: `PEER_HANDSHAKE_SUCCESS` at INFO with chain
  affiliation per peer (networkId / bestHash / forkAccepted / supportsSnap)

### Config
- `sepolia-chain.conf`: full fork chain populated
- `sepolia-chain.conf`: 5 canonical bootnodes from go-ethereum master,
  replacing the corrupted-key list
- `sepolia-chain.conf`: `dns-discovery-domains = ["all.sepolia.ethdisco.net"]`
- `logback.xml`: `NetworkPeerManagerActor` ERROR → INFO so the diagnostic
  log reaches operator output

### Ops (barad-dûr)
- `sepolia/docker-compose.yml`: `entrypoint:["java"]` override (the image's
  default ENTRYPOINT hardcodes the stale `fukuii-assembly-0.1.240.jar` path
  — same workaround the primary compose already uses)
- `sepolia/fukuii-conf/sepolia.conf`: enable `do-snap-sync = true` (with
  `do-fast-sync = true` as prerequisite per existing config validator)

## Verification (live, on Barad-dûr)

Pre-fix:
```
Bootstrap nodes: 22 total (6 config, 0 DNS, 16 static)
0 chain-head peer handshakes (only genesis-only)
FORKID_VALIDATION: ErrLocalIncompatibleOrStale for ForkId(0x268956b6, None)  × 6
```

Post-fix:
```
Bootstrap nodes: 244 total (5 config, 219 DNS, 20 static)
8 chain-head peer handshakes (latestBlock=10789376, forkAccepted=true,
                              supportsSnap=true)
FORKID_VALIDATION: Connect for ForkId(0x268956b6, None)  × 7
SNAP pivot selection: networkBest=10789376, base=10789376 (source=network),
                      pivot=10789312
```

## Out of scope

#1201 — PivotHeaderBootstrap fails to fetch the pivot block header from the
chain-head peers it just handshaked with (`no header returned` after 10
retries). Tracked separately because diagnosing it requires this fix to be
in place first.

The Pekko HTTP timeout on lighthouse `engine_upcheck` is also unchanged —
that's pre-existing and unrelated to fork validation.

## Test plan

- [x] `sbt compile` clean
- [x] Live: chain-head Sepolia peers (forkId=0x268956b6) `Connect` ✓
- [x] Live: SNAP pivot selected from real chain-head peer ✓
- [x] Live: `PEER_HANDSHAKE_SUCCESS` log entries visible at INFO with full
      chain affiliation ✓
- [ ] Live: account download begins (blocked on #1201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
