### PR TITLE
fix(network): fallback to ChainWeight.zero in ETH/63-68 STATUS when not stored

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus63ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus63ExchangeState.scala
@@ -23,11 +23,17 @@ case class EthNodeStatus63ExchangeState(
   override protected def createStatusMsg(): MessageSerializable = {
     val bestBlockHeader = getBestBlockHeader()
 
+    // See EthNodeStatus64ExchangeState — ChainWeightStorage isn't populated post-SNAP-sync
+    // on post-merge chains; fall back to zero rather than throwing and killing the handshake.
     val chainWeight = blockchainReader
       .getChainWeightByHash(bestBlockHeader.hash)
-      .getOrElse(
-        throw new IllegalStateException(s"Chain weight not found for hash ${bestBlockHeader.hash}")
-      )
+      .getOrElse {
+        log.debug(
+          s"Chain weight not stored for best block ${bestBlockHeader.hash} (SNAP-sync state); " +
+            s"advertising ChainWeight.zero in ETH/63 STATUS"
+        )
+        com.chipprbots.ethereum.domain.ChainWeight.zero
+      }
 
     val status = BaseETH6XMessages.Status(
       protocolVersion = Capability.ETH63.version,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -98,11 +98,21 @@ case class EthNodeStatus64ExchangeState(
     val bestBlockHeader = getBestBlockHeader()
     val bestBlockNumber = blockchainReader.getBestBlockNumber()
 
+    // ChainWeightStorage isn't populated for blocks reached via SNAP sync (the pivot block
+    // has no upstream PoW chain in our DB to sum difficulties over). On post-merge chains
+    // this never gets backfilled because we don't import pre-merge blocks. Falling back to
+    // ChainWeight.zero is operationally safe: peers use ForkId for compatibility checks
+    // (EIP-2124), not the wire TD field. ETH/64-68 sepolia/mainnet handshakes were 100%
+    // failing here before the fallback. See OOM-investigation 2026-05-14.
     val chainWeight = blockchainReader
       .getChainWeightByHash(bestBlockHeader.hash)
-      .getOrElse(
-        throw new IllegalStateException(s"Chain weight not found for hash ${bestBlockHeader.hash}")
-      )
+      .getOrElse {
+        log.debug(
+          s"Chain weight not stored for best block ${bestBlockHeader.hash} (SNAP-sync state); " +
+            s"advertising ChainWeight.zero in ETH/64-68 STATUS"
+        )
+        com.chipprbots.ethereum.domain.ChainWeight.zero
+      }
 
     val genesisHash = blockchainReader.genesisHeader.hash
 


### PR DESCRIPTION
## Summary
- Sepolia health check found every ETH/64-68 outbound STATUS throwing IllegalStateException because ChainWeightStorage has no entry for the SNAP-pivot best block. ~30 unique block hashes failing, 400+ WARN/ERROR per 5 min. Peer pool capped at 1.
- Falls back to ChainWeight.zero when the lookup is empty. TD field is advisory post-merge (peers use ForkId for compat).

## Test plan
- [x] sbt compile clean
- [ ] Deploy: verify ETH/64-68 handshake no longer throws (log "Chain weight not stored" at DEBUG)
- [ ] Verify active peer count rises above 1 within ~5 min of restart
- [ ] Sync throughput recovers to multi-peer regime

🤖 Generated with [Claude Code](https://claude.com/claude-code)