### PR TITLE
fix(network): lower lagging-peer eviction floor from 5 → 2

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -1109,9 +1109,15 @@ object NetworkPeerManagerActor {
   private[network] val LaggingPeerMaxEvictionsPerCycle: Int = 5
 
   /** Below this floor of handshaked peers, skip eviction — better to keep a stale peer
-    * than to crater the connection pool on a small network like Mordor.
+    * than to crater the connection pool on a small network. The floor is intentionally
+    * low (2): on thin testnets like sepolia we often see only 3-5 SNAP-capable peers
+    * total, and the lagging-peer pathology is most acute exactly there. A floor of 5
+    * would skip eviction entirely and the stuck peers would never recycle out. Two is
+    * still enough to prevent a single sweep from leaving us peerless mid-sync; the
+    * per-cycle cap of 5 plus the 10-minute hysteresis provide the heavier-weight
+    * safeties.
     */
-  private[network] val LaggingPeerMinPoolFloor: Int = 5
+  private[network] val LaggingPeerMinPoolFloor: Int = 2
 
   /** Brief IP-blacklist applied to the evicted peer so we don't immediately re-dial it
     * via the same enode + dispatcher loop. 2 minutes matches PR #1235's


### PR DESCRIPTION
## Summary

Quick follow-up to #1239. Drop \`LaggingPeerMinPoolFloor\` from 5 to 2.

## Observation

Sepolia immediately post-#1239-deploy: \`active=3 peers (3 snap-capable)\`. All 3 are stuck behind the CL head (the well-known 9707885-block peer plus 2 others that hit the 3-strike snapless threshold). The floor of 5 correctly skipped the eviction sweep — but with floor=5 on a thin network like sepolia, eviction is effectively gated off forever.

## Change

\`LaggingPeerMinPoolFloor: 5 → 2\`. Comment updated to explain the rationale: on thin testnets the lagging-peer pathology is most acute exactly where the pool is small. Heavier safeties stay in place:

- 5-evictions-per-cycle cap
- 10-minute hysteresis
- Pre-merge gate

Floor of 2 still means we never evict our last 2 peers — single sweep can't leave us peerless mid-sync.

## Where this leaves the error chain

Eight PRs landed this session for the SNAP sync stabilization:

| # | Status | Effect |
|---|---|---|
| 1232-1236 | merged | Earlier OOM / control-plane fixes |
| 1237 | merged | Strike-counted snapless+stateless demotion |
| 1238 | merged | Periodic best-block re-probe |
| 1239 | merged | Lagging-peer eviction (floor=5, blocks small networks) |
| **this PR** | open | Drop floor to 2 so sepolia (3-peer pool) actually evicts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)