### PR TITLE
fix(hive,forkid): unwedge cross-client sync sims at single-peer scale

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -97,6 +97,25 @@ fi
 [ -n "$PRAGUE_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.prague-timestamp=$PRAGUE_TS"
 [ -n "$OSAKA_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.osaka-timestamp=$OSAKA_TS"
 
+# Sync configuration: hive provides exactly one peer per sink test
+# (HIVE_BOOTNODE → static-nodes.json below). Fukuii's production defaults
+# (sync.conf) target multi-peer networks: SNAP requires a snap-capable peer
+# and fast-sync needs `min-peers-to-choose-pivot-block + margin = 6` voters
+# to elect a pivot. Both wedge under hive's single-peer constraint:
+#   * Suite 1 (`ethereum/sync`) runs geth / nethermind without their SNAP
+#     servers enabled, so fukuii sees zero snap peers, sits in SNAP's
+#     bootstrap-retry loop (5-min default), and the 60s sim budget elapses
+#     before any fall-back kicks in.
+#   * Even after fallback, fast-sync's PivotBlockSelector won't reach quorum
+#     with one voter.
+# Disable SNAP and shrink fast-sync's quorum to 1 peer here. Production
+# settings remain unchanged for non-hive runs.
+FLAGS="$FLAGS -Dfukuii.sync.do-snap-sync=false"
+FLAGS="$FLAGS -Dfukuii.sync.do-fast-sync=true"
+FLAGS="$FLAGS -Dfukuii.sync.min-peers-to-choose-pivot-block=1"
+FLAGS="$FLAGS -Dfukuii.sync.peers-to-choose-pivot-block-margin=0"
+FLAGS="$FLAGS -Dfukuii.sync.peers-to-fetch-from=1"
+
 # RPC
 FLAGS="$FLAGS -Dfukuii.network.rpc.http.enabled=true"
 FLAGS="$FLAGS -Dfukuii.network.rpc.http.interface=0.0.0.0"

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -36,11 +36,11 @@ case class EthNodeStatus64ExchangeState(
 
     val localBestBlock = blockchainReader.getBestBlockNumber()
     val localGenesisHash = blockchainReader.genesisHeader.hash
-    // Use current system time if best block is genesis (timestamp 0) — this happens at startup
-    // before Engine API imports any blocks. Without this, ForkID incorrectly reports pre-Shanghai
-    // and all post-merge peers reject us.
-    val storedTimestamp = blockchainReader.getBlockHeaderByNumber(localBestBlock).map(_.unixTimestamp).getOrElse(0L)
-    val localBestTimestamp = if (storedTimestamp == 0L) System.currentTimeMillis() / 1000 else storedTimestamp
+    // ForkId reflects local chain state at the head block (head number + head
+    // timestamp), per EIP-2124/EIP-6122 and go-ethereum's reference. No
+    // wall-clock substitution — see `createStatusMsg` below for the hive-sync
+    // interop bug that caused.
+    val localBestTimestamp = blockchainReader.getBlockHeaderByNumber(localBestBlock).map(_.unixTimestamp).getOrElse(0L)
     val localForkId = ForkId.create(localGenesisHash, blockchainConfig)(localBestBlock, localBestTimestamp)
 
     log.info(
@@ -121,10 +121,14 @@ case class EthNodeStatus64ExchangeState(
     //
     // To align with core-geth: Use actual bestBlockNumber for ForkId calculation.
     val forkIdBlockNumber = bestBlockNumber
-    // Use system time when at genesis to correctly advertise post-merge fork status
-    val forkIdTimestamp =
-      if (bestBlockHeader.unixTimestamp == 0L) System.currentTimeMillis() / 1000 else bestBlockHeader.unixTimestamp
-    val forkId = ForkId.create(genesisHash, blockchainConfig)(forkIdBlockNumber, forkIdTimestamp)
+    // Pass the block's timestamp directly. Per EIP-2124/EIP-6122 the wire
+    // forkId must mirror the local chain state at the head block; geth's
+    // `forkid.NewID(config, genesis, head, time)` does no wall-clock substitution.
+    // A node at genesis with `unixTimestamp == 0` correctly advertises
+    // `ForkId(genesisCRC, Some(firstFork))` — checkSubset/checkSuperset on the
+    // peer side reach Connect. See EthNodeStatus69ExchangeState for the
+    // hive-sync interop bug the previous wall-clock fallback caused.
+    val forkId = ForkId.create(genesisHash, blockchainConfig)(forkIdBlockNumber, bestBlockHeader.unixTimestamp)
 
     val status = ETH64.Status(
       protocolVersion = negotiatedCapability.version,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -111,10 +111,20 @@ case class EthNodeStatus69ExchangeState(
     val bestBlockNumber = blockchainReader.getBestBlockNumber()
     val genesisHash = blockchainReader.genesisHeader.hash
 
-    // Compute ForkId from current block (same as ETH64-68)
-    val forkIdTimestamp =
-      if (bestBlockHeader.unixTimestamp == 0L) System.currentTimeMillis() / 1000 else bestBlockHeader.unixTimestamp
-    val forkId = ForkId.create(genesisHash, blockchainConfig)(bestBlockNumber, forkIdTimestamp)
+    // Compute ForkId from current block. Per EIP-2124/EIP-6122 the wire forkId
+    // must reflect the local chain state at the head block (head number + head
+    // timestamp). go-ethereum's `forkid.NewID(config, genesis, head, time)` uses
+    // the block's timestamp directly with no wall-clock fallback (eth/protocols/
+    // eth/handler.go). A node at genesis with `unixTimestamp == 0` correctly
+    // advertises `ForkId(genesisCRC, Some(firstFork))` — peers reach Connect
+    // through EIP-2124's checkSubset/checkSuperset rules. Substituting wall-clock
+    // here causes fukuii to advertise a forkId chain its actual chain has not
+    // yet crossed, breaking interop with peers (geth, nethermind) whose own
+    // chain state lags the wall clock — the symptom on hive sync sims where
+    // `sync fukuii from go-ethereum` and `sync fukuii from nethermind` time
+    // out at 60s while `sync fukuii from fukuii` succeeds (both sides share
+    // the wall-clock skew so they happen to agree).
+    val forkId = ForkId.create(genesisHash, blockchainConfig)(bestBlockNumber, bestBlockHeader.unixTimestamp)
 
     // ETH/69: no TD, use block range instead
     val status = ETH69.Status(


### PR DESCRIPTION
## Summary

Addresses the four pre-existing fukuii-tagged failures in hive's `ethereum/sync` simulator (suite 1, `sync`):

- `sync go-ethereum from fukuii` — 60s timeout
- `sync nethermind from fukuii` — 60s timeout
- `sync fukuii from go-ethereum` — 60s timeout (was instant crash before #1211/#1212)
- `sync fukuii from nethermind` — 60s timeout (was instant crash before #1211/#1212)

`sync fukuii from fukuii` already passes in ~50s, so the sync stack itself is functional — what breaks is the cross-client / single-peer combination.

## Two changes

**1. `hive/fukuii/fukuii.sh` — pin sync to single-peer-friendly settings.** `sync.conf` production defaults assume multi-peer networks: SNAP needs a snap-capable peer, fast-sync's `PivotBlockSelector` needs `min-peers + margin = 6` voters to elect a pivot. Hive provides exactly one peer per sink test (`HIVE_BOOTNODE` → `static-nodes.json`). Suite 1 runs geth / nethermind without their SNAP servers enabled — so fukuii sees zero snap peers, sits in SNAP's 5-min `bootstrapRetryTimeout` loop, and the sim's 60s budget elapses before any fall-back fires. Even when fall-back would fire, fast-sync's quorum can't be reached with one voter. Override `do-snap-sync=false`, `min-peers-to-choose-pivot-block=1`, `peers-to-choose-pivot-block-margin=0`, `peers-to-fetch-from=1` in hive only. Production `sync.conf` is untouched.

**2. `EthNodeStatus64ExchangeState` / `EthNodeStatus69ExchangeState` — drop the `System.currentTimeMillis() / 1000` fallback for `forkIdTimestamp`.** The wire forkId must mirror local chain state at the head block per EIP-2124 / EIP-6122, and go-ethereum's `forkid.NewID(config, genesis, head, time)` takes the block's timestamp directly with no wall-clock substitution. A node at genesis with `unixTimestamp == 0` correctly advertises `ForkId(genesisCRC, Some(firstFork))` and reaches Connect through `checkSubset`/`checkSuperset` on the peer side. Substituting wall-clock made fukuii claim to be at a fork its actual chain hadn't yet crossed — fine when both sides shared the wall-clock skew (`sync fukuii from fukuii`), broken against peers (geth, nethermind) whose chain state lags wall-clock.

Reference clients: go-ethereum `eth/protocols/eth/handler.go` calls `forkid.NewID(chainConfig, genesisHash, headNumber, headTime)` with no fallback; besu and reth do likewise.

## Test plan

- [ ] Hive · sync run: 4 fukuii-tagged tests pass (gate green)
- [ ] `Test and Build (JDK 25, Scala 3.3.7)` still passes (no test relies on the wall-clock fallback)
- [ ] `sync fukuii from fukuii` still passes (defaults swap to fast-sync but with min-peers=1 it should complete in similar wall time)
- [ ] Mordor / ETC mainnet sync unaffected — production `sync.conf` untouched, and the forkId fallback was only mattering on chains with timestamp-based forks (ETC has none)

## Note

Continuation of the work in #1211 / #1212. Those fixes resolved unit-test breakage and the post-merge TTD wedge; this PR addresses the cross-client interop residue.

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze)_