### PR TITLE
fix(engine): isolate Engine API HTTP server on dedicated ActorSystem — closes #1209

### DIFF
--- a/src/main/resources/engine-api-system.conf
+++ b/src/main/resources/engine-api-system.conf
@@ -1,0 +1,57 @@
+# Engine API ActorSystem override (#1209).
+#
+# This file is loaded by `EngineApiHttpServer` to construct a *separate*
+# ActorSystem for the Engine API HTTP server, isolated from the main node's
+# `default-dispatcher` (which hosts every peer-handshake actor / RLPx framing /
+# ETH69_STATUS exchange / blacklisting). Without isolation, peer-flood at
+# bootstrap starves Pekko HTTP's TCP acceptor + parser actors and lighthouse's
+# `engine_forkchoiceUpdated` POSTs intermittently fail to reach the handler
+# within its ~8s client timeout.
+#
+# Pekko HTTP has no `pekko.http.server.dispatcher` config key — the canonical
+# isolation pattern is a separate ActorSystem (mirrors go-ethereum's `n.httpAuth`
+# and reth's `with_tokio_runtime()` for the auth RPC).
+#
+# Only `pekko.actor.default-dispatcher` and `pekko.http.server.*` are overridden
+# here. Logging, mailboxes, and everything else inherit from the main
+# `application.conf`/`pekko.conf` via the `withFallback(ConfigFactory.load())`
+# call in `EngineApiHttpServer`.
+
+pekko {
+  actor {
+    # The Engine API ActorSystem's default-dispatcher hosts Pekko HTTP's TCP
+    # acceptor, per-connection actors, request parser, and response writer.
+    # Sized to comfortably handle a single CL client's keep-alive connection +
+    # bursts during forkchoiceUpdated / newPayload pipelines.
+    default-dispatcher {
+      type = Dispatcher
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-min = 4
+        parallelism-factor = 1.0
+        parallelism-max = 8
+      }
+      throughput = 5
+    }
+  }
+
+  # Pekko HTTP server tuning aligned with go-ethereum's `rpc.DefaultHTTPTimeouts`
+  # (read/write 30s, idle 120s) and lighthouse's single-in-flight request pattern.
+  http.server {
+    # Lighthouse's HTTP client times out at ~8s, so 30s is generous server-side.
+    # Defaults to 20s — bump slightly to match geth.
+    request-timeout = 30s
+
+    # Lighthouse holds a keep-alive connection across ~12s upcheck cycles plus
+    # forkchoiceUpdated / newPayload. Default is 60s; geth uses 120s.
+    idle-timeout = 120s
+
+    # Lighthouse pipelines exchangeCapabilities + forkchoiceUpdated +
+    # getBlobsV1 on the same socket. Default `pipelining-limit = 1` serializes
+    # them; bumping prevents head-of-line blocking.
+    pipelining-limit = 16
+
+    # Cap concurrent connections. Lighthouse opens 1-2; this is a sanity bound.
+    max-connections = 32
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
@@ -2,12 +2,16 @@ package com.chipprbots.ethereum.consensus.engine
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.Route
+
+import com.typesafe.config.{Config => TypesafeConfig, ConfigFactory}
 
 import cats.effect.unsafe.IORuntime
 
@@ -21,20 +25,34 @@ import com.chipprbots.ethereum.utils.Logger
 
 /** Separate HTTP server for the Engine API on the authrpc port (default 8551). JWT-authenticated, accepts only engine_*
   * methods.
+  *
+  * Runs on a **dedicated `ActorSystem`** (see #1209). Pekko HTTP's server-side TCP acceptor, per-connection actor, and
+  * request parser all run on the system's `default-dispatcher`. If we share the main node's ActorSystem with this
+  * server, the same dispatcher hosts every peer-handshake actor (`PeerActor`, RLPx framing, ETH69_STATUS exchange,
+  * blacklisting). On Sepolia / mainnet bootstrap with 16+ simultaneous peer handshakes, the default-dispatcher
+  * mailboxes deepen and Lighthouse's `engine_forkchoiceUpdated` POSTs can't reach the handler within its ~8s client
+  * timeout — it intermittently stalls for minutes at a time.
+  *
+  * Pekko HTTP has no `pekko.http.server.dispatcher` config key, so this is the canonical isolation pattern (mirrors
+  * go-ethereum's `n.httpAuth` separate `httpServer` and reth's `with_tokio_runtime()` for the auth RPC).
   */
 class EngineApiHttpServer(
     controller: EngineApiController,
     jwtAuth: JwtAuthenticator,
     config: EngineApiHttpServer.Config
-)(implicit system: ActorSystem)
-    extends Logger {
+) extends Logger {
 
-  implicit val formats: Formats = DefaultFormats
-  // Engine API runs on its own dispatcher so a busy default-dispatcher
-  // (e.g. peer-manager flooded with cross-network dialers) can't stall
-  // forkchoiceUpdated / newPayload and push the CL into optimistic mode.
-  implicit val ec: ExecutionContext = system.dispatchers.lookup("engine-api-dispatcher")
-  implicit val ioRuntime: IORuntime = IORuntime.global
+  // Dedicated ActorSystem isolated from the main node's peer-management dispatchers.
+  // Loads `engine-api-system.conf` from the classpath which overrides only
+  // `pekko.actor.default-dispatcher` and `pekko.http.server.*` — every other Pekko
+  // setting (logging, mailboxes, etc.) is inherited from the main `application.conf`.
+  private val systemConfig: TypesafeConfig =
+    ConfigFactory.load("engine-api-system.conf").withFallback(ConfigFactory.load())
+  implicit private val system: ActorSystem = ActorSystem("engine-api", systemConfig)
+  implicit private val ec: ExecutionContext = system.dispatcher
+  implicit private val ioRuntime: IORuntime = IORuntime.global
+
+  implicit private val formats: Formats = DefaultFormats
 
   private var bindingOpt: Option[Http.ServerBinding] = None
 
@@ -84,9 +102,9 @@ class EngineApiHttpServer(
       }
     }
 
-  private def processRequest(json: JValue): Future[JsonRpcResponse] =
+  private def processRequest(json: JValue): Future[JsonRpcResponse] = {
+    val method = (json \ "method").extractOpt[String].getOrElse("unknown")
     try {
-      val method = (json \ "method").extractOpt[String].getOrElse("unknown")
       log.debug(s"Engine API request: method=$method")
       val request = JsonRpcRequest(
         jsonrpc = (json \ "jsonrpc").extractOpt[String].getOrElse("2.0"),
@@ -106,6 +124,7 @@ class EngineApiHttpServer(
         log.error(s"Engine API request decode error for method=$method: ${e.getMessage}", e)
         Future.successful(JsonRpcResponse("2.0", None, Some(JsonRpcError.InternalError), JNull))
     }
+  }
 
   private def responseToJson(resp: JsonRpcResponse): JValue = {
     var fields: List[(String, JValue)] = List("jsonrpc" -> JString(resp.jsonrpc))
@@ -124,20 +143,35 @@ class EngineApiHttpServer(
     val bindFuture = Http().newServerAt(config.interface, config.port).bind(route)
     bindFuture.foreach { binding =>
       bindingOpt = Some(binding)
-      log.info(s"Engine API server started on ${config.interface}:${config.port}")
+      log.info(
+        s"Engine API server started on ${config.interface}:${config.port} " +
+          s"(isolated ActorSystem '${system.name}', default-dispatcher='engine-api-dispatcher')"
+      )
     }
     bindFuture
   }
 
+  /** Unbinds the server and terminates the dedicated ActorSystem. Caller should `Await` if shutdown ordering matters
+    * (e.g. before the main node's ActorSystem terminates).
+    */
   def stop(): Future[Unit] =
     bindingOpt match {
       case Some(binding) =>
-        binding.unbind().map { _ =>
+        binding.unbind().flatMap { _ =>
           bindingOpt = None
-          log.info("Engine API server stopped")
+          log.info("Engine API server stopped — terminating isolated ActorSystem")
+          system.terminate().map(_ => ())
         }
       case None =>
-        Future.successful(())
+        // Server never started; still tear down the system to free resources.
+        system.terminate().map(_ => ())
+    }
+
+  /** Synchronous shutdown convenience for shutdown hooks that don't have an ec available. */
+  def stopSync(timeout: FiniteDuration = 10.seconds): Unit =
+    try Await.result(stop(), timeout)
+    catch {
+      case _: Exception => ()
     }
 }
 


### PR DESCRIPTION
## Summary

- Engine API HTTP server now runs on a **dedicated `ActorSystem`** isolated from the main node's peer-handshake / RLPx / ETH69_STATUS dispatcher work
- New `engine-api-system.conf` classpath resource overrides only `pekko.actor.default-dispatcher` (4-8 fork-join threads) and `pekko.http.server.*` (request-timeout=30s, idle-timeout=120s, pipelining-limit=16, max-connections=32); everything else inherits via `withFallback`
- `stop()` unbinds + terminates the engine ActorSystem; new `stopSync()` for shutdown hooks
- Latent NPE fix in `processRequest`'s catch block (`method` was inside the try scope; pulled out)

## Why

On Sepolia bootstrap, Lighthouse's `engine_forkchoiceUpdated` POSTs intermittently time out for minutes at a time. Pekko HTTP's server-side TCP acceptor + parser run on the main ActorSystem's `default-dispatcher`, which is also where every `PeerActor` / RLPx-framing / handshake actor lives. Under 16+ simultaneous peer handshakes, default-dispatcher mailboxes deepen and Lighthouse's ~8s upcheck timeout fires before its request reaches the handler. This blocks the end-to-end validation of #1207 (CL-driven SNAP pivot) — the EL stays `el_offline=true` from the CL's perspective and never receives the FCU it needs to drive SNAP pivot selection.

Pekko HTTP has no `pekko.http.server.dispatcher` config key. A separate ActorSystem is the canonical isolation pattern; mirrors go-ethereum's `n.httpAuth` separate `httpServer` and reth's `with_tokio_runtime()` for the auth RPC.

## Test plan

- [x] 64 engine + SNAP unit tests pass
- [x] `sbt scalafmtAll` clean
- [x] Build succeeds (assembly 0.5.0)
- [ ] Live Sepolia: deploy on Barad-dûr fukuii-sepolia paired with Lighthouse — expect:
  - Continuous successful `exchangeCapabilities` heartbeats every ~12s without minute-long gaps
  - `el_offline=false` from `/eth/v1/node/syncing`
  - First `engine_forkchoiceUpdated` reaches handler
  - `🛰  SNAP pivot from CL forkchoiceUpdated` log line (#1207 path) fires
  - SNAP account download begins
- [ ] ETC mainnet: no behavior change (Engine API not enabled; engine system never constructed)

## Related

- closes #1209
- unblocks #1207 / #1208 end-to-end Sepolia validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)