### PR TITLE
ops(sepolia): document SEPOLIA_DATA_DIR override via .env.example

### DIFF
--- a/ops/barad-dur/sepolia/.env.example
+++ b/ops/barad-dur/sepolia/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env` and adjust for your host. `.env` is gitignored.
+#
+# Sepolia data dir. Point at the fastest local disk you have — RocksDB
+# I/O patterns saturate slow disks and generate host-wide page-cache
+# pressure (which on shared dev hosts can trigger systemd-oomd kills of
+# other cgroups, e.g. the GNOME session). On chippr's main dev host this
+# lives on the root SSD; on barad-dur production it lives on dedicated
+# NVMe under /home/dontpanic/. Default fallback in docker-compose.yml
+# points at /chipprbots ZFS which is slow — set this override for any
+# host where /chipprbots is HDD-backed.
+SEPOLIA_DATA_DIR=/etc/fukuii/sepolia


### PR DESCRIPTION
## Summary
- Adds .env.example documenting that SEPOLIA_DATA_DIR should be set to a fast disk path on hosts where the compose default (/chipprbots ZFS) is HDD-backed.
- No code change. Documentation only — `.env` itself is gitignored.

## Why
On 2026-05-14 the slow ZFS at /chipprbots generated page-cache pressure that systemd-oomd misinterpreted as memory exhaustion in the GNOME cgroup (it kills based on PSI/pgscan rate, not absolute usage). Moving sepolia data to root SSD eliminated the OOM cascade. PR documents the override path so future operators don't repeat the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)