### PR TITLE
fix(discovery): empty-Neighbors response + canonical ENR port encoding — closes #1221

### DIFF
--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -135,7 +135,7 @@ FLAGS="$FLAGS -Dfukuii.network.discovery.port=30303"
 # below (HIVE_BOOTNODE), so discovery isn't needed to find peers; disabling it
 # sidesteps the parser bug. Underlying scalanet hash-validation regression
 # tracked separately — restore discovery in hive runs once that is fixed.
-FLAGS="$FLAGS -Dfukuii.network.discovery.discovery-enabled=false"
+FLAGS="$FLAGS -Dfukuii.network.discovery.discovery-enabled=true"
 
 # Chain import — prefer /chain.rlp, otherwise concatenate /blocks/*.rlp (consensus sim).
 if [ -f "/chain.rlp" ]; then

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/EthereumNodeRecord.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/EthereumNodeRecord.scala
@@ -86,6 +86,20 @@ object EthereumNodeRecord {
     }
   }
 
+  /** Encode an unsigned 16-bit port as a canonical big-endian byte vector with no leading
+    * zeros, per EIP-778's RLP rules (matches go-ethereum's `uint16` enr entry).
+    *   - port == 0   → empty byte vector (RLP-canonical zero)
+    *   - port < 256  → single byte
+    *   - else        → exactly 2 bytes (big-endian)
+    *
+    * The legacy `ByteVector.fromInt(port)` form emitted 4 bytes with leading zeros, which
+    * geth's strict RLP decoder rejects → falls back to default 0 → triggers errLowPort.
+    */
+  private def encodePort(port: Int): ByteVector =
+    if (port == 0) ByteVector.empty
+    else if (port < 256) ByteVector(port.toByte)
+    else ByteVector.fromShort(port.toShort)
+
   def fromNode(node: Node, privateKey: PrivateKey, seq: Long, customAttrs: (ByteVector, ByteVector)*)(
       implicit sigalg: SigAlg,
       codec: Codec[Content]
@@ -100,8 +114,14 @@ object EthereumNodeRecord {
       Keys.id -> ByteVector("v4".getBytes(UTF_8)),
       Keys.secp256k1 -> sigalg.compressPublicKey(sigalg.toPublicKey(privateKey)).value.toByteVector,
       ipKey -> ByteVector(node.address.ip.getAddress),
-      tcpKey -> ByteVector.fromInt(node.address.tcpPort),
-      udpKey -> ByteVector.fromInt(node.address.udpPort)
+      // Ports are RLP-canonical big-endian integers (EIP-778) — no leading zeros.
+      // go-ethereum's `enr.UDP` / `enr.TCP` decode to `uint16` with strict RLP and
+      // reject the 4-byte `ByteVector.fromInt` form (it sees leading zeros, fails
+      // canonical-RLP, falls back to default 0, then `Node.UDP() <= 1024` triggers
+      // `errLowPort` which makes geth/besu drop fukuii's NODES responses.
+      // Closes #1221).
+      tcpKey -> encodePort(node.address.tcpPort),
+      udpKey -> encodePort(node.address.udpPort)
     )
 
     // Make sure a custom attribute doesn't overwrite a pre-defined one.

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -204,12 +204,22 @@ object DiscoveryNetwork {
             maybeRespond {
               handler.findNode(caller)(target)
             } { nodes =>
-              nodes
-                .take(config.kademliaBucketSize) // NOTE: Other nodes could use a different setting.
-                .grouped(maxNeighborsPerPacket)
-                .toList
+              // Per discv4 spec and go-ethereum's `handleFindnode`
+              // (eth/p2p/discover/v4_udp.go), a FindNode response is ALWAYS
+              // sent — even an empty Neighbors packet — so the peer's RPC
+              // pipeline doesn't time out. Without this, fresh fukuii nodes
+              // with empty kBuckets silently drop every FindNode, breaking
+              // geth/besu/nethermind discovery walks (#1221) and inbound
+              // peer dials when fukuii is the bootnode/source.
+              val groups =
+                nodes
+                  .take(config.kademliaBucketSize)
+                  .grouped(maxNeighborsPerPacket)
+                  .toList
+              val toSend = if (groups.isEmpty) List(List.empty[Node]) else groups.map(_.toList)
+              toSend
                 .traverse { group =>
-                  channel.send(Neighbors(group.toList, 0))
+                  channel.send(Neighbors(group, 0))
                 }
                 .void
             }

--- a/scalanet/discovery/ut/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
+++ b/scalanet/discovery/ut/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetworkSpec.scala
@@ -579,6 +579,35 @@ class DiscoveryNetworkSpec extends AsyncFlatSpec with Matchers {
     }
   }
 
+  // Regression for #1221: pre-fix, an empty handler result silently dropped the FindNode —
+  // `nodes.grouped(...).traverse(...)` is a no-op on an empty list. go-ethereum's
+  // `handleFindnode` (eth/p2p/discover/v4_udp.go) sends Neighbors even when empty. Without
+  // this, fresh fukuii nodes with empty kBuckets never respond to FindNode, breaking
+  // inbound peer discovery (geth/besu peer routing tables drop fukuii) and hive's
+  // `ethereum/sync` test 5 (sync go-ethereum from fukuii).
+  it should "respond with an empty Neighbors when the handler returns Some(Nil) (regression for #1221)" in test {
+    new Fixture {
+      override val test = for {
+        _ <- network.startHandling {
+          StubDiscoveryRPC(
+            findNode = _ => _ => IO.pure(Some(Nil))
+          )
+        }
+        channel <- peerGroup.createServerChannel(from = remoteAddress)
+        findNode = FindNode(remotePublicKey, validExpiration)
+        _ <- channel.sendPayloadToSUT(findNode, remotePrivateKey)
+        msg <- channel.nextMessageFromSUT()
+      } yield {
+        msg should not be empty
+        assertMessageFrom(publicKey, msg) {
+          case Neighbors(nodes, expiration) =>
+            nodes shouldBe empty
+            assertExpirationSet(expiration)
+        }
+      }
+    }
+  }
+
   it should "respond with an ENRResponse with the correct hash if the handler returns Some ENR" in test {
     new Fixture {
       override val test = for {


### PR DESCRIPTION
## Summary

Closes #1221. Two related bugs in fukuii's discovery layer that together prevented geth/besu/nethermind peers from successfully discovering fukuii via DHT walk and adding it to their routing tables.

### Bug 1: v4 FindNode silently dropped when local kBuckets are empty

\`DiscoveryNetwork.scala\` had:

\`\`\`scala
nodes.take(config.kademliaBucketSize).grouped(maxNeighborsPerPacket).toList
  .traverse { group => channel.send(Neighbors(group.toList, 0)) }
\`\`\`

When \`nodes\` is \`Nil\` (fresh fukuii with no known peers), \`grouped(...).toList\` returns an empty list, \`traverse(...)\` on empty list is a no-op — **no Neighbors packet is ever sent**. Geth's discovery times out and never promotes fukuii to its routing table.

go-ethereum's \`handleFindnode\` (\`eth/p2p/discover/v4_udp.go\`) always sends a Neighbors response: \`if len(p.Nodes) > 0 || !sent { t.send(from, fromID, &p) }\`. The v5 sync responder already handled the empty case correctly; v4 was the gap.

### Bug 2: ENR ports encoded as 4-byte non-canonical RLP

\`EthereumNodeRecord.fromNode\` used \`ByteVector.fromInt(port)\` which produces 4 bytes big-endian *with leading zeros* (e.g. \`0x00 0x00 0x76 0x5F\` for port 30303). Per EIP-778 + RLP canonical-form rules, integer values must have no leading zeros. go-ethereum's \`enr.UDP\` / \`enr.TCP\` decode to \`uint16\` with strict RLP — the 4-byte form is rejected, the field falls back to default \`0\`, and \`Node.UDP() <= 1024\` triggers **\`errLowPort\`** in \`verifyResponseNode\` (\`p2p/discover/v5_udp.go\`). Geth discards every NODES record fukuii sends.

Captured pre-fix in geth verbose log:

\`\`\`
DEBUG Invalid record in NODES/v5  err="low port"
DEBUG ENR request failed          err="0 nodes in response for distance zero"
\`\`\`

Post-fix:

\`\`\`
TRACE << NODES/v5  tot=1 n=1
DEBUG Node revalidated  b=12 q=fast    ← fukuii now in geth's routing table
\`\`\`

Fix: canonical port encoding — empty for 0, 1 byte for <256, 2 bytes for ≤65535. Matches geth's \`uint16\` enr entry format byte-for-byte.

### \`fukuii.sh\`: re-enable discovery

The hive adapter previously disabled discovery to sidestep this exact bug; with the FindNode + port encoding fixes in place, discovery is functional. Inbound peer dials (the test 5 / Sepolia bootnode case) require fukuii to respond to PING + FINDNODE.

## Hive validation (local)

\`\`\`
./hive --sim ethereum/sync --client fukuii,go-ethereum --sim.parallelism 1
\`\`\`

| Test | Pre-fix | Post-fix |
|---|---|---|
| 5. sync go-ethereum from fukuii | geth log: \`Invalid record err="low port"\` repeated for 60 s, fukuii never added to routing table | geth log: \`<< NODES tot=1 n=1\` + \`Node revalidated b=12 q=fast\` — full discovery flow green |

Test 5 still hits 60 s timeout because geth's *dialer* (separate from discovery) hasn't picked fukuii up within the test budget — that's a different timing issue and out of scope for this PR. The discovery layer is now fully working and that's what matters for Sepolia peer accumulation.

## Sepolia impact

This is the bug that was preventing Sepolia peers from keeping fukuii in their routing tables: every peer that walked the DHT and queried fukuii would receive an unparseable ENR, drop us, and we'd accumulate only outbound-dialed peers. Combined with PRs #1217 / #1219 / #1220, Sepolia post-merge sync should now bootstrap properly.

## Test plan

- [x] New regression test in \`DiscoveryNetworkSpec\`: empty handler result emits empty Neighbors packet
- [x] Local hive \`ethereum/sync\`: discovery flow is green for fukuii (geth promotes fukuii to \`q=fast\`)
- [x] \`sbt scalafmtCheckAll\` clean
- [x] Existing \`EthereumNodeRecordSpec\` round-trip tests still pass (port encoding change is canonical-form, fully compatible with both \`ByteVector.toInt(signed=false)\` and geth's strict RLP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)