### PR TITLE
fix(engine): publish BeaconHead on FCU SYNCING short-circuit (unblocks cold-start sync)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -442,10 +442,17 @@ class EngineApiService(
           blockchainReader.getReceiptsByHash(forkChoiceState.headBlockHash).isEmpty
 
       if (!blockExistsByHash && !isGenesis) {
-        // Head unknown — client is still syncing to this head
+        // Head unknown — client is still syncing to this head. Notify ForkChoiceManager
+        // anyway so its BeaconHead listener (SyncController) can drive SNAP-sync pivot
+        // selection. Without this, post-merge cold-start hangs forever in CL-PIVOT
+        // wait state because the FCU short-circuits before publishBeaconHead fires.
+        forkChoiceManager.applyForkChoiceState(forkChoiceState)
         EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
         Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
       } else if (headOptimistic) {
+        // Same rationale as the unknown-head case: drive ForkChoiceManager so SNAP sync
+        // can re-pivot on the freshest CL head while we're still optimistically caught up.
+        forkChoiceManager.applyForkChoiceState(forkChoiceState)
         EngineApiMetrics.recordForkchoiceUpdated("SYNCING")
         Right(ForkchoiceUpdatedResponse(payloadStatus = PayloadStatusV1(Syncing)))
       } else if (safeUnknown || finalizedUnknown) {

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -549,5 +549,42 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
       // (the last valid ancestor before the invalid block)
       r2.latestValidHash shouldBe Some(genesisHeader.hash)
     }
+
+    /** Regression for cold-start sync bootstrap (post-merge chains).
+      *
+      * Pre-fix, `engine_forkchoiceUpdated` short-circuited to SYNCING for unknown heads
+      * **without** invoking `forkChoiceManager.applyForkChoiceState`, which is the only path
+      * that publishes `BeaconHead` to the ForkChoiceManager listener. SyncController's
+      * BeaconHead handler is the trigger that forwards `CLPivotHint` to SNAPSyncController;
+      * without it, SNAP sync sat in `[CL-PIVOT] waiting for engine_forkchoiceUpdated` forever
+      * — fukuii accepted every newPayload as `ACCEPTED (parent unknown)` but never started
+      * actually syncing.
+      */
+    "publish BeaconHead to ForkChoiceManager listener even when the head is unknown (SYNCING short-circuit)"
+      .taggedAs(UnitTest) in new EngineApiTestSetup {
+      import org.apache.pekko.testkit.TestProbe
+
+      // EphemBlockchainTestSetup provides `system: ActorSystem` for us.
+      val probe = TestProbe()(system)
+      forkChoiceManager.setListener(probe.ref)
+
+      val unknownHead = ByteString(Array.fill(32)(0xab.toByte))
+      val state = ForkChoiceState(
+        headBlockHash = unknownHead,
+        safeBlockHash = ByteString(new Array[Byte](32)),
+        finalizedBlockHash = ByteString(new Array[Byte](32))
+      )
+
+      val response = engineApi.forkchoiceUpdated(state, payloadAttributes = None).unsafeRunSync()
+      response.isRight shouldBe true
+      response.toOption.get.payloadStatus.status shouldBe Syncing
+
+      // Critical assertion: BeaconHead must reach the listener so SyncController can drive
+      // SNAP sync's CL-PIVOT trigger. Pre-fix this would TIMEOUT — applyForkChoiceState
+      // was never called on the SYNCING short-circuit path.
+      val beacon = probe.expectMsgType[ForkChoiceManager.BeaconHead]
+      beacon.headHash shouldBe unknownHead
+      beacon.knownHeader shouldBe None
+    }
   }
 }


### PR DESCRIPTION
## Summary

Cold-start sync bootstrap on post-merge chains (Sepolia, ETH mainnet) hung forever in `[CL-PIVOT] waiting for engine_forkchoiceUpdated`. Lighthouse *was* sending forkchoiceUpdated but fukuii's SNAPSyncController never started.

**Root cause**: `EngineApiService.forkchoiceUpdated` short-circuits to SYNCING for unknown / optimistic heads — the typical cold-start state where fukuii is at block 0 and lighthouse hasn't completed beacon sync yet — by returning early before invoking `forkChoiceManager.applyForkChoiceState(...)`. That call is the **only** path that publishes `BeaconHead` to the registered listener (SyncController), which forwards `CLPivotHint` to SNAPSyncController.

Without it, the wire diagram for cold-start sync was broken:

```
Lighthouse → engine_forkchoiceUpdated(unknown_head)
          ↓
EngineApiService.forkchoiceUpdated
          ↓ (short-circuits to SYNCING — return early)
          ✗ ForkChoiceManager.applyForkChoiceState NEVER CALLED
          ✗ BeaconHead NEVER PUBLISHED
          ✗ SyncController NEVER receives CLPivotHint
          ✗ SNAPSyncController stays in `bootstrapping` state forever
```

## Fix

Both unknown-head and optimistic-head short-circuits now call `forkChoiceManager.applyForkChoiceState` first (publishes BeaconHead unconditionally per its own contract), then return SYNCING.

## Live Sepolia validation

**Pre-fix** (SNAPSyncController log):
```
[CL-PIVOT] Post-merge chain (TTD configured), waiting for
engine_forkchoiceUpdated from CL (engineApiRequired=true, waited=145s)
... 195s ... forever.
```

**Post-fix** (within seconds of first CL forkchoice):
```
Fork choice updated: head=...
Received CL-driven beacon head ... (knownHeader=10817812)
[CL-PIVOT] Received CL-driven head ... knownHeader=10817812
🛰  SNAP pivot from CL forkchoiceUpdated
Beginning fast state sync with 16 concurrent workers
```

## Test plan

- [x] Unit: regression added in `EngineApiServiceSpec` — drives FCU with an unknown head, registers a TestProbe as ForkChoiceManager listener, asserts BeaconHead arrives. Pre-fix this would TIMEOUT.
- [x] Engine + ForkChoiceManager suites: 32/32 pass
- [x] Live Sepolia: rebuilt + redeployed; SNAP sync now starts within 5s of first CL forkchoice (vs never)
- [ ] Hive engine Paris suite should remain 65/65 pass (Paris hive doesn't exercise cold-start, but verifies no regression in known-head FCU path)

## Stack

Final blocker in the post-merge sync chain. With this fix landed alongside the merged #1225 / #1226 / #1227, fukuii can finally bootstrap a Sepolia chain from genesis via lighthouse-driven SNAP sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)