### PR TITLE
fix(ci): forkid Long.MaxValue filter + hive TTD gate

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -79,7 +79,17 @@ FLAGS="$FLAGS -Dfukuii.blockchains.hive.istanbul-block-number=$ISTANBUL"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.muir-glacier-block-number=$MUIRGLACIER"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.berlin-block-number=$BERLIN"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.olympia-block-number=$LONDON"
-FLAGS="$FLAGS -Dfukuii.blockchains.hive.terminal-total-difficulty=$TTD"
+
+# Terminal total difficulty: only set when the hive sim explicitly provides one.
+# fukuii's SNAPSyncController treats `terminal-total-difficulty.isDefined` as
+# "post-merge chain" and then waits for engine_forkchoiceUpdated from the CL
+# before picking a SNAP pivot (engine-api-required = true is the sync.conf
+# default — see #1208). Pre-merge hive sims (including ethereum/sync) have no
+# CL, so passing the $MAX sentinel here would wedge the sink at head=0 for the
+# full 60s simulator budget and fail every fukuii-tagged sync sub-test.
+if [ "$TTD" != "$MAX" ]; then
+    FLAGS="$FLAGS -Dfukuii.blockchains.hive.terminal-total-difficulty=$TTD"
+fi
 
 # Timestamp-based forks
 [ -n "$SHANGHAI_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.shanghai-timestamp=$SHANGHAI_TS"

--- a/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
+++ b/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
@@ -47,6 +47,16 @@ object ForkId {
 
   val noFork: BigInt = BigInt("1000000000000000000")
 
+  // Two sentinels mark "fork not activated":
+  //   * 10^18  — the value used in *.chain.conf (`val noFork`)
+  //   * Long.MaxValue — the in-code fallback when the conf key is missing
+  //     (BlockchainConfig.fromRawConfig and ForkBlockNumbers.Empty)
+  // Both must be filtered out of the EIP-2124 fork-id checksum chain.
+  // See ForkBlockNumbers.mergeNetsplitBlockNumber: only sepolia-chain.conf
+  // sets `merge-netsplit-block-number`, so all other chains hit the
+  // Long.MaxValue branch and previously polluted gatherBlockForks.
+  private val maxBlockSentinel: BigInt = BigInt(Long.MaxValue)
+
   def gatherForks(config: BlockchainConfig): List[BigInt] =
     (gatherBlockForks(config) ++ gatherTimestampForks(config)).distinct.sorted
 
@@ -56,7 +66,7 @@ object ForkId {
       else None
     }
     (maybeDaoBlock.toList ++ config.forkBlockNumbers.all)
-      .filterNot(v => v == 0 || v == noFork)
+      .filterNot(v => v == 0 || v == noFork || v == maxBlockSentinel)
       .distinct
       .sorted
   }


### PR DESCRIPTION
## Summary

Two CI fixes for `staging`:

- **`8118efb` fix(forkid): filter Long.MaxValue defaults from gatherBlockForks** — `mergeNetsplitBlockNumber` defaults to `BigInt(Long.MaxValue)` when the conf key is missing. Only `sepolia-chain.conf` defines it, so every other chain's gatherBlockForks list was polluted with a spurious `Long.MaxValue` entry. Resolves `ForkIdSpec` ETC assertions and the forkId-mismatch class of hive sync handshake rejections.

- **`369fa30` fix(hive): only set terminal-total-difficulty when sim provides one** — the hive adapter unconditionally passed `-Dfukuii.blockchains.hive.terminal-total-difficulty=$TTD` even when `$TTD == $MAX` (the script's "no merge" sentinel). #1208's `isPostMergeChain = terminalTotalDifficulty.isDefined` then incorrectly classified pre-merge hive sims as post-merge and wedged SNAP on the CL-wait gate. Mirrors the existing engine-api `$TTD != $MAX` gate.

## Verified on CI

- `Test and Build (JDK 25, Scala 3.3.7)` — green (was red on `ForkIdSpec`)
- Hive · sync — `sync fukuii from fukuii` recovered to passing.

## Remaining (not addressed here)

Four pre-existing cross-client failures in `run / sync` survive both fixes — `sync go-ethereum from fukuii`, `sync nethermind from fukuii` (60s timeouts, fukuii as source) and `sync fukuii from go-ethereum`, `sync fukuii from nethermind` (~140 ms instant container exits, fukuii as sink). These existed on `staging` before this PR and need separate diagnosis from the per-client logs in the `hive-logs-sync` artifact.

## Note

Originally opened as #1212 → `staging` (merged). This PR is the same branch; rebased base from `main` → `staging` so the diff collapses to just the two fix commits.

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze