### PR TITLE
fix(snap): raise EmptyResponseStrikeThreshold 3 → 5 for both account and storage

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -139,7 +139,11 @@ class AccountRangeCoordinator(
   //   * PivotRefreshed → clear strikes (peer deserves a clean slate on the new root)
   //   * PeerUnavailable → clear strikes (and the peer entry from statelessPeers too)
   private[actors] val emptyResponseStrikes = mutable.Map.empty[com.chipprbots.ethereum.network.PeerId, Int]
-  private val EmptyResponseStrikeThreshold: Int = 3
+  // Raised 3 → 5 on 2026-05-14: even with PR #1255 clearing snapless on PivotRefreshed,
+  // the 3-strike threshold drained sepolia's small peer pool between pivots, producing
+  // eligible=0 stalls within each pivot window. 5 strikes gives peers more rope; mirrors
+  // Nethermind's threshold; lines up with the bumped storage threshold.
+  private val EmptyResponseStrikeThreshold: Int = 5
   private var pivotRefreshRequested = false
   private var pivotWasRefreshed = false
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -134,11 +134,18 @@ class StorageRangeCoordinator(
   // a transient peer hiccup the same recovery path used elsewhere in the codebase.
   private val statelessPeers = mutable.Set[String]()
   // Strike counter for empty storage-range responses. Mirror of AccountRangeCoordinator's
-  // emptyResponseStrikes: a peer must miss N=3 consecutive empties (no intervening success)
+  // emptyResponseStrikes: a peer must miss N=5 consecutive empties (no intervening success)
   // before being marked stateless. Cleared on PivotRefreshed, PeerUnavailable, or any
   // successful (slot-bearing) response.
+  //
+  // Threshold raised 3 → 5 on 2026-05-14 after sepolia observation: on small peer pools
+  // (3-8 peers), 3 strikes drains peers into stateless faster than pivot refreshes can
+  // clear them. Result: eligible=0 windows recur every pivot cycle. Mirrors the small-pool
+  // fix shape applied to account (PR-2 / #1255 cleared sticky snapless on PivotRefreshed).
+  // Reference clients use 5 (Nethermind) or unlimited+throughput-tracker (Geth); 3 was
+  // overly aggressive for our policy.
   private val emptyResponseStrikes = mutable.Map.empty[String, Int]
-  private val EmptyResponseStrikeThreshold: Int = 3
+  private val EmptyResponseStrikeThreshold: Int = 5
   private var pivotRefreshRequested = false
 
   // Contract completion tracking for progress estimation.


### PR DESCRIPTION
Even after PR #1255 cleared snapless on pivot, the 3-strike threshold drained sepolia's small peer pool within each pivot window. Raising to 5 (matches Nethermind) gives peers more rope. Costs ≈ 2 extra wasted dispatches per peer per pivot. Benefit: eligible stays > 0 for the full pivot window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)