### PR TITLE
Revert #1215 — exposes a SNAPSyncController peer-tracking race, not the right hive fix

### DIFF
--- a/src/main/resources/conf/hive.conf
+++ b/src/main/resources/conf/hive.conf
@@ -6,20 +6,8 @@ fukuii {
   }
 
   sync {
-    # SNAP enabled so the post-merge hive `ethereum/sync` simulator (suite 1)
-    # routes via the CL-driven SNAP pivot path added in #1208: the sim's CL
-    # pushes engine_forkchoiceUpdated(head=block_3000), ForkChoiceManager
-    # publishes BeaconHead, SyncController forwards as CLPivotHint, and
-    # SNAPSyncController picks the CL head as pivot. With SNAP off, fukuii
-    # falls back to pre-merge regular-sync (forward GetBlockHeaders from
-    # block 1) which post-merge geth / nethermind sources don't serve, so
-    # they disconnect after handshake — the symptom captured in the
-    # `sync nethermind from fukuii` per-client logs (handshake OK, then
-    # peer count drops to 0 within 10s, "Waiting for peers… 60s").
-    # do-fast-sync stays true because ConfigValidator requires it whenever
-    # do-snap-sync is true (SNAP can fall back to fast).
-    do-fast-sync = true
-    do-snap-sync = true
+    do-fast-sync = false
+    do-snap-sync = false
   }
 
   # Archive pruning for chain import — reference count pruning requires


### PR DESCRIPTION
Reverts #1215.

## Why

PR #1215 (one-line `hive.conf` flip enabling `do-snap-sync=true`/`do-fast-sync=true`) successfully routed fukuii through #1208's CL-driven SNAP pivot path. The CL plumbing fires correctly — confirmed in the per-client log:

```
20:11:48,807  [CL-PIVOT] Post-merge chain (TTD configured), waiting for fcu
20:11:49,005  Fork choice updated: head=d4a8090b...
20:11:51,817  PEER_HANDSHAKE_SUCCESS ... cap=ETH69 supportsSnap=true forkAccepted=true
20:11:53,830  🛰  SNAP pivot from CL forkchoiceUpdated
20:11:53,831  CL head: 3000, State root: a0767d6024b34a71...
```

But `startAccountRangeSync` then logs:

```
20:11:53,836  WARN No peers with snap/1 capability found (Map().size peers connected)
```

i.e. `SNAPSyncController.peersToDownloadFrom` is **empty** 2 seconds after the peer's handshake completed with `supportsSnap=true` and `forkAccepted=true`. After the 30 s grace period, SNAP falls back to fast sync — by which time the peer has actually disconnected (`Network [60s]: active=0 peers`). All four fukuii-tagged sync sub-tests fail again, and worse than before — `sync fukuii from fukuii` (test 8) regresses too because both fukuii instances hit the same SNAP-path bug.

## Root cause is real but not in hive.conf

Pekko message-ordering race between `NetworkPeerManagerActor`'s peer-registration path and `SNAPSyncController.peersToDownloadFromMap` population. With hive.conf's pre-#1215 defaults (`do-snap-sync=false`/`do-fast-sync=false`), this code path was **never exercised in hive** — flipping the flags exposed a pre-existing fukuii bug, not a hive-config bug. A proper fix needs a deterministic reproducer plus test coverage, not another guess on staging.

## What this restores

The post-#1212 / post-#1214 baseline:
- `sync fukuii from fukuii` passes
- 4 fukuii-tagged cross-client tests fail at 60 s timeout (same as before this PR series)
- `Test and Build` (JDK 25) green

## Side note

`SNAPSyncController.scala:2109` has a Scala s-string interpolation bug — `s"... ($peersToDownloadFrom.size peers connected)"` does not call `.size`. The literal `Map()` in the log is the empty-map `toString`. Worth fixing when the peer-tracking issue is properly addressed (separate cosmetic ticket).

## Recommendation for next attempt

Don't make further changes to enable the post-merge path until the `peersToDownloadFromMap` race is understood — likely needs:
1. Logback bump for `BlockchainHostActor` and `SNAPSyncController.actors` to INFO during a single targeted hive run, to capture the exact ordering of `PeerHandshakeSuccessful` → SNAPSyncController peer registration → `startAccountRangeSync`.
2. A unit test in `SNAPSyncControllerSpec` that posts a `PeerHandshakeSuccessful` with `supportsSnap=true` immediately followed by a `CLPivotHint`, asserting `peersToDownloadFrom` is non-empty when `startAccountRangeSync` runs.

https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5moSy7j9ShxAWSSDJUqze)_