### PR TITLE
feat(snap): port go-ethereum StackTrie for streaming MPT construction

### DIFF
--- a/ops/barad-dur/docker-compose.yml
+++ b/ops/barad-dur/docker-compose.yml
@@ -112,8 +112,8 @@ services:
     image: ${FUKUII_IMAGE:-chipprbots/fukuii:latest}
     container_name: fukuii-primary
     restart: unless-stopped
-    mem_limit: 6g
-    memswap_limit: 6g
+    mem_limit: 8g
+    memswap_limit: 8g
     ports:
       - "${FUKUII_PRIMARY_RPC_PORT:-8545}:8545"       # JSON-RPC HTTP (internal)
       - "${FUKUII_PRIMARY_WS_PORT:-8546}:8546"         # JSON-RPC WebSocket (internal)
@@ -131,11 +131,13 @@ services:
     # invoke `java` directly here.
     entrypoint: ["java"]
     command:
-      - "-Xmx4g"
-      - "-Xms1g"
+      - "-Xmx6g"
+      - "-Xms2g"
       - "-Xss10M"
       - "-XX:+UseG1GC"
       - "-XX:MaxGCPauseMillis=200"
+      - "-XX:+HeapDumpOnOutOfMemoryError"
+      - "-XX:HeapDumpPath=/app/data/logs/heapdump.hprof"
       - "-Dconfig.file=/app/conf/etc.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-jar"

--- a/ops/barad-dur/fukuii-conf-1/etc.conf
+++ b/ops/barad-dur/fukuii-conf-1/etc.conf
@@ -26,6 +26,25 @@ fukuii {
     peer-response-timeout = 90.seconds
     blacklist-duration = 60.seconds
     critical-blacklist-duration = 30.minutes
+
+    snap-sync {
+      # Phase 2 SNAP rewrite — streaming MPT construction via StackTrie.
+      # Eliminates the multi-GiB in-memory pivot trie and the multi-minute
+      # flush. ETC mainnet is the speed-comparison benchmark vs. the prior
+      # deferred-merkleization run on the same harness.
+      use-stack-trie = true
+
+      # Pivot at network tip (offset=0) maximises the SNAP serve window.
+      # Proactive refresh fires at 120-block drift well before the 128-block
+      # cliff where peers stop serving the chosen state.
+      pivot-block-offset = 0
+
+      max-pivot-staleness-blocks = 4096
+      request-timeout = 60.seconds
+      min-snap-peers = 3
+      snap-peer-eviction-interval = 10s
+      max-evictions-per-cycle = 5
+    }
   }
 
   network {

--- a/ops/barad-dur/sepolia/docker-compose.yml
+++ b/ops/barad-dur/sepolia/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: chipprbots/fukuii:latest
     container_name: fukuii-sepolia
     restart: unless-stopped
+    mem_limit: 8g
+    memswap_limit: 8g
     ports:
       - "8555:8545"       # JSON-RPC HTTP
       - "8556:8546"       # JSON-RPC WebSocket
@@ -37,11 +39,13 @@ services:
     # symlink instead. Mirrors the pattern in the primary docker-compose.yml.
     entrypoint: ["java"]
     command:
-      - "-Xmx4g"
+      - "-Xmx6g"
       - "-Xms2g"
       - "-Xss10M"
       - "-XX:+UseG1GC"
       - "-XX:MaxGCPauseMillis=200"
+      - "-XX:+HeapDumpOnOutOfMemoryError"
+      - "-XX:HeapDumpPath=/app/data/logs/heapdump.hprof"
       - "-Dconfig.file=/app/conf/sepolia.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-jar"

--- a/ops/cirith-ungol/conf/etc.conf
+++ b/ops/cirith-ungol/conf/etc.conf
@@ -71,6 +71,13 @@ fukuii {
     critical-blacklist-duration = 30.minutes
 
     snap-sync {
+      # Phase 2 SNAP rewrite — streaming MPT construction via StackTrie.
+      # Eliminates the multi-GiB in-memory pivot trie and the multi-minute
+      # flush. Mordor is the validation environment: small state (~3M
+      # accounts) makes a full sync cheap to repeat while we observe the
+      # new write path under real network conditions.
+      use-stack-trie = true
+
       # The SNAP protocol guarantees serving state for the most recent ~128 blocks.
       # offset=0 maximizes the serve window: pivot sits at the tip, giving the full
       # 128 blocks (~28 min on Mordor at 13s/block) before peers drop support.

--- a/ops/cirith-ungol/docker-compose.yml
+++ b/ops/cirith-ungol/docker-compose.yml
@@ -79,7 +79,10 @@ services:
       - "9098:9095"
     volumes:
       # Configuration files
-      - ./conf/etc.conf:/app/conf/etc.conf:ro
+      # Mount as mordor.conf so App.setNetworkConfig("mordor") picks it up via
+      # its $network.conf filesystem lookup (otherwise it falls back to the
+      # JAR-bundled classpath conf/mordor.conf and clears our -Dconfig.file).
+      - ./conf/etc.conf:/app/conf/mordor.conf:ro
       - ./conf/logback.xml:/app/conf/logback.xml:ro
       # Custom JVM settings: 6GB heap + G1GC for SNAP sync trie finalization
       - ./conf/application.ini:/app/fukuii/conf/application.ini:ro
@@ -110,7 +113,7 @@ services:
       - "-Xss10M"
       - "-XX:+UseG1GC"
       - "-XX:MaxGCPauseMillis=200"
-      - "-Dconfig.file=/app/conf/etc.conf"
+      - "-Dconfig.file=/app/conf/mordor.conf"
       - "-Dfukuii.datadir=/app/data"
       - "-Dfukuii.network.rpc.http.port=8545"
       - "-Dfukuii.metrics.enabled=true"

--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -14,6 +14,16 @@ sync {
   snap-sync {
     # Enable SNAP sync (requires do-snap-sync = true)
     enabled = true
+    # Phase 2 of the SNAP rewrite (geth-style streaming MPT construction).
+    # When true, the AccountRange and StorageRange coordinators build per-task
+    # streaming Merkle Patricia tries via SnapHashTrie / StackTrie rather than
+    # the legacy MerklePatriciaTrie + DeferredWriteMptStorage approach. This
+    # eliminates the multi-GiB in-memory pivot trie and the multi-minute flush
+    # that has been the OOM trigger and throughput ceiling.
+    #
+    # Default false during the validation rollout. Enable per-network in the
+    # network conf for opt-in testing (e.g. mordor.conf, sepolia.conf).
+    use-stack-trie = false
     # Number of blocks before the best block to use as pivot for SNAP sync
     # Core-geth uses 64 blocks (fsMinFullBlocks) as the minimum threshold
     # This allows SNAP sync to start much sooner after genesis

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
@@ -283,8 +283,15 @@ class PivotBlockSelector(
   }
 
   private def collectVoters(previousBestBlockNumber: Option[BigInt] = None): ElectionDetails = {
+    // Require maxBlockNumber > 0. ETH/64-/68 STATUS doesn't carry the peer's
+    // best block number; Bug 32's eager probe in NetworkPeerManagerActor populates
+    // it once the peer replies to GetBlockHeaders(bestHash, 1). Until that reply
+    // arrives, maxBlockNumber stays at 0 and the peer must not vote — otherwise
+    // the highest-known-number is 0, expectedPivotBlock collapses to 0, and the
+    // selector asks for genesis. Equivalent to the `peer.maxBlockNumber > 0`
+    // filters SNAPSyncController applies in three sites for the same reason.
     val peersUsedToChooseTarget = peersToDownloadFrom.collect {
-      case (_, PeerWithInfo(peer, PeerInfo(_, _, true, maxBlockNumber, _))) =>
+      case (_, PeerWithInfo(peer, PeerInfo(_, _, true, maxBlockNumber, _))) if maxBlockNumber > 0 =>
         (peer, maxBlockNumber)
     }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -313,6 +313,12 @@ class SNAPSyncController(
 
   override def preStart(): Unit = {
     log.info("SNAP Sync Controller initialized")
+    log.info(
+      s"SNAPSyncConfig: useStackTrie=${snapSyncConfig.useStackTrie}, " +
+        s"accountConcurrency=${snapSyncConfig.accountConcurrency}, " +
+        s"storageBatchSize=${snapSyncConfig.storageBatchSize}, " +
+        s"pivotBlockOffset=${snapSyncConfig.pivotBlockOffset}"
+    )
     progressMonitor.startPeriodicLogging()
   }
 
@@ -1540,7 +1546,8 @@ class SNAPSyncController(
                       initialMaxInFlightPerPeer = 3, // Recovery: accounts done, storage gets 3 of 5 per-peer budget
                       initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
                       minResponseBytes = snapSyncConfig.storageMinResponseBytes,
-                      deferredMerkleization = snapSyncConfig.deferredMerkleization
+                      deferredMerkleization = snapSyncConfig.deferredMerkleization,
+                      useStackTrie = snapSyncConfig.useStackTrie
                     )
                     .withDispatcher("sync-dispatcher"),
                   s"storage-range-coordinator-$coordinatorGeneration"
@@ -2350,7 +2357,8 @@ class SNAPSyncController(
               5, // Full per-peer budget during AccountRangeSync (storage+bytecode deferred to 0)
             trieFlushThreshold = snapSyncConfig.accountTrieFlushThreshold,
             initialResponseBytes = snapSyncConfig.accountInitialResponseBytes,
-            minResponseBytes = snapSyncConfig.accountMinResponseBytes
+            minResponseBytes = snapSyncConfig.accountMinResponseBytes,
+            useStackTrie = snapSyncConfig.useStackTrie
           )
           .withDispatcher("sync-dispatcher"),
         s"account-range-coordinator-$coordinatorGeneration"
@@ -2424,7 +2432,8 @@ class SNAPSyncController(
                 0, // Defer storage dispatch during AccountRangeSync — prevents false pivot refreshes from stale-root timeouts
               initialResponseBytes = snapSyncConfig.storageInitialResponseBytes,
               minResponseBytes = snapSyncConfig.storageMinResponseBytes,
-              deferredMerkleization = snapSyncConfig.deferredMerkleization
+              deferredMerkleization = snapSyncConfig.deferredMerkleization,
+              useStackTrie = snapSyncConfig.useStackTrie
             )
             .withDispatcher("sync-dispatcher"),
           s"storage-range-coordinator-$coordinatorGeneration"
@@ -3838,7 +3847,20 @@ case class SNAPSyncConfig(
     // Use for local SNAP-serving nodes (e.g. Besu with --snapsync-server-enabled) that may
     // disconnect after storage phase but are needed for trie node healing.
     // Format: enode://PUBKEY@HOST:PORT
-    snapServerPeers: List[java.net.URI] = Nil
+    snapServerPeers: List[java.net.URI] = Nil,
+    /** Phase 2 of the SNAP rewrite (`snap-stacktrie-port` plan).
+      *
+      * When `true`, the SNAP write path uses streaming `SnapHashTrie`
+      * (one per AccountTask, one per storage contract) instead of the legacy
+      * `MerklePatriciaTrie` + `DeferredWriteMptStorage` approach. Memory is
+      * bounded by trie depth rather than account count; the multi-GiB
+      * in-memory pivot trie and its 13.6-minute collapse are eliminated.
+      *
+      * Default `false` — opt in via `sync.snap-sync.use-stack-trie = true`
+      * in sync.conf for testing. Will become the default once Sepolia +
+      * Mordor validation completes (Step 5 of the plan).
+      */
+    useStackTrie: Boolean = false
 )
 
 object SNAPSyncConfig {
@@ -3953,7 +3975,11 @@ object SNAPSyncConfig {
               try Some(new java.net.URI(s.toString))
               catch { case _: Exception => None }
             }
-        else Nil
+        else Nil,
+      useStackTrie =
+        if (snapConfig.hasPath("use-stack-trie"))
+          snapConfig.getBoolean("use-stack-trie")
+        else false
     )
   }
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrie.scala
@@ -1,0 +1,133 @@
+package com.chipprbots.ethereum.blockchain.sync.snap
+
+import scala.collection.mutable
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.mpt.StackTrie
+
+/** Hash-scheme RocksDB-batching wrapper around [[StackTrie]] for SNAP sync.
+  *
+  * The StackTrie itself is strictly write-only and emits finalised nodes via a
+  * callback. This wrapper owns the batching policy:
+  *
+  *   - each emitted `(hash, RLP blob)` pair is appended to an in-memory buffer;
+  *   - when the buffer crosses `batchSizeThreshold` total bytes, the entire
+  *     buffer is handed to the `writeBatch` callback (a single batched RocksDB
+  *     write) and cleared;
+  *   - `commit()` finalises the right-boundary path and flushes the remainder.
+  *
+  * The `writeBatch` callback is the integration boundary. Callers pass in a
+  * function adapted from their storage layer — typically `mptStorage.storeRawNodes`
+  * for the SNAP path, which goes through `FastSyncNodeStorage` and picks up the
+  * pivot-block-number tag for pruning automatically.
+  *
+  * == Why this is so simple ==
+  *
+  * geth's equivalent (`pathTrie` / `hashTrie` in `eth/protocols/snap/gentrie.go`)
+  * carries non-trivial boundary logic — left-boundary skip on resume, ancestor
+  * deletion, right-boundary discard. Almost all of that complexity is
+  * path-scheme-specific: in path scheme, exactly one node exists at each trie
+  * path, so stale partial state from a prior session must be cleaned up to
+  * avoid structural conflicts.
+  *
+  * Fukuii uses hash scheme — nodes are keyed by their keccak256 hash, so two
+  * nodes with different contents can never collide. Re-emitting an already-
+  * written node is a no-op (RocksDB just overwrites the same key with the same
+  * value). The boundary problem dissolves.
+  *
+  * If we later need to recover bytes wasted by re-emitting already-committed
+  * nodes on resume, a `skipLeftBoundary` mode can be added — but it's a perf
+  * optimisation, not a correctness requirement.
+  *
+  * == Concurrency ==
+  *
+  * Not thread-safe. The expected usage is one wrapper instance per
+  * `AccountTask` (or per per-contract storage trie), with all `update` and
+  * `commit` calls dispatched from a single actor or thread.
+  *
+  * @param writeBatch        called with `(nodeHash, rlpBlob)` pairs when the
+  *                          batch threshold is reached or on `commit()`. The
+  *                          caller owns the actual disk write semantics
+  *                          (synchronous vs queued, fsync vs not, etc.).
+  * @param batchSizeThreshold flush the batch when the accumulated blob bytes
+  *                           reach this size. 8 MiB matches geth's
+  *                           `batchSizeThreshold` in `eth/protocols/snap/sync.go`.
+  */
+final class SnapHashTrie(
+    writeBatch: Seq[(ByteString, Array[Byte])] => Unit,
+    val batchSizeThreshold: Int = SnapHashTrie.DefaultBatchSizeBytes
+) {
+
+  private val pending = mutable.ArrayBuffer.empty[(ByteString, Array[Byte])]
+  private var pendingBytes: Long = 0L
+
+  private val stackTrie = new StackTrie((_, hash, blob) => emit(hash, blob))
+
+  /** Insert `value` under `key`. Keys must arrive in strictly-ascending
+    * hex-nibble order (after `HexPrefix.bytesToNibbles`). The underlying
+    * StackTrie enforces this; violations throw.
+    */
+  def update(key: Array[Byte], value: Array[Byte]): Unit =
+    stackTrie.update(key, value)
+
+  /** Finalise the right-boundary path and flush any pending batch.
+    *
+    * Returns the 32-byte trie root hash. After commit, the wrapper must be
+    * `reset()` before any further `update` calls.
+    */
+  def commit(): ByteString = {
+    val root = stackTrie.hash()
+    flush()
+    root
+  }
+
+  /** Discard any in-memory state without flushing. Used when a range is being
+    * abandoned (pivot roll, abort, shutdown).
+    *
+    * Note: emissions already flushed to disk during the doomed run are NOT
+    * rolled back — they're still valid hash-content-addressed trie nodes and
+    * will simply be unreferenced until pruning cleans them up.
+    */
+  def reset(): Unit = {
+    stackTrie.reset()
+    pending.clear()
+    pendingBytes = 0L
+  }
+
+  /** Bytes currently buffered in the pending batch (not yet flushed). */
+  def pendingBatchBytes: Long = pendingBytes
+
+  /** Number of `(hash, blob)` pairs currently buffered. */
+  def pendingBatchCount: Int = pending.size
+
+  // ---- internals ----
+
+  private def emit(hash: ByteString, blob: Array[Byte]): Unit = {
+    // StackTrie reuses internal buffers across emissions — deep-copy.
+    pending += hash -> blob.clone()
+    pendingBytes += blob.length
+    if (pendingBytes >= batchSizeThreshold) flush()
+  }
+
+  private def flush(): Unit = {
+    if (pending.nonEmpty) {
+      // toSeq creates an immutable snapshot before clearing.
+      writeBatch(pending.toSeq)
+      pending.clear()
+      pendingBytes = 0L
+    }
+  }
+}
+
+object SnapHashTrie {
+
+  /** 8 MiB, matching geth's `batchSizeThreshold` in `eth/protocols/snap/sync.go`.
+    *
+    * Sized so that the 16 active account tasks plus their per-contract storage
+    * tries cumulatively bound in-flight buffered state to ~128-256 MiB worst
+    * case — large enough to amortise RocksDB write overhead, small enough to
+    * keep heap pressure manageable.
+    */
+  val DefaultBatchSizeBytes: Int = 8 * 1024 * 1024
+}

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -69,7 +69,22 @@ class AccountRangeCoordinator(
     trieFlushThreshold: Int = 50000,
     initialResponseBytesConfig: Int = 524288,
     minResponseBytesConfig: Int = 102400,
-    accountTrieEcOverride: Option[ExecutionContext] = None
+    accountTrieEcOverride: Option[ExecutionContext] = None,
+    /** Phase 2 of the SNAP rewrite (Step 3 of `snap-stacktrie-port` plan).
+      *
+      * When `true`, accounts arriving in each `AccountTask` are inserted into
+      * a per-task [[com.chipprbots.ethereum.blockchain.sync.snap.SnapHashTrie]]
+      * (which wraps a streaming `StackTrie`) rather than into the shared
+      * `MerklePatriciaTrie` over `DeferredWriteMptStorage`. The single 4 GiB
+      * in-memory pivot trie and its multi-minute flush are eliminated; memory
+      * is bounded to ~8 MiB write batches per task.
+      *
+      * When `false` (default), the legacy MPT-put-then-deferred-flush path is
+      * used unchanged. This gives operators an opt-in migration path; the
+      * legacy path will be removed in Step 5 of the plan once the StackTrie
+      * path is validated on Sepolia + Mordor.
+      */
+    useStackTrie: Boolean = false
 ) extends Actor
     with ActorLogging {
 
@@ -443,10 +458,21 @@ class AccountRangeCoordinator(
 
   // State trie for storing accounts.
   // In SNAP, we start with an empty local DB and rebuild the state trie from downloaded ranges.
+  // ONLY used when `useStackTrie == false` (legacy path). When `useStackTrie == true`, each
+  // AccountTask owns its own `SnapHashTrie` in `taskStackTries` below.
   private var stateTrie: MerklePatriciaTrie[ByteString, Account] = {
     import com.chipprbots.ethereum.mpt.byteStringSerializer
     MerklePatriciaTrie[ByteString, Account](deferredStorage)
   }
+
+  // Per-task StackTrie state (only populated when `useStackTrie == true`).
+  // Keyed by `task.last` — each AccountTask has a unique end-of-range boundary.
+  // The 16 ranges produce 16 fragment roots; the SNAP healing phase reconciles
+  // them against the pivot's actual root. This matches go-ethereum's per-task
+  // `genTrie *StackTrie` pattern in `eth/protocols/snap/sync.go`.
+  //
+  // `private[actors]` so the test spec can verify the per-task lifecycle.
+  private[actors] val taskStackTries: mutable.Map[ByteString, SnapHashTrie] = mutable.Map.empty
 
   override def preStart(): Unit = {
     if (skippedTasks.nonEmpty) {
@@ -1074,12 +1100,25 @@ class AccountRangeCoordinator(
     val (chunk, rest) = remaining.splitAt(storeChunkSize)
 
     try {
-      var currentTrie = stateTrie
-      chunk.foreach { case (accountHash, account) =>
-        currentTrie = currentTrie.put(accountHash, account)
+      if (useStackTrie) {
+        // StackTrie path: route accounts to this task's per-range StackTrie.
+        // Inserts are O(depth) memory + O(1) amortised compute; emitted nodes
+        // batch-flush to RocksDB inside SnapHashTrie at the 8 MiB threshold,
+        // so we never accumulate a multi-GiB in-memory pivot trie.
+        import com.chipprbots.ethereum.domain.Account.accountSerializer
+        val trie = getOrCreateTaskStackTrie(task)
+        chunk.foreach { case (accountHash, account) =>
+          trie.update(accountHash.toArray, accountSerializer.toBytes(account))
+        }
+      } else {
+        // Legacy MPT path: single global trie over DeferredWriteMptStorage.
+        // Buffers everything in memory until threshold-based flush.
+        var currentTrie = stateTrie
+        chunk.foreach { case (accountHash, account) =>
+          currentTrie = currentTrie.put(accountHash, account)
+        }
+        stateTrie = currentTrie
       }
-      stateTrie = currentTrie
-      // No persist per chunk — DeferredWriteMptStorage buffers everything in memory
 
       val newStored = storedSoFar + chunk.size
       // Report incremental progress so the stagnation watchdog sees activity
@@ -1111,10 +1150,26 @@ class AccountRangeCoordinator(
         if (isTaskRangeComplete) {
           task.done = true
           completedTasks += task
-          log.info(
-            s"Account range COMPLETE: ${task.rangeString} " +
-              s"(${completedTasks.size}/$concurrency ranges done, $accountsDownloaded accounts total)"
-          )
+          // On the StackTrie path, the task's per-range StackTrie has accumulated all of
+          // this range's accounts; commit it to finalise the right boundary and flush the
+          // remaining pending batch to RocksDB. The fragment root is logged for diagnostics
+          // — it does NOT match the pivot's claimed root (each task produces only a
+          // partial trie); healing reconciles fragments against the pivot root.
+          if (useStackTrie) {
+            taskStackTries.remove(task.last).foreach { trie =>
+              val fragmentRoot = trie.commit()
+              log.info(
+                s"Account range COMPLETE: ${task.rangeString} " +
+                  s"(${completedTasks.size}/$concurrency ranges done, $accountsDownloaded accounts total, " +
+                  s"fragment root ${fragmentRoot.take(4).toArray.map("%02x".format(_)).mkString})"
+              )
+            }
+          } else {
+            log.info(
+              s"Account range COMPLETE: ${task.rangeString} " +
+                s"(${completedTasks.size}/$concurrency ranges done, $accountsDownloaded accounts total)"
+            )
+          }
           // Send progress snapshot so controller can resume from saved positions
           sendProgressSnapshot()
         } else {
@@ -1125,20 +1180,29 @@ class AccountRangeCoordinator(
           sendProgressSnapshot()
         }
 
-        // Threshold-based flush: only flush to RocksDB when accumulated nodes exceed threshold.
-        // With pipelining, per-response flushing (50-200ms each) blocks the coordinator
-        // and becomes the throughput bottleneck. Threshold-based flushing amortizes the cost.
-        accountsSinceLastFlush += totalCount
-        if (accountsSinceLastFlush >= trieFlushThreshold) {
-          accountsSinceLastFlush = 0
-          spawnFlushTrieAsync()
-          // CheckCompletion is sent from the flush completion handler.
-        } else {
-          log.debug(
-            s"Stored all $totalCount accounts in-memory ($accountsDownloaded total, ${accountsSinceLastFlush} since last flush)"
-          )
-          // Check if all tasks are complete
+        if (useStackTrie) {
+          // StackTrie path: no global flush required. Each task's SnapHashTrie
+          // batches its emissions and flushes to RocksDB at the 8 MiB threshold
+          // (or on task-complete commit). Just check whether all tasks are done.
+          log.debug(s"Stored all $totalCount accounts via StackTrie ($accountsDownloaded total)")
           self ! CheckCompletion
+        } else {
+          // Legacy MPT path — threshold-based global flush.
+          //
+          // With pipelining, per-response flushing (50-200ms each) blocks the coordinator
+          // and becomes the throughput bottleneck. Threshold-based flushing amortises the cost.
+          accountsSinceLastFlush += totalCount
+          if (accountsSinceLastFlush >= trieFlushThreshold) {
+            accountsSinceLastFlush = 0
+            spawnFlushTrieAsync()
+            // CheckCompletion is sent from the flush completion handler.
+          } else {
+            log.debug(
+              s"Stored all $totalCount accounts in-memory ($accountsDownloaded total, ${accountsSinceLastFlush} since last flush)"
+            )
+            // Check if all tasks are complete
+            self ! CheckCompletion
+          }
         }
       }
     } catch {
@@ -1151,12 +1215,28 @@ class AccountRangeCoordinator(
     }
   }
 
+  /** Get-or-create the per-task `SnapHashTrie` for the StackTrie path. Each
+    * task gets its own streaming trie keyed by `task.last` (the end-of-range
+    * boundary, unique per task). Nodes emitted by the wrapper flush to
+    * `mptStorage` via `storeRawNodes` — which routes through the existing
+    * `FastSyncNodeStorage` and picks up pivot-block-number tagging for
+    * pruning automatically.
+    */
+  private def getOrCreateTaskStackTrie(task: AccountTask): SnapHashTrie =
+    taskStackTries.getOrElseUpdate(
+      task.last,
+      new SnapHashTrie(batch => mptStorage.storeRawNodes(batch))
+    )
+
   /** Flush all in-memory trie nodes to RocksDB in a single batch. This collapses the entire in-memory trie (RLP-encode
     * + Keccak-256 hash all nodes), then writes everything to RocksDB via one WriteBatch. After flush, the trie is
     * rebuilt from the persisted root hash so old in-memory nodes can be garbage collected.
     *
     * Used directly only from `finalizeTrie` (where the actor is in `finalizing` and no concurrent puts can race).
     * Periodic flushes during account download go through `spawnFlushTrieAsync`.
+    *
+    * NOTE: legacy MPT path only. The StackTrie path flushes per-task at task completion via
+    * `SnapHashTrie.commit()`; no global flush is needed.
     */
   private def flushTrieToStorage(): Unit =
     deferredStorage.flush().foreach { rootHash =>
@@ -1295,6 +1375,28 @@ class AccountRangeCoordinator(
   private def finalizeTrie(): Either[String, ByteString] =
     try {
       log.info("Finalizing state trie...")
+
+      if (useStackTrie) {
+        // StackTrie path: each task's SnapHashTrie was committed on task-complete in
+        // `handleStoreAccountChunk`, flushing its right boundary + remaining batch to
+        // RocksDB. Defensively commit any stragglers (should be empty unless a task
+        // finished after its `isTaskRangeComplete` branch was missed).
+        if (taskStackTries.nonEmpty) {
+          log.warning(s"Finalising ${taskStackTries.size} uncommitted task StackTries (unexpected)")
+          taskStackTries.values.foreach { trie => val _ = trie.commit() }
+          taskStackTries.clear()
+        }
+        // Use the pivot's claimed root as the "finalized root". With per-task fragments
+        // there is no single computed root; healing reconciles the on-disk trie against
+        // `stateRoot` regardless. This matches what `pivotWasRefreshed` mode does on
+        // the legacy MPT path (returns the computed root which doesn't match pivot,
+        // controller persists it, healing reconciles).
+        log.info(
+          s"State trie finalization complete (StackTrie path, 16 fragments). " +
+            s"Reported root: ${stateRoot.take(8).toArray.map("%02x".format(_)).mkString}..."
+        )
+        return Right(stateRoot)
+      }
 
       // Flush any remaining deferred writes to RocksDB
       flushTrieToStorage()
@@ -1473,7 +1575,8 @@ object AccountRangeCoordinator {
       trieFlushThreshold: Int = 50000,
       initialResponseBytes: Int = 524288,
       minResponseBytes: Int = 102400,
-      accountTrieEcOverride: Option[ExecutionContext] = None
+      accountTrieEcOverride: Option[ExecutionContext] = None,
+      useStackTrie: Boolean = false
   ): Props =
     Props(
       new AccountRangeCoordinator(
@@ -1488,7 +1591,8 @@ object AccountRangeCoordinator {
         trieFlushThreshold,
         initialResponseBytes,
         minResponseBytes,
-        accountTrieEcOverride
+        accountTrieEcOverride,
+        useStackTrie
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -57,7 +57,16 @@ class StorageRangeCoordinator(
     configMinResponseBytes: Int = 131072,
     deferredMerkleization: Boolean = true,
     flatBatchEntryThreshold: Int = 1000,
-    flatBatchEcOverride: Option[ExecutionContext] = None
+    flatBatchEcOverride: Option[ExecutionContext] = None,
+    /** Phase 2 of the SNAP rewrite (Step 4 of `snap-stacktrie-port` plan).
+      *
+      * When `true`, per-contract storage tries are built with a streaming
+      * `SnapHashTrie` instead of `MerklePatriciaTrie` + `DeferredWriteMptStorage`.
+      * Each contract's trie is constructed in O(depth) memory rather than
+      * holding the whole trie in memory until flush. Same opt-in semantics as
+      * `AccountRangeCoordinator.useStackTrie`.
+      */
+    useStackTrie: Boolean = false
 ) extends Actor
     with ActorLogging {
 
@@ -485,34 +494,60 @@ class StorageRangeCoordinator(
     val localFlatSlotStorage = flatSlotStorage // capture for Future
     val constructionStateRoot = stateRoot // tag with current pivot root
 
+    val localUseStackTrie = useStackTrie
+
     import scala.concurrent.{Future, blocking}
     Future {
       blocking {
         val startMs = System.currentTimeMillis()
 
-        // Batch-local deferred storage — thread-safe: only this Future writes to it.
-        val batchStorage = new DeferredWriteMptStorage(localMptStorage)
-
         // Flat slot storage: accumulate all (accountHash++slotHash → value) writes
         // for a single atomic batch commit alongside trie nodes.
         var flatBatch = localFlatSlotStorage.emptyBatchUpdate
 
-        accountData.foreach { case (accountHash, slots) =>
-          // Sort by key for better trie locality — sequential keys share prefixes,
-          // reducing node reconstructions during insertion
-          val sortedSlots = slots.sortBy(_._1)(ByteStringOrdering)
-          import com.chipprbots.ethereum.mpt.byteStringSerializer
-          var trie = MerklePatriciaTrie[ByteString, ByteString](batchStorage)
-          sortedSlots.foreach { case (slotHash, slotValue) =>
-            trie = trie.put(slotHash, slotValue)
+        if (localUseStackTrie) {
+          // StackTrie path: one SnapHashTrie per contract, built and committed inline.
+          // To preserve the existing single-RocksDB-batch flush semantics, route all
+          // SnapHashTrie writeBatch callbacks into a shared accumulator and flush once
+          // after every contract in this batch has committed.
+          val accumulated = mutable.ArrayBuffer.empty[(ByteString, Array[Byte])]
+          val accumulator: Seq[(ByteString, Array[Byte])] => Unit = { batch =>
+            accumulated ++= batch
+          }
+          accountData.foreach { case (accountHash, slots) =>
+            val sortedSlots = slots.sortBy(_._1)(ByteStringOrdering)
+            val trie = new com.chipprbots.ethereum.blockchain.sync.snap.SnapHashTrie(accumulator)
+            sortedSlots.foreach { case (slotHash, slotValue) =>
+              trie.update(slotHash.toArray, slotValue.toArray)
+            }
+            val _ = trie.commit()
+            flatBatch = flatBatch.and(localFlatSlotStorage.putSlotsBatch(accountHash, sortedSlots.toSeq))
+          }
+          if (accumulated.nonEmpty) {
+            localMptStorage.storeRawNodes(accumulated.toSeq)
+          }
+        } else {
+          // Legacy MPT path: per-contract MerklePatriciaTrie over a batch-local
+          // DeferredWriteMptStorage. Holds all batch nodes in memory until flush.
+          val batchStorage = new DeferredWriteMptStorage(localMptStorage)
+
+          accountData.foreach { case (accountHash, slots) =>
+            // Sort by key for better trie locality — sequential keys share prefixes,
+            // reducing node reconstructions during insertion
+            val sortedSlots = slots.sortBy(_._1)(ByteStringOrdering)
+            import com.chipprbots.ethereum.mpt.byteStringSerializer
+            var trie = MerklePatriciaTrie[ByteString, ByteString](batchStorage)
+            sortedSlots.foreach { case (slotHash, slotValue) =>
+              trie = trie.put(slotHash, slotValue)
+            }
+
+            // Write to flat storage: accountHash ++ slotHash → slotValue
+            flatBatch = flatBatch.and(localFlatSlotStorage.putSlotsBatch(accountHash, sortedSlots.toSeq))
           }
 
-          // Write to flat storage: accountHash ++ slotHash → slotValue
-          flatBatch = flatBatch.and(localFlatSlotStorage.putSlotsBatch(accountHash, sortedSlots.toSeq))
+          // Flush trie nodes to RocksDB
+          batchStorage.flush()
         }
-
-        // Flush trie nodes to RocksDB
-        batchStorage.flush()
 
         // Commit flat slot writes — single additional RocksDB write batch
         flatBatch.commit()
@@ -1354,7 +1389,8 @@ object StorageRangeCoordinator {
       minResponseBytes: Int = 131072,
       deferredMerkleization: Boolean = true,
       flatBatchEntryThreshold: Int = 1000,
-      flatBatchEcOverride: Option[ExecutionContext] = None
+      flatBatchEcOverride: Option[ExecutionContext] = None,
+      useStackTrie: Boolean = false
   ): Props =
     Props(
       new StorageRangeCoordinator(
@@ -1372,7 +1408,8 @@ object StorageRangeCoordinator {
         configMinResponseBytes = minResponseBytes,
         deferredMerkleization = deferredMerkleization,
         flatBatchEntryThreshold = flatBatchEntryThreshold,
-        flatBatchEcOverride = flatBatchEcOverride
+        flatBatchEcOverride = flatBatchEcOverride,
+        useStackTrie = useStackTrie
       )
     )
 

--- a/src/main/scala/com/chipprbots/ethereum/mpt/StackTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/StackTrie.scala
@@ -1,0 +1,510 @@
+package com.chipprbots.ethereum.mpt
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.crypto
+
+/** Streaming Merkle Patricia Trie builder, ported from go-ethereum's
+  * `trie/stacktrie.go`.
+  *
+  * The StackTrie is optimised for one specific access pattern: keys arrive in
+  * strictly-ascending hex-nibble order and the trie is built in a single
+  * left-to-right pass. As each new key is inserted, any unhashed elder sibling
+  * on the rightmost path of the trie is finalised (RLP-encoded, hashed if its
+  * encoded form is >= 32 bytes) and emitted via the `onTrieNode` callback. The
+  * finalised subtree becomes a single `Hashed` placeholder, so the live
+  * non-hashed nodes form only the path from root to the most-recent leaf.
+  *
+  * Memory bound: O(trie depth). For an account trie of 10M accounts the depth
+  * is ~6 + extensions, so total live `StNode` count is at most ~16 regardless
+  * of how many keys have been inserted.
+  *
+  * `update` is the only mutating method; `hash` finalises the right boundary
+  * and returns the root hash. After `hash` the StackTrie cannot be updated
+  * again unless `reset` is called first.
+  *
+  * The `onTrieNode(path, hash, blob)` callback is invoked once per finalised
+  * non-inlined node. Receivers must deep-copy `path` and `blob` if they want
+  * to retain them: the StackTrie reuses internal buffers across calls.
+  *
+  * Boundary handling (left-skip on resume, right-discard on abort, RocksDB
+  * batch ownership) is the wrapper's responsibility. This class is strictly
+  * write-only: it never reads from any backing storage.
+  */
+final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit) {
+  import StackTrie._
+
+  private var root: StNode = StNode.empty
+  // last hex key seen, for strict-ascending sort enforcement
+  private var last: Array[Byte] = Array.emptyByteArray
+
+  /** Insert `value` under `key`. Keys must arrive in strictly ascending order
+    * after conversion to hex nibbles. Empty values are rejected (use a real
+    * "delete" model if you need removals — SNAP sync never deletes).
+    */
+  def update(key: Array[Byte], value: Array[Byte]): Unit = {
+    require(value.length > 0, "StackTrie does not accept empty values")
+    val hex = HexPrefix.bytesToNibbles(key)
+    val cmp = byteCompare(last, hex)
+    require(cmp < 0, s"StackTrie keys must be strictly ascending: last=${hexStr(last)} >= new=${hexStr(hex)}")
+    last = hex
+    root = insert(root, hex, value, EmptyPath)
+  }
+
+  /** Finalise the right-boundary path and return the trie root hash.
+    *
+    * After this call, the StackTrie's root is a `Hashed` placeholder. Further
+    * `update` calls will fail until `reset()` is invoked.
+    */
+  def hash(): ByteString = {
+    hashNode(root, EmptyPath)
+    if (root.typ == Hashed && root.value.length == 32) ByteString(root.value)
+    else if (root.typ == Empty) ByteString(crypto.kec256(EmptyTrieRlp))
+    else {
+      // root is inline (<32B) — its blob is its own RLP. The "root hash" is
+      // keccak256 of that blob (callers want a 32-byte root, not the inline blob).
+      ByteString(crypto.kec256(root.value))
+    }
+  }
+
+  /** Clear all state. After reset, the StackTrie can be reused for a new range. */
+  def reset(): Unit = {
+    root = StNode.empty
+    last = Array.emptyByteArray
+  }
+
+  // ---- internals ----
+
+  /** Recursive descent insertion. Returns the (possibly new) node that should
+    * replace `node` at this position. Always returns either `node` (mutated in
+    * place) or a fresh node; never returns Empty unless `node` was Empty.
+    */
+  private def insert(node: StNode, key: Array[Byte], value: Array[Byte], path: Array[Byte]): StNode = {
+    node.typ match {
+      case Empty =>
+        StNode.newLeaf(key, value)
+
+      case Leaf =>
+        val origKey = node.key
+        val diff = diffIndex(origKey, key)
+        if (diff >= origKey.length) {
+          // Either duplicate key (diff == both lengths) or our key extends past
+          // existing leaf's terminator. SNAP sync keys are all 64 hex nibbles
+          // (32-byte hashes), so both cases imply a duplicate insert.
+          throw new IllegalStateException(
+            s"StackTrie: duplicate or extending key at path ${hexStr(path)} (existing key=${hexStr(origKey)}, new key=${hexStr(key)})"
+          )
+        }
+        if (diff == 0) {
+          // No shared prefix: convert leaf into a branch with two leaves.
+          val branch = StNode.newBranch()
+          val origIdx = origKey(0) & 0xff
+          val newIdx = key(0) & 0xff
+          branch.children(origIdx) = StNode.newLeaf(sliceFrom(origKey, 1), node.value)
+          branch.children(newIdx) = StNode.newLeaf(sliceFrom(key, 1), value)
+          // Hash the original-side leaf immediately (it can never gain more keys).
+          hashNode(branch.children(origIdx), appendNibble(path, origIdx.toByte))
+          branch
+        } else {
+          // Shared prefix of length `diff`: ext over the prefix, branch with two leaves.
+          val branch = StNode.newBranch()
+          val origIdx = origKey(diff) & 0xff
+          val newIdx = key(diff) & 0xff
+          branch.children(origIdx) = StNode.newLeaf(sliceFrom(origKey, diff + 1), node.value)
+          branch.children(newIdx) = StNode.newLeaf(sliceFrom(key, diff + 1), value)
+          val newPath = appendNibbles(path, origKey, 0, diff)
+          hashNode(branch.children(origIdx), appendNibble(newPath, origIdx.toByte))
+          val ext = StNode.newExt(sliceRange(origKey, 0, diff), branch)
+          ext
+        }
+
+      case Ext =>
+        val extKey = node.key
+        val diff = diffIndex(extKey, key)
+        if (diff >= extKey.length) {
+          // Full ext key consumed — descend into the child.
+          val keyTail = sliceFrom(key, extKey.length)
+          val newPath = appendNibbles(path, extKey, 0, extKey.length)
+          node.children(0) = insert(node.children(0), keyTail, value, newPath)
+          node
+        } else if (diff == 0) {
+          // No shared prefix: ext becomes a branch (or a branch directly if extKey.length == 1).
+          val branch = StNode.newBranch()
+          val origIdx = extKey(0) & 0xff
+          val newIdx = key(0) & 0xff
+          // Original side: either the child directly (if ext key was 1 nibble) or a shorter ext over the remaining key.
+          val origChild =
+            if (extKey.length == 1) node.children(0)
+            else StNode.newExt(sliceFrom(extKey, 1), node.children(0))
+          branch.children(origIdx) = origChild
+          branch.children(newIdx) = StNode.newLeaf(sliceFrom(key, 1), value)
+          hashNode(branch.children(origIdx), appendNibble(path, origIdx.toByte))
+          branch
+        } else {
+          // Partial shared prefix.
+          val branch = StNode.newBranch()
+          val origIdx = extKey(diff) & 0xff
+          val newIdx = key(diff) & 0xff
+          val origChild =
+            if (diff + 1 == extKey.length) node.children(0)
+            else StNode.newExt(sliceFrom(extKey, diff + 1), node.children(0))
+          branch.children(origIdx) = origChild
+          branch.children(newIdx) = StNode.newLeaf(sliceFrom(key, diff + 1), value)
+          val newPath = appendNibbles(path, extKey, 0, diff)
+          hashNode(branch.children(origIdx), appendNibble(newPath, origIdx.toByte))
+          StNode.newExt(sliceRange(extKey, 0, diff), branch)
+        }
+
+      case Branch =>
+        val idx = key(0) & 0xff
+        // Left-finalisation: hash the most-recently-unhashed elder sibling.
+        // Invariant: at most one slot < idx holds a non-Hashed node.
+        var i = idx - 1
+        var done = false
+        while (i >= 0 && !done) {
+          val sib = node.children(i)
+          if (sib != null && sib.typ != Empty) {
+            if (sib.typ != Hashed) hashNode(sib, appendNibble(path, i.toByte))
+            done = true
+          }
+          i -= 1
+        }
+        val keyTail = sliceFrom(key, 1)
+        val childPath = appendNibble(path, idx.toByte)
+        val existing = node.children(idx)
+        if (existing == null || existing.typ == Empty)
+          node.children(idx) = StNode.newLeaf(keyTail, value)
+        else
+          node.children(idx) = insert(existing, keyTail, value, childPath)
+        node
+
+      case Hashed =>
+        throw new IllegalStateException(
+          s"StackTrie: sort violation — attempted insert into already-finalised subtree at path ${hexStr(path)}"
+        )
+    }
+  }
+
+  /** Finalise `node` recursively: hash any unhashed children, RLP-encode this
+    * node, then either store the encoded blob in `node.value` (if < 32 bytes
+    * and not at the root) or compute keccak256 and store the hash (emitting
+    * via `onTrieNode`).
+    *
+    * No-op if `node` is already `Hashed` or `Empty`.
+    */
+  private def hashNode(node: StNode, path: Array[Byte]): Unit = {
+    if (node == null || node.typ == Hashed || node.typ == Empty) return
+
+    node.typ match {
+      case Leaf =>
+        val blob = encodeLeaf(node)
+        finalise(node, blob, path)
+
+      case Ext =>
+        // Hash the single child first.
+        val childPath = appendNibbles(path, node.key, 0, node.key.length)
+        hashNode(node.children(0), childPath)
+        val blob = encodeExt(node)
+        finalise(node, blob, path)
+
+      case Branch =>
+        // Hash all non-hashed children in slot order.
+        var i = 0
+        while (i < 16) {
+          val c = node.children(i)
+          if (c != null && c.typ != Empty && c.typ != Hashed)
+            hashNode(c, appendNibble(path, i.toByte))
+          i += 1
+        }
+        val blob = encodeBranch(node)
+        finalise(node, blob, path)
+
+      case _ => // unreachable
+    }
+  }
+
+  /** Apply the inline-or-hash rule to a finalised node's encoded blob.
+    *
+    * The root (empty `path`) is always hashed even if its encoded blob is
+    * smaller than 32 bytes, because callers depend on a 32-byte root hash.
+    */
+  private def finalise(node: StNode, blob: Array[Byte], path: Array[Byte]): Unit = {
+    if (blob.length < 32 && path.length > 0) {
+      // Inline: the parent will splice these bytes directly into its own RLP.
+      node.value = blob
+    } else {
+      val h = crypto.kec256(blob)
+      onTrieNode(path, ByteString(h), blob)
+      node.value = h
+    }
+    node.typ = Hashed
+    node.key = Array.emptyByteArray
+    // Release child references for GC.
+    var i = 0
+    while (i < 16) { node.children(i) = null; i += 1 }
+  }
+
+  // ---- RLP encoding helpers (purpose-built for StNode) ----
+
+  /** Encode a Leaf as `RLP([HP-encoded(key, isLeaf=true), value])`. */
+  private def encodeLeaf(node: StNode): Array[Byte] = {
+    val hp = HexPrefix.encode(node.key, isLeaf = true)
+    encodeListOf2(encodeBytes(hp), encodeBytes(node.value))
+  }
+
+  /** Encode an Extension as `RLP([HP-encoded(key, isLeaf=false), childRef])`. */
+  private def encodeExt(node: StNode): Array[Byte] = {
+    val hp = HexPrefix.encode(node.key, isLeaf = false)
+    val childRef = encodeChildRef(node.children(0))
+    encodeListOf2(encodeBytes(hp), childRef)
+  }
+
+  /** Encode a Branch as `RLP([c0, c1, ..., c15, terminator])`. SNAP sync
+    * branches never carry a terminator value (keys are fixed-length 32-byte
+    * hashes), so slot 17 is always the empty string.
+    */
+  private def encodeBranch(node: StNode): Array[Byte] = {
+    val refs = new Array[Array[Byte]](17)
+    var i = 0
+    while (i < 16) {
+      refs(i) = encodeChildRef(node.children(i))
+      i += 1
+    }
+    refs(16) = EmptyBytesRlp // terminator value (empty string)
+    var total = 0
+    i = 0
+    while (i < 17) { total += refs(i).length; i += 1 }
+    val header = listHeader(total)
+    val out = new Array[Byte](header.length + total)
+    var pos = 0
+    System.arraycopy(header, 0, out, pos, header.length); pos += header.length
+    i = 0
+    while (i < 17) {
+      System.arraycopy(refs(i), 0, out, pos, refs(i).length)
+      pos += refs(i).length
+      i += 1
+    }
+    out
+  }
+
+  /** Encode a single child reference for inclusion in a parent's RLP list.
+    *
+    *  - null / Empty → RLP empty string (`0x80`)
+    *  - Hashed with 32-byte hash → RLP string of 32 bytes (`0xa0 || hash`)
+    *  - Hashed with inline <32B blob → the blob bytes spliced in raw
+    *    (the blob IS its own RLP encoding)
+    */
+  private def encodeChildRef(child: StNode): Array[Byte] = {
+    if (child == null || child.typ == Empty) {
+      EmptyBytesRlp
+    } else if (child.typ == Hashed) {
+      if (child.value.length == 32) encodeBytes(child.value)
+      else child.value // inline RLP — splice raw
+    } else {
+      throw new IllegalStateException(
+        s"StackTrie: encoding non-Hashed/non-Empty child (typ=${typeName(child.typ)})"
+      )
+    }
+  }
+
+  /** RLP-encode a single byte string. Standard RLP rules. */
+  private def encodeBytes(b: Array[Byte]): Array[Byte] = {
+    val len = b.length
+    if (len == 1 && (b(0) & 0xff) < 0x80) {
+      // Single byte under 0x80 encodes as itself.
+      val out = new Array[Byte](1)
+      out(0) = b(0)
+      out
+    } else if (len < 56) {
+      val out = new Array[Byte](1 + len)
+      out(0) = (0x80 + len).toByte
+      System.arraycopy(b, 0, out, 1, len)
+      out
+    } else {
+      val lenBytes = lengthAsBytes(len)
+      val out = new Array[Byte](1 + lenBytes.length + len)
+      out(0) = (0xb7 + lenBytes.length).toByte
+      System.arraycopy(lenBytes, 0, out, 1, lenBytes.length)
+      System.arraycopy(b, 0, out, 1 + lenBytes.length, len)
+      out
+    }
+  }
+
+  private def encodeListOf2(a: Array[Byte], b: Array[Byte]): Array[Byte] = {
+    val total = a.length + b.length
+    val header = listHeader(total)
+    val out = new Array[Byte](header.length + total)
+    System.arraycopy(header, 0, out, 0, header.length)
+    System.arraycopy(a, 0, out, header.length, a.length)
+    System.arraycopy(b, 0, out, header.length + a.length, b.length)
+    out
+  }
+
+  private def listHeader(contentLen: Int): Array[Byte] = {
+    if (contentLen < 56) {
+      val out = new Array[Byte](1)
+      out(0) = (0xc0 + contentLen).toByte
+      out
+    } else {
+      val lenBytes = lengthAsBytes(contentLen)
+      val out = new Array[Byte](1 + lenBytes.length)
+      out(0) = (0xf7 + lenBytes.length).toByte
+      System.arraycopy(lenBytes, 0, out, 1, lenBytes.length)
+      out
+    }
+  }
+
+  /** Big-endian, minimum-length encoding of a non-negative length. */
+  private def lengthAsBytes(n: Int): Array[Byte] = {
+    if (n == 0) return Array.emptyByteArray
+    val byteCount = (32 - Integer.numberOfLeadingZeros(n) + 7) / 8
+    val out = new Array[Byte](byteCount)
+    var i = byteCount - 1
+    var v = n
+    while (i >= 0) {
+      out(i) = (v & 0xff).toByte
+      v >>>= 8
+      i -= 1
+    }
+    out
+  }
+}
+
+object StackTrie {
+
+  // Node-type tags. Sealed-trait-free representation is deliberate: an Int tag
+  // lets the dispatch be a tight match without allocating type witnesses.
+  type NodeType = Int
+  final val Empty: NodeType = 0
+  final val Branch: NodeType = 1
+  final val Ext: NodeType = 2
+  final val Leaf: NodeType = 3
+  final val Hashed: NodeType = 4
+
+  /** A node in the StackTrie. Mutable by design — geth's `stNode` is the same.
+    *
+    * Field meanings depend on `typ`:
+    *  - Empty: all fields ignored.
+    *  - Leaf: `key` holds the remaining hex-nibble suffix; `value` holds the
+    *    raw account/slot value.
+    *  - Ext: `key` holds the shared hex-nibble prefix; `children(0)` is the
+    *    single child.
+    *  - Branch: `children(0..15)` are the 16 nibble slots; `key` is empty.
+    *  - Hashed: `value` is either a 32-byte hash (parent encodes as
+    *    `RLPValue(hash)`) or a < 32 byte RLP blob (parent splices raw);
+    *    `key` and `children` are cleared for GC.
+    */
+  final class StNode(
+      var typ: NodeType,
+      var key: Array[Byte],
+      var value: Array[Byte],
+      val children: Array[StNode]
+  )
+
+  object StNode {
+    def empty: StNode = new StNode(Empty, Array.emptyByteArray, Array.emptyByteArray, new Array[StNode](16))
+    def newLeaf(key: Array[Byte], value: Array[Byte]): StNode =
+      new StNode(Leaf, key, value, new Array[StNode](16))
+    def newBranch(): StNode =
+      new StNode(Branch, Array.emptyByteArray, Array.emptyByteArray, new Array[StNode](16))
+    def newExt(key: Array[Byte], child: StNode): StNode = {
+      val n = new StNode(Ext, key, Array.emptyByteArray, new Array[StNode](16))
+      n.children(0) = child
+      n
+    }
+  }
+
+  // The RLP encoding of an empty trie (an empty string).
+  private val EmptyTrieRlp: Array[Byte] = Array(0x80.toByte)
+  // RLP encoding of an empty string, used for absent branch slots / terminator.
+  private val EmptyBytesRlp: Array[Byte] = Array(0x80.toByte)
+  // Reusable empty hex-path buffer.
+  private val EmptyPath: Array[Byte] = Array.emptyByteArray
+
+  // ---- small utilities (package-private for tests) ----
+
+  /** Index of the first differing nibble between `a` and `b`, capped at the
+    * shorter length. If one is a prefix of the other, returns the shorter length.
+    */
+  private[mpt] def diffIndex(a: Array[Byte], b: Array[Byte]): Int = {
+    val n = math.min(a.length, b.length)
+    var i = 0
+    while (i < n && a(i) == b(i)) i += 1
+    i
+  }
+
+  /** Unsigned big-endian byte-array compare. Returns -1/0/1. */
+  private[mpt] def byteCompare(a: Array[Byte], b: Array[Byte]): Int = {
+    val n = math.min(a.length, b.length)
+    var i = 0
+    while (i < n) {
+      val ai = a(i) & 0xff
+      val bi = b(i) & 0xff
+      if (ai != bi) return if (ai < bi) -1 else 1
+      i += 1
+    }
+    Integer.compare(a.length, b.length)
+  }
+
+  /** Allocate a slice `arr(from .. arr.length)`. */
+  private[mpt] def sliceFrom(arr: Array[Byte], from: Int): Array[Byte] = {
+    val n = arr.length - from
+    if (n <= 0) Array.emptyByteArray
+    else {
+      val out = new Array[Byte](n)
+      System.arraycopy(arr, from, out, 0, n)
+      out
+    }
+  }
+
+  /** Allocate a slice `arr(from until until)`. */
+  private[mpt] def sliceRange(arr: Array[Byte], from: Int, until: Int): Array[Byte] = {
+    val n = until - from
+    if (n <= 0) Array.emptyByteArray
+    else {
+      val out = new Array[Byte](n)
+      System.arraycopy(arr, from, out, 0, n)
+      out
+    }
+  }
+
+  /** Append a single nibble to a path. Allocates a new array. */
+  private[mpt] def appendNibble(path: Array[Byte], nibble: Byte): Array[Byte] = {
+    val out = new Array[Byte](path.length + 1)
+    if (path.length > 0) System.arraycopy(path, 0, out, 0, path.length)
+    out(path.length) = nibble
+    out
+  }
+
+  /** Append the slice `nibbles(from until from+count)` to a path. */
+  private[mpt] def appendNibbles(path: Array[Byte], nibbles: Array[Byte], from: Int, count: Int): Array[Byte] = {
+    if (count <= 0) {
+      if (path.length == 0) EmptyPath else path
+    } else {
+      val out = new Array[Byte](path.length + count)
+      if (path.length > 0) System.arraycopy(path, 0, out, 0, path.length)
+      System.arraycopy(nibbles, from, out, path.length, count)
+      out
+    }
+  }
+
+  private[mpt] def hexStr(arr: Array[Byte]): String = {
+    val sb = new StringBuilder(arr.length)
+    var i = 0
+    while (i < arr.length) {
+      val c = arr(i) & 0x0f
+      sb.append(if (c < 10) ('0' + c).toChar else ('a' + (c - 10)).toChar)
+      i += 1
+    }
+    sb.toString
+  }
+
+  private def typeName(t: NodeType): String = t match {
+    case Empty  => "Empty"
+    case Branch => "Branch"
+    case Ext    => "Ext"
+    case Leaf   => "Leaf"
+    case Hashed => "Hashed"
+    case _      => s"Unknown($t)"
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -23,6 +23,7 @@ import com.chipprbots.ethereum.network.p2p.MessageSerializable
 import com.chipprbots.ethereum.network.p2p.messages.BaseETH6XMessages
 import com.chipprbots.ethereum.network.p2p.messages.Capability
 import com.chipprbots.ethereum.network.p2p.messages.Codes
+import com.chipprbots.ethereum.network.p2p.messages.ETH62
 import com.chipprbots.ethereum.network.p2p.messages.ETH62.{BlockHeaders => ETH62BlockHeaders}
 import com.chipprbots.ethereum.network.p2p.messages.ETH62.NewBlockHashes
 import com.chipprbots.ethereum.network.p2p.messages.ETH66
@@ -234,13 +235,41 @@ class NetworkPeerManagerActor(
       peerEventBusActor ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
       peerEventBusActor ! Subscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peer.id)))
 
-      // Do NOT send unsolicited GetBlockHeaders after handshake.
-      // The sync engine (BlockFetcher/HeadersFetcher) will request headers when needed through
-      // the normal PeersClient polling mechanism. Sending GetBlockHeaders immediately violates
-      // the expected message flow in devp2p protocol tests and is not standard behavior
-      // (geth does not send unsolicited GetBlockHeaders after Status exchange).
-      // For ETH69+, latestBlock/latestBlockHash are already in the Status message.
-      // For ETH64+, ForkId in Status provides fork validation without needing block headers.
+      // Besu-style eager best-block probe.
+      // ETH/64-/68 STATUS carries `bestHash` but not the peer's best block *number* — only
+      // ETH/61 (long gone) and ETH/69 do. Without the number, fast-sync `PivotBlockSelector`
+      // sees `peer.maxBlockNumber == 0`, picks pivot = 0, and never converges (the loop
+      // we hit on Barad-dûr 2026-04-29). Geth resolves this lazily inside the downloader by
+      // probing the chosen peer's bestHash; besu and nethermind do it eagerly the moment
+      // STATUS completes. We follow the eager pattern: one `GetBlockHeaders(bestHash, 1)`
+      // immediately after handshake, the response routes through `updateMaxBlock` via the
+      // existing `BlockHeadersCode` subscription and populates `PeerInfo.maxBlockNumber`.
+      //
+      // Skip the probe for:
+      //  * ETH/69 — STATUS already carries latestBlock (stuffed into chainWeight.totalDifficulty
+      //    by the handshaker), so maxBlockNumber is set on construction.
+      //  * Peers at genesis (`bestHash == genesisHash`) — they're block 0 by definition;
+      //    `peerHasUpdatedBestBlock` already accepts them as `isAtGenesis`.
+      //
+      // Peers that don't reply to the probe simply stay at maxBlockNumber=0 and get filtered
+      // by `peerHasUpdatedBestBlock` — no disconnect, since Mordor peers can be flaky and
+      // we don't want to throw away connections for one missed reply (Bug 26 lesson).
+      if (peerInfo.remoteStatus.capability != Capability.ETH69 && !peerInfo.isAtGenesis) {
+        val bestHash = peerInfo.remoteStatus.bestHash
+        val probe: MessageSerializable =
+          if (Capability.usesRequestId(peerInfo.remoteStatus.capability))
+            ETH66.GetBlockHeaders(ETH66.nextRequestId, Right(bestHash), 1, 0, reverse = false)
+          else
+            ETH62.GetBlockHeaders(Right(bestHash), 1, 0, reverse = false)
+        log.debug(
+          "BEST_BLOCK_PROBE: peer={} cap={} bestHash={} — asking for header at bestHash to discover block number",
+          peer.id,
+          peerInfo.remoteStatus.capability,
+          ByteStringUtils.hash2string(bestHash)
+        )
+        peerManagerActor ! PeerManagerActor.SendMessage(probe, peer.id)
+      }
+
       NetworkMetrics.registerAddHandshakedPeer(peer)
       context.become(handleMessages(peersWithInfo + (peer.id -> PeerWithInfo(peer, peerInfo))))
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -107,6 +107,32 @@ class PivotBlockSelectorSpec
     expectGetBlockHeadersRequests(Seq(peer1, peer2, peer3), blockNumber = 0)
   }
 
+  it should "skip peers whose maxBlockNumber is still 0 (probe reply not yet arrived)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in new TestSetup {
+    // All three peers have forkAccepted=true but maxBlockNumber=0 — i.e., they
+    // handshaked but their Bug 32 best-block probe hasn't been answered yet.
+    // The selector must NOT pick a pivot from these peers; otherwise it asks for
+    // block 0 (genesis) and loops forever. Mirrors the SNAP-side
+    // `peer.maxBlockNumber > 0` filter.
+    updateHandshakedPeers(
+      HandshakedPeers(
+        threeAcceptedPeers
+          .updated(peer1, threeAcceptedPeers(peer1).copy(maxBlockNumber = 0))
+          .updated(peer2, threeAcceptedPeers(peer2).copy(maxBlockNumber = 0))
+          .updated(peer3, threeAcceptedPeers(peer3).copy(maxBlockNumber = 0))
+      )
+    )
+
+    pivotBlockSelector ! SelectPivotBlock
+
+    // No subscriptions, no GetBlockHeaders, no fastSync ! Result — selector parks.
+    peerMessageBus.expectNoMessage()
+    networkPeerManager.expectNoMessage()
+    fastSync.expectNoMessage()
+  }
+
   it should "retry if there are no enough peers" taggedAs (UnitTest, SyncTest) in new TestSetup {
     updateHandshakedPeers(HandshakedPeers(singlePeer))
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrieSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrieSpec.scala
@@ -1,0 +1,207 @@
+package com.chipprbots.ethereum.blockchain.sync.snap
+
+import scala.collection.mutable
+import scala.util.Random
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.mpt.{ByteArraySerializable, MerklePatriciaTrie}
+import com.chipprbots.ethereum.testing.TestMptStorage
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Tests for [[SnapHashTrie]] — the batching wrapper around [[StackTrie]].
+  *
+  * The StackTrie itself is already validated against `MerklePatriciaTrie` in
+  * `StackTrieSpec`. This spec focuses on the wrapper's responsibilities:
+  *
+  *   - emissions flow through the `writeBatch` callback,
+  *   - batching honours the size threshold,
+  *   - `commit` flushes pending state,
+  *   - `reset` clears in-memory state cleanly,
+  *   - root hashes still match the reference MPT for the same inputs.
+  */
+class SnapHashTrieSpec extends AnyFlatSpec with Matchers {
+
+  // ---- helpers ----
+
+  private implicit val byteArraySerializer: ByteArraySerializable[Array[Byte]] =
+    new ByteArraySerializable[Array[Byte]] {
+      def toBytes(input: Array[Byte]): Array[Byte] = input
+      def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
+    }
+
+  /** A recording `writeBatch` callback. Each invocation appends its batch to
+    * the list of recorded batches, and every (hash, blob) pair is added to a
+    * cumulative map for later inspection.
+    */
+  private final class RecordingWriter {
+    val batches: mutable.ArrayBuffer[Seq[(ByteString, Array[Byte])]] = mutable.ArrayBuffer.empty
+    val combined: mutable.LinkedHashMap[ByteString, Array[Byte]] = mutable.LinkedHashMap.empty
+    var totalBytes: Long = 0L
+
+    val writeBatch: Seq[(ByteString, Array[Byte])] => Unit = { batch =>
+      batches += batch
+      batch.foreach { case (h, b) =>
+        combined += h -> b
+        totalBytes += b.length
+      }
+    }
+  }
+
+  /** Build a reference MPT root for the given (key, value) pairs. */
+  private def referenceRoot(pairs: Seq[(Array[Byte], Array[Byte])]): Array[Byte] = {
+    var trie: MerklePatriciaTrie[Array[Byte], Array[Byte]] =
+      MerklePatriciaTrie[Array[Byte], Array[Byte]](new TestMptStorage())
+    pairs.foreach { case (k, v) => trie = trie.put(k, v) }
+    trie.getRootHash
+  }
+
+  private def sortByKey(pairs: Seq[(Array[Byte], Array[Byte])]): Seq[(Array[Byte], Array[Byte])] =
+    pairs.sortWith { case ((a, _), (b, _)) => java.util.Arrays.compareUnsigned(a, b) < 0 }
+
+  private def generatedPairs(n: Int, seed: Long): Seq[(Array[Byte], Array[Byte])] = {
+    val rng = new Random(seed)
+    val raw = (0 until n).map { _ =>
+      val k = new Array[Byte](32); rng.nextBytes(k)
+      val v = new Array[Byte](16 + rng.nextInt(48)); rng.nextBytes(v)
+      (k, v)
+    }
+    sortByKey(raw)
+  }
+
+  // ---- empty trie ----
+
+  it should "produce the canonical empty-trie root with no batch flushes for an empty input" taggedAs UnitTest in {
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    val root = w.commit().toArray
+    root shouldEqual MerklePatriciaTrie.EmptyRootHash
+    rec.batches shouldBe empty
+  }
+
+  // ---- single update ----
+
+  it should "flush exactly one batch with one entry for a single-key trie" taggedAs UnitTest in {
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    w.update(kec256("k1".getBytes), "v1".getBytes)
+    val root = w.commit().toArray
+    root shouldEqual referenceRoot(Seq(kec256("k1".getBytes) -> "v1".getBytes))
+    rec.batches should have size 1
+    rec.batches.head should have size 1
+    val (hash, blob) = rec.batches.head.head
+    ByteString(kec256(blob)) shouldEqual hash
+    ByteString(root) shouldEqual hash
+  }
+
+  // ---- large batch, root equality ----
+
+  it should "produce the same root as MerklePatriciaTrie for 1 000 random sorted keys" taggedAs UnitTest in {
+    val pairs = generatedPairs(1000, seed = 0xfeedfaceL)
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    pairs.foreach { case (k, v) => w.update(k, v) }
+    val root = w.commit().toArray
+    root shouldEqual referenceRoot(pairs)
+    // Below the default 8 MiB threshold; one batch on commit.
+    rec.batches should have size 1
+    // Every entry should be content-addressed correctly.
+    rec.combined.foreach { case (h, b) => ByteString(kec256(b)) shouldEqual h }
+  }
+
+  // ---- threshold-driven mid-stream flushes ----
+
+  it should "flush mid-stream when the batch threshold is exceeded" taggedAs UnitTest in {
+    // Pick a small threshold and enough keys to force multiple flushes.
+    val tinyThreshold = 4 * 1024 // 4 KiB
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch, batchSizeThreshold = tinyThreshold)
+    val pairs = generatedPairs(500, seed = 0xc0ffeeL)
+    pairs.foreach { case (k, v) => w.update(k, v) }
+    val root = w.commit().toArray
+    root shouldEqual referenceRoot(pairs)
+    // Many flushes expected; lower bound is "more than one".
+    rec.batches.size should be > 1
+    // Each flushed batch (except possibly the last) crossed the threshold.
+    rec.batches.init.foreach { batch =>
+      batch.map(_._2.length).sum should be >= tinyThreshold / 4 // generous bound
+    }
+    // All emissions are content-addressed.
+    rec.combined.foreach { case (h, b) => ByteString(kec256(b)) shouldEqual h }
+  }
+
+  // ---- pendingBatchBytes accounting ----
+
+  it should "track pendingBatchBytes correctly between flushes" taggedAs UnitTest in {
+    val tinyThreshold = 16 * 1024 // 16 KiB
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch, batchSizeThreshold = tinyThreshold)
+    val pairs = generatedPairs(50, seed = 0xabcdL)
+    pairs.foreach { case (k, v) => w.update(k, v) }
+    // Before commit, pendingBatchBytes is whatever's accumulated since the last flush.
+    val beforeCommit = w.pendingBatchBytes
+    val _ = w.commit()
+    // After commit, the pending buffer must be empty.
+    w.pendingBatchBytes shouldEqual 0L
+    w.pendingBatchCount shouldEqual 0
+    // The bytes we observed before commit plus any already-flushed bytes must
+    // equal the total bytes seen by the writer.
+    val alreadyFlushed = rec.batches.dropRight(if (rec.batches.nonEmpty) 1 else 0).flatten.map(_._2.length.toLong).sum
+    val finalFlush = rec.batches.lastOption.map(_.map(_._2.length.toLong).sum).getOrElse(0L)
+    (alreadyFlushed + finalFlush) shouldEqual rec.totalBytes
+    beforeCommit should be <= rec.totalBytes
+  }
+
+  // ---- reset semantics ----
+
+  it should "clear pending state and resume cleanly after reset" taggedAs UnitTest in {
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    w.update(kec256("a".getBytes), "v-a".getBytes)
+    w.update(kec256("b".getBytes), "v-b".getBytes)
+    // No commit; reset should clear everything pending.
+    val countBefore = rec.batches.size
+    w.reset()
+    w.pendingBatchBytes shouldEqual 0L
+    w.pendingBatchCount shouldEqual 0
+    // No new batches flushed by reset itself.
+    rec.batches.size shouldEqual countBefore
+    // After reset, we can build a fresh trie.
+    val pairs = generatedPairs(20, seed = 0x123L)
+    pairs.foreach { case (k, v) => w.update(k, v) }
+    val root = w.commit().toArray
+    root shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- emission integrity ----
+
+  it should "deep-copy emitted blobs so the caller is safe against StackTrie buffer reuse" taggedAs UnitTest in {
+    // We can't directly probe internal buffer reuse, but we can verify the
+    // recorded blobs survive — i.e. their content remains valid after the
+    // StackTrie has emitted further nodes that might (in principle) have
+    // overwritten earlier buffers.
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    val pairs = generatedPairs(200, seed = 0xdadaL)
+    pairs.foreach { case (k, v) => w.update(k, v) }
+    val _ = w.commit()
+    // Re-verify every recorded blob against its claimed hash. If the wrapper
+    // hadn't deep-copied, mid-stream mutations could have corrupted earlier
+    // entries.
+    rec.combined.foreach { case (h, b) => ByteString(kec256(b)) shouldEqual h }
+  }
+
+  // ---- ordering still enforced (delegated to StackTrie) ----
+
+  it should "reject descending keys (sort enforcement delegated to StackTrie)" taggedAs UnitTest in {
+    val rec = new RecordingWriter
+    val w = new SnapHashTrie(rec.writeBatch)
+    w.update(Array[Byte](0x20.toByte), "v1".getBytes)
+    an[IllegalArgumentException] should be thrownBy
+      w.update(Array[Byte](0x10.toByte), "v2".getBytes)
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -1218,4 +1218,49 @@ class AccountRangeCoordinatorSpec
 
     system.stop(coord)
   }
+
+  it should "honour resumeProgress on the StackTrie path (Step 6 — restart durability)" taggedAs UnitTest in {
+    // Step 6 of the snap-stacktrie-port plan: verify resume cursors work with
+    // useStackTrie = true. The existing `AccountRangeProgress` →
+    // `putSnapSyncProgress` flow already journals per-task cursors to RocksDB;
+    // on restart, the controller passes `resumeProgress` into the coordinator
+    // and each task's `next` is advanced past where the prior session left off.
+    // For the StackTrie path this is sufficient: SnapHashTrie instances are
+    // re-created from scratch (content-addressed nodes on disk remain valid),
+    // and sort enforcement is satisfied because resumed `next` is monotonically
+    // ascending vs. any prior in-memory state (there is none after restart).
+    val root = kec256(ByteString("stacktrie-resume-root"))
+    // With concurrency = 1 the single AccountTask covers the entire 32-byte
+    // hash space, so its `last` boundary is the maximum 32-byte value.
+    val rangeLast = AccountTask.MaxHash32
+    val resumedNext = ByteString(Array.fill[Byte](32)(0x77.toByte)) // mid-range
+
+    val coord = TestActorRef[AccountRangeCoordinator](
+      AccountRangeCoordinator.props(
+        stateRoot = root,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        concurrency = 1, // single range so we can predict task.last
+        snapSyncController = TestProbe().ref,
+        resumeProgress = Map(rangeLast -> resumedNext),
+        accountTrieEcOverride = Some(system.dispatcher),
+        useStackTrie = true
+      )
+    )
+    val ua = coord.underlyingActor
+
+    // The single range's task.next must have been advanced to `resumedNext`,
+    // not the canonical zero-start; sort-enforcement on the per-task
+    // SnapHashTrie will work because every future insert is > resumedNext.
+    val pending = ua.pendingTasks.toList
+    pending should have size 1
+    pending.head.next shouldEqual resumedNext
+    pending.head.last shouldEqual rangeLast
+
+    // No SnapHashTrie has been instantiated yet (lazy creation on first chunk).
+    ua.taskStackTries shouldBe empty
+
+    system.stop(coord)
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -1098,4 +1098,124 @@ class AccountRangeCoordinatorSpec
     val sendMsg2 = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](2.seconds)
     sendMsg2.peerId shouldBe peer2.id
   }
+
+  // -----------------------------------------------------------------------
+  // StackTrie write-path (Step 3 of `snap-stacktrie-port` plan)
+  // -----------------------------------------------------------------------
+  // The legacy MPT path stays the default and is exercised by every other
+  // test above. These tests opt-in via `useStackTrie = true` and verify:
+  //   - per-task SnapHashTrie instances are created lazily on first chunk store
+  //   - accounts are routed through the StackTrie (writes hit mptStorage via
+  //     storeRawNodes; the legacy `stateTrie` field stays empty)
+  //   - on task completion the StackTrie is committed and removed from the
+  //     per-task map (no leaks across tasks)
+
+  /** Construct a TestActorRef coordinator with `useStackTrie = true`. */
+  private def newStackTrieCoordinator(
+      stateRoot: ByteString = kec256(ByteString("stacktrie-test-root")),
+      controller: TestProbe = TestProbe(),
+      storage: TestMptStorage = new TestMptStorage(),
+      concurrency: Int = 4
+  ): (TestActorRef[AccountRangeCoordinator], TestMptStorage) = {
+    val ref = TestActorRef[AccountRangeCoordinator](
+      AccountRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = storage,
+        concurrency = concurrency,
+        snapSyncController = controller.ref,
+        accountTrieEcOverride = Some(system.dispatcher),
+        useStackTrie = true
+      )
+    )
+    (ref, storage)
+  }
+
+  /** Build a strict-ascending sequence of (accountHash, Account) pairs starting
+    * at `task.next` so insertion order satisfies the StackTrie's sort invariant.
+    */
+  private def stackTrieFixtureAccounts(
+      task: AccountTask,
+      count: Int
+  ): Seq[(ByteString, com.chipprbots.ethereum.domain.Account)] = {
+    val seed = task.next.toArray
+    (1 to count).map { i =>
+      val hash = new Array[Byte](32)
+      Array.copy(seed, 0, hash, 0, math.min(seed.length, hash.length))
+      // Mutate the trailing bytes by i, big-endian — guarantees strictly ascending.
+      hash(31) = (hash(31) + i).toByte
+      val acct = com.chipprbots.ethereum.domain.Account.empty().increaseNonce()
+      ByteString(hash) -> acct
+    }
+  }
+
+  it should "route account inserts through per-task SnapHashTrie when useStackTrie is enabled" taggedAs UnitTest in {
+    val root = kec256(ByteString("stacktrie-test-root"))
+    val (coord, storage) = newStackTrieCoordinator(stateRoot = root)
+    val ua = coord.underlyingActor
+    val task = AccountTask(
+      next = ByteString(Array.fill[Byte](32)(0x00)),
+      last = ByteString(Array.fill[Byte](32)(0xff.toByte)),
+      rootHash = root
+    )
+    val accounts = stackTrieFixtureAccounts(task, 8)
+    val nodesBefore = storage.synchronized { /* peek size via decode-then-count */ 0 }
+
+    // Drive the chunk-store path directly. isTaskRangeComplete = false (more responses
+    // could follow for this range), so the per-task SnapHashTrie should remain in the map.
+    coord ! Messages.StoreAccountChunk(task, accounts, accounts.size, storedSoFar = 0, isTaskRangeComplete = false)
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    ua.taskStackTries should contain key task.last
+    // No global stateTrie touch — its root should still be the empty-root hash.
+    ByteString(ua.getStateRoot.toArray) shouldEqual ByteString(MerklePatriciaTrie.EmptyRootHash)
+    val _ = nodesBefore // suppress unused warning while the storage poking is a no-op
+
+    system.stop(coord)
+  }
+
+  it should "commit and clear per-task SnapHashTrie when a task range completes" taggedAs UnitTest in {
+    val root = kec256(ByteString("stacktrie-commit-root"))
+    val (coord, _) = newStackTrieCoordinator(stateRoot = root)
+    val ua = coord.underlyingActor
+    val task = AccountTask(
+      next = ByteString(Array.fill[Byte](32)(0x00)),
+      last = ByteString(Array.fill[Byte](32)(0xff.toByte)),
+      rootHash = root
+    )
+    val accounts = stackTrieFixtureAccounts(task, 4)
+
+    // Drive the final chunk for this task with isTaskRangeComplete = true.
+    coord ! Messages.StoreAccountChunk(task, accounts, accounts.size, storedSoFar = 0, isTaskRangeComplete = true)
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    // After commit, the per-task StackTrie should have been removed.
+    ua.taskStackTries should not contain key(task.last)
+
+    system.stop(coord)
+  }
+
+  it should "not touch legacy stateTrie or accountsSinceLastFlush on the StackTrie path" taggedAs UnitTest in {
+    val root = kec256(ByteString("stacktrie-isolation-root"))
+    val (coord, _) = newStackTrieCoordinator(stateRoot = root)
+    val ua = coord.underlyingActor
+    val task = AccountTask(
+      next = ByteString(Array.fill[Byte](32)(0x00)),
+      last = ByteString(Array.fill[Byte](32)(0xff.toByte)),
+      rootHash = root
+    )
+    val accounts = stackTrieFixtureAccounts(task, 12)
+
+    coord ! Messages.StoreAccountChunk(task, accounts, accounts.size, storedSoFar = 0, isTaskRangeComplete = false)
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    // Legacy stateTrie root stays at the empty-root hash.
+    ByteString(ua.getStateRoot.toArray) shouldEqual ByteString(MerklePatriciaTrie.EmptyRootHash)
+
+    system.stop(coord)
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -716,4 +716,44 @@ class StorageRangeCoordinatorSpec
 
     system.stop(coord)
   }
+
+  // -----------------------------------------------------------------------
+  // StackTrie write-path (Step 4 of `snap-stacktrie-port` plan)
+  // -----------------------------------------------------------------------
+  // Verify the coordinator constructs and operates normally with the flag
+  // enabled. The actual per-contract trie-building happens asynchronously on
+  // `trieBuilderEc` (a separate thread pool); end-to-end verification of the
+  // node emissions is exercised by the Sepolia test run that follows Step 5.
+
+  it should "construct successfully with useStackTrie = true" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("storage-stacktrie-construct-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = system.actorOf(
+      StorageRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        flatSlotStorage = new FlatSlotStorage(EphemDataSource()),
+        maxAccountsPerBatch = 8,
+        maxInFlightRequests = 8,
+        requestTimeout = 30.seconds,
+        snapSyncController = snapSyncController.ref,
+        useStackTrie = true
+      )
+    )
+
+    coordinator should not be null
+
+    // Smoke: accept the basic lifecycle messages without error.
+    coordinator ! Messages.StartStorageRangeSync(stateRoot)
+    coordinator ! Messages.StorageGetProgress
+    expectMsgType[Any](3.seconds)
+
+    system.stop(coordinator)
+  }
 }

--- a/src/test/scala/com/chipprbots/ethereum/mpt/StackTrieSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/mpt/StackTrieSpec.scala
@@ -1,0 +1,283 @@
+package com.chipprbots.ethereum.mpt
+
+import scala.collection.mutable
+import scala.util.Random
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.testing.TestMptStorage
+import com.chipprbots.ethereum.testing.Tags._
+
+/** Tests for [[StackTrie]].
+  *
+  * The bedrock invariant: for any set of (key, value) pairs inserted in
+  * strictly-ascending hex-nibble order, `StackTrie.hash()` must produce the
+  * same 32-byte root hash as inserting the same pairs into a
+  * [[MerklePatriciaTrie]] backed by an arbitrary `MptStorage`. The
+  * MerklePatriciaTrie is the reference oracle.
+  */
+class StackTrieSpec extends AnyFlatSpec with Matchers {
+
+  // ---- helpers ----
+
+  /** Implicit serializer used by the reference MerklePatriciaTrie tests below. */
+  private implicit val byteArraySerializer: com.chipprbots.ethereum.mpt.ByteArraySerializable[Array[Byte]] =
+    new com.chipprbots.ethereum.mpt.ByteArraySerializable[Array[Byte]] {
+      def toBytes(input: Array[Byte]): Array[Byte] = input
+      def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
+    }
+
+  /** Build a reference MPT root for the given (key, value) pairs. */
+  private def referenceRoot(pairs: Seq[(Array[Byte], Array[Byte])]): Array[Byte] = {
+    var trie: MerklePatriciaTrie[Array[Byte], Array[Byte]] =
+      MerklePatriciaTrie[Array[Byte], Array[Byte]](new TestMptStorage())
+    pairs.foreach { case (k, v) => trie = trie.put(k, v) }
+    trie.getRootHash
+  }
+
+  /** Build a StackTrie root for the same pairs, discarding emitted nodes. */
+  private def stackTrieRoot(pairs: Seq[(Array[Byte], Array[Byte])]): Array[Byte] = {
+    val st = new StackTrie((_, _, _) => ())
+    pairs.foreach { case (k, v) => st.update(k, v) }
+    st.hash().toArray
+  }
+
+  /** Build a StackTrie and collect every emitted node into a hash → blob map. */
+  private def stackTrieWithEmissions(
+      pairs: Seq[(Array[Byte], Array[Byte])]
+  ): (Array[Byte], Map[ByteString, Array[Byte]]) = {
+    val collected = mutable.LinkedHashMap.empty[ByteString, Array[Byte]]
+    val st = new StackTrie((_, hash, blob) => {
+      // Defensive: callers must deep-copy if they want to retain the blob.
+      collected += hash -> blob.clone()
+    })
+    pairs.foreach { case (k, v) => st.update(k, v) }
+    val root = st.hash().toArray
+    (root, collected.toMap)
+  }
+
+  /** Sort a sequence of (key, value) pairs by big-endian unsigned key. */
+  private def sortByKey(pairs: Seq[(Array[Byte], Array[Byte])]): Seq[(Array[Byte], Array[Byte])] =
+    pairs.sortWith { case ((a, _), (b, _)) => StackTrie.byteCompare(a, b) < 0 }
+
+  /** Generate `n` (32-byte hash, value-bytes) pairs with the given seed. */
+  private def generatedPairs(n: Int, seed: Long): Seq[(Array[Byte], Array[Byte])] = {
+    val rng = new Random(seed)
+    val raw = (0 until n).map { _ =>
+      val k = new Array[Byte](32); rng.nextBytes(k)
+      val v = new Array[Byte](16 + rng.nextInt(48)); rng.nextBytes(v)
+      (k, v)
+    }
+    sortByKey(raw)
+  }
+
+  // ---- empty trie ----
+
+  it should "produce the canonical empty-trie root for an empty input" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    val root = st.hash().toArray
+    root shouldEqual MerklePatriciaTrie.EmptyRootHash
+  }
+
+  // ---- single-key tries ----
+
+  it should "match MerklePatriciaTrie for a single short key" taggedAs UnitTest in {
+    val pairs = Seq(Array[Byte](0x01) -> Array[Byte](0xaa.toByte))
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "match MerklePatriciaTrie for a single 32-byte hash key" taggedAs UnitTest in {
+    val pairs = Seq(
+      kec256("alpha".getBytes) -> "value-alpha".getBytes
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- two-key cases (branch + leaf paths) ----
+
+  it should "match MerklePatriciaTrie for two keys with no shared prefix" taggedAs UnitTest in {
+    val pairs = sortByKey(
+      Seq(
+        Array[Byte](0x10.toByte) -> "v1".getBytes,
+        Array[Byte](0x20.toByte) -> "v2".getBytes
+      )
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "match MerklePatriciaTrie for two keys with a shared byte prefix" taggedAs UnitTest in {
+    val pairs = sortByKey(
+      Seq(
+        Array[Byte](0x11.toByte, 0x22.toByte) -> "value-a".getBytes,
+        Array[Byte](0x11.toByte, 0x33.toByte) -> "value-b".getBytes
+      )
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "match MerklePatriciaTrie for two keys sharing an odd-nibble prefix" taggedAs UnitTest in {
+    // Nibble-level prefix: 0x1 only (one nibble), differing on the second nibble.
+    val pairs = sortByKey(
+      Seq(
+        Array[Byte](0x12.toByte, 0x34.toByte) -> "alpha".getBytes,
+        Array[Byte](0x15.toByte, 0x67.toByte) -> "beta".getBytes
+      )
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- branch saturation (16 children at one slot depth) ----
+
+  it should "match MerklePatriciaTrie for a fully-saturated 16-child branch" taggedAs UnitTest in {
+    val pairs = sortByKey(
+      (0 until 16).map { i =>
+        val k = Array[Byte]((i << 4).toByte, 0x00.toByte) // upper nibble varies, lower nibble same
+        val v = s"value-$i".getBytes
+        k -> v
+      }
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- deep / extension-heavy ----
+
+  it should "match MerklePatriciaTrie for keys sharing a long extension prefix" taggedAs UnitTest in {
+    // Both keys share the first 31 bytes, differ in the last byte.
+    val shared = new Array[Byte](31)
+    new Random(0xabcdef).nextBytes(shared)
+    val pairs = sortByKey(
+      Seq(
+        (shared :+ 0x00.toByte) -> "first".getBytes,
+        (shared :+ 0xff.toByte) -> "last".getBytes
+      )
+    )
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- large random batches (the real test) ----
+
+  it should "match MerklePatriciaTrie for 100 random 32-byte keys (sorted)" taggedAs UnitTest in {
+    val pairs = generatedPairs(100, seed = 0x1234L)
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "match MerklePatriciaTrie for 1 000 random 32-byte keys (sorted)" taggedAs UnitTest in {
+    val pairs = generatedPairs(1000, seed = 0x5678L)
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "match MerklePatriciaTrie for 10 000 random 32-byte keys (sorted)" taggedAs UnitTest in {
+    val pairs = generatedPairs(10000, seed = 0xdeadbeefL)
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- inline-vs-hashed boundary ----
+
+  it should "produce inline (sub-32-byte) values for tiny tries" taggedAs UnitTest in {
+    // A single very-short leaf would normally inline, but we always hash at root.
+    val pairs = Seq(Array[Byte](0x00.toByte) -> Array[Byte](0x42.toByte))
+    val (root, emissions) = stackTrieWithEmissions(pairs)
+    // For a single tiny leaf, the leaf is the root. Its RLP < 32 bytes, but
+    // the root-path hashing rule forces us to emit + hash it.
+    root.length shouldBe 32
+    emissions.keySet should contain(ByteString(root))
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+  }
+
+  it should "not emit inline child blobs as separate nodes" taggedAs UnitTest in {
+    // For a tree of two keys where the branch + leaves all fit < 32 bytes
+    // RLP-encoded, the branch's children are inline and shouldn't appear in
+    // the emissions map separately. Only the root (or whatever isn't inline)
+    // should be emitted.
+    val pairs = sortByKey(
+      Seq(
+        Array[Byte](0x01.toByte) -> Array[Byte](0x10.toByte),
+        Array[Byte](0x02.toByte) -> Array[Byte](0x20.toByte)
+      )
+    )
+    val (root, emissions) = stackTrieWithEmissions(pairs)
+    stackTrieRoot(pairs) shouldEqual referenceRoot(pairs)
+    // The root is always hashed. There should be at most one emission
+    // (the root itself).
+    emissions.size should be <= 1
+    emissions.keys.toSeq should contain only ByteString(root)
+  }
+
+  // ---- emission coverage: every non-inline node appears once ----
+
+  it should "emit exactly one blob per finalised non-inline node" taggedAs UnitTest in {
+    val pairs = generatedPairs(50, seed = 0xcafeL)
+    val (_, emissions) = stackTrieWithEmissions(pairs)
+    // Every emitted hash should match keccak256 of its blob.
+    emissions.foreach { case (hash, blob) =>
+      ByteString(kec256(blob)) shouldEqual hash
+    }
+    // No two emissions should share a hash.
+    emissions.keys.toSeq.distinct.size shouldEqual emissions.size
+  }
+
+  // ---- sort enforcement ----
+
+  it should "reject a duplicate key insert" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    val k = Array[Byte](0x10.toByte)
+    st.update(k, Array[Byte](0x01.toByte))
+    an[IllegalArgumentException] should be thrownBy st.update(k, Array[Byte](0x02.toByte))
+  }
+
+  it should "reject a strictly-descending key insert" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    st.update(Array[Byte](0x20.toByte), Array[Byte](0x01.toByte))
+    an[IllegalArgumentException] should be thrownBy
+      st.update(Array[Byte](0x10.toByte), Array[Byte](0x02.toByte))
+  }
+
+  it should "reject an empty value" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    an[IllegalArgumentException] should be thrownBy
+      st.update(Array[Byte](0x10.toByte), Array.emptyByteArray)
+  }
+
+  // ---- reset semantics ----
+
+  it should "produce the empty root after reset" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    st.update(Array[Byte](0x10.toByte), "value".getBytes)
+    val _ = st.hash()
+    st.reset()
+    val reset = st.hash().toArray
+    reset shouldEqual MerklePatriciaTrie.EmptyRootHash
+  }
+
+  it should "allow re-use after reset for a fresh trie" taggedAs UnitTest in {
+    val st = new StackTrie((_, _, _) => ())
+    st.update(Array[Byte](0x10.toByte), "first".getBytes)
+    val _ = st.hash()
+    st.reset()
+    val pairs = generatedPairs(20, seed = 0xfeedL)
+    pairs.foreach { case (k, v) => st.update(k, v) }
+    val root2 = st.hash().toArray
+    root2 shouldEqual referenceRoot(pairs)
+  }
+
+  // ---- diffIndex utility unit tests ----
+
+  it should "compute diffIndex correctly for hex nibbles" taggedAs UnitTest in {
+    StackTrie.diffIndex(Array[Byte](1, 2, 3), Array[Byte](1, 2, 3)) shouldEqual 3
+    StackTrie.diffIndex(Array[Byte](1, 2, 3), Array[Byte](1, 2, 4)) shouldEqual 2
+    StackTrie.diffIndex(Array[Byte](1, 2, 3), Array[Byte](1, 2, 3, 4)) shouldEqual 3
+    StackTrie.diffIndex(Array.emptyByteArray, Array[Byte](1)) shouldEqual 0
+  }
+
+  it should "compute byteCompare correctly as unsigned" taggedAs UnitTest in {
+    // 0x80 is greater than 0x7f when treated as unsigned (Scala's signed Byte
+    // would otherwise put 0x80 = -128 < 0x7f).
+    StackTrie.byteCompare(Array[Byte](0x80.toByte), Array[Byte](0x7f.toByte)) should be > 0
+    StackTrie.byteCompare(Array[Byte](0x01.toByte), Array[Byte](0x01.toByte, 0x00.toByte)) should be < 0
+    StackTrie.byteCompare(Array.emptyByteArray, Array.emptyByteArray) shouldEqual 0
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/EtcPeerManagerSpec.scala
@@ -349,10 +349,82 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     // Verify NO GetBlockHeaders request is sent to avoid disconnect with reason 0x10 (Other)
     // Many peers disconnect genesis-only nodes as a peer selection policy
     peer1Probe.expectNoMessage()
+    peerManager.expectNoMessage(100.millis)
 
     // Verify peer is still added to handshaked peers
     requestSender.send(peersInfoHolder, PeerInfoRequest(peer1.id))
     requestSender.expectMsg(PeerInfoResponse(Some(genesisInfo)))
+  }
+
+  it should "send a best-block probe (GetBlockHeaders by bestHash) after handshake on ETH/64-/68" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new TestSetup {
+    expectInitialSubscriptions()
+
+    // peer1Info is built with capability = ETH63 above; override to ETH68 (modern peer)
+    // and pin maxBlockNumber to 0 so we exercise the not-yet-known-number path.
+    val eth68Status = peer1Info.remoteStatus.copy(capability = Capability.ETH68)
+    val eth68Info = peer1Info.copy(remoteStatus = eth68Status, maxBlockNumber = 0)
+
+    peersInfoHolder ! PeerHandshakeSuccessful(peer1, eth68Info)
+
+    // Drain the two subscriptions that always follow handshake.
+    peerEventBus.expectMsg(Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer1.id))))
+    peerEventBus.expectMsgClass(classOf[Subscribe])
+
+    // The probe should land on the peerManager TestProbe as a SendMessage to peer1.
+    val sent = peerManager.expectMsgClass(classOf[PeerManagerActor.SendMessage])
+    sent.peerId shouldBe peer1.id
+    sent.message.code shouldBe Codes.GetBlockHeadersCode
+    // ETH/66+ uses request-id-prefixed envelope.
+    sent.message.underlyingMsg shouldBe a[com.chipprbots.ethereum.network.p2p.messages.ETH66.GetBlockHeaders]
+    val gbh =
+      sent.message.underlyingMsg.asInstanceOf[com.chipprbots.ethereum.network.p2p.messages.ETH66.GetBlockHeaders]
+    gbh.block shouldBe Right(eth68Info.remoteStatus.bestHash)
+    gbh.maxHeaders shouldBe BigInt(1)
+    gbh.skip shouldBe BigInt(0)
+    gbh.reverse shouldBe false
+  }
+
+  it should "skip the best-block probe on ETH/69 (number is in STATUS)" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new TestSetup {
+    expectInitialSubscriptions()
+
+    val eth69Status = peer1Info.remoteStatus.copy(capability = Capability.ETH69)
+    val eth69Info = peer1Info.copy(remoteStatus = eth69Status)
+
+    peersInfoHolder ! PeerHandshakeSuccessful(peer1, eth69Info)
+
+    // Drain the two subscriptions and assert no probe.
+    peerEventBus.expectMsg(Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer1.id))))
+    peerEventBus.expectMsgClass(classOf[Subscribe])
+    peerManager.expectNoMessage(100.millis)
+  }
+
+  it should "discover peer block number from probe response on ETH/64-/68" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new TestSetup {
+    expectInitialSubscriptions()
+
+    // ETH/68 peer with no known block number yet.
+    val eth68Status = peer1Info.remoteStatus.copy(capability = Capability.ETH68)
+    val eth68Info = peer1Info.copy(remoteStatus = eth68Status, maxBlockNumber = 0)
+
+    setupNewPeer(peer1, peer1Probe, eth68Info)
+
+    // Probe response arrives via the existing BlockHeadersCode subscription. The
+    // header carries the bestHash from STATUS and a real block number; updateMaxBlock
+    // should pick up the number and write it into PeerInfo.maxBlockNumber.
+    val probeReply = baseBlockHeader.copy(number = 24463116)
+    peersInfoHolder ! MessageFromPeer(BlockHeaders(Seq(probeReply)), peer1.id)
+
+    requestSender.send(peersInfoHolder, PeerInfoRequest(peer1.id))
+    val resp = requestSender.expectMsgType[PeerInfoResponse]
+    resp.peerInfo.map(_.maxBlockNumber) shouldBe Some(BigInt(24463116))
   }
 
   it should "route SNAP protocol messages to registered SNAPSyncController" taggedAs (
@@ -564,12 +636,20 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
         )
       )
 
-      // NetworkPeerManagerActor intentionally does NOT send a GetBlockHeaders on
-      // handshake success — the sync engine pulls what it needs through the
-      // normal PeersClient polling path. Sending unsolicited GetBlockHeaders
-      // deviates from geth's devp2p behavior and caused peers implementing
-      // strict handshake expectations to disconnect with reason 0x10.
+      // After handshake completes, NetworkPeerManagerActor issues a Besu-style
+      // best-block probe (GetBlockHeaders by bestHash, count=1) on ETH/64-/68 so the
+      // peer's block number can be discovered — STATUS doesn't carry it on those
+      // protocol versions. The probe is routed via `peerManagerActor ! SendMessage`,
+      // so it lands on the `peerManager` TestProbe, never on the per-peer `peerProbe`.
+      // Genesis peers and ETH/69 peers are skipped (see dedicated tests below).
       peerProbe.expectNoMessage(100.millis)
+      val nonGenesis = peerInfo.remoteStatus.bestHash != peerInfo.remoteStatus.genesisHash
+      val notEth69 = peerInfo.remoteStatus.capability != Capability.ETH69
+      if (nonGenesis && notEth69) {
+        val probe = peerManager.expectMsgClass(classOf[PeerManagerActor.SendMessage])
+        probe.peerId shouldBe peer.id
+        probe.message.code shouldBe Codes.GetBlockHeadersCode
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 2 of the SNAP rewrite. Ports go-ethereum's StackTrie to Scala and routes the per-task SNAP write path through it, replacing the legacy `MerklePatriciaTrie` + `DeferredWriteMptStorage` build. Gated behind `sync.snap-sync.use-stack-trie` (default `false`).

The legacy path materialised the entire pivot trie in memory, then flushed it in a multi-minute single-actor blocking pass — the OOM trigger and the throughput ceiling at the end of accounts. The StackTrie path commits per task as the SNAP server walks key-ordered, so memory is bounded by the per-task buffer and flushes are short and amortised.

## What's here

| Layer | Commits |
| --- | --- |
| Core port | `feat(snap): port go-ethereum StackTrie for streaming MPT construction` |
| Batching wrapper | `feat(snap): SnapHashTrie batching wrapper for StackTrie emissions` |
| Account coordinator | `feat(snap): integrate per-task SnapHashTrie into AccountRangeCoordinator` |
| Storage coordinator | `feat(snap): integrate per-contract SnapHashTrie into StorageRangeCoordinator` |
| Restart durability | `test(snap): regression test confirming StackTrie path honours resumeProgress` |
| Config wire-up | `feat(snap): wire useStackTrie flag through SyncConfig + coordinator Props` |
| Validation harness | `deploy(cirith-ungol): enable use-stack-trie for Mordor validation` |
| Sepolia OOM hardening | `ops(barad-dur/sepolia): cap memory + capture heap dumps on OOM` |

The flag is wired through `SNAPSyncConfig` → all three coordinator construction sites in `SNAPSyncController` (initial AccountRange, post-account StorageRange, and AccountRange restart). Default `false` keeps every existing deployment on the legacy path.

## Validation

Full Mordor SNAP completed end-to-end via StackTrie on Cirith Ungol with `use-stack-trie = true`:

| Phase | Result |
| --- | --- |
| Accounts | 2,712,561 in ~62 min (485/s avg) |
| Bytecodes | 57,507 (10/s) |
| Storage slots | 1,137,345 (203/s avg) |
| Healing | 674,137 nodes fetched |
| Total elapsed | 1h33m (5,584s) |

Memory stayed bounded (~3.8 GB RES against 5 GB Xmx through the run, ~7.5 GB at peak during healing — no OOM, no GC death spiral). Three proactive pivot refreshes were handled cleanly with no data loss. Phase transitions (Accounts → Code+Storage → Healing → Validation → Completed) all fired.

Throughput note: this run is slower than the prior deferred-merkleization Mordor benchmark (59m). That gap is largely the per-batch commit cost vs. the legacy single-flush model; that's the right target for the next iteration but does not block landing the path itself.

## Operational footgun fixed

`ops/cirith-ungol/docker-compose.yml` previously mounted `etc.conf` at `/app/conf/etc.conf` and pointed `-Dconfig.file` at the same path. Initial validation showed all `snap-sync` overrides silently ignored — runtime read base defaults despite the file being correct. Root cause: `App.setNetworkConfig(\"mordor\")` looks for `\$network.conf` in the launcher config dir and, on miss, **clears the explicit `-Dconfig.file`** and falls back to the JAR-bundled classpath `conf/mordor.conf`. Fix: mount the same file at `/app/conf/mordor.conf` so the lookup succeeds. This is operator-only — no source change needed — but is the reason the deploy commit is here.

## Test plan

- [x] `node/testOnly *StackTrieSpec` — 21 tests, golden-hash equality with `MerklePatriciaTrie` across empty/single/2-key prefix/16-child/100/1k/10k random
- [x] `node/testOnly *SnapHashTrieSpec` — 8 tests covering threshold flush, reset, deep-copy
- [x] `node/testOnly *AccountRangeCoordinatorSpec` — 37 tests including StackTrie-path resume durability
- [x] `node/testOnly *StorageRangeCoordinatorSpec` — 22 tests including StackTrie construction smoke
- [x] Full Mordor SNAP end-to-end on Cirith Ungol with `use-stack-trie = true`
- [ ] Full ETC mainnet SNAP on Barad-dûr primary with `use-stack-trie = true` — next benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)