### PR TITLE
fix(sync,rlp): unblock SNAP pivot bootstrap on Sepolia — closes #1201

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
@@ -381,23 +381,29 @@ object PeersClient {
   ): Option[Peer] = {
     log.debug("Evaluating {} peers to find best peer", peersToDownloadFrom.size)
 
+    // Filter out peers whose bestHash == genesisHash. These peers have nothing to
+    // serve and silently return empty responses to GetBlockHeaders, GetBlockBodies,
+    // GetReceipts etc. — masking sync wedges as transient timeouts.
+    //
+    // Bug #1201 (Sepolia): half the post-fork-fix peer pool was Sepolia bootnodes
+    // sitting at genesis (`bestHash == genesisHash`, TD=131072). PivotHeaderBootstrap's
+    // BestPeer selection round-robined into them and reported "no header returned"
+    // for blocks they literally don't have. forkAccepted=true is necessary but not
+    // sufficient — the peer must also have advanced past genesis.
     val peersToUse = peersToDownloadFrom.values
       .map { case PeerWithInfo(peer, peerInfo) =>
-        val isReady = peerInfo.forkAccepted
+        val isReady = peerInfo.forkAccepted && !peerInfo.isAtGenesis
         log.debug(
-          "Peer {} ({}) - ready: {}, maxBlock: {}",
-          peer.id,
-          peer.remoteAddress,
-          isReady,
-          peerInfo.maxBlockNumber
+          s"Peer ${peer.id} (${peer.remoteAddress}) - ready: $isReady, " +
+            s"maxBlock: ${peerInfo.maxBlockNumber}, atGenesis: ${peerInfo.isAtGenesis}"
         )
         log.debug("Peer {} chainWeight: {}", peer.id, peerInfo.chainWeight)
         (peer, peerInfo, isReady)
       }
-      .collect { case (peer, PeerInfo(_, chainWeight, true, _, _), _) =>
+      .collect { case (peer, peerInfo, true) =>
         log.debug("Peer {} is ready and eligible for selection", peer.id)
-        log.debug("Peer {} chainWeight: {}", peer.id, chainWeight)
-        (peer, chainWeight)
+        log.debug("Peer {} chainWeight: {}", peer.id, peerInfo.chainWeight)
+        (peer, peerInfo.chainWeight)
       }
 
     if (peersToUse.nonEmpty) {
@@ -410,11 +416,13 @@ object PeersClient {
     }
   }
 
-  // Legacy method for backward compatibility
+  // Legacy method for backward compatibility — kept in sync with the logger-aware
+  // overload above: skip forkRejected peers AND skip peers stuck at genesis.
   def bestPeer(peersToDownloadFrom: Map[PeerId, PeerWithInfo]): Option[Peer] = {
     val peersToUse = peersToDownloadFrom.values
-      .collect { case PeerWithInfo(peer, PeerInfo(_, chainWeight, true, _, _)) =>
-        (peer, chainWeight)
+      .collect {
+        case PeerWithInfo(peer, peerInfo) if peerInfo.forkAccepted && !peerInfo.isAtGenesis =>
+          (peer, peerInfo.chainWeight)
       }
 
     if (peersToUse.nonEmpty) {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
@@ -209,6 +209,34 @@ class PeersClient(
         )
         bestPeer(filteredPeers, log)
 
+      case BestPeerWithMinBlock(minBlock) =>
+        // Two-tier selection: peers with known maxBlockNumber >= minBlock are
+        // strictly better than peers with maxBlockNumber == 0 (unknown chain
+        // state). Try the known-good tier first; if empty, fall back to the
+        // unknown tier — which is correct behaviour for ETH/64-68 peers whose
+        // maxBlockNumber stays at 0 because their STATUS doesn't carry a
+        // block number and we don't receive block messages from them post-merge.
+        val knownAheadPeers = peersToDownloadFrom.filter { case (_, peerWithInfo) =>
+          peerWithInfo.peerInfo.maxBlockNumber >= minBlock
+        }
+        if (knownAheadPeers.nonEmpty) {
+          log.debug(
+            "BestPeerWithMinBlock({}): {} peers have known maxBlockNumber >= target",
+            minBlock,
+            knownAheadPeers.size
+          )
+          bestPeer(knownAheadPeers, log)
+        } else {
+          val unknownChainHeadPeers = peersToDownloadFrom.filter { case (_, peerWithInfo) =>
+            peerWithInfo.peerInfo.maxBlockNumber == 0
+          }
+          log.debug(
+            s"BestPeerWithMinBlock($minBlock): no peer with known maxBlockNumber >= target; " +
+              s"falling back to ${unknownChainHeadPeers.size} peer(s) with maxBlockNumber=0 (chain state unknown)"
+          )
+          bestPeer(unknownChainHeadPeers, log)
+        }
+
       case BestSnapPeerExcluding(exclude) =>
         val snapPeers = peersToDownloadFrom.filter { case (peerId, peerWithInfo) =>
           !exclude.contains(peerId) && peerWithInfo.peerInfo.remoteStatus.supportsSnap
@@ -375,6 +403,20 @@ object PeersClient {
   case class BestSnapPeerExcluding(exclude: Set[PeerId]) extends PeerSelector
   case class BestNodeDataPeerExcluding(exclude: Set[PeerId]) extends PeerSelector
 
+  /** Pick a peer whose advertised chain head is at least `minBlock`. Use this
+    * for absolute-block-number requests (e.g. PivotHeaderBootstrap targeting a
+    * specific pivot) where peers behind that height literally have nothing to
+    * return.
+    *
+    * ETH/69 peers report `latestBlock` in STATUS, so `maxBlockNumber` reflects
+    * their true chain head. ETH/64-68 peers don't carry a block number in
+    * STATUS and their `maxBlockNumber` stays at `0` post-merge (no incoming
+    * block messages to update it via `peerHasUpdatedBestBlock`). We therefore
+    * include `maxBlockNumber == 0` peers as a fallback — they MAY have the
+    * block but we can't tell.
+    */
+  case class BestPeerWithMinBlock(minBlock: BigInt) extends PeerSelector
+
   def bestPeer(
       peersToDownloadFrom: Map[PeerId, PeerWithInfo],
       log: org.apache.pekko.event.LoggingAdapter
@@ -431,5 +473,20 @@ object PeersClient {
     } else {
       None
     }
+  }
+
+  /** Static helper mirroring the BestPeerWithMinBlock selector for unit testing. */
+  def bestPeerWithMinBlock(
+      peersToDownloadFrom: Map[PeerId, PeerWithInfo],
+      minBlock: BigInt
+  ): Option[Peer] = {
+    val knownAheadPeers = peersToDownloadFrom.filter { case (_, peerWithInfo) =>
+      peerWithInfo.peerInfo.maxBlockNumber >= minBlock
+    }
+    if (knownAheadPeers.nonEmpty) bestPeer(knownAheadPeers)
+    else
+      bestPeer(peersToDownloadFrom.filter { case (_, peerWithInfo) =>
+        peerWithInfo.peerInfo.maxBlockNumber == 0
+      })
   }
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrap.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrap.scala
@@ -14,6 +14,7 @@ import com.chipprbots.ethereum.network.p2p.messages.ETH66
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{BlockHeaders => ETH66BlockHeaders}
 import com.chipprbots.ethereum.blockchain.sync.PeersClient.{
   BestPeer,
+  BestPeerWithMinBlock,
   BestSnapPeer,
   NoSuitablePeer,
   Request,
@@ -95,19 +96,27 @@ final class PivotHeaderBootstrap(
   private def fetchOnce(): Unit = {
     val msg = ETH66.GetBlockHeaders(ETH66.nextRequestId, Left(targetBlock), maxHeaders = 1, skip = 0, reverse = false)
 
-    // Prefer SNAP-capable peers (they're more likely to have recent headers).
-    // If no SNAP peer is available, fall back to any peer.
-    val selector = if (preferSnapPeers) BestSnapPeer else BestPeer
+    // Pick a peer that actually has the target block. BestPeerWithMinBlock prefers
+    // peers with known maxBlockNumber >= targetBlock (typically ETH/69 peers reporting
+    // latestBlock in STATUS) and falls back to peers with maxBlockNumber=0 (chain
+    // state unknown — typically ETH/64-68 peers post-merge whose STATUS doesn't carry
+    // a block number).
+    //
+    // preferSnapPeers is honoured as a soft signal — if it's set, we try
+    // BestSnapPeer first (which doesn't filter on minBlock), then fall through to
+    // BestPeerWithMinBlock if no SNAP peer responds.
+    val selector = if (preferSnapPeers) BestSnapPeer else BestPeerWithMinBlock(targetBlock)
     val req = Request[ETH66.GetBlockHeaders](msg, selector, (m: ETH66.GetBlockHeaders) => m)
 
     (peersClient ? req)
       .flatMap {
         case NoSuitablePeer if preferSnapPeers =>
-          // No SNAP peer available — try any peer as fallback
-          log.debug("No SNAP-capable peer for pivot header, falling back to BestPeer")
+          // No SNAP peer available — try any peer with the target block as fallback
+          log.debug("No SNAP-capable peer for pivot header, falling back to BestPeerWithMinBlock")
           val fallbackMsg =
             ETH66.GetBlockHeaders(ETH66.nextRequestId, Left(targetBlock), maxHeaders = 1, skip = 0, reverse = false)
-          val fallbackReq = Request[ETH66.GetBlockHeaders](fallbackMsg, BestPeer, (m: ETH66.GetBlockHeaders) => m)
+          val fallbackReq =
+            Request[ETH66.GetBlockHeaders](fallbackMsg, BestPeerWithMinBlock(targetBlock), (m: ETH66.GetBlockHeaders) => m)
           peersClient ? fallbackReq
         case other =>
           scala.concurrent.Future.successful(other)

--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH66.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH66.scala
@@ -49,12 +49,21 @@ object ETH66 {
 
       override def toRLPEncodable: RLPEncodeable = {
         import msg._
+        // Canonical-RLP integer encoding (Yellow Paper Appendix B): zero MUST be
+        // the empty byte string, not [0x00]. Geth/besu/nethermind reject the
+        // non-canonical [0x00] form for uint64/bool fields and silently drop the
+        // request, returning an empty BlockHeaders response. Root cause of #1201:
+        // skip=0 and reverse=false were both encoded as [0x00] by the implicit
+        // BigInt/Int RLP encoders. Bypass them here — bigIntToUnsignedByteArray
+        // produces empty bytes for zero (canonical form).
+        def num(b: BigInt): RLPValue = RLPValue(ByteUtils.bigIntToUnsignedByteArray(b))
+        val reverseFlag: RLPValue =
+          if (reverse) RLPValue(Array[Byte](1.toByte)) else RLPValue(Array.emptyByteArray)
         val blockQuery = block match {
-          case Left(blockNumber) => RLPList(blockNumber, maxHeaders, skip, if (reverse) 1 else 0)
-          case Right(blockHash)  => RLPList(RLPValue(blockHash.toArray[Byte]), maxHeaders, skip, if (reverse) 1 else 0)
+          case Left(blockNumber) => RLPList(num(blockNumber), num(maxHeaders), num(skip), reverseFlag)
+          case Right(blockHash)  => RLPList(RLPValue(blockHash.toArray[Byte]), num(maxHeaders), num(skip), reverseFlag)
         }
-        // Use bigIntToUnsignedByteArray to properly encode request-id (0 should be empty bytes per RLP spec)
-        RLPList(RLPValue(ByteUtils.bigIntToUnsignedByteArray(requestId)), blockQuery)
+        RLPList(num(requestId), blockQuery)
       }
     }
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -98,6 +98,28 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     PeersClient.bestPeer(onlyGenesis) shouldEqual None
   }
 
+  it should "filter peers by maxBlockNumber for absolute-block requests" taggedAs (UnitTest, SyncTest) in {
+    // Sepolia repro: PivotHeaderBootstrap asks for block 10789531. Among the
+    // peer pool, only peers whose advertised maxBlockNumber is at least the
+    // target should be selected. Peers reporting `latestBlock=9707885` (older
+    // ETH/69 peer behind chain head) literally don't have block 10789531 and
+    // would return an empty headers list — matching the failure in #1201.
+    val peerBehind = peer1.id -> PeerWithInfo(peer1, peerInfo(td = 9707885).copy(maxBlockNumber = 9707885))
+    val peerAhead = peer2.id -> PeerWithInfo(peer2, peerInfo(td = 100).copy(maxBlockNumber = 10789600))
+    val pool = Map(peerBehind, peerAhead)
+    PeersClient.bestPeerWithMinBlock(pool, BigInt(10789531)) shouldEqual Some(peer2)
+  }
+
+  it should "fall back to maxBlockNumber=0 peers when no peer is known to be ahead" taggedAs (UnitTest, SyncTest) in {
+    // ETH/64-68 peers post-merge have maxBlockNumber=0 (no STATUS field carries
+    // the block number, no incoming block messages to update). They MIGHT have
+    // the block; we just don't know. Better to try them than fail outright.
+    val peerUnknown = peer1.id -> PeerWithInfo(peer1, peerInfo(td = 17_000_000_000_000_000L.toInt).copy(maxBlockNumber = 0))
+    val peerBehind = peer2.id -> PeerWithInfo(peer2, peerInfo(td = 50).copy(maxBlockNumber = 100))
+    val pool = Map(peerUnknown, peerBehind)
+    PeersClient.bestPeerWithMinBlock(pool, BigInt(10789531)) shouldEqual Some(peer1)
+  }
+
   object Peers {
     implicit val system: ActorSystem = ActorSystem("PeersClient_System")
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -79,6 +79,25 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     }
   }
 
+  it should "exclude peers stuck at genesis even if their TD is higher" taggedAs (UnitTest, SyncTest) in {
+    // Sepolia/ETC reproducer: bootnode at genesis with the original POW TD (131072)
+    // and a real chain-head peer with a lower TD (e.g. ETH/69 block-number proxy).
+    // Pre-fix #1201: the legacy `bestPeer` selected the genesis peer because
+    // its TD was higher; PivotHeaderBootstrap then asked it for a chain-head
+    // header and got `no header returned`, retrying until exhausted.
+    val genesisOnly = peer1.id -> PeerWithInfo(peer1, peerInfoAtGenesis(td = 17_000_000_000_000_000L.toInt))
+    val chainHead = peer2.id -> PeerWithInfo(peer2, peerInfo(td = 100))
+    PeersClient.bestPeer(Map(genesisOnly, chainHead)) shouldEqual Some(peer2)
+  }
+
+  it should "return None when every available peer is at genesis" taggedAs (UnitTest, SyncTest) in {
+    val onlyGenesis = Map(
+      peer1.id -> PeerWithInfo(peer1, peerInfoAtGenesis(td = 50)),
+      peer2.id -> PeerWithInfo(peer2, peerInfoAtGenesis(td = 200))
+    )
+    PeersClient.bestPeer(onlyGenesis) shouldEqual None
+  }
+
   object Peers {
     implicit val system: ActorSystem = ActorSystem("PeersClient_System")
 
@@ -86,12 +105,17 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     val peer2: Peer = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), TestProbe().ref, false)
     val peer3: Peer = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), TestProbe().ref, false)
 
+    // Distinct bestHash and genesisHash so isAtGenesis returns false by default.
+    // Tests that need a genesis-only peer can override via `peerInfoAtGenesis`.
+    private val genesisHash = ByteString("genesis-hash")
+    private val chainHeadHash = ByteString("chain-head-hash")
+
     private val peerStatus = RemoteStatus(
       capability = Capability.ETH63,
       networkId = 1,
       chainWeight = ChainWeight.zero,
-      bestHash = ByteString.empty,
-      genesisHash = ByteString.empty
+      bestHash = chainHeadHash,
+      genesisHash = genesisHash
     )
 
     def peerInfo(td: Int, fork: Boolean = true): PeerInfo =
@@ -100,7 +124,18 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         ChainWeight(BigInt(td)),
         forkAccepted = fork,
         maxBlockNumber = 42,
-        bestBlockHash = ByteString.empty
+        bestBlockHash = chainHeadHash
+      )
+
+    /** A peer that has handshaked but is stuck at genesis — bestHash == genesisHash.
+      * Common on Sepolia where bootnodes are fresh-state and on ETC where some peers
+      * advertise SNAP/1 but never advance past genesis. They literally have no chain
+      * data to serve.
+      */
+    def peerInfoAtGenesis(td: Int): PeerInfo =
+      peerInfo(td).copy(
+        remoteStatus = peerStatus.copy(bestHash = genesisHash),
+        bestBlockHash = genesisHash
       )
   }
 }


### PR DESCRIPTION
## Summary

- **Closes #1201** — verified end-to-end on Barad-dûr fukuii-sepolia.

Three independent fixes landed across the bootstrap path. Each was
necessary; the third was sufficient.

## Step 1 — exclude genesis-only peers (commit \`72fdd34\`)

\`PeerInfo.isAtGenesis\` (\`bestHash == genesisHash\`) was defined since
at least #1015 but **never called**. Sepolia bootnodes sit at genesis with
\`TD=131072\`; \`bestPeer\` sorted by TD and picked them roughly half the
time, returning empty header lists.

- \`PeersClient.bestPeer\` (both overloads): skip \`peerInfo.isAtGenesis\`.
- \`PeersClientSpec\`: fixture update (was using \`ByteString.empty\` for
  both bestHash and genesisHash, accidentally marking every test peer as
  at-genesis) + 2 new tests.

## Step 2 — match peer chain head against requested block (commit \`4959446\`)

Even after step 1, an ETH/68 chain-head peer (TD = post-merge terminal
~17 quadrillion) wins TD-ranking, but its actual chain head is unknown
(\`maxBlockNumber=0\`; ETH/68 STATUS doesn't carry a block number).

- New \`PeerSelector\` \`BestPeerWithMinBlock(minBlock)\`. Two-tier:
  1. Peers with \`maxBlockNumber >= minBlock\` — preferred (typically
     ETH/69 reporting \`latestBlock\` in STATUS).
  2. Peers with \`maxBlockNumber == 0\` — fallback (chain state unknown).
- \`PivotHeaderBootstrap\` uses this selector for both the primary and
  SNAP-fallback request paths.

## Step 3 — canonical RLP encoding (commit \`d0dd821\`) ⭐

**The actual root cause.** Per Yellow Paper Appendix B, integer 0 MUST be
the empty byte string (0x80 on the wire). Fukuii's implicit BigInt/Int
RLP encoders emit \`[0x00]\` for the integer 0 — non-canonical form.

Geth/besu/nethermind RLP decoders are STRICT about canonical form for
uint64 and bool fields. \`skip=0\` and \`reverse=false\` in our
GetBlockHeaders request decoded as malformed — peers silently dropped
the request and responded with an empty BlockHeaders list.

\`ETH66.GetBlockHeaders\` encoder now bypasses the implicit codecs and
uses \`ByteUtils.bigIntToUnsignedByteArray\` directly for numeric fields
(produces empty bytes for zero). Reverse flag encoded as \`[0x01]\` for
true and an empty array for false.

## Tests

\`PeersClientSpec\` 5/5 green (was 1):

- existing TD-ranking test (with fixture update)
- "exclude peers stuck at genesis even if their TD is higher"
- "return None when every available peer is at genesis"
- "filter peers by maxBlockNumber for absolute-block requests"
- "fall back to maxBlockNumber=0 peers when no peer is known to be ahead"

## Verification (live, on Barad-dûr fukuii-sepolia)

Pre-fix:
\`\`\`
+6 empty-headers / 60s in Network summary
Pivot header bootstrap retry 10/10 for block 10789608 (no header returned)
PivotHeaderBootstrap exhaustion every ~60s, SNAP wedged.
\`\`\`

Post-fix:
\`\`\`
+0 empty-headers across 6 consecutive Network [60s] windows
Pivot header bootstrap complete for block 3879657 — notifying SNAP sync
Pivot header bootstrap complete for block 3882217 (requested 3882217)
SNAP rolling pivot forward as chain advances; bootstrap succeeds each time.
\`\`\`

## Out of scope

The non-canonical zero-encoding bug exists in the broader \`bigIntCodec\`
and \`intCodec\` implicits (rlp/RLPImplicits.scala lines 52, 67–69). Other
ETH messages with zero-valued numeric/bool fields likely have the same
issue but wear it less often — they may help explain past intermittent
peer rejection patterns on ETC and Mordor too. A broader fix to those
encoders is a follow-up; this PR is surgical to the path that's actively
blocking Sepolia sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)