### PR TITLE
fix(snap): reject stale SNAP peers when refreshing pivot on post-merge chains

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -2991,11 +2991,32 @@ class SNAPSyncController(
   private def refreshPivotInPlace(reason: String): Unit = {
     log.info(s"Refreshing pivot in-place: $reason")
 
-    // Select a new pivot from the current network best
-    val newPivotOpt = currentNetworkBestFromSnapPeers()
-      .map { networkBest =>
-        networkBest - snapSyncConfig.pivotBlockOffset
+    // CL-anchored freshness floor (post-merge chains only). See `pivotPassesFreshnessFloor`
+    // for the regression context. Pre-merge chains (no CL) keep the old behavior because
+    // there is no authoritative "tip" reference.
+    val clHeadNumber: Option[BigInt] =
+      if (isPostMergeChain) clPivotHint.flatMap(_.knownHeader).map(_.number) else None
+
+    val networkBestOpt = currentNetworkBestFromSnapPeers()
+    val newPivotOpt = networkBestOpt
+      .filter { networkBest =>
+        SNAPSyncController.pivotPassesFreshnessFloor(
+          networkBest = networkBest,
+          clHeadNumber = clHeadNumber,
+          maxStaleness = snapSyncConfig.maxPivotStalenessBlocks
+        ) match {
+          case Right(()) => true
+          case Left(floor) =>
+            log.warning(
+              s"Rejecting stale SNAP peer best=$networkBest as pivot — below CL-anchored " +
+                s"freshness floor=$floor (CL head=${clHeadNumber.getOrElse("?")}, " +
+                s"maxPivotStalenessBlocks=${snapSyncConfig.maxPivotStalenessBlocks}). " +
+                "Waiting for a fresher SNAP-capable peer."
+            )
+            false
+        }
       }
+      .map(networkBest => networkBest - snapSyncConfig.pivotBlockOffset)
       .filter(_ > 0)
 
     if (newPivotOpt.isEmpty) {
@@ -3789,6 +3810,38 @@ object SNAPSyncController {
       storagePhaseForceCompleted: Boolean
   ): Boolean =
     snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted
+
+  /** Freshness gate for `refreshPivotInPlace`: reject candidate pivots whose source peer is
+    * more than `maxStaleness` blocks behind the CL-driven head.
+    *
+    * Background: the post-merge SNAP refresh path used to take `max(snapPeer.maxBlockNumber)`
+    * as the new pivot with no comparison against the actual chain tip. When the only
+    * SNAP-capable peers left in the pool were lagging (e.g. one still reporting block
+    * 10_447_000 while sepolia's CL head was at 10_847_xxx — observed May 13 2026), the
+    * refresh kept picking the stuck-peer's block, then immediately tripped the same-root
+    * fallback and restart. This filter blocks that path: on post-merge chains we know the
+    * authoritative tip (via `clPivotHint`), so we require pivot sources to be within
+    * `maxStaleness` of it. Pre-merge chains pass through unchanged (clHeadNumber=None).
+    *
+    * @param networkBest  the best SNAP peer's maxBlockNumber
+    * @param clHeadNumber the consensus-layer head block number, when available
+    * @param maxStaleness configured `maxPivotStalenessBlocks` (default 4096)
+    * @return Right(()) if the candidate is fresh enough, Left(floor) with the rejected
+    *         freshness floor for diagnostic logging on the call site
+    */
+  private[snap] def pivotPassesFreshnessFloor(
+      networkBest: BigInt,
+      clHeadNumber: Option[BigInt],
+      maxStaleness: Long
+  ): Either[BigInt, Unit] = clHeadNumber match {
+    case Some(clHead) =>
+      val floor = clHead - maxStaleness
+      if (networkBest < floor) Left(floor) else Right(())
+    case None =>
+      // Pre-merge / pre-CL-hint state: no authoritative tip to compare against. Preserve the
+      // legacy "take whatever peer offers" behavior.
+      Right(())
+  }
 
   def props(
       blockchainReader: BlockchainReader,

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -1123,6 +1123,58 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     val ticksBeforeEviction = (10 * 60 * 1000L) / DownloadStagnationCheckIntervalMs
     ticksBeforeEviction shouldBe 20L // 20 ticks per 10-minute window
   }
+
+  // ── pivotPassesFreshnessFloor — regression for the sepolia oscillation ────
+  // refreshPivotInPlace used to take max(snapPeer.maxBlockNumber) verbatim.
+  // When the only SNAP-capable peer in the pool was stuck behind (block
+  // 10_447_000 while sepolia's CL head was at 10_847_xxx), the refresh kept
+  // picking the stuck-peer's block, then immediately tripped the same-root
+  // fallback, then restarted, then re-refreshed back to 10_447_000, ad infinitum.
+  // The freshness-floor filter wired in below stops that path.
+  "pivotPassesFreshnessFloor" should "accept a fresh peer (within maxStaleness of CL head)" taggedAs UnitTest in {
+    SNAPSyncController.pivotPassesFreshnessFloor(
+      networkBest = BigInt(10_847_168),
+      clHeadNumber = Some(BigInt(10_847_413)),
+      maxStaleness = 4096
+    ) shouldBe Right(())
+  }
+
+  it should "reject a stale peer that lags more than maxStaleness behind the CL head" taggedAs UnitTest in {
+    // The exact regression: SNAP peer reporting block 10_447_000 while CL head is at
+    // 10_847_413 — 400K blocks of drift, way past the 4096 staleness window.
+    val networkBest = BigInt(10_447_000)
+    val clHead = BigInt(10_847_413)
+    val maxStaleness = 4096L
+    val expectedFloor = clHead - maxStaleness // 10_843_317
+
+    SNAPSyncController.pivotPassesFreshnessFloor(
+      networkBest = networkBest,
+      clHeadNumber = Some(clHead),
+      maxStaleness = maxStaleness
+    ) shouldBe Left(expectedFloor)
+  }
+
+  it should "accept a peer exactly at the floor (boundary inclusive)" taggedAs UnitTest in {
+    val clHead = BigInt(10_847_413)
+    val maxStaleness = 4096L
+    val onFloor = clHead - maxStaleness // 10_843_317
+
+    SNAPSyncController.pivotPassesFreshnessFloor(
+      networkBest = onFloor,
+      clHeadNumber = Some(clHead),
+      maxStaleness = maxStaleness
+    ) shouldBe Right(())
+  }
+
+  it should "pass through unchanged on the pre-merge path (no CL head)" taggedAs UnitTest in {
+    // ETC mainnet etc. — there is no consensus layer, so no authoritative tip to anchor
+    // against. The filter must be a no-op there to preserve the legacy peer-best-wins path.
+    SNAPSyncController.pivotPassesFreshnessFloor(
+      networkBest = BigInt(0), // even genesis passes when no CL head is known
+      clHeadNumber = None,
+      maxStaleness = 4096L
+    ) shouldBe Right(())
+  }
 }
 
 /** Test helper: a `StateValidator` subclass that returns canned results without traversing the trie. Used in


### PR DESCRIPTION
## Summary

\`refreshPivotInPlace\` used to take \`max(snapPeer.maxBlockNumber)\` verbatim as the candidate pivot, with no comparison against the actual chain tip. On post-merge chains (sepolia, mainnet) the CL feeds us an authoritative head via \`CLPivotHint\`, but the SNAP-capable peer pool can lag arbitrarily — a peer can stay connected and pass capability filters while reporting a chain head from hundreds of thousands of blocks ago.

## Observed wedge (sepolia, May 13 2026)

The only SNAP-capable peer left in the pool at refresh time was at block 10_447_000 while the CL head was at ~10_847_xxx. The refresh accepted it, the same-root fallback tripped, a full SNAP restart fired, and the cycle repeated:

\`\`\`
20:22  pivot 10846984 → 10447000  root 45828488 → 4d108d68
20:24  Pivot refresh produced same root → full restart
20:32  pivot 10847055 → 10447000  root eba62d39 → 4d108d68
21:14  pivot 10847256 → 10447000  root 5f7b3da8 → 4d108d68
21:26  pivot 10847271 → 10447000  root da7de9cf → 4d108d68
\`\`\`

Every fresh-tip refresh followed by another fallback to the stuck peer's block. Account-range progress stalled at ~120 K accounts / ~28 K codehashes after two hours of cycling.

## Root cause

The pre-existing \`maxPivotStalenessBlocks\` config (4096 default) was already consulted at *initial pivot selection* (\`pivotTooStaleAgainstNetworkHead\`, line 1230-1252) and at *startup recovery* (drift check, line 1475) — never on in-flight refresh. The post-merge code path has a much better freshness anchor available than peer-best: the CL head from \`clPivotHint.knownHeader.number\`.

## Fix

- New helper \`SNAPSyncController.pivotPassesFreshnessFloor\`: pure function returning \`Right(())\` for candidates within \`maxStaleness\` of the CL head, or \`Left(floor)\` for stale candidates with the rejected floor for diagnostic logging.
- Wired into \`refreshPivotInPlace\`: when \`isPostMergeChain\` and a CL hint is buffered, candidates that fall below \`clHead - maxStaleness\` are rejected with a one-line warning and the existing 30 s retry path takes over.
- Pre-merge chains (ETC mainnet etc.) pass through unchanged — no authoritative tip reference exists, so the legacy \`take whatever peer offers\` behavior is preserved.

## What this does NOT fix

- The deeper question of *why* peers stuck 400 K blocks behind are still in the connection set in the first place. This patch makes the refresh path robust to it; a separate investigation into peer-eviction policy for chronically-lagging peers is worth doing later.
- The fallback during pre-merge sync (ETC) — there is no CL hint there, so this filter is a no-op.

## Test plan

- [x] Four unit tests in \`SNAPSyncControllerSpec\`:
  - fresh peer (within maxStaleness of CL head) → accepted
  - regression case (10_447_000 vs 10_847_413 with 4096 staleness) → rejected with correct floor
  - boundary peer exactly at \`clHead - maxStaleness\` → accepted (boundary-inclusive)
  - pre-merge path (no CL head) → passthrough
- [x] \`sbt Test/compile; assembly\` clean (3 pre-existing minor warnings, no errors)
- [x] Image rebuilt and deployed to sepolia — JAVA_TOOL_OPTIONS / useStackTrie / backpressure all still wired correctly
- [ ] Sepolia full-sync rerun: pivot refreshes only land on fresh peers; no 10_847_xxx → 10_447_000 fallback events; account-range download proceeds past the previous wedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)