### PR TITLE
fix(snap): strike-counted snapless+stateless peer demotion (was: one-shot)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -109,19 +109,37 @@ class AccountRangeCoordinator(
   // Kept for spec compatibility; reflects whether the storage source is currently engaged.
   private[actors] def storageBackpressureActive: Boolean = backpressureSources.contains("storage")
 
-  // Stateless peer tracking: peers that return "Missing proof for empty account range"
-  // OR consecutive timeouts are unable to serve the current state root. Cleared on
-  // PivotRefreshed because the new root may be inside the peer's serve window.
+  // Stateless peer tracking: peers CONFIRMED unable to serve the current state root after
+  // crossing the strike threshold below. Cleared on PivotRefreshed because the new root may
+  // be inside the peer's serve window.
   // `private[actors]` so AccountRangeCoordinatorSpec can drive the state via TestActorRef.
   private[actors] val statelessPeers = mutable.Set[com.chipprbots.ethereum.network.PeerId]()
   // Snapless peer tracking (#1197): peers whose SNAP handler returns
   // `AccountRangePacket{Accounts: nil, Proof: nil}` indicating `chain.Snapshots()` is
-  // structurally unavailable (typical core-geth `--syncmode full` configuration on ETC
-  // mainnet — see project_eth68_snap_research memory). The peer's snapshot won't
-  // materialize this session, so this set survives PivotRefreshed (root-independent).
+  // structurally unavailable. CONFIRMED after EmptyResponseStrikeThreshold consecutive
+  // empty-with-empty-proof signals (no intervening successful response). Survives
+  // PivotRefreshed (root-independent) — see project_eth68_snap_research memory for the
+  // core-geth `--syncmode full` rationale: a peer with no snapshot tree won't grow one.
   // Bytecode + trie-node healing coordinators are unaffected — those code paths use
   // direct DB lookups that don't depend on the snapshot tree.
   private[actors] val snaplessPeers = mutable.Set[com.chipprbots.ethereum.network.PeerId]()
+  // Strike counter for empty-with-empty-proof responses (the only signal that drives
+  // statelessPeers + snaplessPeers entry today). The previous policy promoted a peer on
+  // the FIRST such response, which on sepolia 2026-05-13 carpet-bombed the peer pool
+  // (snapPeers=3 advertised → 1 dispatched-to). Reference clients: geth keeps a single
+  // global statelessPeers and no explicit strikes (uses a throughput/latency tracker);
+  // nethermind uses 5 strikes. We pick 3 — enough to survive a transient empty cycle
+  // (peer warming up after restart, network hiccup) without being so generous that genuinely
+  // useless peers eat the dispatch budget.
+  //
+  // Lifecycle:
+  //   * empty-with-empty-proof from peer → strike++
+  //   * strike >= threshold → enter statelessPeers AND snaplessPeers (confirmed)
+  //   * any successful response from peer → recordPeerSuccess clears strikes
+  //   * PivotRefreshed → clear strikes (peer deserves a clean slate on the new root)
+  //   * PeerUnavailable → clear strikes (and the peer entry from statelessPeers too)
+  private[actors] val emptyResponseStrikes = mutable.Map.empty[com.chipprbots.ethereum.network.PeerId, Int]
+  private val EmptyResponseStrikeThreshold: Int = 3
   private var pivotRefreshRequested = false
   private var pivotWasRefreshed = false
 
@@ -133,29 +151,41 @@ class AccountRangeCoordinator(
 
   private def markPeerStateless(peer: Peer, reason: String): Unit = {
     val isEmptyProofSignal = reason.contains("Missing proof for empty account range")
-    val shouldMark = if (isEmptyProofSignal) {
-      // Peer explicitly returned empty response — immediately stateless AND snapless.
-      // The empty-with-empty signal means `chain.Snapshots()` is unavailable on this
-      // peer for any root, not just the current one (#1197).
-      snaplessPeers.add(peer.id)
+    if (!isEmptyProofSignal) return
+    // Already-confirmed peers stay confirmed; further strikes are noise.
+    if (snaplessPeers.contains(peer.id)) return
+
+    val priorStrikes = emptyResponseStrikes.getOrElse(peer.id, 0)
+    val strikes = priorStrikes + 1
+    emptyResponseStrikes(peer.id) = strikes
+
+    if (strikes < EmptyResponseStrikeThreshold) {
       log.info(
-        s"Peer ${peer.id.value} marked SNAPLESS (no snapshot tree) — will skip for " +
-          s"GetAccountRange this session. Bytecode/healing remain available."
+        s"Peer ${peer.id.value} empty-proof strike $strikes/$EmptyResponseStrikeThreshold for root " +
+          s"${stateRoot.take(4).toHex} (reason: $reason). Still eligible for dispatch."
       )
-      true
-    } else {
-      false
+      return
     }
 
-    if (shouldMark) {
-      statelessPeers.add(peer.id)
-      log.info(
-        s"Peer ${peer.id.value} marked stateless for root ${stateRoot.take(4).toHex} " +
-          s"(${statelessPeers.size}/${knownAvailablePeers.size} peers stateless)"
-      )
-      maybeRequestPivotRefresh()
-    }
+    // Threshold reached — promote to confirmed snapless + stateless. Snapless is sticky
+    // (root-independent, survives PivotRefreshed per #1197); stateless clears on the next
+    // PivotRefreshed.
+    snaplessPeers.add(peer.id)
+    statelessPeers.add(peer.id)
+    log.info(
+      s"Peer ${peer.id.value} marked SNAPLESS after $strikes consecutive empty-proof responses " +
+        s"— will skip for GetAccountRange this session. Bytecode/healing remain available. " +
+        s"(${statelessPeers.size}/${knownAvailablePeers.size} peers stateless for root ${stateRoot.take(4).toHex})"
+    )
+    maybeRequestPivotRefresh()
   }
+
+  /** Reset the strike counter for a peer that has just produced a useful response (real
+    * accounts OR a boundary proof). Cheap to over-invoke; the goal is "any forward progress
+    * from this peer wipes prior strikes."
+    */
+  private def recordPeerSuccess(peerId: com.chipprbots.ethereum.network.PeerId): Unit =
+    emptyResponseStrikes.remove(peerId)
 
   private def maybeRequestPivotRefresh(): Unit = {
     if (pivotRefreshRequested) return
@@ -576,7 +606,10 @@ class AccountRangeCoordinator(
       // NOTE: snaplessPeers is INTENTIONALLY NOT cleared here (#1197). A peer with no
       // snapshot tree won't grow one across a pivot refresh; clearing would just put
       // them back in dispatch rotation to immediately re-classify and waste a cycle.
+      // Strike counter IS cleared: the new root is a fresh opportunity and a peer with 1-2
+      // strikes deserves another shot.
       statelessPeers.clear()
+      emptyResponseStrikes.clear()
       pivotRefreshRequested = false
 
       // Clear per-peer adaptive state (new root = new response characteristics)
@@ -640,6 +673,11 @@ class AccountRangeCoordinator(
       // AbstractRetryingPeerTask.java:158 both treat disconnect as transient re-queue, not failure.
       knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
       peerCooldownUntilMs.remove(peerId)
+      // Drop strike counter — a reconnect under the same id should start fresh.
+      knownAvailablePeers.find(_.id.value == peerId).foreach(p => emptyResponseStrikes.remove(p.id))
+      // Note: snaplessPeers entry is preserved per #1197 — if the peer reconnects under a
+      // NEW PeerId, that's handled by PeerAvailable's stale-id-eviction path; same id =
+      // same physical node = same lack-of-snapshot.
       // #1184: drain the slots ourselves rather than relying on the worker → TaskFailed
       // cascade. drainActiveTasks sends WorkerRequestCancelled to each affected worker so they
       // leave `working` state cleanly and don't reject redispatch with TaskFailed(0, "Worker
@@ -944,6 +982,9 @@ class AccountRangeCoordinator(
           // Reset pivot refresh backoff on servable-root evidence: real account data or a boundary proof.
           if (accountCount > 0 || proof.nonEmpty) {
             consecutiveUnproductiveRefreshes = 0
+            // The peer served us a useful response. Wipe any prior empty-proof strikes so
+            // a future transient empty doesn't push a known-good peer over the threshold.
+            recordPeerSuccess(peer.id)
           }
 
           task.pending = false

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -126,10 +126,19 @@ class StorageRangeCoordinator(
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
   private val peerCooldownDefault = 10.seconds
 
-  // Binary stateless peer detection: peers that cannot serve the current state root.
-  // When ALL known peers become stateless, request a pivot refresh from the controller.
-  // This replaces the slow counter-based global backoff (was: 10 empties → 2 min pause).
+  // Stateless peer tracking: peers CONFIRMED unable to serve the current state root after
+  // crossing the strike threshold below. When ALL known peers are stateless, request a
+  // pivot refresh from the controller.
+  // The previous single-failure binary mark caused the same peer-pool collapse pathology
+  // we observed in AccountRangeCoordinator on sepolia 2026-05-13. Strike counting gives
+  // a transient peer hiccup the same recovery path used elsewhere in the codebase.
   private val statelessPeers = mutable.Set[String]()
+  // Strike counter for empty storage-range responses. Mirror of AccountRangeCoordinator's
+  // emptyResponseStrikes: a peer must miss N=3 consecutive empties (no intervening success)
+  // before being marked stateless. Cleared on PivotRefreshed, PeerUnavailable, or any
+  // successful (slot-bearing) response.
+  private val emptyResponseStrikes = mutable.Map.empty[String, Int]
+  private val EmptyResponseStrikeThreshold: Int = 3
   private var pivotRefreshRequested = false
 
   // Contract completion tracking for progress estimation.
@@ -173,13 +182,33 @@ class StorageRangeCoordinator(
     statelessPeers.contains(peer.id.value)
 
   private def markPeerStateless(peer: Peer): Unit = {
-    statelessPeers.add(peer.id.value)
+    val id = peer.id.value
+    // Already-confirmed peers stay confirmed; extra strikes are noise.
+    if (statelessPeers.contains(id)) return
+
+    val priorStrikes = emptyResponseStrikes.getOrElse(id, 0)
+    val strikes = priorStrikes + 1
+    emptyResponseStrikes(id) = strikes
+
+    if (strikes < EmptyResponseStrikeThreshold) {
+      log.info(
+        s"Peer $id empty-storage strike $strikes/$EmptyResponseStrikeThreshold for root " +
+          s"${stateRoot.take(4).toHex}. Still eligible for dispatch."
+      )
+      return
+    }
+
+    statelessPeers.add(id)
     log.info(
-      s"Peer ${peer.id.value} marked stateless for storage root ${stateRoot.take(4).toHex} " +
-        s"(${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
+      s"Peer $id marked stateless after $strikes consecutive empty storage responses for root " +
+        s"${stateRoot.take(4).toHex} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"
     )
     maybeRequestPivotRefresh()
   }
+
+  /** Reset strike counter when peer produces a useful response. Cheap to over-invoke. */
+  private def recordPeerSuccess(peerId: String): Unit =
+    emptyResponseStrikes.remove(peerId)
 
   private def maybeRequestPivotRefresh(): Unit = {
     if (pivotRefreshRequested) return
@@ -766,6 +795,7 @@ class StorageRangeCoordinator(
       // Mirrors AccountRangeCoordinator.PeerUnavailable (go-ethereum revertRequests pattern).
       knownAvailablePeers.find(_.id.value == peerId).foreach(knownAvailablePeers -= _)
       peerCooldownUntilMs.remove(peerId)
+      emptyResponseStrikes.remove(peerId)
       val inFlight = activeTasks.filter { case (_, (peer, _, _)) => peer.id.value == peerId }.keys.toSeq
       if (inFlight.nonEmpty) {
         log.debug(s"Peer $peerId disconnected — re-queuing ${inFlight.size} in-flight storage request(s)")
@@ -891,6 +921,7 @@ class StorageRangeCoordinator(
 
       // Clear all per-peer adaptive state — fresh start with new root
       statelessPeers.clear()
+      emptyResponseStrikes.clear()
       pivotRefreshRequested = false
       lastDispatchOrResponseMs = System.currentTimeMillis()
       peerCooldownUntilMs.clear()
@@ -1206,6 +1237,7 @@ class StorageRangeCoordinator(
 
     // Non-empty response with actual slot data — clear stateless marking and reset backoff.
     statelessPeers.remove(peer.id.value)
+    recordPeerSuccess(peer.id.value)
     consecutiveUnproductiveRefreshes = 0
     lastDispatchOrResponseMs = System.currentTimeMillis()
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -626,26 +626,72 @@ class AccountRangeCoordinatorSpec
   // separate `snaplessPeers` set that survives PivotRefreshed because the peer's
   // snapshot won't materialise mid-session.
 
-  it should "mark a peer SNAPLESS on 'Missing proof for empty account range' (#1197)" taggedAs UnitTest in {
-    // handleTaskFailed only calls markPeerStateless when the task's rootHash matches
-    // the coordinator's current stateRoot (otherwise it's a stale-root failure from a
-    // pre-pivot-refresh request, which doesn't reflect on the peer's snapshot state).
-    // Match the coordinator's default newCoordinator() stateRoot so the path is exercised.
+  it should "mark a peer SNAPLESS only after EmptyResponseStrikeThreshold consecutive empty-proof responses (#1197)" taggedAs UnitTest in {
+    // The previous policy promoted on the FIRST empty-proof response, which on sepolia
+    // 2026-05-13 collapsed the snap-peer pool from 3-8 connected → 1 dispatched-to. The
+    // new policy requires 3 consecutive strikes (no intervening successful response) to
+    // mark the peer. Reference clients: geth has no explicit counter (uses throughput
+    // tracking); nethermind uses 5; we pick 3 as a balance.
     val stateRoot = kec256(ByteString("trie-async-test-root"))
     val coord = newCoordinator(stateRoot = stateRoot)
     val ua = coord.underlyingActor
     val pendingProbe = TestProbe()
     val peer = PeerTestHelpers.createTestPeer("snapless-peer", pendingProbe.ref)
 
+    // Strikes 1 and 2 — peer still eligible.
     seedActiveTask(coord, BigInt(701), peer, rootHash = stateRoot)
-
-    // Drive the empty-with-empty failure path through the public coordinator API.
     coord ! Messages.TaskFailed(BigInt(701), "Missing proof for empty account range")
+    seedActiveTask(coord, BigInt(702), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(702), "Missing proof for empty account range")
     coord ! Messages.GetProgress
-    expectMsgType[AccountRangeStats](2.seconds) // sequential barrier
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    ua.statelessPeers should not contain peer.id
+    ua.snaplessPeers should not contain peer.id
+    ua.emptyResponseStrikes.get(peer.id) shouldBe Some(2)
+
+    // Strike 3 — promoted to confirmed snapless + stateless.
+    seedActiveTask(coord, BigInt(703), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(703), "Missing proof for empty account range")
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
 
     ua.statelessPeers should contain(peer.id)
     ua.snaplessPeers should contain(peer.id)
+
+    system.stop(coord)
+  }
+
+  it should "reset the empty-proof strike counter when a peer returns a useful response" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("trie-async-test-root"))
+    val coord = newCoordinator(stateRoot = stateRoot)
+    val ua = coord.underlyingActor
+    val pendingProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("strike-reset-peer", pendingProbe.ref)
+
+    // Two strikes — not yet promoted.
+    seedActiveTask(coord, BigInt(801), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(801), "Missing proof for empty account range")
+    seedActiveTask(coord, BigInt(802), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(802), "Missing proof for empty account range")
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+    ua.emptyResponseStrikes.get(peer.id) shouldBe Some(2)
+
+    // A successful response (proof.nonEmpty branch) resets the counter via recordPeerSuccess.
+    // Easiest way to drive this from the spec is to seed the strike map and call the helper
+    // directly; the production path is the `if (accountCount > 0 || proof.nonEmpty)` branch
+    // in handleTaskComplete.
+    seedActiveTask(coord, BigInt(803), peer, rootHash = stateRoot)
+    coord ! Messages.TaskComplete(
+      BigInt(803),
+      Right((0, Seq.empty, Seq(ByteString("proof-node-bytes")))) // empty accounts + non-empty proof = boundary success
+    )
+    coord ! Messages.GetProgress
+    expectMsgType[AccountRangeStats](2.seconds)
+
+    ua.emptyResponseStrikes.get(peer.id) shouldBe None
+    ua.snaplessPeers should not contain peer.id
 
     system.stop(coord)
   }


### PR DESCRIPTION
## Summary

Replace one-shot snapless/stateless promotion with N=3 strike counters in \`AccountRangeCoordinator\` and \`StorageRangeCoordinator\`. Any successful response from a peer resets its strike count. The end-state confirmed-snapless behavior (sticky-for-session per #1197) is preserved.

## Why

Sepolia 2026-05-13: at the moment the stall watchdog reported \`snapPeers=3\`, the dispatch view (\`activePeerCount\`) was at 1. The filter chain in \`AccountRangeCoordinator.scala:387\` is:

\`\`\`scala
knownAvailablePeers.count(p =>
  !isPeerStateless(p) && !isPeerSnapless(p) && !isPeerCoolingDown(p)
).max(1)
\`\`\`

One \"Missing proof for empty account range\" response immediately marked the peer in BOTH \`statelessPeers\` and \`snaplessPeers\`. \`snaplessPeers\` is session-permanent (preserved across pivot refresh by design — #1197 reasoning is that a peer with no snapshot tree won't grow one). So a single empty-with-empty response — which can happen on a transient warming-up phase, a network blip, or just being mid-pivot relative to the peer's snap-serve window — permanently sidelined that peer for the rest of the session.

ETC mainnet hit the same wedge historically.

## What the reference clients do

- **geth** — no explicit strike counter; uses request throughput/latency tracking over a 1-minute window plus a single global \`statelessPeers\` set
- **nethermind** — explicit 5-strike threshold for invalid responses
- Neither client has a sticky session-permanent snapless concept

## Change

3 strikes (consecutive empty-with-empty-proof responses, no intervening success). At threshold, peer enters both confirmed sets exactly as before. Any successful response (real accounts OR a boundary proof) wipes prior strikes. \`PivotRefreshed\` clears strikes (new root = clean slate, matches the existing 'clear statelessPeers' semantics); \`snaplessPeers\` stays sticky per #1197. \`PeerUnavailable\` clears strikes for the departing peer.

Same shape in \`StorageRangeCoordinator\` (no snapless concept there — just stateless).

## Tier table after this PR

| Trigger | Strikes 1-2 | Strikes ≥ 3 |
|---|---|---|
| Empty-with-empty-proof (Account) | log info, still dispatchable | confirmed snapless+stateless |
| Empty storage range (Storage) | log info, still dispatchable | confirmed stateless |
| Success at any point | strikes → 0 | (peer already excluded) |

## Test plan

- [x] Updated \`AccountRangeCoordinatorSpec\`'s existing #1197 one-shot test to drive 3 strikes (passes)
- [x] New test: 2 strikes → useful response → strikes back to 0 (passes)
- [x] Existing tests that seed \`snaplessPeers\` directly still pass — confirmed-set behavior unchanged
- [x] \`sbt Test/compile\` clean (only pre-existing warnings)
- [ ] Sepolia rerun: \`snapPeers=N\` from stall watchdog should match \`activePeerCount\` (off by at most 1 due to transient strikes); peer pool stops collapsing to 1

## Where this leaves the error chain

This is the first of three PRs unwedging the peer-pool collapse identified after the stack-trie / OOM fix chain settled. Sequel:

- PR-N+1: periodic best-block re-probe (keep \`maxBlockNumber\` fresh post-merge)
- PR-N+2: disconnect chronically-lagging peers (free the connection slot the 9707885-block stuck peer is hoarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)