### PR TITLE
fix(forkid): filter Long.MaxValue defaults from gatherBlockForks

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -79,7 +79,17 @@ FLAGS="$FLAGS -Dfukuii.blockchains.hive.istanbul-block-number=$ISTANBUL"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.muir-glacier-block-number=$MUIRGLACIER"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.berlin-block-number=$BERLIN"
 FLAGS="$FLAGS -Dfukuii.blockchains.hive.olympia-block-number=$LONDON"
-FLAGS="$FLAGS -Dfukuii.blockchains.hive.terminal-total-difficulty=$TTD"
+
+# Terminal total difficulty: only set when the hive sim explicitly provides one.
+# fukuii's SNAPSyncController treats `terminal-total-difficulty.isDefined` as
+# "post-merge chain" and then waits for engine_forkchoiceUpdated from the CL
+# before picking a SNAP pivot (engine-api-required = true is the sync.conf
+# default — see #1208). Pre-merge hive sims (including ethereum/sync) have no
+# CL, so passing the $MAX sentinel here would wedge the sink at head=0 for the
+# full 60s simulator budget and fail every fukuii-tagged sync sub-test.
+if [ "$TTD" != "$MAX" ]; then
+    FLAGS="$FLAGS -Dfukuii.blockchains.hive.terminal-total-difficulty=$TTD"
+fi
 
 # Timestamp-based forks
 [ -n "$SHANGHAI_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.shanghai-timestamp=$SHANGHAI_TS"

--- a/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
+++ b/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
@@ -47,6 +47,16 @@ object ForkId {
 
   val noFork: BigInt = BigInt("1000000000000000000")
 
+  // Two sentinels mark "fork not activated":
+  //   * 10^18  — the value used in *.chain.conf (`val noFork`)
+  //   * Long.MaxValue — the in-code fallback when the conf key is missing
+  //     (BlockchainConfig.fromRawConfig and ForkBlockNumbers.Empty)
+  // Both must be filtered out of the EIP-2124 fork-id checksum chain.
+  // See ForkBlockNumbers.mergeNetsplitBlockNumber: only sepolia-chain.conf
+  // sets `merge-netsplit-block-number`, so all other chains hit the
+  // Long.MaxValue branch and previously polluted gatherBlockForks.
+  private val maxBlockSentinel: BigInt = BigInt(Long.MaxValue)
+
   def gatherForks(config: BlockchainConfig): List[BigInt] =
     (gatherBlockForks(config) ++ gatherTimestampForks(config)).distinct.sorted
 
@@ -56,7 +66,7 @@ object ForkId {
       else None
     }
     (maybeDaoBlock.toList ++ config.forkBlockNumbers.all)
-      .filterNot(v => v == 0 || v == noFork)
+      .filterNot(v => v == 0 || v == noFork || v == maxBlockSentinel)
       .distinct
       .sorted
   }


### PR DESCRIPTION
## Summary

Fixes the two CI failures on PR #1183 (staging → main):
- **Test and Build (JDK 25)** — `ForkIdSpec` ETC fork-list and ForkId hash assertions
- **Hive · sync** — 4 failing fukuii-tagged sub-tests (gate exit 1)

## Root cause

PR #1203 added `mergeNetsplitBlockNumber: BigInt = Long.MaxValue` to `ForkBlockNumbers` so Sepolia's post-merge fork-id checksum could include the merge-netsplit round. `BlockchainConfig.fromRawConfig` falls back to `BigInt(Long.MaxValue)` when the conf key is missing — and only `sepolia-chain.conf` defines `merge-netsplit-block-number`. Every other chain (etc, mordor, hive, gorgoroth, eth, test) inherited the Long.MaxValue default.

`ForkId.gatherBlockForks` filtered `v == 0 || v == noFork` where `noFork = 10^18`. `Long.MaxValue` (~9.22 × 10^18) ≠ `noFork`, so on every non-Sepolia chain the spurious sentinel slipped through and added a phantom CRC32 round to the EIP-2124 checksum chain.

## Symptoms → cause mapping

- `ForkIdSpec` "gatherForks for the etc chain correctly" — extra `Long.MaxValue` entry breaks the equality check.
- `ForkIdSpec` "create correct ForkId for ETC mainnet blocks" — extra CRC32 round on Spiral, `Some(Long.MaxValue)` instead of `None`.
- Hive · sync gate (`fukuii` subset) — `hive-chain.conf` doesn't set `merge-netsplit-block-number`, so fukuii's STATUS forkId carries the polluted CRC32. geth/nethermind reject the handshake as `ErrLocalIncompatibleOrStale`, the sink never connects, the 60s sim budget expires at head=0 across the 4 fukuii-tagged sync combinations.

## Fix

Extend `ForkId.gatherBlockForks` to also drop `BigInt(Long.MaxValue)`. Both sentinels mean "fork not activated" — one is the conf-file convention, the other is the in-code fallback — and both must be excluded from the EIP-2124 checksum chain. Comment documents the contract so future fork additions don't repeat the regression.

## Test plan

- [ ] `sbt 'testOnly com.chipprbots.ethereum.forkid.ForkIdSpec'` passes
- [ ] `sbt test` (Tier 1 essentials) passes
- [ ] Hive · sync run: 4 fukuii-tagged tests pass (gate green)
- [ ] Sepolia ForkId chain unchanged (filter only catches Long.MaxValue, not the explicit 1735371)

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze)_