### PR TITLE
fix(engine): commit field must be 8 hex chars for getClientVersionV1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -285,7 +285,9 @@ lazy val node = {
         version,
         scalaVersion,
         sbtVersion,
-        BuildInfoKey.action("gitHeadCommit") { git.gitHeadCommit.?.value.flatten.map(_.take(7)).getOrElse("unknown") },
+        // engine_getClientVersionV1 requires `commit` to be exactly 8 hex chars
+        // (4 bytes per execution-apis spec); 7 trips Lighthouse's length check.
+        BuildInfoKey.action("gitHeadCommit") { git.gitHeadCommit.?.value.flatten.map(_.take(8)).getOrElse("unknown") },
         BuildInfoKey.action("gitCurrentBranch") { 
           val branch = git.gitCurrentBranch.?.value.getOrElse("")
           if (branch != null && branch.nonEmpty) branch else "unknown"


### PR DESCRIPTION
## Summary

- Change `BuildInfo.gitHeadCommit` from 7-char to 8-char abbreviated SHA so that `engine_getClientVersionV1`'s `commit` field meets the execution-apis spec's exact 4-byte / 8-hex-char requirement.

## Background

PR #1224 fixed the `commit` field to be hex-only. However, sbt-buildinfo's abbreviation length was 7 characters, which trips Lighthouse's separate length check:

```
WARN  Execution engine call failed
      error: InvalidClientVersion("Input must be exactly 8 characters long (excluding any '0x' prefix)")
```

This caused `engine_upcheck` to fail intermittently on Sepolia, even after the broader fixes (#1224, #1225, #1228) cleared the el_offline state.

## Fix

`build.sbt:288` — `take(7)` → `take(8)`. Inline comment added explaining the spec requirement.

## Validation (live on Sepolia)

Pre-fix: `engine_getClientVersionV1` returned `"commit":"384e5a3"` (7 chars) → Lighthouse `InvalidClientVersion` errors every upcheck cycle.

Post-fix (this branch built locally and deployed to fukuii-sepolia):
```
$ curl -s -X POST http://localhost:8561 ... -d '{"method":"engine_getClientVersionV1",...}'
{"jsonrpc":"2.0","result":[{"code":"FK","name":"Fukuii","version":"0.5.0","commit":"384e5a36"}]}
```
- `commit` is exactly 8 hex chars
- Lighthouse logs no longer contain `InvalidClientVersion` warnings
- CL transitioned `Stalled → Synced`, exec_hash now consistently `(verified)`

## Test plan

- [x] Local Sepolia validation: getClientVersionV1 returns 8-char commit, Lighthouse upcheck succeeds
- [x] sbt assembly builds cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)