### PR TITLE
fix(network): enforce blacklist on INBOUND connections (was: outbound-only)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -328,6 +328,12 @@ class PeerManagerActor(
   ): Unit = {
     val alreadyConnectedToPeer = connectedPeers.isConnectionHandled(remoteAddress)
     val isPendingPeersNotMaxValue = connectedPeers.incomingPendingPeersCount < peerConfiguration.maxPendingPeers
+    // Reject inbound dials from blacklisted addresses. Previously the blacklist was only
+    // honored on the outbound (`canConnectTo`) path, so a peer we disconnected for chronic
+    // lag would simply re-dial us inbound seconds later and rejoin the handshaked set —
+    // making PR #1242's 30-min hold ineffective. Sepolia 2026-05-14: same peer IPs
+    // re-connected 25s after being blacklisted for 30 min.
+    val isNotBlacklisted = !blacklist.isBlacklisted(PeerAddress(remoteAddress.getHostString))
 
     val validConnection = for {
       validHandler <- validateConnection(
@@ -339,6 +345,11 @@ class PeerManagerActor(
         validHandler,
         MaxIncomingPendingConnections(connection),
         isPendingPeersNotMaxValue
+      )
+      _ <- validateConnection(
+        validNumber,
+        IncomingConnectionBlacklisted(remoteAddress, connection),
+        isNotBlacklisted
       )
     } yield validNumber
 
@@ -658,6 +669,10 @@ class PeerManagerActor(
       log.debug("Another connection with {} is already opened. Disconnecting", remoteAddress)
       connection ! PoisonPill
 
+    case IncomingConnectionBlacklisted(remoteAddress, connection) =>
+      log.debug("Rejecting incoming connection from blacklisted address {}", remoteAddress)
+      connection ! PoisonPill
+
     case MaxOutgoingConnections =>
       log.debug("Maximum number of connected peers reached")
 
@@ -862,6 +877,8 @@ object PeerManagerActor {
   case class MaxIncomingPendingConnections(connection: ActorRef) extends ConnectionError
 
   case class IncomingConnectionAlreadyHandled(address: InetSocketAddress, connection: ActorRef) extends ConnectionError
+
+  case class IncomingConnectionBlacklisted(address: InetSocketAddress, connection: ActorRef) extends ConnectionError
 
   case object MaxOutgoingConnections extends ConnectionError
 


### PR DESCRIPTION
## Summary
- Blacklist was only consulted on outbound dials (canConnectTo). Inbound handleConnection path checked only alreadyConnected + maxPendingPeers. So every blacklist policy — PR #1235's short-tier UselessPeer, PR #1242's 30-min chronic-laggard hold, all of them — was bypassable: the peer just dialed back inbound.
- Sepolia 2026-05-14 confirmed: blacklisted peer IPs reconnected within 25s as INBOUND_CAP_OFFSETS.

## Test plan
- [x] sbt compile clean
- [ ] Deploy: verify the two stuck sepolia peers (146.190.1.103, 170.64.250.88) stay disconnected for full 30 min after PR #1242 eviction
- [ ] No regression in legitimate peer-pool size — inbound peers that haven't been blacklisted continue to handshake normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)