### PR TITLE
fix(engine): correct BPO1/BPO2 blob-base-fee update fractions (follow-up to #1226)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -1137,6 +1137,14 @@ object BlobGasUtils {
   val BLOB_BASE_FEE_UPDATE_FRACTION: BigInt = BigInt(3338477)
   // EIP-7691 (Prague): BLOB_BASE_FEE_UPDATE_FRACTION bumped to scale with 9-blob MAX.
   val PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION: BigInt = BigInt(5007716)
+  // EIP-7892 BPO1/BPO2 update fractions (geth `params.config.go`
+  // `DefaultBPO{1,2}BlobConfig.UpdateFraction`). These scale with each fork's MAX so the
+  // EIP-7918 reserve-price comparison and the `getBlobGasPrice` exponential give the
+  // right answer post-Osaka. Without them, fukuii uses Prague's smaller fraction →
+  // higher computed `blobPrice` → reservePrice ≤ blobPrice almost always → EIP-7918
+  // alternate branch never triggers and we fall back to EIP-4844, mismatching geth.
+  val BPO1_BLOB_BASE_FEE_UPDATE_FRACTION: BigInt = BigInt(8346193)
+  val BPO2_BLOB_BASE_FEE_UPDATE_FRACTION: BigInt = BigInt(11684671)
   val MIN_BLOB_BASE_FEE: BigInt = BigInt(1)
 
   // EIP-7918: BLOB_BASE_COST = 2^13 — the per-blob execution gas cost used in the
@@ -1219,15 +1227,17 @@ object BlobGasUtils {
     fakeExponential(MIN_BLOB_BASE_FEE, excessBlobGas, fraction)
   }
 
-  /** Fork-aware blob-base-fee update fraction. Prague raised it from Cancun's 3338477 to 5007716;
-    * Osaka and the BPO forks inherit the Prague value (no further change documented in the
-    * Sepolia BlobScheduleConfig).
+  /** Fork-aware blob-base-fee update fraction. Each BPO bumps the fraction proportional to
+    * its MAX, matching geth's `params.config.go` `Default{Cancun,Prague,Osaka,BPO1,BPO2}BlobConfig.UpdateFraction`.
+    * Osaka itself reuses the Prague value (Osaka's blob params are unchanged from Prague).
     */
   def updateFractionFor(
       blockTimestamp: Long,
       blockchainConfig: com.chipprbots.ethereum.utils.BlockchainConfig
   ): BigInt =
-    if (blockchainConfig.isPragueTimestamp(blockTimestamp)) PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION
+    if (blockchainConfig.isBpo2Timestamp(blockTimestamp)) BPO2_BLOB_BASE_FEE_UPDATE_FRACTION
+    else if (blockchainConfig.isBpo1Timestamp(blockTimestamp)) BPO1_BLOB_BASE_FEE_UPDATE_FRACTION
+    else if (blockchainConfig.isPragueTimestamp(blockTimestamp)) PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION
     else BLOB_BASE_FEE_UPDATE_FRACTION
 
   /** Compute the expected `excessBlobGas` of a child block given its parent and timestamp.

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/BlobGasBpoScheduleSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/BlobGasBpoScheduleSpec.scala
@@ -128,6 +128,28 @@ class BlobGasBpoScheduleSpec extends AnyFlatSpec with Matchers {
     computed shouldBe BigInt(8388378)
   }
 
+  it should "use BPO2 update fraction so high-excess cases still hit the reserve-price branch" in {
+    // Live Sepolia 2026-05-09 BLOB-DIAG sample: high parent.excess (12.7M) where Prague's
+    // smaller updateFraction (5_007_716) would compute blobPrice ≈ 12 * 131072 = 1_572_864
+    // wei, vs reservePrice = 8192 * 44 = 360_448. Prague fraction → blobPrice > reservePrice
+    // → EIP-7918 branch NOT taken → EIP-4844 formula used → 11_971_190 (wrong).
+    //
+    // Geth uses BPO2's larger updateFraction (11_684_671) where blobPrice ≈ 2 * 131072 =
+    // 262_144 < reservePrice → EIP-7918 alt branch IS taken → 13_107_147 (correct).
+    //
+    // This test pins the BPO2 update fraction selection so a regression to Prague's value
+    // would re-introduce the bug seen on live Sepolia post-#1226 merge.
+    val cfg = withForks(prague = Some(pragueTs), osaka = Some(osakaTs), bpo1 = Some(bpo1Ts), bpo2 = Some(bpo2Ts))
+    val computed = BlobGasUtils.expectedExcessBlobGas(
+      parentExcessBlobGas = BigInt(12757622),
+      parentBlobGasUsed = BigInt(1048576), // 8 blobs
+      parentBaseFee = BigInt(44),
+      childTimestamp = bpo2Ts + 100,
+      blockchainConfig = cfg
+    )
+    computed shouldBe BigInt(13107147)
+  }
+
   "BlockchainConfig" should "expose isBpo1Timestamp / isBpo2Timestamp predicates" in {
     val cfg = withForks(bpo1 = Some(bpo1Ts), bpo2 = Some(bpo2Ts))
     cfg.isBpo1Timestamp(bpo1Ts - 1) shouldBe false


### PR DESCRIPTION
## Summary

Follow-up to #1226. The EIP-7918 reserve-price logic was correct but used Prague's `UPDATE_FRACTION` (5,007,716) for all post-Prague forks. Geth's `params.config.go` actually defines per-fork values:

| Fork | UpdateFraction (geth) | Was in fukuii |
|------|----------------------|---------------|
| Cancun | 3,338,477 | correct |
| Prague | 5,007,716 | correct |
| Osaka | 5,007,716 (= Prague) | correct |
| **BPO1** | **8,346,193** | wrong (used Prague's) |
| **BPO2** | **11,684,671** | wrong (used Prague's) |

These scale with each fork's MAX so `fakeExponential` blobPrice gives the right answer for the EIP-7918 reserve-price comparison.

## Symptom

With Prague's smaller fraction, `blobPrice` came out **larger** than reserve for mid-to-high `parent.excess` values, so the EIP-7918 alternate branch never triggered — fukuii fell through to EIP-4844 and rejected canonical Sepolia payloads with `INCORRECT_EXCESS_BLOB_GAS`.

## Live Sepolia regression sample

Captured via BLOB-DIAG instrumentation (parent values match canonical via public RPC):

```
parent.excess = 12_757_622, parent.used = 1_048_576, parent.baseFee = 44
target = 14 blobs (1_835_008), max = 21 blobs (2_752_512)

Prague fraction (5_007_716):
  fakeExp(1, 12_757_622, 5_007_716) = 12
  blobPrice = 12 * 131_072 = 1_572_864
  reservePrice = 8_192 * 44 = 360_448
  1_572_864 > 360_448  ->  EIP-4844 branch  ->  expected = 11_971_190 (WRONG)

BPO2 fraction (11_684_671):
  fakeExp(1, 12_757_622, 11_684_671) = 2
  blobPrice = 2 * 131_072 = 262_144
  reservePrice = 360_448
  262_144 < 360_448  ->  EIP-7918 alt branch  ->  expected = 13_107_147 (correct)
```

## Live validation post-deploy

- **Pre-fix**: lighthouse `Invalid execution payload` warnings ~6/sec
- **Post-fix**: **0 warnings**, fukuii returns `ACCEPTED` for every canonical Sepolia payload (only rejected due to "parent unknown" — orthogonal sync-bootstrap concern)
- Lighthouse `el_offline=false`, `is_syncing=false`, `sync_distance=1` (beacon caught up)

## Test plan

- [x] Unit: `BlobGasBpoScheduleSpec` 11/11 pass — pins the regression case (parent.excess=12,757,622) so a revert to Prague's fraction for BPO2 would fail
- [x] Live Sepolia: rebuilt + redeployed with this fix; 0 INVALID payloads in 90s
- [ ] Hive engine Paris suite: should remain 65/65 pass (Paris doesn't exercise BPO so this is no-op there)

Reference: geth `params/config.go` — DefaultBPO1BlobConfig / DefaultBPO2BlobConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)