### PR TITLE
debug(snap): [ACCOUNT-STATE] instrumentation + drop misleading activePeerCount floor

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -411,11 +411,21 @@ class AccountRangeCoordinator(
   // without waiting for the next PeerAvailable message.
   private val knownAvailablePeers = mutable.Set[Peer]()
 
-  /** Number of active (non-stateless, non-cooling-down) snap-capable peers. Used to cap worker count — one worker per
-    * peer avoids peer flooding.
+  /** Number of active (non-stateless, non-snapless, non-cooling-down) snap-capable peers.
+    * Returns the actual count — no floor — so the progress log truthfully reports 0 when
+    * all peers are demoted (the case that drives the account stall). Previously this had
+    * `.max(1)` which masked the stall: progress log said "1 peers" while dispatch was
+    * starving on zero eligible peers. See PR-1 of `this-is-the-same-fluttering-eagle.md`.
     */
   private def activePeerCount: Int =
-    knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerSnapless(p) && !isPeerCoolingDown(p)).max(1)
+    knownAvailablePeers.count(p => !isPeerStateless(p) && !isPeerSnapless(p) && !isPeerCoolingDown(p))
+
+  // Periodic state-dump cadence — at most one INFO snapshot every 30 seconds. Time-based
+  // throttling (not modulo) so a call-rate spike doesn't overflow the log pipe. Same pattern
+  // as PR #1250's [STORAGE-STATE] (subsequently switched from modulo to time-based for the
+  // same reason).
+  private var lastStateLogMs: Long = 0L
+  private val StateLogIntervalMs: Long = 30_000L
 
   // Per-peer adaptive byte budgeting (ported from StorageRangeCoordinator).
   // Geth's snap handler supports up to 2MB responses. Starting at 512KB and probing upward
@@ -1173,7 +1183,31 @@ class AccountRangeCoordinator(
       .filterNot(isPeerSnapless)
       .filterNot(isPeerCoolingDown)
       .toList
-    if (eligiblePeers.isEmpty) return
+    val now = System.currentTimeMillis()
+    val shouldLog = now - lastStateLogMs >= StateLogIntervalMs
+    if (shouldLog) {
+      lastStateLogMs = now
+      log.info(
+        s"[ACCOUNT-STATE] pending=${pendingTasks.size} active=${activeTasks.size} " +
+          s"workers-known=${knownAvailablePeers.size} stateless=${statelessPeers.size} " +
+          s"snapless=${snaplessPeers.size} cooling=${peerCooldownUntilMs.size} " +
+          s"eligible=${eligiblePeers.size} strikes=${emptyResponseStrikes.size} " +
+          s"maxInflight=$maxInFlightPerPeer root=${stateRoot.take(4).toHex}"
+      )
+    }
+    if (eligiblePeers.isEmpty) {
+      // Promoted from silent return to INFO so the first occurrence per 30s window
+      // is visible. Sharing `shouldLog` with the STATE snapshot above keeps total
+      // log volume from this method ≤ 2 lines / 30 s — robust against call-rate spikes.
+      if (shouldLog) {
+        log.info(
+          s"[ACCOUNT-REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +
+            s"${statelessPeers.size} stateless, ${snaplessPeers.size} snapless, " +
+            s"${peerCooldownUntilMs.size} cooling. pending: ${pendingTasks.size}"
+        )
+      }
+      return
+    }
 
     for (peer <- eligiblePeers if pendingTasks.nonEmpty)
       dispatchIfPossible(peer)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -1429,9 +1429,12 @@ class StorageRangeCoordinator(
       }
   }
 
-  // Periodic state-dump cadence — every 5th redispatch (≈ every 2.5 min at 30s tick) emits an
-  // INFO snapshot of pool state. Cheap and answers "why isn't storage draining?" from logs alone.
-  private var redispatchTickCount: Long = 0L
+  // Periodic state-dump cadence — at most one INFO snapshot every 30 seconds. tryRedispatchPendingTasks
+  // can be called many times per second under heavy storage flow (each AddStorageTasks call
+  // chains into it), so modulo-based throttling produced log floods that overflowed the live
+  // monitor pipe; time-based throttling is robust against call-rate spikes.
+  private var lastStateLogMs: Long = 0L
+  private val StateLogIntervalMs: Long = 30_000L
 
   private def tryRedispatchPendingTasks(): Unit = {
     if (tasks.isEmpty) return
@@ -1440,8 +1443,10 @@ class StorageRangeCoordinator(
     val eligiblePeers = knownAvailablePeers
       .filterNot(p => isPeerStateless(p) || isPeerCoolingDown(p))
       .toList
-    redispatchTickCount += 1
-    if (redispatchTickCount % 5 == 0L) {
+    val now = System.currentTimeMillis()
+    val shouldLog = now - lastStateLogMs >= StateLogIntervalMs
+    if (shouldLog) {
+      lastStateLogMs = now
       log.info(
         s"[STORAGE-STATE] pending=${tasks.size} active=${activeTasks.size} " +
           s"workers-known=${knownAvailablePeers.size} stateless=${statelessPeers.size} " +
@@ -1450,11 +1455,13 @@ class StorageRangeCoordinator(
       )
     }
     if (eligiblePeers.isEmpty) {
-      log.info(
-        s"[STORAGE-REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +
-          s"${statelessPeers.size} stateless, " +
-          s"${knownAvailablePeers.count(isPeerCoolingDown)} cooling. pending: ${tasks.size}"
-      )
+      if (shouldLog) {
+        log.info(
+          s"[STORAGE-REDISPATCH] No eligible peers — ${knownAvailablePeers.size} known, " +
+            s"${statelessPeers.size} stateless, " +
+            s"${knownAvailablePeers.count(isPeerCoolingDown)} cooling. pending: ${tasks.size}"
+        )
+      }
       if (tasks.nonEmpty && activeTasks.isEmpty) {
         storageIdleChecks += 1
         if (storageIdleChecks >= storageIdleEscapeThreshold) {


### PR DESCRIPTION
PR-1 of the account-stall plan. Mirrors PR #1250 instrumentation for the account coordinator. Also drops a `.max(1)` floor in activePeerCount that was hiding the stall (real 0 reported as 1) and switches storage's state-log throttle from modulo to time-based (30s) — the modulo flooded the log pipe under heavy flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)