### PR TITLE
fix(consensus): use header-only lookup post-PivotHeaderBootstrap — closes #1205

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/ConsensusAdapter.scala
@@ -41,18 +41,26 @@ class ConsensusAdapter(
 ) extends Logger {
   def evaluateBranchBlock(
       block: Block
-  )(implicit blockExecutionScheduler: IORuntime, blockchainConfig: BlockchainConfig): IO[BlockImportResult] =
-    blockchainReader.getBestBlock() match {
-      case Some(bestBlock) =>
-        if (isBlockADuplicate(block.header, bestBlock.header.number)) {
+  )(implicit blockExecutionScheduler: IORuntime, blockchainConfig: BlockchainConfig): IO[BlockImportResult] = {
+    // Resolve the best block's header without requiring its body. Prefer the
+    // full-block lookup (so the existing mock-based tests keep working) and fall
+    // back to header-only when the body isn't persisted — exactly the state right
+    // after PivotHeaderBootstrap completes. Without this fallback, post-bootstrap
+    // imports dead-end on `getBestBlock() == None` and the consumer retries
+    // forever with `BlockImportFailed("Couldn't find the current best block")`.
+    val bestHeaderOpt =
+      blockchainReader.getBestBlock().map(_.header).orElse(blockchainReader.getBestBlockHeader())
+    bestHeaderOpt match {
+      case Some(bestHeader) =>
+        if (isBlockADuplicate(block.header, bestHeader.number)) {
           log.debug("Ignoring duplicated block: {}", block.idTag)
           IO.pure(DuplicateBlock)
         } else {
           // If chain weight lookup fails, treat it as recoverable: log and continue.
-          if (blockchainReader.getChainWeightByHash(bestBlock.header.hash).isEmpty) {
+          if (blockchainReader.getChainWeightByHash(bestHeader.hash).isEmpty) {
             log.warn(
               "Total chain weight for current best block {} is missing — continuing import (test harness may not provide chain weight)",
-              bestBlock.header.hashAsHexString
+              bestHeader.hashAsHexString
             )
           }
 
@@ -61,7 +69,7 @@ class ConsensusAdapter(
           // doBlockPreValidation runs on a different thread pool (validationScheduler) which can
           // race with the storage write, causing intermittent HeaderParentNotFoundError.
           // The consensus.evaluateBranch will validate blocks during execution.
-          val validated = if (bestBlock.header.hash == block.header.parentHash) {
+          val validated = if (bestHeader.hash == block.header.parentHash) {
             IO.pure(Right(BlockExecutionSuccess): Either[ValidationBeforeExecError, BlockExecutionSuccess])
           } else {
             doBlockPreValidation(block)
@@ -70,15 +78,16 @@ class ConsensusAdapter(
             case Left(error) =>
               IO.pure(BlockImportFailed(error.reason.toString))
             case Right(BlockExecutionSuccess) =>
-              enqueueAndGetBranch(block, bestBlock.number)
+              enqueueAndGetBranch(block, bestHeader.number)
                 .map(forwardAndTranslateConsensusResult) // a new branch was created so we give it to consensus
                 .getOrElse(IO.pure(BlockEnqueued)) // the block was not rooted so it was simply enqueued
           }
         }
       case None =>
-        log.error("Couldn't find the current best block")
-        IO.pure(BlockImportFailed("Couldn't find the current best block"))
+        log.error("Couldn't find the current best block header")
+        IO.pure(BlockImportFailed("Couldn't find the current best block header"))
     }
+  }
 
   private def forwardAndTranslateConsensusResult(
       newBranch: NonEmptyList[Block]

--- a/src/main/scala/com/chipprbots/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/ConsensusImpl.scala
@@ -10,6 +10,7 @@ import scala.annotation.tailrec
 
 import com.chipprbots.ethereum.consensus.Consensus._
 import com.chipprbots.ethereum.domain.Block
+import com.chipprbots.ethereum.domain.BlockHeader
 import com.chipprbots.ethereum.domain.BlockchainImpl
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
@@ -52,18 +53,22 @@ class ConsensusImpl(
   override def evaluateBranch(
       branch: NonEmptyList[Block]
   )(implicit blockExecutionScheduler: IORuntime, blockchainConfig: BlockchainConfig): IO[ConsensusResult] =
-    blockchainReader.getBestBlock() match {
-      case Some(bestBlock) =>
-        blockchainReader.getChainWeightByHash(bestBlock.header.hash) match {
-          case Some(weight) => handleBranchImport(branch, bestBlock, weight)
-          case None         => returnNoTotalDifficulty(bestBlock)
+    // Try the full-block lookup first (existing mock-based tests rely on it),
+    // then fall back to header-only — that's the state right after PivotHeaderBootstrap
+    // completes. handleBranchImport only consumes header.hash and header.number,
+    // so a header is sufficient. Closes #1201's post-bootstrap follow-up.
+    blockchainReader.getBestBlock().map(_.header).orElse(blockchainReader.getBestBlockHeader()) match {
+      case Some(bestHeader) =>
+        blockchainReader.getChainWeightByHash(bestHeader.hash) match {
+          case Some(weight) => handleBranchImport(branch, bestHeader, weight)
+          case None         => returnNoTotalDifficultyForHeader(bestHeader)
         }
       case None => returnNoBestBlock()
     }
 
   private def handleBranchImport(
       branch: NonEmptyList[Block],
-      currentBestBlock: Block,
+      currentBestHeader: BlockHeader,
       currentBestBlockWeight: ChainWeight
   )(implicit
       blockExecutionScheduler: IORuntime,
@@ -71,11 +76,11 @@ class ConsensusImpl(
   ): IO[ConsensusResult] = {
 
     val consensusResult: IO[ConsensusResult] =
-      if (currentBestBlock.isParentOf(branch.head)) {
+      if (currentBestHeader.hash == branch.head.header.parentHash) {
         IO.delay(importToTop(branch, currentBestBlockWeight)).evalOn(blockExecutionScheduler.compute)
       } else {
         IO
-          .delay(importToNewBranch(branch, currentBestBlock.number, currentBestBlockWeight))
+          .delay(importToNewBranch(branch, currentBestHeader.number, currentBestBlockWeight))
           .evalOn(blockExecutionScheduler.compute)
       }
 
@@ -170,15 +175,18 @@ class ConsensusImpl(
   private def newBranchWeight(newBranch: NonEmptyList[Block], parentWeight: ChainWeight) =
     newBranch.foldLeft(parentWeight)((w, b) => w.increase(b.header))
 
-  private def returnNoTotalDifficulty(bestBlock: Block): IO[ConsensusError] = {
+  private def returnNoTotalDifficulty(bestBlock: Block): IO[ConsensusError] =
+    returnNoTotalDifficultyForHeader(bestBlock.header)
+
+  private def returnNoTotalDifficultyForHeader(bestHeader: BlockHeader): IO[ConsensusError] = {
     log.error(
       "Getting total difficulty for current best block with hash: {} failed",
-      bestBlock.header.hashAsHexString
+      bestHeader.hashAsHexString
     )
     IO.pure(
       ConsensusError(
         Nil,
-        s"Couldn't get total difficulty for current best block with hash: ${bestBlock.header.hashAsHexString}"
+        s"Couldn't get total difficulty for current best block with hash: ${bestHeader.hashAsHexString}"
       )
     )
   }

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -108,6 +108,19 @@ class BlockchainReader(
     bestBlock
   }
 
+  /** Returns the best-block header even when the body isn't stored locally. This is the
+    * common state right after PivotHeaderBootstrap completes for SNAP sync — only the
+    * pivot header is persisted (no body, no receipts) until the SNAP→regular handoff or
+    * post-SNAP block import populates them. Callers that only need the header (e.g.
+    * ConsensusAdapter for branch-resolution) should prefer this over `getBestBlock()`,
+    * which returns None in that state and forces them into a `BlockImportFailed`
+    * retry loop. Closes #1201's post-bootstrap follow-up.
+    */
+  def getBestBlockHeader(): Option[BlockHeader] = {
+    val bestKnownBlockinfo = appStateStorage.getBestBlockInfo()
+    getBlockHeaderByHash(bestKnownBlockinfo.hash)
+  }
+
   def genesisHeader: BlockHeader =
     getBlockHeaderByNumber(0).getOrElse(throw new IllegalStateException("Genesis header not found"))
 

--- a/src/test/scala/com/chipprbots/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -147,11 +147,15 @@ class ConsensusAdapterSpec
     val block: Block = getBlock(6, parent = bestBlock.header.hash)
 
     setBlockExists(block, inChain = false, inQueue = false)
+    // After the post-PivotHeaderBootstrap fix, evaluateBranchBlock falls back to
+    // getBestBlockHeader() when the full block isn't available. Both must report
+    // None for the "no best block" scenario.
     (blockchainReader.getBestBlock _).expects().returning(None)
+    (blockchainReader.getBestBlockHeader _).expects().returning(None)
     setChainWeightForBlock(bestBlock, currentWeight)
 
     whenReady(consensusAdapter.evaluateBranchBlock(block).unsafeToFuture())(
-      _ shouldBe BlockImportFailed("Couldn't find the current best block")
+      _ shouldBe BlockImportFailed("Couldn't find the current best block header")
     )
   }
 


### PR DESCRIPTION
## Summary

- Closes #1205

After PivotHeaderBootstrap completes (#1201 fix from #1204), only the
pivot block's header is persisted — body and receipts come later via SNAP
account download. \`BlockchainReader.getBestBlock()\` returns \`None\` in
that state because the body isn't in storage. \`ConsensusAdapter\` and
\`ConsensusImpl\` treated this as fatal:
\`BlockImportFailed("Couldn't find the current best block")\` in a tight
retry loop.

The branch evaluation only consumes \`header.number\`, \`header.hash\`, and
the chain-weight lookup — all of which are available without the body.

## Changes

- \`BlockchainReader.getBestBlockHeader()\`: new method that resolves best
  block info to a header by hash, without requiring the body.
- \`ConsensusAdapter.evaluateBranchBlock\`: try \`getBestBlock()\` first
  (preserves existing test behavior), fall back to \`getBestBlockHeader()\`
  when the full block isn't available.
- \`ConsensusImpl.evaluateBranch\`: same fallback. \`handleBranchImport\`
  now takes \`BlockHeader\` instead of \`Block\` (only header.hash and
  header.number were ever used).
- Refactor \`returnNoTotalDifficulty(Block)\` to delegate to
  \`returnNoTotalDifficultyForHeader(BlockHeader)\` for shared error
  formatting across both code paths.

## Tests

- ConsensusAdapterSpec: 16/16 green
- ConsensusImplSpec: 4/4 green
- Updated "should handle no best block available error when importing to top"
  to mock both \`getBestBlock\` and \`getBestBlockHeader\` returning None —
  that's the genuine "no best block" scenario at every level.

## Verification

Pre-fix:
\`\`\`
Pivot header bootstrap complete for block 3882217
Branch resolution at SNAP pivot floor (3882217), importing 37 blocks directly
ERROR ConsensusAdapter — Couldn't find the current best block
ERROR BlockImporter — Block 3882218 import failed: BlockImportFailed(Couldn't find the current best block)
[same error every retry]
\`\`\`

Post-fix:
\`\`\`
0 occurrences of "Couldn't find the current best block" in 11 minutes of runtime
\`\`\`

The branch-resolution dead-end is gone. Sync progress past the pivot now
depends on whether PivotHeaderBootstrap can repeatedly succeed against the
peer pool — a separate, residual issue tracked on #1201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)