### PR TITLE
fix(hive): enable SNAP in hive.conf for post-merge sync sim CL path

### DIFF
--- a/src/main/resources/conf/hive.conf
+++ b/src/main/resources/conf/hive.conf
@@ -6,8 +6,20 @@ fukuii {
   }
 
   sync {
-    do-fast-sync = false
-    do-snap-sync = false
+    # SNAP enabled so the post-merge hive `ethereum/sync` simulator (suite 1)
+    # routes via the CL-driven SNAP pivot path added in #1208: the sim's CL
+    # pushes engine_forkchoiceUpdated(head=block_3000), ForkChoiceManager
+    # publishes BeaconHead, SyncController forwards as CLPivotHint, and
+    # SNAPSyncController picks the CL head as pivot. With SNAP off, fukuii
+    # falls back to pre-merge regular-sync (forward GetBlockHeaders from
+    # block 1) which post-merge geth / nethermind sources don't serve, so
+    # they disconnect after handshake — the symptom captured in the
+    # `sync nethermind from fukuii` per-client logs (handshake OK, then
+    # peer count drops to 0 within 10s, "Waiting for peers… 60s").
+    # do-fast-sync stays true because ConfigValidator requires it whenever
+    # do-snap-sync is true (SNAP can fall back to fast).
+    do-fast-sync = true
+    do-snap-sync = true
   }
 
   # Archive pruning for chain import — reference count pruning requires


### PR DESCRIPTION
## Summary

Single boolean flip in `src/main/resources/conf/hive.conf`: `do-snap-sync = true` and `do-fast-sync = true` (was both `false`).

This routes fukuii through the **CL-driven SNAP pivot path** that #1208 already added, so the post-merge `ethereum/sync` simulator can drive sync via Engine API the way geth and nethermind expect.

## Evidence

The hive `ethereum/sync` suite 1 chain ships with `terminalTotalDifficulty: 131072, mergeNetsplitBlock: 0, shanghaiTime: 0, cancunTime: 0` — fully post-merge from genesis. The simulator's CL pushes `engine_forkchoiceUpdated(head=block_3000)` to both source and sink and expects them to sync via the post-merge protocol.

Per-client log triangulation from the latest staging run:

| Log | Client | Bootnode points to | Outcome |
|---|---|---|---|
| `15f364aa` | geth sink | geth source | **PASS** — `Syncing beacon headers downloaded=512 left=2487 eta=102.054ms`, head=3000 in 3s |
| `02da17b2` | nethermind sink | geth source | **PASS** — `Processed 0…1 \| 44.4 ms` 1s after handshake, then bulk import |
| `243cf31b` | nethermind sink | **fukuii source** | **FAIL** — `PEER_HANDSHAKE_SUCCESS` then within 10s `Peers: 0 \| with best block: 0`, `Waiting for peers… 10s … 60s` |

And the corresponding fukuii source log shows `PEER_HANDSHAKE_SUCCESS … cap=ETH69 supportsSnap=true forkAccepted=true` for the nethermind peer at 13:30:40.880, then no further peer activity, then `Network [60s]: active=0 peers` at 13:31:19.697 — peer dropped fukuii within the 10–40s window.

## Root cause

`hive.conf` was setting `do-snap-sync=false / do-fast-sync=false`, so `SyncController.start()` matched the `(_, false, false, false)` arm and called `startRegularSync()`. Regular sync issues forward `GetBlockHeaders{block: 1, maxHeaders: 1024, reverse: false}` — a pre-merge sync pattern. Post-merge geth and nethermind don't serve that pattern as a sync server (they expect the sink to walk backward from the head hash, the way the `Syncing beacon headers` line in the geth-success log shows). After handshake fukuii is silent on the wire requests its peers actually make, peers disconnect it as useless, sim's 60s budget elapses.

`sync fukuii from fukuii` survived only because both sides ran the same non-responsive regular-sync code, so neither dropped the other as "useless" — but neither made progress either; the test passed in 50s only because fukuii↔fukuii happens to land on a code path that imports the sim's newPayload chain via Engine API directly.

## Why this fix works

With `do-snap-sync=true`, the match arm becomes `(false, _, true, _)` → `startSnapSync()`. `SyncController.preStart()` registers as `ForkChoiceManager` listener (gated on `isPostMergeChain && forkChoiceManagerOpt.isDefined`, both true here). When the sim sends `forkchoiceUpdated`, `ForkChoiceManager.publishBeaconHead` fires, `SyncController.handleBeaconHead` forwards as `CLPivotHint`, and `SNAPSyncController.startSnapSync()` picks the CL head as pivot. The whole post-merge sync flow #1208 designed runs as intended.

`do-fast-sync=true` is set too because `ConfigValidator` rejects `do-snap-sync=true` without `do-fast-sync=true` (SNAP needs a fast-sync fall-back path).

## Surgical scope

- **One file changed**: `src/main/resources/conf/hive.conf`
- **Two booleans flipped** plus an explanatory comment block
- **No source-code changes**
- **No `fukuii.sh` changes**
- **Production `sync.conf` untouched** (already had defaults true)

If this fixes the hive sync gate, we're done. If only some of the 4 fukuii-tagged tests succeed, the failure mode will narrow to the specific case and we can iterate from a known-good baseline.

## Test plan

- [ ] Hive · sync run — 4 fukuii-tagged tests on staging baseline pass
- [ ] `sync fukuii from fukuii` (test 8) still passes
- [ ] `Test and Build (JDK 25, Scala 3.3.7)` still green (no test relies on hive.conf having sync disabled)
- [ ] Mordor / ETC mainnet unaffected — only `hive.conf` changed, ETC uses `etc-chain.conf` + base sync.conf

## Note

This continues the work in #1211 / #1212 (forkid + TTD plumbing) and #1214 (revert of the bad PR #1213 attempt). The previous revert restored test 8 to passing; this PR addresses the remaining 4 failures with the lesson learned: **enable** the post-merge SNAP path that already exists, don't try to bypass it.

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze)_