### PR TITLE
fix(snap): release queue backpressure on pivot refresh (was: deadlock)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -230,6 +230,17 @@ class ByteCodeCoordinator(
       peerCooldownUntilMillis.clear()
       peerResponseBytesTarget.clear()
       consecutiveTaskFailures = 0
+      // Mirror the storage-side fix (sepolia 2026-05-14 deadlock): if back-pressure was
+      // engaged for the old root, the new root is the right time to release it. If the
+      // queue is still above the high-water mark, the next AddByteCodeTasks will re-engage.
+      if (backpressureActive) {
+        backpressureActive = false
+        log.info(
+          s"ByteCode queue back-pressure RELEASED on pivot refresh (queue depth=${pendingTasks.size}). " +
+            s"Will re-engage if queue crosses high-water=$backpressureHighWatermark again."
+        )
+        snapSyncController ! SNAPSyncController.ByteCodeBackpressureChanged(paused = false)
+      }
 
     case PeerAvailable(peer) =>
       knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -923,6 +923,26 @@ class StorageRangeCoordinator(
       statelessPeers.clear()
       emptyResponseStrikes.clear()
       pivotRefreshRequested = false
+
+      // Force-release storage back-pressure. Observed deadlock on sepolia 2026-05-14:
+      // the queue locks at >100K pending → backpressure ENGAGED → AccountRangeCoordinator
+      // dispatch paused → storage can't drain (no usable peers for current root) →
+      // backpressure never releases (low-water = 50K is unreachable) → account stalls →
+      // 5/5 critical SNAP failures → fallback to FastSync (which is also stuck on sepolia
+      // because peers don't serve GetNodeData on ETH/68+).
+      //
+      // The fix: pivot refresh is the natural recovery moment. New root → maybe new
+      // peers can serve the queued tasks → drain might resume. Let account dispatch
+      // resume; if the queue overflows past the high-water mark again, the next
+      // notifyBackpressureIfChanged() call from AddStorageTasks will re-engage.
+      if (backpressureActive) {
+        backpressureActive = false
+        log.info(
+          s"Storage queue back-pressure RELEASED on pivot refresh (queue depth=${tasks.size}). " +
+            s"Will re-engage if queue crosses high-water=$backpressureHighWatermark again."
+        )
+        snapSyncController ! SNAPSyncController.StorageBackpressureChanged(paused = false)
+      }
       lastDispatchOrResponseMs = System.currentTimeMillis()
       peerCooldownUntilMs.clear()
       peerBatchSize.clear()


### PR DESCRIPTION
## Summary

PR #1233's storage queue backpressure had a deadlock under sustained drain failure: once engaged, it only released when the queue drained below the low-water mark — but if peers don't serve the current root, drain is zero and the queue is monotonically non-decreasing. The pause was preventing symptom (queue growth) but couldn't trigger recovery. On sepolia 2026-05-14 this stalled sync at 810 K accounts for 5+ hours until the 5/5 SNAP-critical-failure threshold gave up.

## Observed cascade

\`\`\`
05:55:35  Storage queue hit 100258 (high-water=100000) → backpressure ENGAGED
05:55:35  AccountRangeCoordinator paused dispatch (0 pending, 2 in flight)
...        Storage can't drain — no usable peers for current root
           Queue stays > low-water (50000) → backpressure never releases
08:02-08:11  Account stall watchdog fires attempts 7-10
08:14:46  Pivot-refresh budget exhausted → 5/5 critical SNAP failure
           → fallback to FastSync (also stuck on sepolia: no ETH63-67 peers
             serve GetNodeData)
\`\`\`

## Fix

Pivot refresh is the natural recovery moment. The new root might be servable by the same peers (or by fresh peers connecting). Force-release backpressure when \`StoragePivotRefreshed\` arrives; if the queue grows past the high-water mark again on the new root, the next \`AddStorageTasks\` call will re-engage cleanly.

Same shape for \`ByteCodePivotRefreshed\` since PR #1233's bytecode backpressure has identical lifecycle.

## Where this fits

This is a follow-up to PR #1233 (queue backpressure introduction). Together with the strike-counted demotion (#1237), best-block re-probe (#1238), lagging-peer eviction (#1239), and floor=2 tuning (#1240), the SNAP sync recovery story is:

1. **Engagement** (PR #1233): backpressure prevents unbounded queue growth
2. **Release on drain** (PR #1233): queue.size ≤ low-water → resume
3. **Release on pivot refresh** (this PR): new root might unwedge drain → release
4. **Worst-case escape**: 5/5 critical-failure → fallback to fast/regular sync

Tests deferred — the change is one branch in each Pivot-refreshed handler; existing strike-counter tests already exercise the PivotRefreshed code path. Manual sepolia validation will confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)