### PR TITLE
fix(snap): lower account-stagnation-timeout 180s → 60s

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -106,9 +106,13 @@ sync {
     # Keeps SNAP startup fast on networks where peers don't support snap (e.g. Mordor).
     snap-capability-grace-period = 30 seconds
     # Account stagnation timeout: if no account range tasks complete within this window,
-    # record a critical failure. Reduced from 15 minutes to catch non-snap peers faster
-    # while still allowing time for large state downloads on supported networks.
-    account-stagnation-timeout = 3 minutes
+    # request an in-place pivot refresh to recover. On small peer pools (sepolia 2-3 peers)
+    # the strike-counted demotion sets (PR #1255/#1256) can land all peers in
+    # stateless+snapless within a single pivot window; the pivot refresh resets those sets
+    # via the recovery path. Lower threshold = faster recovery from these windows.
+    # Trade-off: too low risks pivot churn on transient slowdowns. 60s balances responsive
+    # recovery against pivot stability (typical pivot interval is 3-5 min on sepolia).
+    account-stagnation-timeout = 60 seconds
     # Maximum concurrent in-flight requests per peer for account and storage coordinators.
     # Core-geth pipelines 5+ concurrent requests per peer. Matching this eliminates idle time
     # between request send and response processing (50-200ms per response round-trip).


### PR DESCRIPTION
Sepolia's 2-3 SNAP-peer pool keeps hitting eligible=0 within pivot windows even after the strike-threshold bump. The pivot-refresh recovery path works (clears snapless via PR-2), but waits 180s. Drop to 60s for faster recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)