### PR TITLE
Revert #1213 — caused hive-sync regressions on tests 8, 12, 16

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -97,25 +97,6 @@ fi
 [ -n "$PRAGUE_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.prague-timestamp=$PRAGUE_TS"
 [ -n "$OSAKA_TS" ] && FLAGS="$FLAGS -Dfukuii.blockchains.hive.osaka-timestamp=$OSAKA_TS"
 
-# Sync configuration: hive provides exactly one peer per sink test
-# (HIVE_BOOTNODE → static-nodes.json below). Fukuii's production defaults
-# (sync.conf) target multi-peer networks: SNAP requires a snap-capable peer
-# and fast-sync needs `min-peers-to-choose-pivot-block + margin = 6` voters
-# to elect a pivot. Both wedge under hive's single-peer constraint:
-#   * Suite 1 (`ethereum/sync`) runs geth / nethermind without their SNAP
-#     servers enabled, so fukuii sees zero snap peers, sits in SNAP's
-#     bootstrap-retry loop (5-min default), and the 60s sim budget elapses
-#     before any fall-back kicks in.
-#   * Even after fallback, fast-sync's PivotBlockSelector won't reach quorum
-#     with one voter.
-# Disable SNAP and shrink fast-sync's quorum to 1 peer here. Production
-# settings remain unchanged for non-hive runs.
-FLAGS="$FLAGS -Dfukuii.sync.do-snap-sync=false"
-FLAGS="$FLAGS -Dfukuii.sync.do-fast-sync=true"
-FLAGS="$FLAGS -Dfukuii.sync.min-peers-to-choose-pivot-block=1"
-FLAGS="$FLAGS -Dfukuii.sync.peers-to-choose-pivot-block-margin=0"
-FLAGS="$FLAGS -Dfukuii.sync.peers-to-fetch-from=1"
-
 # RPC
 FLAGS="$FLAGS -Dfukuii.network.rpc.http.enabled=true"
 FLAGS="$FLAGS -Dfukuii.network.rpc.http.interface=0.0.0.0"

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -36,11 +36,11 @@ case class EthNodeStatus64ExchangeState(
 
     val localBestBlock = blockchainReader.getBestBlockNumber()
     val localGenesisHash = blockchainReader.genesisHeader.hash
-    // ForkId reflects local chain state at the head block (head number + head
-    // timestamp), per EIP-2124/EIP-6122 and go-ethereum's reference. No
-    // wall-clock substitution — see `createStatusMsg` below for the hive-sync
-    // interop bug that caused.
-    val localBestTimestamp = blockchainReader.getBlockHeaderByNumber(localBestBlock).map(_.unixTimestamp).getOrElse(0L)
+    // Use current system time if best block is genesis (timestamp 0) — this happens at startup
+    // before Engine API imports any blocks. Without this, ForkID incorrectly reports pre-Shanghai
+    // and all post-merge peers reject us.
+    val storedTimestamp = blockchainReader.getBlockHeaderByNumber(localBestBlock).map(_.unixTimestamp).getOrElse(0L)
+    val localBestTimestamp = if (storedTimestamp == 0L) System.currentTimeMillis() / 1000 else storedTimestamp
     val localForkId = ForkId.create(localGenesisHash, blockchainConfig)(localBestBlock, localBestTimestamp)
 
     log.info(
@@ -121,14 +121,10 @@ case class EthNodeStatus64ExchangeState(
     //
     // To align with core-geth: Use actual bestBlockNumber for ForkId calculation.
     val forkIdBlockNumber = bestBlockNumber
-    // Pass the block's timestamp directly. Per EIP-2124/EIP-6122 the wire
-    // forkId must mirror the local chain state at the head block; geth's
-    // `forkid.NewID(config, genesis, head, time)` does no wall-clock substitution.
-    // A node at genesis with `unixTimestamp == 0` correctly advertises
-    // `ForkId(genesisCRC, Some(firstFork))` — checkSubset/checkSuperset on the
-    // peer side reach Connect. See EthNodeStatus69ExchangeState for the
-    // hive-sync interop bug the previous wall-clock fallback caused.
-    val forkId = ForkId.create(genesisHash, blockchainConfig)(forkIdBlockNumber, bestBlockHeader.unixTimestamp)
+    // Use system time when at genesis to correctly advertise post-merge fork status
+    val forkIdTimestamp =
+      if (bestBlockHeader.unixTimestamp == 0L) System.currentTimeMillis() / 1000 else bestBlockHeader.unixTimestamp
+    val forkId = ForkId.create(genesisHash, blockchainConfig)(forkIdBlockNumber, forkIdTimestamp)
 
     val status = ETH64.Status(
       protocolVersion = negotiatedCapability.version,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -111,20 +111,10 @@ case class EthNodeStatus69ExchangeState(
     val bestBlockNumber = blockchainReader.getBestBlockNumber()
     val genesisHash = blockchainReader.genesisHeader.hash
 
-    // Compute ForkId from current block. Per EIP-2124/EIP-6122 the wire forkId
-    // must reflect the local chain state at the head block (head number + head
-    // timestamp). go-ethereum's `forkid.NewID(config, genesis, head, time)` uses
-    // the block's timestamp directly with no wall-clock fallback (eth/protocols/
-    // eth/handler.go). A node at genesis with `unixTimestamp == 0` correctly
-    // advertises `ForkId(genesisCRC, Some(firstFork))` — peers reach Connect
-    // through EIP-2124's checkSubset/checkSuperset rules. Substituting wall-clock
-    // here causes fukuii to advertise a forkId chain its actual chain has not
-    // yet crossed, breaking interop with peers (geth, nethermind) whose own
-    // chain state lags the wall clock — the symptom on hive sync sims where
-    // `sync fukuii from go-ethereum` and `sync fukuii from nethermind` time
-    // out at 60s while `sync fukuii from fukuii` succeeds (both sides share
-    // the wall-clock skew so they happen to agree).
-    val forkId = ForkId.create(genesisHash, blockchainConfig)(bestBlockNumber, bestBlockHeader.unixTimestamp)
+    // Compute ForkId from current block (same as ETH64-68)
+    val forkIdTimestamp =
+      if (bestBlockHeader.unixTimestamp == 0L) System.currentTimeMillis() / 1000 else bestBlockHeader.unixTimestamp
+    val forkId = ForkId.create(genesisHash, blockchainConfig)(bestBlockNumber, forkIdTimestamp)
 
     // ETH/69: no TD, use block range instead
     val status = ETH69.Status(


### PR DESCRIPTION
Reverts #1213.

## What went wrong

PR #1213 caused two regressions in the hive `ethereum/sync` simulator relative to the post-#1212 baseline:

| Test | fukuii role | Pre-#1213 | Post-#1213 | Δ |
|---|---|---|---|---|
| 8  | sink ↔ fukuii src | **49.8s ✓** | 60s timeout | **regression** |
| 9  | source → geth sink | 60s timeout | 60s timeout | — |
| 10 | source → nethermind sink | 60s timeout | 60s timeout | — |
| 12 | sink ← geth src | 60s timeout | **~141ms instant exit** | **regression** |
| 16 | sink ← nethermind src | 61s timeout | **~131ms instant exit** | **regression** |

Net: failing fukuii-tagged tests went from **4 → 5**. The previously-passing `sync fukuii from fukuii` broke, and the two cases where fukuii is the sink against a non-fukuii source went back to the instant-exit failure mode that #1211/#1212 had originally cleared.

## Root cause of the regressions

**Test 8 broke because `do-snap-sync=false` doesn't actually skip SNAP.** `SyncController.scala:227` (`case FastSync.FallbackToSnapSync`) unconditionally calls `startSnapSync()` whenever fast-sync detects an ETH/68/69 peer with no GetNodeData support. So the override caused fast-sync ↔ SNAP bouncing, and the 60s sim budget elapsed before either path settled. fukuii↔fukuii had been working in 50s by going to SNAP directly without that bounce.

**Tests 12, 16 instant exits are less certain without per-client docker logs**, but the timing matches the pre-#1212 failure class — most likely the forkId timestamp-fallback removal interacting badly with non-fukuii peer handshake behaviour.

## Action

Reverting restores the post-#1212 baseline (4 failing fukuii-tagged tests, test 8 green) so we can iterate on a smaller, lower-risk fix without breaking what was working. See the body of the revert commit for the full rationale.

## Lessons for the next attempt

1. **Don't pair changes.** Land the hive script change and the forkId change separately so we can isolate which one moves the needle.
2. **`do-snap-sync=false` alone won't disable SNAP** — `FallbackToSnapSync` reaches it. Fixing the cross-client cases needs either a guard on the fallback path, or a path that gives up on SNAP/fast-sync after a short retry budget instead of after 5 minutes.
3. **The forkId wall-clock fallback may still be wrong but isn't the right thing to remove without testing** — the path it interacts with on non-fukuii peers (and the resulting instant exits) needs the per-client logs from `hive-logs-sync` to diagnose properly.

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze)_