### PR TITLE
fix(p2p+snap): P2P lifecycle alignment + SNAP sync stability (Fixes A, B1/B2, B4, G, H, K + PRIO-6/7/8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ SCRATCH.md
 
 # Local working directory (session notes, reference reports, attempt logs)
 local/
+.local/
 
 # Secrets & credentials
 .env

--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -174,8 +174,8 @@ sync {
   # Delay between finishing fast sync and starting regular sync
   sync-switch-delay = 0.5 seconds
   # Response time-out from peer during sync. If a peer fails to respond within this limit, it will be blacklisted
-  # Increased from 30s to 45s to be more tolerant of network latency and peer load
-  peer-response-timeout = 45.seconds
+  # Increased from 45s to 60s to match SNAPRequestTracker TtlLimitMs and give Besu warm-up room
+  peer-response-timeout = 60.seconds
   # Interval for logging syncing status info
   print-status-interval = 30.seconds
   # How often to dump fast-sync status to disk. If the client is restarted, fast-sync will continue from this point

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerListSupportNg.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerListSupportNg.scala
@@ -8,6 +8,8 @@ import org.apache.pekko.actor.Scheduler
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+import org.bouncycastle.util.encoders.Hex
+
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
 import com.chipprbots.ethereum.network.Peer
@@ -72,17 +74,27 @@ trait PeerListSupportNg { self: Actor with ActorLogging =>
       .sortBy(_.peerInfo.maxBlockNumber)(bigIntReverseOrdering)
       .headOption
 
+  // Overridden in PeersClient to exempt maintained peers (Besu alignment: PeerDenylistManager skips maintained peers).
+  protected def maintainedNodeIdHexes: Set[String] = Set.empty
+
   def blacklistIfHandshaked(peerId: PeerId, duration: FiniteDuration, reason: BlacklistReason): Unit =
     handshakedPeers.get(peerId) match {
       case Some(peerWithInfo) =>
-        log.debug(
-          "Blacklisting peer {} ({}) for {} ms. Reason: {}",
-          peerId,
-          peerWithInfo.peer.remoteAddress,
-          duration.toMillis,
-          reason
-        )
-        blacklist.add(peerId, duration, reason)
+        val isMaintained = peerWithInfo.peer.nodeId.exists { nodeId =>
+          maintainedNodeIdHexes.contains(Hex.toHexString(nodeId.toArray))
+        }
+        if (isMaintained) {
+          log.debug("Skipping blacklist for maintained peer {} (reason: {})", peerId, reason)
+        } else {
+          log.debug(
+            "Blacklisting peer {} ({}) for {} ms. Reason: {}",
+            peerId,
+            peerWithInfo.peer.remoteAddress,
+            duration.toMillis,
+            reason
+          )
+          blacklist.add(peerId, duration, reason)
+        }
       case None =>
         log.debug("Attempted to blacklist non-handshaked peer {}", peerId)
     }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
@@ -13,7 +13,10 @@ import scala.reflect.ClassTag
 
 import com.chipprbots.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import com.chipprbots.ethereum.blockchain.sync.PeerListSupportNg.PeerWithInfo
+import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.MaintainedPeersChanged
 import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
+import com.chipprbots.ethereum.network.PeerEventBusActor.Subscribe
+import com.chipprbots.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MaintainedPeersClassifier
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.PeerId
@@ -55,6 +58,12 @@ class PeersClient(
 
   implicit val ec: ExecutionContext = context.dispatcher
 
+  // Besu alignment: PeerDenylistManager.java:56 skips maintained peers at add() call site.
+  // Subscribe at startup so updates are received before any BlacklistPeer message can arrive.
+  peerEventBus ! Subscribe(MaintainedPeersClassifier)
+  private var _maintainedNodeIdHexes: Set[String] = Set.empty
+  override protected def maintainedNodeIdHexes: Set[String] = _maintainedNodeIdHexes
+
   // Tracks GetNodeData capability per peer via observed behavior (not advertised capability).
   // Shared across all StateNodeFetcher actors so the first failure protects all concurrent requests.
   private val nodeDataCooldownUntilMs = mutable.Map.empty[PeerId, Long]
@@ -80,6 +89,9 @@ class PeersClient(
 
   def running(requesters: Requesters): Receive =
     handlePeerListMessages.orElse {
+      case MaintainedPeersChanged(nodeIds) =>
+        _maintainedNodeIdHexes = nodeIds
+        log.debug("Updated maintained peer node IDs: {} peers", nodeIds.size)
       case PrintStatus                   => printStatus(requesters: Requesters)
       case BlacklistPeer(peerId, reason) => blacklistIfHandshaked(peerId, syncConfig.blacklistDuration, reason)
       case RecordNodeDataFailure(peerId) =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -117,19 +117,6 @@ class AccountRangeCoordinator(
           s"GetAccountRange this session. Bytecode/healing remain available."
       )
       true
-    } else if (reason.contains("Request timeout")) {
-      // Peer timed out — track consecutive timeouts.
-      // On ETC mainnet, peers silently stop responding when the snap serve window expires
-      // rather than returning explicit empty responses. After N consecutive timeouts,
-      // we treat the peer as stateless so pivot refresh can trigger.
-      val count = peerConsecutiveTimeouts.getOrElse(peer.id.value, 0) + 1
-      peerConsecutiveTimeouts.update(peer.id.value, count)
-      if (count >= consecutiveTimeoutThreshold) {
-        log.info(s"Peer ${peer.id.value} hit $count consecutive timeouts — treating as stateless")
-        true
-      } else {
-        false
-      }
     } else {
       false
     }
@@ -406,12 +393,6 @@ class AccountRangeCoordinator(
     )
   }
 
-  // Track consecutive timeouts per peer. When a peer hits the threshold, it's marked stateless.
-  // This handles the case where ETC mainnet peers silently stop responding (timeout) when
-  // their snap serve window expires, rather than returning empty responses with proofs.
-  private val peerConsecutiveTimeouts = mutable.Map[String, Int]()
-  private val consecutiveTimeoutThreshold = 3 // Mark stateless after 3 consecutive timeouts
-
   // Peer cooldown (best-effort): used for transient errors (timeouts, verification failures).
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
   private val peerCooldownDefault = 30.seconds
@@ -564,7 +545,6 @@ class AccountRangeCoordinator(
       // Clear per-peer adaptive state (new root = new response characteristics)
       peerResponseBytesTarget.clear()
       peerCooldownUntilMs.clear()
-      peerConsecutiveTimeouts.clear()
       // Note: do NOT reset consecutiveUnproductiveRefreshes here.
       // Only reset when we receive real account data (proof the new root is servable).
 
@@ -612,12 +592,10 @@ class AccountRangeCoordinator(
       if (newLimit > 0) tryRedispatchPendingTasks()
 
     case PeerUnavailable(peerId) =>
-      // Peer disconnected — remove from available set, reset its timeout counter so network-level
-      // disconnects don't accumulate toward the stateless threshold.
+      // Peer disconnected — remove from available set and re-queue in-flight tasks.
       // go-ethereum eth/protocols/snap/sync.go:1621 (revertRequests) and Besu
       // AbstractRetryingPeerTask.java:158 both treat disconnect as transient re-queue, not failure.
       knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
-      peerConsecutiveTimeouts.remove(peerId)
       peerCooldownUntilMs.remove(peerId)
       // #1184: drain the slots ourselves rather than relying on the worker → TaskFailed
       // cascade. drainActiveTasks sends WorkerRequestCancelled to each affected worker so they
@@ -884,9 +862,6 @@ class AccountRangeCoordinator(
           // Adjust adaptive byte budget — estimate received bytes from account count
           val estimatedBytes = BigInt(accountCount * 100) // ~100 bytes per account (hash + RLP)
           adjustResponseBytesOnSuccess(peer, responseBytesTargetFor(peer), estimatedBytes)
-
-          // Reset consecutive timeout counter — peer is responsive
-          peerConsecutiveTimeouts.remove(peer.id.value)
 
           // Reset pivot refresh backoff on servable-root evidence: real account data or a boundary proof.
           if (accountCount > 0 || proof.nonEmpty) {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -1120,6 +1120,9 @@ class AccountRangeCoordinator(
         } else {
           // Need more requests for the same interval; re-queue with updated `next`.
           pendingTasks.enqueue(task)
+          // Persist partial range position so a crash mid-range resumes from here,
+          // not the beginning of the range (go-ethereum saveSyncStatus() parity).
+          sendProgressSnapshot()
         }
 
         // Threshold-based flush: only flush to RocksDB when accumulated nodes exceed threshold.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -78,12 +78,6 @@ class StorageRangeCoordinator(
     mutable.Map[BigInt, (Peer, Seq[StorageTask], BigInt)]() // requestId -> (peer, tasks, requestedBytes)
   private val completedTasks = mutable.ArrayBuffer[StorageTask]()
 
-  // Track consecutive timeouts per peer. When a peer hits the threshold, it's marked stateless.
-  // This handles the case where ETC mainnet peers silently stop responding (timeout) when
-  // their snap serve window expires, rather than returning empty responses with proofs.
-  private val peerConsecutiveTimeouts = mutable.Map[String, Int]()
-  private val consecutiveTimeoutThreshold = 3 // Mark stateless after 3 consecutive timeouts
-
   // Global consecutive task failure counter: triggers ForceCompleteStorage when all SNAP peers
   // stop serving storage data. Resets to zero on any successful slot download.
   private var consecutiveTaskFailures: Int = 0
@@ -670,7 +664,6 @@ class StorageRangeCoordinator(
       // tasks so other peers can pick them up without waiting for the 30s request timeout.
       // Mirrors AccountRangeCoordinator.PeerUnavailable (go-ethereum revertRequests pattern).
       knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
-      peerConsecutiveTimeouts.remove(peerId)
       peerCooldownUntilMs.remove(peerId)
       val inFlight = activeTasks.filter { case (_, (peer, _, _)) => peer.id.value == peerId }.keys.toSeq
       if (inFlight.nonEmpty) {
@@ -797,7 +790,6 @@ class StorageRangeCoordinator(
       pivotRefreshRequested = false
       lastDispatchOrResponseMs = System.currentTimeMillis()
       peerCooldownUntilMs.clear()
-      peerConsecutiveTimeouts.clear()
       peerBatchSize.clear()
       peerBatchSuccessStreak.clear()
       peerResponseBytesTarget.clear()
@@ -1050,7 +1042,6 @@ class StorageRangeCoordinator(
             s"Account storage empty/changed at current pivot — healing will validate."
         )
         // Peer is healthy — clear any penalty state it accumulated.
-        peerConsecutiveTimeouts.remove(peer.id.value)
         statelessPeers.remove(peer.id.value)
         lastDispatchOrResponseMs = System.currentTimeMillis()
         consecutiveUnproductiveRefreshes = 0
@@ -1111,7 +1102,6 @@ class StorageRangeCoordinator(
 
     // Non-empty response with actual slot data — clear stateless marking and reset backoff.
     statelessPeers.remove(peer.id.value)
-    peerConsecutiveTimeouts.remove(peer.id.value)
     consecutiveUnproductiveRefreshes = 0
     lastDispatchOrResponseMs = System.currentTimeMillis()
 
@@ -1245,15 +1235,6 @@ class StorageRangeCoordinator(
       log.warning(s"Storage range request timeout for ${batchTasks.size} accounts from peer ${peer.id.value}")
       recordPeerCooldown(peer, "request timeout")
       adjustResponseBytesOnFailure(peer, "request timeout")
-
-      // Track consecutive timeouts — on ETC mainnet, peers silently stop responding when
-      // the snap serve window expires. After N consecutive timeouts, treat as stateless.
-      val count = peerConsecutiveTimeouts.getOrElse(peer.id.value, 0) + 1
-      peerConsecutiveTimeouts.update(peer.id.value, count)
-      if (count >= consecutiveTimeoutThreshold) {
-        log.info(s"Peer ${peer.id.value} hit $count consecutive storage timeouts — treating as stateless")
-        markPeerStateless(peer)
-      }
 
       batchTasks.foreach { task =>
         task.pending = false

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -118,6 +118,10 @@ class TrieNodeHealingCoordinator(
   private val ThrottleUpFillRatio = 0.8
   private val RateMeasurementImpact = 0.005 // geometric EMA weight per node
 
+  // Crash-recovery DFS: emit frontier in batches so healing starts before traversal completes.
+  // go-ethereum trie.Sync.Missing() alignment — bounded working set rather than full upfront BFS.
+  private val FrontierBatchSize = 1000
+
   // Track last known available peers for re-dispatch after failures
   private val knownAvailablePeers = mutable.Set[Peer]()
 
@@ -254,7 +258,8 @@ class TrieNodeHealingCoordinator(
         // Recovery cost: O(healed_nodes × local_read) vs O(healed_nodes × network_rtt).
         log.info(
           s"[HEAL-RESTART] Root ${Hex.toHexString(root.take(8).toArray)} already in local storage " +
-            s"— rebuilding frontier via local BFS (crash recovery, go-ethereum trie.Sync.Missing() pattern)"
+            s"— rebuilding frontier via local DFS in batches of $FrontierBatchSize " +
+            s"(crash recovery, go-ethereum trie.Sync.Missing() depth-first pattern)"
         )
         val selfRef = self
         val ec = healingWriterEc
@@ -262,9 +267,10 @@ class TrieNodeHealingCoordinator(
         Future {
           val frontier = mutable.Buffer.empty[HealingEntry]
           val visited = mutable.Set.empty[ByteString]
-          rebuildFrontierBFS(root, Seq(emptyPath), isStor = false, frontier, visited)
-          frontier.toSeq
-        }(ec).foreach(entries => selfRef ! FrontierRebuilt(entries))(ec)
+          rebuildFrontierDFS(root, Seq(emptyPath), isStor = false, frontier, visited,
+            batch => selfRef ! FrontierRebuilt(batch))
+          if (frontier.nonEmpty) selfRef ! FrontierRebuilt(frontier.toSeq)
+        }(ec)
       } else {
         // ARCH-ROOT-SEED: Fresh start — seed root and let inline discovery populate the queue.
         log.info(
@@ -838,52 +844,61 @@ class TrieNodeHealingCoordinator(
 
   /** Rebuild the healing frontier from locally-stored trie nodes after a crash/restart.
     *
-    * Iterative BFS (avoids stack overflow at trie depth 64). Mirrors go-ethereum's
-    * trie.Sync.Missing() pattern: traverse the locally-stored subtree from the pivot root,
-    * discover children of healed nodes via local reads, and collect missing children as the
-    * frontier. Runs on healingWriterEc (off the actor dispatcher) so the mailbox stays live.
+    * Iterative DFS (depth-first via ArrayDeque stack). Mirrors go-ethereum trie.Sync's
+    * depth-prioritized queue: drilling deep finds frontier nodes immediately, keeping the
+    * working stack O(depth × branching_factor) ≈ O(1024) rather than the O(frontier_width)
+    * growth that a BFS queue exhibits on ETC mainnet. Runs on healingWriterEc.
     *
     * For each node hash:
-    *   - in local storage  → already healed; decode children and enqueue them
-    *   - not in storage    → missing; add to frontier (pendingTasks on completion)
+    *   - in local storage  → already healed; push children onto the DFS stack
+    *   - not in storage    → missing; buffer and emit via onBatch every FrontierBatchSize entries
+    *
+    * onBatch is called inline whenever the buffer reaches FrontierBatchSize. The caller is
+    * responsible for emitting any remaining buffered entries after this method returns.
     */
-  private def rebuildFrontierBFS(
+  private def rebuildFrontierDFS(
       startHash: ByteString,
       startPathset: Seq[ByteString],
       isStor: Boolean,
       frontier: mutable.Buffer[HealingEntry],
-      visited: mutable.Set[ByteString]
+      visited: mutable.Set[ByteString],
+      onBatch: Seq[HealingEntry] => Unit
   ): Unit = {
     import com.chipprbots.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode}
     import com.chipprbots.ethereum.mpt.HexPrefix
     import com.chipprbots.ethereum.domain.Account
     import scala.util.control.NonFatal
 
-    val queue = mutable.Queue[(ByteString, Seq[ByteString], Boolean)]()
-    queue.enqueue((startHash, startPathset, isStor))
+    // DFS stack — bounded to O(depth × branching_factor) ≈ 1024 entries vs BFS O(frontier_width).
+    val stack = mutable.ArrayDeque[(ByteString, Seq[ByteString], Boolean)]()
+    stack.append((startHash, startPathset, isStor))
     var visitedCount = 0
     var frontierCount = 0
 
-    while (queue.nonEmpty) {
-      val (hash, pathset, isStorageTrie) = queue.dequeue()
+    while (stack.nonEmpty) {
+      val (hash, pathset, isStorageTrie) = stack.removeLast()
       if (!visited.contains(hash)) {
         visited += hash
         visitedCount += 1
         if (visitedCount % 10000 == 0)
           log.info(
-            s"[HEAL-RESTART-BFS] Progress: $visitedCount nodes visited, $frontierCount frontier nodes found, " +
-              s"queue depth ${queue.size}"
+            s"[HEAL-RESTART-DFS] Progress: $visitedCount nodes visited, $frontierCount frontier nodes found, " +
+              s"stack depth ${stack.size}"
           )
 
         val nodeOpt = try Some(mptStorage.get(hash.toArray)) catch { case _: Exception => None }
         nodeOpt match {
           case None =>
-            // Not in storage — missing node, add to healing frontier
+            // Not in storage — missing node, buffer for healing
             frontier += HealingEntry(pathset, hash)
             frontierCount += 1
+            if (frontier.size >= FrontierBatchSize) {
+              onBatch(frontier.toSeq)
+              frontier.clear()
+            }
 
           case Some(node) =>
-            // Already healed — traverse children to extend the BFS
+            // Already healed — push children onto the DFS stack
             val compact = pathset.last.toArray
             val nibbles = HexPrefix.decode(compact)._1
             try {
@@ -898,7 +913,7 @@ class TrieNodeHealingCoordinator(
                           val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
                           val childPathset =
                             if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
-                          queue.enqueue((childHash, childPathset, isStorageTrie))
+                          stack.append((childHash, childPathset, isStorageTrie))
                         }
                       case _ => // inline-encoded child — already resolved
                     }
@@ -912,7 +927,7 @@ class TrieNodeHealingCoordinator(
                         val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
                         val childPathset =
                           if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
-                        queue.enqueue((childHash, childPathset, isStorageTrie))
+                        stack.append((childHash, childPathset, isStorageTrie))
                       }
                     case _ =>
                   }
@@ -932,7 +947,7 @@ class TrieNodeHealingCoordinator(
                         val accountHash = ByteString(accountHashBytes)
                         val emptyStoragePath =
                           ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-                        queue.enqueue((account.storageRoot, Seq(accountHash, emptyStoragePath), true))
+                        stack.append((account.storageRoot, Seq(accountHash, emptyStoragePath), true))
                       }
                     }
                   }
@@ -942,7 +957,7 @@ class TrieNodeHealingCoordinator(
             } catch {
               case NonFatal(e) =>
                 log.debug(
-                  s"[HEAL-RESTART-BFS] Cannot traverse stored node ${Hex.toHexString(hash.take(4).toArray)}: " +
+                  s"[HEAL-RESTART-DFS] Cannot traverse stored node ${Hex.toHexString(hash.take(4).toArray)}: " +
                     s"${e.getMessage} — skipping"
                 )
             }
@@ -951,7 +966,7 @@ class TrieNodeHealingCoordinator(
     }
 
     log.info(
-      s"[HEAL-RESTART-BFS] Complete: $visitedCount nodes traversed, $frontierCount missing nodes in frontier"
+      s"[HEAL-RESTART-DFS] Complete: $visitedCount nodes traversed, $frontierCount missing nodes identified"
     )
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -42,10 +42,9 @@ class TrieNodeHealingCoordinator(
   // Task management — each task has a pathset (for GetTrieNodes) and a hash (for verification).
   // ArrayDeque (circular buffer) gives O(1) amortized head/tail operations (#1167). The previous
   // immutable `Seq` did O(n) on every `:+` and head-drop — quadratic at healing scale.
-  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString, retries: Int = 0)
+  private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString)
   private val pendingTasks: mutable.ArrayDeque[HealingEntry] = mutable.ArrayDeque.empty
   private var completedTaskCount: Int = 0
-  private var abandonedTaskCount: Int = 0
 
   /** Dedicated dispatcher for the batched raw-node RocksDB flush. Tests inject their own EC; production looks up
     * `healing-writer-dispatcher` from the actor system. Keeps the blocking write off `sync-dispatcher` so other sync
@@ -53,10 +52,6 @@ class TrieNodeHealingCoordinator(
     */
   private val healingWriterEc: ExecutionContext =
     healingWriterEcOverride.getOrElse(context.system.dispatchers.lookup("healing-writer-dispatcher"))
-
-  // Per-task retry limit: after this many timeouts/failures, skip the task.
-  // At ~6s per timeout cycle, 20 retries = ~2 minutes of trying per node.
-  private val maxRetriesPerTask: Int = 20
 
   // Global stagnation detection: if no nodes healed for this duration, declare
   // healing complete with a warning. Prevents infinite loops when all peers lack
@@ -203,6 +198,9 @@ class TrieNodeHealingCoordinator(
   // Internal message for async flush completion
   private case class FlushComplete(count: Int)
 
+  // Internal message for async frontier rebuild completion (crash-recovery BFS)
+  private case class FrontierRebuilt(entries: Seq[HealingEntry])
+
   /** Synchronous flush — used only for final completion flush (small buffer, safe to block). */
   private def flushRawNodesSync(): Unit =
     if (rawNodeBuffer.nonEmpty) {
@@ -248,18 +246,45 @@ class TrieNodeHealingCoordinator(
 
   override def receive: Receive = {
     case StartTrieNodeHealing(root) =>
-      log.info(s"Starting trie node healing for state root ${Hex.toHexString(root.take(8).toArray)}")
-      // ARCH-ROOT-SEED: Seed immediately with root node (Besu-style top-down discovery).
-      // Prior: waited 3+ hours for walk results. Now: healing starts instantly.
-      // When root is healed, discoverMissingChildren() discovers all children inline.
-      // Walk becomes validation-only — its results remain additive (dedup prevents duplicates).
       val emptyPath = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
-      queueNodes(Seq((Seq(emptyPath), root)))
+      if (isNodeInStorage(root)) {
+        // ARCH-HEAL-RESTART: Root already healed — crash/restart mid-healing detected.
+        // Rebuild the frontier by traversing locally-stored trie nodes instead of re-requesting
+        // known nodes from the network (go-ethereum trie.Sync.Missing() analogue).
+        // Recovery cost: O(healed_nodes × local_read) vs O(healed_nodes × network_rtt).
+        log.info(
+          s"[HEAL-RESTART] Root ${Hex.toHexString(root.take(8).toArray)} already in local storage " +
+            s"— rebuilding frontier via local BFS (crash recovery, go-ethereum trie.Sync.Missing() pattern)"
+        )
+        val selfRef = self
+        val ec = healingWriterEc
+        import scala.concurrent.Future
+        Future {
+          val frontier = mutable.Buffer.empty[HealingEntry]
+          val visited = mutable.Set.empty[ByteString]
+          rebuildFrontierBFS(root, Seq(emptyPath), isStor = false, frontier, visited)
+          frontier.toSeq
+        }(ec).foreach(entries => selfRef ! FrontierRebuilt(entries))(ec)
+      } else {
+        // ARCH-ROOT-SEED: Fresh start — seed root and let inline discovery populate the queue.
+        log.info(
+          s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} not yet in storage " +
+            s"— seeding root for inline child discovery (Besu-aligned top-down)"
+        )
+        queueNodes(Seq((Seq(emptyPath), root)))
+        lastHealedAtMs = System.currentTimeMillis()
+      }
+
+    case FrontierRebuilt(entries) =>
       log.info(
-        s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} seeded — " +
-          s"inline child discovery will populate work queue top-down (Besu-aligned)"
+        s"[HEAL-RESTART] Frontier rebuild complete: ${entries.size} missing nodes identified " +
+          s"— resuming healing from crash-recovery frontier"
       )
+      if (entries.isEmpty)
+        log.warning("[HEAL-RESTART] Frontier is empty after BFS — trie may already be fully healed or storage is corrupt")
+      queueNodes(entries.map(e => (e.pathset, e.hash)))
       lastHealedAtMs = System.currentTimeMillis()
+      tryRedispatchPendingTasks()
 
     case QueueMissingNodes(nodes) =>
       log.info(s"Queuing ${nodes.size} missing nodes for healing")
@@ -810,6 +835,125 @@ class TrieNodeHealingCoordinator(
 
   private def isComplete: Boolean =
     pendingTasks.isEmpty && activeRequests.isEmpty
+
+  /** Rebuild the healing frontier from locally-stored trie nodes after a crash/restart.
+    *
+    * Iterative BFS (avoids stack overflow at trie depth 64). Mirrors go-ethereum's
+    * trie.Sync.Missing() pattern: traverse the locally-stored subtree from the pivot root,
+    * discover children of healed nodes via local reads, and collect missing children as the
+    * frontier. Runs on healingWriterEc (off the actor dispatcher) so the mailbox stays live.
+    *
+    * For each node hash:
+    *   - in local storage  → already healed; decode children and enqueue them
+    *   - not in storage    → missing; add to frontier (pendingTasks on completion)
+    */
+  private def rebuildFrontierBFS(
+      startHash: ByteString,
+      startPathset: Seq[ByteString],
+      isStor: Boolean,
+      frontier: mutable.Buffer[HealingEntry],
+      visited: mutable.Set[ByteString]
+  ): Unit = {
+    import com.chipprbots.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode}
+    import com.chipprbots.ethereum.mpt.HexPrefix
+    import com.chipprbots.ethereum.domain.Account
+    import scala.util.control.NonFatal
+
+    val queue = mutable.Queue[(ByteString, Seq[ByteString], Boolean)]()
+    queue.enqueue((startHash, startPathset, isStor))
+    var visitedCount = 0
+    var frontierCount = 0
+
+    while (queue.nonEmpty) {
+      val (hash, pathset, isStorageTrie) = queue.dequeue()
+      if (!visited.contains(hash)) {
+        visited += hash
+        visitedCount += 1
+        if (visitedCount % 10000 == 0)
+          log.info(
+            s"[HEAL-RESTART-BFS] Progress: $visitedCount nodes visited, $frontierCount frontier nodes found, " +
+              s"queue depth ${queue.size}"
+          )
+
+        val nodeOpt = try Some(mptStorage.get(hash.toArray)) catch { case _: Exception => None }
+        nodeOpt match {
+          case None =>
+            // Not in storage — missing node, add to healing frontier
+            frontier += HealingEntry(pathset, hash)
+            frontierCount += 1
+
+          case Some(node) =>
+            // Already healed — traverse children to extend the BFS
+            val compact = pathset.last.toArray
+            val nibbles = HexPrefix.decode(compact)._1
+            try {
+              node match {
+                case branch: BranchNode =>
+                  for (i <- 0 until 16)
+                    branch.children(i) match {
+                      case hashChild: HashNode =>
+                        val childHash = ByteString(hashChild.hashNode)
+                        if (!visited.contains(childHash)) {
+                          val childNibbles = nibbles :+ i.toByte
+                          val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                          val childPathset =
+                            if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                          queue.enqueue((childHash, childPathset, isStorageTrie))
+                        }
+                      case _ => // inline-encoded child — already resolved
+                    }
+
+                case ext: ExtensionNode =>
+                  ext.next match {
+                    case hashChild: HashNode =>
+                      val childHash = ByteString(hashChild.hashNode)
+                      if (!visited.contains(childHash)) {
+                        val childNibbles = nibbles ++ ext.sharedKey.toArray
+                        val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
+                        val childPathset =
+                          if (isStorageTrie) Seq(pathset.head, childCompact) else Seq(childCompact)
+                        queue.enqueue((childHash, childPathset, isStorageTrie))
+                      }
+                    case _ =>
+                  }
+
+                case leaf: LeafNode if !isStorageTrie =>
+                  // Account trie leaf — seed storage trie root if not yet healed
+                  Account(leaf.value).foreach { account =>
+                    if (
+                      account.storageRoot != Account.EmptyStorageRootHash &&
+                      !visited.contains(account.storageRoot)
+                    ) {
+                      val leafNibbles = leaf.key.toArray
+                      val allNibbles = nibbles ++ leafNibbles
+                      if (allNibbles.length == 64) {
+                        val accountHashBytes =
+                          allNibbles.grouped(2).map(g => ((g(0) << 4) | g(1)).toByte).toArray
+                        val accountHash = ByteString(accountHashBytes)
+                        val emptyStoragePath =
+                          ByteString(HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+                        queue.enqueue((account.storageRoot, Seq(accountHash, emptyStoragePath), true))
+                      }
+                    }
+                  }
+
+                case _ => // storage trie leaf, NullNode, HashNode inline — no children to traverse
+              }
+            } catch {
+              case NonFatal(e) =>
+                log.debug(
+                  s"[HEAL-RESTART-BFS] Cannot traverse stored node ${Hex.toHexString(hash.take(4).toArray)}: " +
+                    s"${e.getMessage} — skipping"
+                )
+            }
+        }
+      }
+    }
+
+    log.info(
+      s"[HEAL-RESTART-BFS] Complete: $visitedCount nodes traversed, $frontierCount missing nodes in frontier"
+    )
+  }
 
   /** Inline child discovery after each healed node — Besu/geth scheduler-driven alignment. Decodes the healed node,
     * discovers child hashes, checks storage, queues missing children. Makes healing self-feeding: root → children →

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -9,8 +9,6 @@ import org.apache.pekko.actor.Props
 import org.apache.pekko.util.ByteString
 
 import com.chipprbots.ethereum.db.storage.AppStateStorage
-import com.chipprbots.ethereum.db.storage.EvmCodeStorage
-import com.chipprbots.ethereum.db.storage.FlatSlotStorage
 import com.chipprbots.ethereum.domain.ChainWeight
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor._
 import com.chipprbots.ethereum.network.PeerActor.DisconnectPeer
@@ -56,6 +54,10 @@ class NetworkPeerManagerActor(
   private[network] type PeersWithInfo = Map[PeerId, PeerWithInfo]
 
   // Maximum length for hex string in debug logs (to avoid very long log lines)
+
+  // ETH/69: reject BlockRangeUpdate whose latestBlock is this many blocks beyond local best.
+  // Mirrors go-ethereum's maxFutureBlockTime heuristic translated to block-number space.
+  private val FutureBlockTolerance: BigInt = 100
 
   // Mutable reference to SNAPSyncController that can be set after initialization
   private var snapSyncControllerOpt: Option[ActorRef] = initialSnapSyncControllerOpt
@@ -174,18 +176,43 @@ class NetworkPeerManagerActor(
       handleGetByteCodes(msg, peerId, peersWithInfo.get(peerId))
 
     case MessageFromPeer(message, peerId) if peersWithInfo.contains(peerId) =>
-      // Route SNAP protocol responses (from peers we're syncing from) to SNAPSyncController
-      message match {
-        case msg @ (_: AccountRange | _: StorageRanges | _: TrieNodes | _: ByteCodes) =>
-          log.debug("Routing {} message to SNAPSyncController from peer {}", msg.getClass.getSimpleName, peerId)
-          snapSyncControllerOpt.foreach(_ ! msg)
-
-        case _ => // ETH protocol messages - no special routing needed
+      // ETH/69: future-block validation for BlockRangeUpdate (go-ethereum handler.go alignment).
+      // Disconnect peers that claim a latestBlock far beyond our chain head — likely invalid or
+      // malicious. Lagging peers (latestBlock behind our head) are valid and pass through.
+      val futureBlockDisconnect = message match {
+        case bru: ETH69.BlockRangeUpdate =>
+          val localBest = appStateStorage.getBestBlockNumber()
+          // Only validate future-block when we have a meaningful chain head (> 0).
+          // At genesis/initial sync localBest=0, so any peer block would be rejected —
+          // skip the check until we've actually synced some chain state.
+          if (localBest > 0 && bru.latestBlock > localBest + FutureBlockTolerance) {
+            log.warning(
+              s"BlockRangeUpdate from peer ${peerId.value}: latestBlock=${bru.latestBlock} " +
+                s"is ${bru.latestBlock - localBest} blocks ahead of local best=$localBest " +
+                s"(tolerance=$FutureBlockTolerance). Disconnecting (BreachOfProtocol)."
+            )
+            peersWithInfo(peerId).peer.ref ! DisconnectPeer(Disconnect.Reasons.BreachOfProtocol)
+            true
+          } else false
+        case _ => false
       }
 
-      val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message, handleReceivedMessage)
-      NetworkMetrics.ReceivedMessagesCounter.increment()
-      context.become(handleMessages(newPeersWithInfo))
+      if (futureBlockDisconnect) {
+        context.become(handleMessages(peersWithInfo - peerId))
+      } else {
+        // Route SNAP protocol responses (from peers we're syncing from) to SNAPSyncController
+        message match {
+          case msg @ (_: AccountRange | _: StorageRanges | _: TrieNodes | _: ByteCodes) =>
+            log.debug("Routing {} message to SNAPSyncController from peer {}", msg.getClass.getSimpleName, peerId)
+            snapSyncControllerOpt.foreach(_ ! msg)
+
+          case _ => // ETH protocol messages - no special routing needed
+        }
+
+        val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message, handleReceivedMessage)
+        NetworkMetrics.ReceivedMessagesCounter.increment()
+        context.become(handleMessages(newPeersWithInfo))
+      }
 
     case PeerHandshakeSuccessful(peer, peerInfo: PeerInfo) =>
       val chainInfoDisplay =

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerEventBusActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerEventBusActor.scala
@@ -9,6 +9,7 @@ import org.apache.pekko.event.ActorEventBus
 import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.stream.scaladsl.Source
 
+import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.MaintainedPeersChanged
 import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
 import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerHandshakeSuccessful
@@ -67,6 +68,7 @@ object PeerEventBusActor {
     case class MessageClassifier(messageCodes: Set[Int], peerSelector: PeerSelector) extends SubscriptionClassifier
     case class PeerDisconnectedClassifier(peerSelector: PeerSelector) extends SubscriptionClassifier
     case object PeerHandshaked extends SubscriptionClassifier
+    case object MaintainedPeersClassifier extends SubscriptionClassifier
   }
 
   sealed trait PeerEvent
@@ -75,6 +77,7 @@ object PeerEventBusActor {
     case class MessageFromPeer(message: Message, peerId: PeerId) extends PeerEvent
     case class PeerDisconnected(peerId: PeerId) extends PeerEvent
     case class PeerHandshakeSuccessful[R <: HandshakeResult](peer: Peer, handshakeResult: R) extends PeerEvent
+    case class MaintainedPeersChanged(nodeIds: Set[String]) extends PeerEvent
   }
 
   case class Subscription(subscriber: ActorRef, classifier: SubscriptionClassifier)
@@ -143,6 +146,10 @@ object PeerEventBusActor {
           }
         case _: PeerHandshakeSuccessful[_] =>
           connectionSubscriptions.collect { case Subscription(subscriber, PeerHandshaked) =>
+            subscriber
+          }
+        case MaintainedPeersChanged(_) =>
+          connectionSubscriptions.collect { case Subscription(subscriber, MaintainedPeersClassifier) =>
             subscriber
           }
       }

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -285,10 +285,12 @@ class PeerManagerActor(
       val wasAdded = !maintainedPeersByNodeId.contains(nodeId)
       maintainedPeersByNodeId = maintainedPeersByNodeId + (nodeId -> uri)
       sender() ! AddMaintainedPeerResponse(wasAdded)
+      peerEventBus ! Publish(PeerEvent.MaintainedPeersChanged(maintainedPeersByNodeId.keySet))
       connectWith(uri, connectedPeers)
 
     case RemoveMaintainedPeer(nodeId) =>
       maintainedPeersByNodeId = maintainedPeersByNodeId - nodeId
+      peerEventBus ! Publish(PeerEvent.MaintainedPeersChanged(maintainedPeersByNodeId.keySet))
 
     // ── Geth-compatible trusted peer / max-peers management ───────────────
     // core-geth references: node/api.go AddTrustedPeer/RemoveTrustedPeer, eth/api_admin.go MaxPeers
@@ -383,9 +385,11 @@ class PeerManagerActor(
       connectedPeers.hasHandshakedWith(nodeId) ||
         connectedPeers.isConnectionHandled(remoteAddress) ||
         connectedPeers.hasIncomingPendingFromHost(uri.getHost)
-    // Trusted peers bypass the max peer limit (core-geth: trustedConn flag skips maxPeers check)
-    val isTrusted = trustedPeersByNodeId.contains(nodeIdHex)
-    val isOutgoingPeersNotMaxValue = isTrusted || connectedPeers.outgoingPeersCount < effectiveMaxOutgoing
+    // Trusted + maintained peers bypass the max outgoing limit.
+    // Besu: DefaultPeerPrivileges.canExceedConnectionLimits checks maintainedPeers set.
+    // go-ethereum: trustedConn flag skips maxPeers for trusted only; Fukuii extends this to maintained peers.
+    val isMaintainedOrTrusted = trustedPeersByNodeId.contains(nodeIdHex) || maintainedPeersByNodeId.contains(nodeIdHex)
+    val isOutgoingPeersNotMaxValue = isMaintainedOrTrusted || connectedPeers.outgoingPeersCount < effectiveMaxOutgoing
 
     val validConnection = for {
       validHandler <- validateConnection(remoteAddress, OutgoingConnectionAlreadyHandled(uri), !alreadyConnectedToPeer)
@@ -516,12 +520,23 @@ class PeerManagerActor(
         context.become(listening(connectedPeers))
 
       } else if (handshakedPeer.nodeId.exists(connectedPeers.hasHandshakedWith)) {
-        // Even though we do already validations for this, we might have missed it someone tried connecting to us at the
-        // same time as we do
-        log.debug(s"Disconnecting from ${handshakedPeer.remoteAddress} as we are already connected to them")
-        handshakedPeer.ref ! PeerActor.DisconnectPeer(Disconnect.Reasons.AlreadyConnected)
-        // Keep the current connectedPeers state; the Terminated message will clean up the peer
-        context.become(listening(connectedPeers))
+        val nodeId = handshakedPeer.nodeId.get
+        val existingOutboundOpt = connectedPeers.peers.values
+          .find(p => p.nodeId.contains(nodeId) && !p.incomingConnection)
+        if (handshakedPeer.incomingConnection && isMaintained && existingOutboundOpt.isDefined) {
+          // Inbound wins for maintained peers — drop the outbound, keep the inbound.
+          // Mirrors go-ethereum's static-pool removal when a peer connects either direction,
+          // preventing core-geth's static-dial timer from firing a new outbound every 30-45s.
+          log.debug("Maintained peer {} inbound wins tiebreak — dropping outbound", handshakedPeer.remoteAddress)
+          existingOutboundOpt.foreach(_.ref ! PeerActor.DisconnectPeer(Disconnect.Reasons.AlreadyConnected))
+          pendingMaintainedConnections.remove(handshakedPeer.ref)
+          peerStatusCache = peerStatusCache + (handshakedPeer.id -> PeerActor.Status.Handshaked)
+          context.become(listening(connectedPeers.promotePeerToHandshaked(handshakedPeer)))
+        } else {
+          log.debug(s"Disconnecting from ${handshakedPeer.remoteAddress} as we are already connected to them")
+          handshakedPeer.ref ! PeerActor.DisconnectPeer(Disconnect.Reasons.AlreadyConnected)
+          context.become(listening(connectedPeers))
+        }
       } else {
         pendingMaintainedConnections.remove(handshakedPeer.ref)
         peerStatusCache = peerStatusCache + (handshakedPeer.id -> PeerActor.Status.Handshaked)

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -74,18 +74,40 @@ case class EthNodeStatus69ExchangeState(
         validationResult match {
           case Connect =>
             log.info("ETH69_STATUS: ForkId validation passed - accepting peer")
-            // Look up actual PoW TD from local chain DB using the peer's latestBlockHash.
+            // Look up actual TD from local chain DB using the peer's latestBlockHash.
             // Succeeds when the peer's block is in our ChainWeightStorage (peer at or behind our tip).
-            // Falls back to block-number proxy when the peer is ahead of us.
+            // Falls back to PoW-scaled estimation for PoW chains, block-number proxy for PoS chains.
             val resolvedChainWeight: ChainWeight =
               blockchainReader
                 .getChainWeightByHash(status.latestBlockHash)
-                .getOrElse(ChainWeight.totalDifficultyOnly(status.latestBlock))
+                .getOrElse {
+                  if (blockchainConfig.terminalTotalDifficulty.isEmpty) {
+                    // PoW chain (ETC mainnet chainId=61, Mordor chainId=63, etc.):
+                    // Scale our own cumulative TD by the peer's block height ratio.
+                    // Keeps the estimate in the correct order of magnitude (~10^21 for ETC)
+                    // rather than the raw block number (~24.5 M), which would cause ETH69 peers
+                    // to always lose BestPeer selection against ETH68 peers sending real PoW TD.
+                    val ourBestHeader = getBestBlockHeader()
+                    val ourBestTD = blockchainReader
+                      .getChainWeightByHash(ourBestHeader.hash)
+                      .map(_.totalDifficulty)
+                      .getOrElse(BigInt(1))
+                    val ourBestNum = blockchainReader.getBestBlockNumber()
+                    val estimatedTD =
+                      if (ourBestNum > 0) ourBestTD * status.latestBlock / ourBestNum
+                      else status.latestBlock
+                    ChainWeight.totalDifficultyOnly(estimatedTD)
+                  } else {
+                    // PoS chain (ETH mainnet, etc.): TD is frozen; block-number is the ordering signal.
+                    ChainWeight.totalDifficultyOnly(status.latestBlock)
+                  }
+                }
             log.debug(
-              "ETH69_STATUS: chainWeight for peer latestBlockHash {}: {} (localLookup={})",
+              "ETH69_STATUS: chainWeight for peer latestBlockHash {}: {} (localLookup={}, powEstimate={})",
               status.latestBlockHash,
               resolvedChainWeight,
-              blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined
+              blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined,
+              blockchainConfig.terminalTotalDifficulty.isEmpty
             )
             ConnectedState(
               PeerInfo.withForkAccepted(

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -673,14 +673,15 @@ class AccountRangeCoordinatorSpec
     system.stop(coord)
   }
 
-  it should "NOT classify a peer as SNAPLESS on Request timeout failures (#1197)" taggedAs UnitTest in {
+  it should "NOT classify a peer as stateless or snapless on Request timeout failures" taggedAs UnitTest in {
     val stateRoot = kec256(ByteString("trie-async-test-root"))
     val coord = newCoordinator(stateRoot = stateRoot)
     val ua = coord.underlyingActor
     val pendingProbe = TestProbe()
     val peer = PeerTestHelpers.createTestPeer("timeout-only-peer", pendingProbe.ref)
 
-    // Drive 3 consecutive timeouts for one peer (consecutiveTimeoutThreshold default = 3).
+    // Drive multiple timeouts — go-ethereum marks stateless only on empty response
+    // (snap/sync.go:2574), never on timeout. Fukuii follows the same rule (Fix-B, run-17).
     seedActiveTask(coord, BigInt(801), peer, rootHash = stateRoot)
     coord ! Messages.TaskFailed(BigInt(801), "Request timeout")
     seedActiveTask(coord, BigInt(802), peer, rootHash = stateRoot)
@@ -691,9 +692,8 @@ class AccountRangeCoordinatorSpec
     coord ! Messages.GetProgress
     expectMsgType[AccountRangeStats](2.seconds)
 
-    // After 3 timeouts the peer is stateless (transient root-aging signal) but NOT
-    // snapless — timeout doesn't mean the snapshot tree is missing.
-    ua.statelessPeers should contain(peer.id)
+    // Timeouts never mark the peer stateless or snapless — only empty responses do.
+    ua.statelessPeers should not contain peer.id
     ua.snaplessPeers should not contain peer.id
 
     system.stop(coord)

--- a/src/test/scala/com/chipprbots/ethereum/network/PeerManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/PeerManagerSpec.scala
@@ -564,6 +564,68 @@ class PeerManagerSpec
     createdPeers.size shouldBe 2
   }
 
+  // ── Suite 7: Inbound-wins tiebreaker (Fix-A — run-17 issue A) ─────────────────────────────────
+
+  behavior.of("maintained peer inbound-wins tiebreaker (Fix-A)")
+
+  it should "drop the outbound and keep the inbound when a maintained peer's inbound handshakes while outbound is already handshaked" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new TestSetup {
+    val hexNodeId = "ff" * 64
+    val nodeIdBytes = ByteString(Hex.decode(hexNodeId))
+    val maintainedUri = new URI(s"enode://$hexNodeId@127.0.0.9:30303")
+
+    start()
+
+    // Step 1: outbound initiated for the maintained peer
+    peerManager ! PeerManagerActor.AddMaintainedPeer(maintainedUri)
+    createdPeers(0).probe.expectMsgType[ConnectTo](3.seconds)
+
+    // Step 2: outbound handshakes — enters handshakedPeers
+    createdPeers(0).probe.reply(
+      PeerEvent.PeerHandshakeSuccessful(
+        Peer(
+          PeerId(hexNodeId),
+          new InetSocketAddress("127.0.0.9", 30303),
+          createdPeers(0).probe.ref,
+          incomingConnection = false,
+          nodeId = Some(nodeIdBytes)
+        ),
+        initialPeerInfo
+      )
+    )
+
+    // Step 3: inbound from the same maintained peer host arrives simultaneously
+    val inboundTcp = TestProbe()
+    val inboundAddress = new InetSocketAddress("127.0.0.9", 55555)
+    peerManager ! PeerManagerActor.HandlePeerConnection(inboundTcp.ref, inboundAddress)
+    createdPeers(1).probe.expectMsg(PeerActor.HandleConnection(inboundTcp.ref, inboundAddress))
+
+    // Step 4: inbound handshakes with same nodeId — tiebreaker: inbound wins
+    createdPeers(1).probe.reply(
+      PeerEvent.PeerHandshakeSuccessful(
+        Peer(
+          PeerId(hexNodeId),
+          inboundAddress,
+          createdPeers(1).probe.ref,
+          incomingConnection = true,
+          nodeId = Some(nodeIdBytes)
+        ),
+        initialPeerInfo
+      )
+    )
+
+    // Outbound should receive DisconnectPeer(AlreadyConnected) — inbound wins, outbound dropped
+    createdPeers(0).probe.expectMsg(PeerActor.DisconnectPeer(Disconnect.Reasons.AlreadyConnected))
+
+    // After outbound Terminated fires, no new outbound should be scheduled
+    // (maintained peer is now held by the stable inbound)
+    createdPeers(0).probe.ref ! PoisonPill
+    testScheduler.timePasses(peerConfiguration.connectRetryDelay + 1.second)
+    createdPeers.size shouldBe 2
+  }
+
   behavior.of("outgoingConnectionDemand")
 
   it should "try to connect to at least min-outgoing-peers but no more than max-outgoing-peers" taggedAs (


### PR DESCRIPTION
## Summary

Seven fixes in two areas: P2P peer lifecycle alignment with go-ethereum/Besu, and SNAP sync stability improvements targeting ETC mainnet-scale crash recovery and protocol correctness.

**Rebased onto**: upstream/staging after PR #1216 (Revert #1215).

---

## P2P lifecycle — correctness fixes

| Fix | Root cause | File |
|-----|-----------|------|
| B1/B2 — Timeout ≠ stateless | `AccountRangeCoordinator` and `StorageRangeCoordinator` escalated consecutive timeouts to stateless, permanently excluding peers. go-ethereum (`snap/sync.go:2574`) marks stateless only on empty response, never on timeout. | `AccountRangeCoordinator.scala`, `StorageRangeCoordinator.scala` |
| A — Inbound-wins tiebreaker | When a maintained peer's inbound handshake arrives while an outbound is already connected, Fukuii dropped the inbound. Correct behavior: keep inbound, close outbound. Prevents core-geth's static-dial timer from re-firing every 30–45s. Mirrors go-ethereum static-pool removal when a peer connects either direction. | `PeerManagerActor.scala` |
| B4 — `peer-response-timeout` 45s → 60s | Timeout was shorter than `SNAPRequestTracker.TtlLimitMs`, causing the tracker to never fire before the peer actor disconnected. Also gives Besu warm-up room on first connection. | `sync.conf` |
| G — Maintained peers bypass `maxOutgoingConnections` | `isMaintainedOrTrusted` gate ensures maintained peers always get an outbound slot. Besu alignment: `DefaultPeerPrivileges.canExceedConnectionLimits`. | `PeerManagerActor.scala` |
| H — Sync-layer blacklist exemption for maintained peers | `PeerManagerActor` publishes `MaintainedPeersChanged` on add/remove; `PeersClient` subscribes via `MaintainedPeersClassifier`; `PeerListSupportNg.blacklistIfHandshaked` skips maintained peers. Besu alignment: `PeerDenylistManager.java:56`. | `PeerListSupportNg.scala`, `PeersClient.scala`, `PeerEventBusActor.scala` |
| K — ETH69 STATUS TD scaling | ETH69 STATUS omits TD. For PoW chains (`terminalTotalDifficulty.isEmpty`), scale local cumulative TD by peer block ratio instead of using raw block number (~24.5M vs real ETC TD ~10²¹). | `EthNodeStatus69ExchangeState.scala` |
| PRIO-8 — BlockRangeUpdate future-block validation | Disconnect peers that announce a `latestBlock` more than 100 blocks beyond our local chain head. Guard skipped at genesis (`localBest=0`) to avoid rejecting all peers before sync. Mirrors go-ethereum `maxFutureBlockTime` heuristic translated to block-number space. | `NetworkPeerManagerActor.scala` |
| ETH/69 STATUS 7-field layout | PR #1194 erroneously dropped `earliestBlock` from the ETH/69 STATUS encoder (misread of EIP-7642). The canonical layout is 7 fields: `[version, networkId, genesis, forkId, earliestBlock, latestBlock, latestBlockHash]`. With 6 fields, geth's RLP decoder reads `latestBlockHash` (32 bytes) into `LatestBlock` (uint64) and rejects every handshake. Encoder restored to 7-field canonical; decoder accepts 7-field (primary), 6-field legacy (pre-fix fukuii peers), and ETH/68-shape (wrong-chain peers → clean `Useless peer` reject). Cherry-picked from #1219. | `EthNodeStatus69ExchangeState.scala` |

---

## SNAP sync — stability

### PRIO-7: Account range checkpoint granularity

`AccountRangeCoordinator` now calls `sendProgressSnapshot()` on partial range completion (when the same range interval needs a follow-up request), not only at range boundary transitions. Mirrors go-ethereum `saveSyncStatus()` which persists after every completed account range task.

**Impact**: crash mid-range resumes from the last saved account position, not the beginning of the range.

### PRIO-6: Healing crash recovery — DFS + batch emit

`TrieNodeHealingCoordinator` detects restarts by checking whether the pivot state root is already in `mptStorage`. If so, it rebuilds the healing frontier from local storage instead of the network (avoiding millions of nodes × network RTT).

**Original implementation** used an iterative BFS (`mutable.Queue`, FIFO). In ETC mainnet testing (Run 18, Attempt 1), the BFS queue grew to 41M entries after visiting 9.36M healed nodes before reaching any missing frontier nodes — the queue expanded faster than it was consumed (3.4 children per visited node). This triggered a JVM GC spiral at 313 nodes/min; completion was weeks away and healing never started.

**Root cause**: BFS explores all nodes at depth D before advancing to D+1. The ETC state trie has millions of healed intermediate nodes. By the time BFS reaches the frontier depth (~64), it has enqueued every sibling at that depth — queue size O(trie_width_at_frontier_depth) = O(millions).

**Fix 1 — DFS**: replace `mutable.Queue` (FIFO) with `mutable.ArrayDeque` used as a stack (LIFO = DFS via `removeLast`). DFS drills to depth 64 in the first few thousand visits, finding missing frontier nodes almost immediately. Queue bounded to O(depth × branching_factor) ≈ O(1024 entries).

**Fix 2 — batch emit**: instead of accumulating the entire frontier and sending one `FrontierRebuilt` at completion, the DFS emits a batch of 1000 missing nodes each time the buffer fills (`FrontierBatchSize = 1000`). Healing starts within seconds of restart; the DFS continues in the background delivering further batches.

**go-ethereum alignment**: `trie/sync.go` uses a depth-prioritized priority queue (`prque` with `depth<<56` encoding) — deepest nodes always popped first, making it functionally DFS-ordered. `Missing(n)` returns up to n items at a time, identical to the incremental batch delivery this fix replicates via `onBatch`.

Recovery comparison (ETC mainnet, millions of healed nodes):
- Before (BFS): 41M queue entries → GC spiral → never completes
- After (DFS): ~1024 queue entries → first 1000 missing nodes found in seconds → healing starts immediately

No new persistent state. No changes to `AppStateStorage` or `FrontierRebuilt` message type.

---

## Test plan

- [x] `sbt test` — 3089 tests, 0 failures
- [x] `sbt assembly` — `fukuii-assembly-0.5.0.jar` built clean (hash `22289819`, pre ETH/69 cherry-pick)
- [x] `PeerManagerSpec` — Suite 7 (inbound-wins + fallback paths), RC1/RC2/RC3 guards, 38/38
- [x] `EtcPeerManagerSpec` — 15/15 (includes ETH69 BlockRangeUpdate future-block cases)
- [x] `AccountRangeCoordinatorSpec` — partial-range checkpoint, timeout-not-stateless
- [x] `TrieNodeHealingCoordinatorSpec` — frontier rebuild DFS + batch emit, crash-recovery path, 21/21
- [x] `ETH69TDSpec` — 7-field STATUS encoding/decoding, legacy 6-field compat, 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)