### PR TITLE
feat(network): periodic peer best-block re-probe to keep maxBlockNumber fresh

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -65,12 +65,36 @@ class NetworkPeerManagerActor(
 
   private var emptyHeaderResponses: Int = 0
 
+  // Last time we observed each peer pushing or replying with a block-height signal. Used by
+  // the periodic best-block re-probe to skip peers whose ETH/69 `BlockRangeUpdate` arrived
+  // recently — they're already keeping `maxBlockNumber` fresh on their own.
+  private val lastBlockSignalMs = scala.collection.mutable.Map.empty[PeerId, Long]
+
   // 60s network summary — read+reset RLPx counters and log one aggregate line
   context.system.scheduler.scheduleWithFixedDelay(
     60.seconds,
     60.seconds,
     self,
     NetworkPeerManagerActor.LogNetworkSummary
+  )(context.dispatcher)
+
+  // Periodic peer best-block re-probe. The post-handshake eager probe (below) updates
+  // `PeerInfo.maxBlockNumber` once; thereafter only `NewBlock` / `NewBlockHashes` gossip
+  // (dead post-merge) or ETH/69 `BlockRangeUpdate` (only if the remote actively pushes)
+  // keeps it current. Without a periodic refresh, peers freeze at their handshake-time
+  // block forever — breaking the freshness floor (PR #1234), the pivot selection in
+  // `SNAPSyncController.currentNetworkBestFromSnapPeers`, and the chronically-lagging-peer
+  // eviction landing in the next PR.
+  //
+  // Cadence: every 5 minutes. One `GetBlockHeaders(bestHash, 1)` per peer is negligible
+  // bandwidth (peers already serve thousands of SNAP requests in that window). Skip
+  // ETH/69 peers whose `BlockRangeUpdate` arrived within the last `BlockSignalStaleAfter`
+  // window — they're already self-reporting.
+  context.system.scheduler.scheduleWithFixedDelay(
+    BestBlockRefreshInterval,
+    BestBlockRefreshInterval,
+    self,
+    NetworkPeerManagerActor.RefreshPeerBestBlocks
   )(context.dispatcher)
 
   // Subscribe to the event of any peer getting handshaked
@@ -153,6 +177,45 @@ class NetworkPeerManagerActor(
       log.info(
         s"Network [60s]: active=$active peers ($snapPeers snap-capable), +$tcpFailed tcp-failed, +$authFailed auth-failed, +$authTimeout auth-timeout, +$emptyHeaders empty-headers"
       )
+
+    case NetworkPeerManagerActor.RefreshPeerBestBlocks =>
+      // Periodically poll each handshaked peer for its current head. Mirrors the eager
+      // post-handshake probe (in `handlePeersInfoEvents`) but runs every
+      // `BestBlockRefreshInterval` so `PeerInfo.maxBlockNumber` stays current without
+      // depending on NewBlock gossip (dead post-merge) or peer-side BlockRangeUpdate
+      // push. Responses route through the existing BlockHeadersCode subscription back
+      // into `updateMaxBlock` and `withBestBlockData`.
+      val now = System.currentTimeMillis()
+      val refreshStaleAfterMs = BlockSignalStaleAfter.toMillis
+      var probed = 0
+      peersWithInfo.foreach { case (peerId, PeerWithInfo(peer, peerInfo)) =>
+        if (peerInfo.isAtGenesis) {
+          // Genesis peers are block 0 by definition — nothing to refresh.
+        } else {
+          // For ETH/69 peers, skip if the remote pushed a `BlockRangeUpdate` recently.
+          val recentlySignaled = peerInfo.remoteStatus.capability == Capability.ETH69 &&
+            lastBlockSignalMs.get(peerId).exists(t => now - t < refreshStaleAfterMs)
+          if (!recentlySignaled) {
+            val bestHash = peerInfo.remoteStatus.bestHash
+            val probe: MessageSerializable =
+              if (Capability.usesRequestId(peerInfo.remoteStatus.capability))
+                ETH66.GetBlockHeaders(ETH66.nextRequestId, Right(bestHash), 1, 0, reverse = false)
+              else
+                ETH62.GetBlockHeaders(Right(bestHash), 1, 0, reverse = false)
+            log.debug(
+              "BEST_BLOCK_REPROBE: peer={} cap={} maxBlock={} — periodic refresh",
+              peer.id,
+              peerInfo.remoteStatus.capability,
+              peerInfo.maxBlockNumber
+            )
+            peerManagerActor ! PeerManagerActor.SendMessage(probe, peer.id)
+            probed += 1
+          }
+        }
+      }
+      if (probed > 0) {
+        log.debug(s"BEST_BLOCK_REPROBE: probed $probed/${peersWithInfo.size} peers for current head")
+      }
   }
 
   /** Processes events and updating the information about each peer
@@ -208,6 +271,15 @@ class NetworkPeerManagerActor(
             snapSyncControllerOpt.foreach(_ ! msg)
 
           case _ => // ETH protocol messages - no special routing needed
+        }
+
+        // Track per-peer block-height signals so the periodic re-probe (RefreshPeerBestBlocks)
+        // can skip ETH/69 peers that are actively pushing BlockRangeUpdate.
+        message match {
+          case _: ETH69.BlockRangeUpdate | _: ETH62BlockHeaders | _: ETH66BlockHeaders |
+              _: BaseETH6XMessages.NewBlock | _: NewBlockHashes =>
+            lastBlockSignalMs(peerId) = System.currentTimeMillis()
+          case _ => // not a block-height signal
         }
 
         val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message, handleReceivedMessage)
@@ -277,6 +349,7 @@ class NetworkPeerManagerActor(
       peerEventBusActor ! Unsubscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peerId)))
       peerEventBusActor ! Unsubscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peerId)))
       NetworkMetrics.registerRemoveHandshakedPeer(peersWithInfo(peerId).peer)
+      lastBlockSignalMs.remove(peerId)
       context.become(handleMessages(peersWithInfo - peerId))
 
   }
@@ -916,6 +989,22 @@ object NetworkPeerManagerActor {
 
   case object GetHandshakedPeers
   private[network] case object LogNetworkSummary
+
+  /** Self-message that drives the periodic best-block re-probe loop. */
+  private[network] case object RefreshPeerBestBlocks
+
+  /** How often to send each handshaked peer a one-shot `GetBlockHeaders(bestHash, 1)` to
+    * refresh `PeerInfo.maxBlockNumber`. Defaults to 5 minutes — small fraction of typical
+    * peer connection lifetimes (~30+ min) and small fraction of pivot-refresh cadence.
+    */
+  private[network] val BestBlockRefreshInterval: FiniteDuration = 5.minutes
+
+  /** Window after which we re-probe an ETH/69 peer even though it has already had a
+    * `BlockRangeUpdate` opportunity. ETH/69 peers that don't actively push BRUs would
+    * otherwise never get re-probed. Half of the re-probe interval so a quiet peer gets
+    * polled within 2.5 minutes regardless of its push cadence.
+    */
+  private[network] val BlockSignalStaleAfter: FiniteDuration = 150.seconds
 
   case class HandshakedPeers(peers: Map[Peer, PeerInfo])
 


### PR DESCRIPTION
## Summary

Schedule a 5-minute periodic \`GetBlockHeaders(bestHash, 1)\` probe to each handshaked peer so \`PeerInfo.maxBlockNumber\` keeps in sync with the peer's actual chain tip. Without this, peers freeze at handshake-time block forever on post-merge chains where \`NewBlock\` gossip is dead and ETH/69 \`BlockRangeUpdate\` only fires when a peer actively pushes.

## Why this matters

Sepolia evidence: a peer reporting \`maxBlockNumber=9_707_885\` while the CL head was at \`10_847_xxx\` (1.1 M blocks behind) had been frozen at that value since its handshake. The freshness filter from #1234 correctly rejected it as a pivot source, but we never re-checked whether the peer had caught up — so the connection sat there indefinitely, occupying a slot in the \`peersToDownloadFrom\` map.

This blocks the next PR (chronically-lagging-peer eviction), which needs current \`maxBlockNumber\` to make sensible decisions.

## Change

- New \`RefreshPeerBestBlocks\` self-message, scheduled every 5 min in \`NetworkPeerManagerActor\`'s constructor
- Handler iterates \`peersWithInfo\`, sends \`GetBlockHeaders(bestHash, 1, 0, reverse=false)\` to each peer (mirroring the existing post-handshake eager probe at lines 257-271)
- Responses route through the existing \`updateMaxBlock\` subscription → \`PeerInfo.withBestBlockData\` updates \`maxBlockNumber\`
- ETH/69 optimization: track \`lastBlockSignalMs\` per peer (any \`BlockRangeUpdate\` / \`BlockHeaders\` / \`NewBlock\` / \`NewBlockHashes\` arrival updates it). Skip the probe when the signal is within 150 s (half the cadence) — peer is already self-reporting. Quiet ETH/69 peers still get polled.
- Clean up \`lastBlockSignalMs\` on \`PeerDisconnected\`

## Bandwidth

One \`GetBlockHeaders\` request per peer per 5 minutes. Each peer already serves thousands of SNAP responses in that window — negligible.

## Test plan

- [x] \`sbt compile\` clean (one pre-existing implicit-sender warning)
- [ ] Sepolia rerun: observe \`BEST_BLOCK_REPROBE\` debug log every 5 minutes; verify a previously-stuck peer's \`maxBlockNumber\` updates if the peer has actually advanced
- [ ] (Deferred) Add a unit test that drives an \`ExplicitlyTriggeredScheduler\` and asserts the GetBlockHeaders dispatch. Harness work is non-trivial relative to the change size.

## Where this leaves the error chain

| # | Status | Effect |
|---|---|---|
| #1237 | merged | Strike-counted snapless/stateless (was: one-shot demotion) |
| **this PR** | open | Periodic best-block re-probe — keep \`maxBlockNumber\` accurate |
| (next) | pending | Disconnect chronically-lagging peers (needs this PR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)