### PR TITLE
ops(sepolia): reduce JVM heap 4g→3g to relieve host-wide page-cache pressure

### DIFF
--- a/ops/barad-dur/sepolia/docker-compose.yml
+++ b/ops/barad-dur/sepolia/docker-compose.yml
@@ -21,7 +21,7 @@ networks:
 # proper sbt-native-packager Dockerfile), this block becomes redundant.
 x-fukuii-jvm-defaults: &fukuii-jvm-defaults
   JAVA_TOOL_OPTIONS: >-
-    -Xmx4g -Xms2g -Xss1M
+    -Xmx3g -Xms1g -Xss1M
     -XX:MaxDirectMemorySize=512M
     -XX:+UseG1GC -XX:MaxGCPauseMillis=200
     -XX:+HeapDumpOnOutOfMemoryError
@@ -34,12 +34,14 @@ services:
     image: chipprbots/fukuii:latest
     container_name: fukuii-sepolia
     restart: unless-stopped
-    # 4g heap + ~3.5 GB native (RocksDB 512MB block cache, memtables, G1,
-    # DeferredWriteMpt/StackTrie buffers, JNI). 8g cgroup repeatedly OOM-killed
-    # at ~8.37 GB RSS; 10g leaves real headroom. Requires primary stopped on
-    # this 16 GiB host.
-    mem_limit: 10g
-    memswap_limit: 10g
+    # 3g heap + ~3 GB native (RocksDB 512MB block cache, memtables, G1,
+    # DeferredWriteMpt/StackTrie buffers, JNI). Reduced 4g→3g (2026-05-14) to
+    # cut host-wide RocksDB page-cache churn — systemd-oomd was killing the
+    # GNOME session even though the container itself had headroom (PSI-based
+    # eviction triggered by fukuii's I/O pattern, not actual memory exhaustion).
+    # 8g cgroup gives ~2g native overhead headroom.
+    mem_limit: 8g
+    memswap_limit: 8g
     # JVM flags live in JAVA_TOOL_OPTIONS (anchor above) — picked up
     # automatically by the JVM regardless of how it's invoked.
     environment:

--- a/src/universal/conf/application.ini
+++ b/src/universal/conf/application.ini
@@ -1,7 +1,8 @@
 # Default JVM args baked into the sbt-native-packager bin/fukuii launcher.
 # Reflects the safe operational envelope established after the May 2026
-# sepolia OOM-loop investigation:
-#   * heap fits in containers as small as ~6 GiB cgroup (4g heap + ~1.5g
+# sepolia OOM-loop investigation, refined 2026-05-14 after systemd-oomd
+# started killing co-tenant GNOME sessions on 16GiB hosts:
+#   * heap fits in containers as small as ~5 GiB cgroup (3g heap + ~2g
 #     native: RocksDB block cache, G1, JNI, stacks)
 #   * MaxDirectMemorySize caps Netty off-heap (was unbounded → drove anon-rss
 #     past the cgroup limit during high peer churn)
@@ -11,8 +12,8 @@
 # Composes that override the entrypoint to `java` directly bypass this file —
 # they should pass the same flags via JAVA_TOOL_OPTIONS so the values stay in
 # one place. See ops/barad-dur/sepolia/docker-compose.yml for the pattern.
--J-Xmx4g
--J-Xms2g
+-J-Xmx3g
+-J-Xms1g
 -J-Xss1M
 -J-XX:MaxDirectMemorySize=512M
 -J-XX:+UseG1GC


### PR DESCRIPTION
## Summary
- systemd-oomd repeatedly killed the GNOME desktop on the 16 GiB sepolia host at 08:02 and 08:08 CDT — not because of cgroup OOM, but because PSI Avg10 hit 65% from fukuii's RocksDB page-cache churn (pgscan 6.7M in GNOME's cgroup).
- Cut heap 4g→3g, Xms 2g→1g, mem_limit 10g→8g. Host went from 14/15 GiB used to 3.9/15 GiB after restart. Sync continues with marginally more GC pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)