### PR TITLE
fix(hive): live-port check on Engine API 8551 (unblocks 'sync fukuii from go-ethereum')

### DIFF
--- a/hive/fukuii/Dockerfile
+++ b/hive/fukuii/Dockerfile
@@ -20,7 +20,11 @@ RUN chmod +x /fukuii.sh /hive-bin/enode.sh
 
 EXPOSE 8545 8546 8551 30303 30303/udp
 
-# Check HTTP RPC port — always available regardless of PoW/PoS mode
-ENV HIVE_CHECK_LIVE_PORT=8545
+# Check Engine API authrpc port (8551) — last port to bind during startup.
+# Hive uses this for its TCP-readiness check; once 8551 accepts connections, the
+# sync simulator can POST engine_newPayload immediately without race. Using 8545
+# (JSON-RPC HTTP) caused 0.7–2s connection-refused fast-fails in `ethereum/sync`
+# tests 4/7/8/16 because fukuii's Engine API server binds AFTER JSON-RPC HTTP.
+ENV HIVE_CHECK_LIVE_PORT=8551
 
 ENTRYPOINT ["/fukuii.sh"]


### PR DESCRIPTION
## Summary

Change \`HIVE_CHECK_LIVE_PORT\` from \`8545\` (JSON-RPC HTTP) to \`8551\` (Engine API authrpc) so hive waits for fukuii's Engine API to bind before signaling "client started" and unleashing the simulator's first \`engine_newPayload\`.

## Why

Hive's \`CheckLive\` (\`hiveproxy/checklive.go\`) does a 100ms-ticker TCP-dial on \`HIVE_CHECK_LIVE_PORT\` until it succeeds, then signals "client started" and the sync simulator immediately POSTs \`engine_newPayload\` to \`:8551\`. Fukuii's startup order (\`StdNode.start\` Phase 3) is:

1. JSON-RPC HTTP (8545) ← live-port was here
2. JSON-RPC WS (8546)
3. JSON-RPC IPC
4. Engine API HTTP (8551)

So with \`HIVE_CHECK_LIVE_PORT=8545\`, hive considered fukuii ready when JSON-RPC bound — but Engine API was still 200–500 ms behind. The first POST landed on a port that hadn't yet bound and got \`dial tcp …:8551: connect: connection refused\`. The simulator failed without a single Engine API call reaching fukuii.

## Validation (local hive run)

\`./hive --sim ethereum/sync --client fukuii,go-ethereum --sim.parallelism 1\`:

| Test | Pre-fix | Post-fix |
|---|---|---|
| 7. sync fukuii from go-ethereum | 0.9s connection-refused fail | **11.8s ✓ PASS** |

Sink fukuii log shows \`Engine API server started on 0.0.0.0:8551 (isolated ActorSystem 'engine-api', default-dispatcher='engine-api-dispatcher')\` 92 ms after JWT load — well within the simulator's POST window once hive waits for 8551.

## Out of scope

Two separate hive-sync failures remain:

- **Test 4 (sync fukuii from fukuii)**: sub-second race even with this fix — Pekko HTTP's TCP listener binds *very* slightly before the HTTP handler is fully ready when both source + sink fukuii containers compete for the same JVM warmup window. Will need a different angle (e.g. POST-binding readiness probe, or SO_REUSEPORT-style listener priming). Out of scope for this PR.
- **Test 5 (sync go-ethereum from fukuii)**: 60s timeout. Fukuii is the source, geth is the sink. geth's discovery PINGs fukuii at UDP 30303 and gets no response — fukuii's discovery is disabled in hive mode (\`fukuii.sh\` line 138). Different issue, separate fix.

## Test plan

- [x] Local hive run: test 7 \"sync fukuii from go-ethereum\" passes in 11.8s (was 0.9s connection-refused fail)
- [x] No code changes — Dockerfile env var only
- [ ] Re-run \`hive-sync\` workflow on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)