### PR TITLE
fix(eth/69): restore canonical 7-field STATUS layout (unblocks hive-sync + Sepolia)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1304,7 +1304,9 @@ class SNAPSyncController(
                       currentPhase = StateHealing
                       startStateHealing()
                     } else {
-                      log.info(s"Beginning fast state sync with ${snapSyncConfig.accountConcurrency} concurrent workers")
+                      log.info(
+                        s"Beginning fast state sync with ${snapSyncConfig.accountConcurrency} concurrent workers"
+                      )
                       currentPhase = AccountRangeSync
                       startAccountRangeSync(header.stateRoot)
                     }
@@ -1454,7 +1456,7 @@ class SNAPSyncController(
           val networkBest = currentNetworkBestFromSnapPeers().getOrElse(BigInt(0))
           val drift = if (networkBest > 0) (networkBest - pivot).abs else BigInt(0)
           if (networkBest > 0 && drift > snapSyncConfig.maxPivotStalenessBlocks) {
-            val storageAlreadyDone  = appStateStorage.isSnapSyncStorageComplete()
+            val storageAlreadyDone = appStateStorage.isSnapSyncStorageComplete()
             val bytecodeAlreadyDone = appStateStorage.isSnapSyncBytecodeComplete()
             if (storageAlreadyDone && bytecodeAlreadyDone) {
               // All data phases complete — content-addressed data is valid across pivot changes.
@@ -1464,8 +1466,8 @@ class SNAPSyncController(
                 s"Recovery: pivot $pivot drifted $drift blocks, but all phases complete. " +
                   "Requesting fresh pivot for healing (go-ethereum/Besu behavior)."
               )
-              accountsComplete      = true
-              storagePhaseComplete  = true
+              accountsComplete = true
+              storagePhaseComplete = true
               bytecodePhaseComplete = true
               // Leave pivotBlock and stateRoot unset — bootstrap will set them.
             } else {

--- a/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/MerklePatriciaTrie.scala
@@ -182,7 +182,9 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
     * @return
     *   accumulated data or None if key doesn't exist
     */
-  private def pathTraverse[T](acc: T, searchKey: Array[Byte], proofMode: Boolean = false)(op: (T, Option[MptNode]) => T): Option[T] = {
+  private def pathTraverse[T](acc: T, searchKey: Array[Byte], proofMode: Boolean = false)(
+      op: (T, Option[MptNode]) => T
+  ): Option[T] = {
 
     @tailrec
     def pathTraverse(

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -381,8 +381,8 @@ class PeerManagerActor(
 
     val alreadyConnectedToPeer =
       connectedPeers.hasHandshakedWith(nodeId) ||
-      connectedPeers.isConnectionHandled(remoteAddress) ||
-      connectedPeers.hasIncomingPendingFromHost(uri.getHost)
+        connectedPeers.isConnectionHandled(remoteAddress) ||
+        connectedPeers.hasIncomingPendingFromHost(uri.getHost)
     // Trusted peers bypass the max peer limit (core-geth: trustedConn flag skips maxPeers check)
     val isTrusted = trustedPeersByNodeId.contains(nodeIdHex)
     val isOutgoingPeersNotMaxValue = isTrusted || connectedPeers.outgoingPeersCount < effectiveMaxOutgoing

--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69.scala
@@ -12,20 +12,22 @@ import com.chipprbots.ethereum.utils.ByteUtils
 /** ETH/69 protocol (EIP-7642) — restructured Status, simplified receipts, BlockRangeUpdate.
   *
   * Key changes from ETH/68:
-  *   - Status message: removes totalDifficulty, reorders fields. Per EIP-7642 the wire layout is `[version, networkId,
-  *     genesis, forkId, latestBlock, latestBlockHash]` — exactly 6 fields. The `earliestBlock` info is conveyed by the
-  *     separate BlockRangeUpdate message (0x11).
+  *   - Status message: removes totalDifficulty, adds block range. Per EIP-7642 the wire layout is `[version, networkId,
+  *     genesis, forkId, earliestBlock, latestBlock, latestBlockHash]` — **7 fields**. Both core-geth's `StatusPacket`
+  *     and besu's `StatusMessage` encode all 7 with `earliestBlock` between `forkId` and `latestBlock`. PR #1194
+  *     erroneously dropped `earliestBlock` thinking BlockRangeUpdate (0x11) carried it; that broke cross-client interop
+  *     because peers' RLP decoder reads `latestBlockHash` (32 bytes) into `latestBlock` (uint64) and rejects the
+  *     handshake with `rlp: input string too long for uint64`. The 7-field layout is restored to match geth/besu.
   *   - Receipt encoding: removes bloom filter, uses flat RLP list with explicit tx-type field
-  *   - New BlockRangeUpdate (0x11) notification message
+  *   - New BlockRangeUpdate (0x11) notification message — sent periodically AFTER the initial 7-field STATUS
   *   - All other messages (GetBlockHeaders, BlockHeaders, etc.) unchanged from ETH/68
   */
 object ETH69 {
 
   /** ETH/69 Status message.
     *
-    * Wire format per EIP-7642: `[version, networkId, genesis, forkId, latestBlock, latestBlockHash]` — 6 fields. The
-    * `earliestBlock` field on this case class is convenience-only (set by `BlockRangeUpdate` later in the session) and
-    * is NOT serialized in the STATUS frame.
+    * Wire format per EIP-7642 (matches geth + besu): `[version, networkId, genesis, forkId, earliestBlock, latestBlock,
+    * latestBlockHash]` — 7 fields.
     */
   case class Status(
       protocolVersion: Int,
@@ -51,14 +53,16 @@ object ETH69 {
         with RLPSerializable {
       override def code: Int = Codes.StatusCode
       import msg._
-      // EIP-7642 wire layout: 6 fields. earliestBlock is intentionally omitted —
-      // it travels via the BlockRangeUpdate (0x11) message instead. Sending 7 fields
-      // here is a fukuii-only legacy and breaks interop with core-geth/besu (#1194).
+      // EIP-7642 wire layout: 7 fields, with earliestBlock between forkId and latestBlock.
+      // Matches go-ethereum's `StatusPacket` (eth/protocols/eth/protocol.go) and besu's
+      // `StatusMessage69` exactly. Closes the cross-client interop break observed in
+      // hive's `ethereum/sync` simulator after PR #1194.
       override def toRLPEncodable: RLPEncodeable = RLPList(
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(protocolVersion)),
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(networkId)),
         RLPValue(genesisHash.toArray[Byte]),
         forkId.toRLPEncodable,
+        RLPValue(ByteUtils.bigIntToUnsignedByteArray(earliestBlock)),
         RLPValue(ByteUtils.bigIntToUnsignedByteArray(latestBlock)),
         RLPValue(latestBlockHash.toArray[Byte])
       )
@@ -69,30 +73,30 @@ object ETH69 {
 
       /** Decode an ETH/69 STATUS frame.
         *
-        * Tolerant of three shapes during the rollout:
-        *   1. EIP-7642 spec (6 fields, forkId at idx 3): `[version, networkId, genesis, forkId, latest, latestHash]` —
-        *      what core-geth, besu, reth, and post-#1194 fukuii send. 2. Legacy fukuii pre-#1194 (7 fields, forkId at
-        *      idx 3): `[version, networkId, genesis, forkId, earliest, latest, latestHash]` — older fukuii nodes.
-        *      `earliestBlock` preserved from wire. 3. ETH/68-shape on ETH/69 channel (6 fields, forkId at idx 5):
-        *      `[version, networkId, td, bestHash, genesis, forkId]` — peers (often wrong-chain like Holesky) that
-        *      announce ETH/69 capability but emit the older ETH/68 STATUS layout. The decode lets the peer reach the
-        *      genesis-hash check, where they get rejected cleanly with `Useless peer` instead of a noisy `DECODE_ERROR`
-        *      and a churning peer pool. We deliberately drop `totalDifficulty` — ETC PoW TD recovery in the handshaker
-        *      uses local ChainWeightStorage, and `latestBlock = 0` (ETH/68 doesn't carry a block number) is harmless
-        *      because the peer fails on genesis mismatch immediately afterward.
+        * Tolerant of three shapes:
+        *   1. **Canonical 7-field EIP-7642** (forkId at idx 3): `[version, networkId, genesis, forkId, earliest,
+        *      latest, latestHash]` — what core-geth's `StatusPacket`, besu's `StatusMessage69`, reth, and post-fix
+        *      fukuii send. 2. **6-field legacy** (forkId at idx 3): `[version, networkId, genesis, forkId, latest,
+        *      latestHash]` — pre-fix fukuii nodes that omitted `earliestBlock` (PR #1194). Treat `earliestBlock = 0` so
+        *      the peer is still accepted; older fukuii nodes are minority and cycle out. 3. **ETH/68-shape on ETH/69
+        *      channel** (6 fields, forkId at idx 5): `[version, networkId, td, bestHash, genesis, forkId]` — peers
+        *      (often wrong-chain like Holesky) that announce ETH/69 capability but emit the older ETH/68 STATUS layout.
+        *      The decode lets the peer reach the genesis-hash check, where they get rejected cleanly with `Useless
+        *      peer` instead of a noisy `DECODE_ERROR`. `totalDifficulty` is dropped on purpose; ETC TD recovery uses
+        *      local ChainWeightStorage.
         *
-        * The 6-field spec path and the ETH/68 path share field count but differ structurally — the spec has the forkId
+        * The 6-field legacy path and the ETH/68 path share field count but differ structurally — legacy has the forkId
         * RLPList at index 3, ETH/68 has it at index 5. Scala pattern matching distinguishes them via the type at each
-        * position (`RLPList` vs `RLPValue`), so case ordering doesn't matter for correctness; we keep spec first for
-        * readability.
+        * position (`RLPList` vs `RLPValue`).
         */
       def toETH69Status: Status = rawDecode(bytes) match {
-        // (1) 6-field EIP-7642 spec shape — what core-geth, besu, reth, and post-#1194 fukuii send.
+        // (1) Canonical 7-field EIP-7642 shape — geth/besu/reth.
         case RLPList(
               RLPValue(protocolVersionBytes),
               RLPValue(networkIdBytes),
               RLPValue(genesisHashBytes),
               forkIdRlp: RLPList,
+              RLPValue(earliestBlockBytes),
               RLPValue(latestBlockBytes),
               RLPValue(latestBlockHashBytes)
             ) =>
@@ -101,15 +105,13 @@ object ETH69 {
             networkId = ByteUtils.bytesToBigInt(networkIdBytes).toLong,
             genesisHash = ByteString(genesisHashBytes),
             forkId = decode[ForkId](forkIdRlp),
-            earliestBlock = BigInt(0),
+            earliestBlock = ByteUtils.bytesToBigInt(earliestBlockBytes),
             latestBlock = ByteUtils.bytesToBigInt(latestBlockBytes),
             latestBlockHash = ByteString(latestBlockHashBytes)
           )
         // (3) 6-field ETH/68-shape on ETH/69 channel (forkId at idx 5) — common from wrong-chain peers
         // (e.g. Holesky-derived testnets) that announce ETH/69 but emit ETH/68 STATUS. We accept the
-        // payload so the genesis check downstream can disconnect them as `Useless peer` instead of
-        // generating noisy `DECODE_ERROR` and churning the peer pool. `totalDifficulty` is dropped on
-        // purpose; ETC TD recovery is handler-side. `latestBlock = 0` is fine — peer fails on genesis next.
+        // payload so the genesis check downstream can disconnect them as `Useless peer`.
         case RLPList(
               RLPValue(protocolVersionBytes),
               RLPValue(networkIdBytes),
@@ -127,23 +129,22 @@ object ETH69 {
             latestBlock = BigInt(0),
             latestBlockHash = ByteString(bestHashBytes)
           )
-        // (2) 7-field legacy fukuii shape — kept for backward compat with pre-#1194 nodes.
+        // (2) 6-field legacy fukuii shape (forkId at idx 3) — pre-fix fukuii nodes that omitted earliestBlock.
+        // Accept with earliestBlock=0 so old fukuii peers still handshake during the rollout window.
         case RLPList(
               RLPValue(protocolVersionBytes),
               RLPValue(networkIdBytes),
               RLPValue(genesisHashBytes),
               forkIdRlp: RLPList,
-              RLPValue(earliestBlockBytes),
               RLPValue(latestBlockBytes),
-              RLPValue(latestBlockHashBytes),
-              _*
+              RLPValue(latestBlockHashBytes)
             ) =>
           Status(
             protocolVersion = ByteUtils.bytesToBigInt(protocolVersionBytes).toInt,
             networkId = ByteUtils.bytesToBigInt(networkIdBytes).toLong,
             genesisHash = ByteString(genesisHashBytes),
             forkId = decode[ForkId](forkIdRlp),
-            earliestBlock = ByteUtils.bytesToBigInt(earliestBlockBytes),
+            earliestBlock = BigInt(0),
             latestBlock = ByteUtils.bytesToBigInt(latestBlockBytes),
             latestBlockHash = ByteString(latestBlockHashBytes)
           )

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrapSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrapSpec.scala
@@ -100,7 +100,10 @@ class PivotHeaderBootstrapSpec
     parent.expectMsgType[PivotHeaderBootstrap.Failed](3.seconds)
   }
 
-  it should "not send Failed on empty headers (WaitForPeer issued, no attempt consumed)" taggedAs (UnitTest, SyncTest) in {
+  it should "not send Failed on empty headers (WaitForPeer issued, no attempt consumed)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in {
     val peersClient = TestProbe()
     val parent = TestProbe()
     mkBootstrap(peersClient, parent, waitForPeerDelay = 50.millis)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
@@ -607,10 +607,12 @@ class TrieNodeHealingCoordinatorSpec
 
     coordinator ! Messages.StartTrieNodeHealing(stateRoot) // seeds root as reqId=1
     // Queue 2 more tasks so 3 requests are dispatched concurrently (default maxInFlightPerPeer=5)
-    coordinator ! Messages.QueueMissingNodes(Seq(
-      (Seq(ByteString(Array[Byte](0x01))), kec256(ByteString("missing-node-2"))),
-      (Seq(ByteString(Array[Byte](0x02))), kec256(ByteString("missing-node-3")))
-    ))
+    coordinator ! Messages.QueueMissingNodes(
+      Seq(
+        (Seq(ByteString(Array[Byte](0x01))), kec256(ByteString("missing-node-2"))),
+        (Seq(ByteString(Array[Byte](0x02))), kec256(ByteString("missing-node-3")))
+      )
+    )
     coordinator ! Messages.HealingPeerAvailable(peer)
     networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds) // reqId=1
     networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds) // reqId=2

--- a/src/test/scala/com/chipprbots/ethereum/network/ETH69TDSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/ETH69TDSpec.scala
@@ -186,24 +186,26 @@ class ETH69TDSpec extends AnyFlatSpec with Matchers {
   }
 
   // -------------------------------------------------------------------------
-  // EIP-7642 STATUS wire format (#1194)
+  // EIP-7642 STATUS wire format
   //
-  // Pre-fix: fukuii's ETH/69 STATUS encoded 7 fields with an extra `earliestBlock`
-  // not in the spec. Real-world peers (core-geth/besu running EIP-7642) send 6
-  // fields and fukuii rejected every one with `Cannot decode ETH69.Status`.
-  // Symptom on ETC mainnet: no peer pool, sync wedged. Mordor was unaffected
-  // because its peer pool was dominated by other fukuii instances + ETH/68.
+  // Both core-geth's `StatusPacket` (eth/protocols/eth/protocol.go) and besu's
+  // `StatusMessage69` encode the canonical 7 fields:
+  //   `[version, networkId, genesis, forkId, earliestBlock, latestBlock, latestBlockHash]`
   //
-  // The fix:
-  //   1. Encoder emits 6 fields per EIP-7642 (no earliestBlock — that info is
-  //      conveyed via the separate BlockRangeUpdate message 0x11).
-  //   2. Decoder accepts both the 6-field spec shape AND the 7-field legacy
-  //      fukuii shape during the transition (so old fukuii peers still work).
+  // PR #1194 erroneously dropped `earliestBlock` based on a misread of EIP-7642 — that
+  // produced a 6-field STATUS that geth rejected with `rlp: input string too long for
+  // uint64, decoding into (eth.StatusPacket).LatestBlock` (geth's decoder reads the
+  // 32-byte `latestBlockHash` into the `LatestBlock` uint64 slot when only 6 fields
+  // arrive). Confirmed in hive's `ethereum/sync` simulator at debug verbosity.
+  //
+  // The current encoder emits the canonical 7 fields. The decoder still accepts the
+  // 6-field legacy shape (for the rollout window where some fukuii peers may still
+  // be running pre-fix builds) and the ETH/68-shape that wrong-chain peers send.
   // -------------------------------------------------------------------------
 
-  it should "encode ETH/69 STATUS as 6 fields per EIP-7642 (no earliestBlock on the wire)" taggedAs UnitTest in {
+  it should "encode ETH/69 STATUS as 7 fields per EIP-7642 (geth/besu canonical)" taggedAs UnitTest in {
     import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
-    import com.chipprbots.ethereum.rlp.{RLPList, RLPValue, rawDecode}
+    import com.chipprbots.ethereum.rlp.{RLPList, rawDecode}
 
     val status = eth69Status(latestBlockNr, latestHash)
     val encoded: Array[Byte] = new StatusEnc(status).toBytes
@@ -211,13 +213,13 @@ class ETH69TDSpec extends AnyFlatSpec with Matchers {
 
     decoded shouldBe a[RLPList]
     val fields = decoded.asInstanceOf[RLPList].items.toList
-    fields should have size 6 // EIP-7642 spec — NOT 7
+    fields should have size 7 // canonical layout matches geth StatusPacket / besu StatusMessage69
   }
 
-  it should "round-trip through the spec-compliant 6-field wire format" taggedAs UnitTest in {
+  it should "round-trip through the spec-compliant 7-field wire format" taggedAs UnitTest in {
     import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
 
-    val original = eth69Status(latestBlockNr, latestHash)
+    val original = eth69Status(latestBlockNr, latestHash).copy(earliestBlock = BigInt(0))
     val encoded: Array[Byte] = new StatusEnc(original).toBytes
     val decoded = encoded.toETH69Status
 
@@ -225,26 +227,35 @@ class ETH69TDSpec extends AnyFlatSpec with Matchers {
     decoded.networkId shouldBe original.networkId
     decoded.genesisHash shouldBe original.genesisHash
     decoded.forkId shouldBe original.forkId
+    decoded.earliestBlock shouldBe original.earliestBlock
     decoded.latestBlock shouldBe original.latestBlock
     decoded.latestBlockHash shouldBe original.latestBlockHash
-    // earliestBlock is not on the spec wire — decoder defaults to 0.
-    decoded.earliestBlock shouldBe BigInt(0)
   }
 
-  it should "decode legacy 7-field fukuii STATUS shape (backward compat with pre-#1194 peers)" taggedAs UnitTest in {
+  it should "preserve a non-zero earliestBlock through the 7-field round-trip" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
+
+    val original = eth69Status(latestBlockNr, latestHash).copy(earliestBlock = BigInt(123))
+    val encoded: Array[Byte] = new StatusEnc(original).toBytes
+    val decoded = encoded.toETH69Status
+
+    decoded.earliestBlock shouldBe BigInt(123)
+    decoded.latestBlock shouldBe latestBlockNr
+    decoded.latestBlockHash shouldBe latestHash
+  }
+
+  it should "decode legacy 6-field fukuii STATUS shape (backward compat with pre-fix peers)" taggedAs UnitTest in {
     import com.chipprbots.ethereum.network.p2p.messages.ETH69.Status._
     import com.chipprbots.ethereum.rlp.{RLPList, RLPValue, encode}
     import com.chipprbots.ethereum.utils.ByteUtils
     import com.chipprbots.ethereum.forkid.ForkId._
 
-    // Hand-build the 7-field legacy shape used by fukuii pre-fix.
-    val legacyEarliest = BigInt(42)
+    // Hand-build the 6-field legacy shape used by pre-fix fukuii.
     val legacyRlp = RLPList(
       RLPValue(ByteUtils.bigIntToUnsignedByteArray(BigInt(Capability.ETH69.version))),
       RLPValue(ByteUtils.bigIntToUnsignedByteArray(BigInt(1))),
       RLPValue(genesisHash.toArray[Byte]),
       dummyForkId.toRLPEncodable,
-      RLPValue(ByteUtils.bigIntToUnsignedByteArray(legacyEarliest)),
       RLPValue(ByteUtils.bigIntToUnsignedByteArray(latestBlockNr)),
       RLPValue(latestHash.toArray[Byte])
     )
@@ -255,8 +266,8 @@ class ETH69TDSpec extends AnyFlatSpec with Matchers {
     decoded.networkId shouldBe 1L
     decoded.latestBlock shouldBe latestBlockNr
     decoded.latestBlockHash shouldBe latestHash
-    // The 7-field branch DOES preserve earliestBlock from the wire.
-    decoded.earliestBlock shouldBe legacyEarliest
+    // 6-field shape doesn't carry earliestBlock — decoder defaults to 0.
+    decoded.earliestBlock shouldBe BigInt(0)
   }
 
   it should "reject malformed STATUS payloads with the canonical error message" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/network/PeerScoreFeedbackSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/PeerScoreFeedbackSpec.scala
@@ -42,7 +42,7 @@ class PeerScoreFeedbackSpec extends AnyFlatSpec with Matchers with ScalaCheckPro
     // Pure all-timeout runs (0/1 vs 0/10) produce identical ratios; mixing in successes makes the
     // degradation visible through the response-rate component.
     val base = (1 to 5).foldLeft(PeerScore.initial)((s, _) => s.recordResponse(1024, latencyMs = 50))
-    val after1Timeout = base.recordTimeout  // ratio: 5/6 ≈ 0.83
+    val after1Timeout = base.recordTimeout // ratio: 5/6 ≈ 0.83
     val after10Timeouts = (1 to 10).foldLeft(base)((s, _) => s.recordTimeout) // ratio: 5/15 ≈ 0.33
     after10Timeouts.score should be < after1Timeout.score
   }


### PR DESCRIPTION
## Summary

PR #1194 erroneously dropped \`earliestBlock\` from fukuii's ETH/69 STATUS encoder based on a misread of EIP-7642. Both go-ethereum's \`StatusPacket\` and besu's \`StatusMessage69\` use the **canonical 7-field layout**:

\`\`\`
[version, networkId, genesis, forkId, earliestBlock, latestBlock, latestBlockHash]
\`\`\`

With fukuii's 6-field encoding, geth's RLP decoder reads \`latestBlockHash\` (32 bytes) into \`LatestBlock\` (uint64) and rejects the handshake with **\`rlp: input string too long for uint64, decoding into (eth.StatusPacket).LatestBlock\`**.

This is the **central blocker** for both hive's \`ethereum/sync\` simulator (every fukuii↔non-fukuii pair fails at handshake) and post-merge Sepolia sync (every ETH/69 peer rejects fukuii at handshake).

## Smoking gun (geth verbose, hive `ethereum/sync` test 12)

\`\`\`
DEBUG Adding p2p peer            peercount=1 id=18028171 conn=inbound name=fukuii/v0.5.0-23d7f4...
DEBUG Ethereum handshake failed  id=18028171 conn=inbound err="invalid message: (code 0) (size 85)
                                 rlp: input string too long for uint64,
                                 decoding into (eth.StatusPacket).LatestBlock"
DEBUG Removing p2p peer          peercount=0 id=18028171 duration=104.986ms
\`\`\`

## Reference-client verification

| Client | Source | Layout |
|---|---|---|
| go-ethereum master | \`eth/protocols/eth/protocol.go\` \`type StatusPacket struct\` | 7 fields incl. \`EarliestBlock uint64\` |
| besu main | \`StatusMessage.java\` comment + \`writeLongScalar\` calls | \`[version, networkId, genesis, forkId, earliestBlock, latestBlock, blockHash]\` |

## Changes

- **Encoder**: writes the canonical 7 fields with \`earliestBlock\` between \`forkId\` and \`latestBlock\`. Matches geth/besu byte-for-byte.
- **Decoder**: accepts three shapes during the rollout window:
  1. Canonical 7-field (geth/besu/reth/post-fix fukuii) — primary path
  2. 6-field legacy (pre-fix fukuii peers) — \`earliestBlock\` defaults to 0
  3. ETH/68-shape on ETH/69 channel (wrong-chain peers) — unchanged; preserved so the downstream genesis check rejects them as \`Useless peer\` cleanly
- **Tests** (\`ETH69TDSpec\`): 4 STATUS encoding/decoding tests updated. All 32 ETH/69 + decoder tests pass.

## Test plan

- [x] 32 ETH/69 + MessageDecoders unit tests pass
- [x] \`sbt scalafmtAll\` clean
- [x] **Local hive reproduction confirmed the fix**:
  - Pre-fix: test 7 (sync fukuii from go-ethereum) — 60s timeout, geth log shows handshake rejected
  - Post-fix: geth log shows \`Ethereum peer connected ... name=fukuii\` — handshake succeeds
- [ ] Re-run hive \`ethereum/sync\` on staging after merge to confirm 60s-timeout failures (tests 9, 10, 12, 16) clear

## Remaining hive-sync failures (out of scope for this PR)

After this fix, two **separate** issues remain visible:

1. **Engine API readiness race** (tests 4, 7, 8, 16): sink fukuii's Engine API at port 8551 not bound when simulator polls — \`dial tcp ...:8551: connect: connection refused\`. From #1210's dedicated ActorSystem startup latency. Will need a separate PR to make StdNode signal "ready" only after Engine API binding completes.
2. **fukuii source serving** (test 5): geth sink connects to fukuii source successfully but never receives blocks within 60s. Source-side ETH/69 BlockHeaders serving may have its own gap. Worth investigating but not on this PR's path.

## Sepolia impact

This fix is **directly on the Sepolia critical path**: Sepolia is post-merge ETH/69 — every Lighthouse-driven peer connection currently fails at fukuii's STATUS handshake for the same reason. After merge, expect lighthouse-paired fukuii on Barad-dûr to start accumulating peers and progressing SNAP sync (combined with #1208's CL-driven pivot).

## Related

- supersedes the misread in #1194 that introduced the 6-field encoding
- unblocks #1207 / #1208 end-to-end Sepolia validation
- complements #1213 (reverted)'s forkid attempt — that was a different angle on the same symptom

🤖 Generated with [Claude Code](https://claude.com/claude-code)