### PR TITLE
fix(snap+p2p): PoW pivot chain weight from peer wire TD; backfill abort; P2P lifecycle

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -158,7 +158,7 @@
     <!-- Network - peer connections and communication -->
     <logger name="com.chipprbots.ethereum.network" level="ERROR" />
     <logger name="com.chipprbots.ethereum.network.PeerActor" level="ERROR" />
-    <logger name="com.chipprbots.ethereum.network.PeerManagerActor" level="ERROR" />
+    <logger name="com.chipprbots.ethereum.network.PeerManagerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.NetworkPeerManagerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.ServerActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.network.KnownNodesManager" level="ERROR" />

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -215,9 +215,14 @@ class BlockchainHostActor(
           startBlockNumber to (startBlockNumber + (skip + 1) * headersCount - 1) by (skip + 1)
         }
 
-        val blockHeaders: Seq[BlockHeader] = range.flatMap { (a: BigInt) =>
-          blockchainReader.getBlockHeaderByNumber(a)
-        }
+        // Stop at first missing header (contiguous prefix — matches Besu EthServer.java break behavior)
+        val blockHeaders: Seq[BlockHeader] =
+          LazyList.from(range).map(a => blockchainReader.getBlockHeaderByNumber(a)).takeWhile(_.isDefined).flatten.toSeq
+
+        log.debug(
+          "GetBlockHeaders: start={} maxReq={} → returning {} headers",
+          startBlockNumber, headersCount, blockHeaders.size
+        )
 
         // Return ETH66+ format if requestId is provided, otherwise ETH62 format
         requestIdOpt match {
@@ -226,14 +231,17 @@ class BlockchainHostActor(
         }
 
       case _ =>
+        // Starting block not found in DB — respond with empty list (matches Besu EthServer.java:158-160).
+        // Never leave the requester waiting with no response; timeouts cause immediate peer drops.
         log.warning(
-          "got request for block headers with invalid block hash/number: block={}, maxHeaders={}, skip={}, reverse={}",
+          "GetBlockHeaders: starting block not found (block={} maxHeaders={} skip={} reverse={}) — responding empty",
           block.fold(_.toString, h => s"0x${h.toArray.map("%02x".format(_)).mkString}"),
-          maxHeaders,
-          skip,
-          reverse
+          maxHeaders, skip, reverse
         )
-        None
+        requestIdOpt match {
+          case Some(requestId) => Some(ETH66.BlockHeaders(requestId, Seq.empty))
+          case None            => Some(ETH62.BlockHeaders(Seq.empty))
+        }
     }
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -221,7 +221,9 @@ class BlockchainHostActor(
 
         log.debug(
           "GetBlockHeaders: start={} maxReq={} → returning {} headers",
-          startBlockNumber, headersCount, blockHeaders.size
+          startBlockNumber,
+          headersCount,
+          blockHeaders.size
         )
 
         // Return ETH66+ format if requestId is provided, otherwise ETH62 format
@@ -236,7 +238,9 @@ class BlockchainHostActor(
         log.warning(
           "GetBlockHeaders: starting block not found (block={} maxHeaders={} skip={} reverse={}) — responding empty",
           block.fold(_.toString, h => s"0x${h.toArray.map("%02x".format(_)).mkString}"),
-          maxHeaders, skip, reverse
+          maxHeaders,
+          skip,
+          reverse
         )
         requestIdOpt match {
           case Some(requestId) => Some(ETH66.BlockHeaders(requestId, Seq.empty))

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
@@ -285,6 +285,33 @@ class PeersClient(
         )
         bestPeer(snapPeers, log)
 
+      case BestSnapPeerWithMinBlockExcluding(minBlock, exclude) =>
+        val eligible = peersToDownloadFrom.filter { case (peerId, peerWithInfo) =>
+          !exclude.contains(peerId) && peerWithInfo.peerInfo.remoteStatus.supportsSnap
+        }
+        val knownAheadPeers = eligible.filter { case (_, peerWithInfo) =>
+          peerWithInfo.peerInfo.maxBlockNumber >= minBlock
+        }
+        if (knownAheadPeers.nonEmpty) {
+          log.debug(
+            "BestSnapPeerWithMinBlockExcluding({}): {} SNAP peers at target after excluding {} tried",
+            minBlock,
+            knownAheadPeers.size,
+            exclude.size
+          )
+          bestPeer(knownAheadPeers, log)
+        } else {
+          val unknownHeadPeers = eligible.filter { case (_, peerWithInfo) =>
+            peerWithInfo.peerInfo.maxBlockNumber == 0
+          }
+          log.debug(
+            "BestSnapPeerWithMinBlockExcluding({}): no known-ahead SNAP peers; {} with unknown chain state remain",
+            minBlock,
+            unknownHeadPeers.size
+          )
+          bestPeer(unknownHeadPeers, log)
+        }
+
       case BestNodeDataPeerExcluding(exclude) =>
         val now = System.currentTimeMillis()
         val nodeDataPeers = peersToDownloadFrom.filter { case (peerId, _) =>
@@ -455,6 +482,12 @@ object PeersClient {
     * idle-pool exclusion in `skeleton.assignTasks()`.
     */
   case class BestPeerWithMinBlockExcluding(minBlock: BigInt, exclude: Set[PeerId]) extends PeerSelector
+
+  /** Like BestPeerWithMinBlockExcluding but restricted to SNAP-capable peers. Mirrors Besu's two-stage pivot pattern:
+    * `PivotSelectorFromPeers` pre-filters by `estimatedChainHeight >= pivot`, then `PivotBlockConfirmer` excludes used
+    * peers. Fukuii combines both concerns here since PivotHeaderBootstrap has no upstream height pre-filter.
+    */
+  case class BestSnapPeerWithMinBlockExcluding(minBlock: BigInt, exclude: Set[PeerId]) extends PeerSelector
 
   def bestPeer(
       peersToDownloadFrom: Map[PeerId, PeerWithInfo],

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrap.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrap.scala
@@ -16,6 +16,7 @@ import com.chipprbots.ethereum.blockchain.sync.PeersClient.{
   BestPeer,
   BestPeerWithMinBlockExcluding,
   BestSnapPeer,
+  BestSnapPeerWithMinBlockExcluding,
   NoSuitablePeer,
   Request,
   RequestFailed
@@ -132,11 +133,17 @@ final class PivotHeaderBootstrap(
     val msg = ETH66.GetBlockHeaders(ETH66.nextRequestId, target, maxHeaders = 1, skip = 0, reverse = false)
 
     // Peer selection:
-    //   By-number (standard ETC mainnet path): BestPeerWithMinBlockExcluding rotates through the pool,
-    //     skipping peers already tried this bootstrap run (Besu peersUsed / go-ethereum idle-pool pattern).
-    //   By-hash / preferSnapPeers: unchanged — CL-driven and SNAP paths don't need exclusion.
+    //   By-number with preferSnapPeers (standard SNAP pivot bootstrap): BestSnapPeerWithMinBlockExcluding
+    //     combines Besu's two-stage pattern — PivotSelectorFromPeers pre-filters by estimatedChainHeight >= pivot,
+    //     PivotBlockConfirmer excludes used peers — into a single selector. This prevents Besu ETH69 (synthetic
+    //     TD ~61.66×10²¹ >> real ETC TD) from being selected when its reported maxBlockNumber is below targetBlock,
+    //     and rotates through remaining SNAP-capable peers via the exclusion set.
+    //   By-number without preferSnapPeers: BestPeerWithMinBlockExcluding rotates through the full pool.
+    //   By-hash (preferSnapPeers=false in SyncController): BestPeer — CL-driven path.
+    //   By-hash + preferSnapPeers: unreachable in production (targetBlock=0, no meaningful minBlock).
     val selector =
-      if (preferSnapPeers) BestSnapPeer
+      if (preferSnapPeers && !byHashMode) BestSnapPeerWithMinBlockExcluding(targetBlock, triedPeers.toSet)
+      else if (preferSnapPeers) BestSnapPeer
       else if (byHashMode) BestPeer
       else BestPeerWithMinBlockExcluding(targetBlock, triedPeers.toSet)
     val req = Request[ETH66.GetBlockHeaders](msg, selector, (m: ETH66.GetBlockHeaders) => m)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -22,7 +22,6 @@ import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
 import com.chipprbots.ethereum.domain.BlockBody
 import com.chipprbots.ethereum.domain.BlockHeader
-import com.chipprbots.ethereum.domain.ChainWeight
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.p2p.messages.Codes
@@ -417,20 +416,31 @@ class ChainDownloader(
         // Store header + chain weight, atomically advancing the backfill cursor in the same
         // RocksDB write batch (#1169) so a crash mid-write never leaves the cursor ahead of
         // the data on disk.
-        val parentWeight = blockchainReader
-          .getChainWeightByHash(header.parentHash)
-          .getOrElse(ChainWeight.totalDifficultyOnly(0))
+        blockchainReader.getChainWeightByHash(header.parentHash) match {
+          case None =>
+            // Parent weight missing means the pivot TD was not seeded for this hash.
+            // Storing TD=0 here would corrupt every subsequent header's accumulated weight.
+            // Abort this batch; the backfill cursor stays at bestHeaderNumber so the next
+            // request will retry from the last committed position.
+            log.warning(
+              "Chain download: parent chain weight missing for block {} parentHash={} — aborting batch (cursor stays at {})",
+              header.number,
+              header.parentHash,
+              bestHeaderNumber
+            )
+            aborted = true
+          case Some(parentWeight) =>
+            blockchainWriter
+              .storeBlockHeader(header)
+              .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
+              .and(appStateStorage.putBackfillBestHeader(header.number))
+              .commit()
 
-        blockchainWriter
-          .storeBlockHeader(header)
-          .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
-          .and(appStateStorage.putBackfillBestHeader(header.number))
-          .commit()
-
-        bodiesQueue :+= header.hash
-        receiptsQueue :+= header.hash
-        prevHash = Some(header.hash)
-        validCount += 1
+            bodiesQueue :+= header.hash
+            receiptsQueue :+= header.hash
+            prevHash = Some(header.hash)
+            validCount += 1
+        }
       } else {
         log.warning(
           "Chain download: header {} parent hash mismatch from peer {}",

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3150,7 +3150,9 @@ class SNAPSyncController(
       .commit()
     log.info(
       s"Updated best block for ETH status: block=$pivotBlockNumber, hash=${pivotHash.toHex.take(16)}..., " +
-        s"estimatedTD=$estimatedTotalDifficulty (source=${if (peerTD.exists(_ > 0)) "PEER_WIRE_TD" else "LINEAR_ESTIMATE"})"
+        s"estimatedTD=$estimatedTotalDifficulty (source=${
+            if (peerTD.exists(_ > 0)) "PEER_WIRE_TD" else "LINEAR_ESTIMATE"
+          })"
     )
   }
 
@@ -3872,17 +3874,16 @@ object SNAPSyncController {
   final case class ProgressAccountEstimate(estimatedTotal: Long)
   final case class ProgressStorageContracts(completedContracts: Int, totalContracts: Int)
 
-  /** Sent by `StorageRangeCoordinator` to the controller when its pending-task queue crosses a
-    * watermark. The controller forwards it to `AccountRangeCoordinator` as a `StorageQueuePressure`
-    * message so account workers stop producing new storage tasks during back-pressure. Workers
-    * already in flight always run to completion. */
+  /** Sent by `StorageRangeCoordinator` to the controller when its pending-task queue crosses a watermark. The
+    * controller forwards it to `AccountRangeCoordinator` as a `StorageQueuePressure` message so account workers stop
+    * producing new storage tasks during back-pressure. Workers already in flight always run to completion.
+    */
   final case class StorageBackpressureChanged(paused: Boolean)
 
-  /** Sent by `ByteCodeCoordinator` to the controller when its pending-task queue crosses a
-    * watermark. Forwarded to `AccountRangeCoordinator` as `ByteCodeQueuePressure`. Bytecode tasks
-    * are produced by account-range completions (one task per batch of code hashes), so the
-    * pause/resume pattern is the same as storage. AccountRangeCoordinator pauses dispatch if
-    * EITHER downstream coordinator is over its high-water mark.
+  /** Sent by `ByteCodeCoordinator` to the controller when its pending-task queue crosses a watermark. Forwarded to
+    * `AccountRangeCoordinator` as `ByteCodeQueuePressure`. Bytecode tasks are produced by account-range completions
+    * (one task per batch of code hashes), so the pause/resume pattern is the same as storage. AccountRangeCoordinator
+    * pauses dispatch if EITHER downstream coordinator is over its high-water mark.
     */
   final case class ByteCodeBackpressureChanged(paused: Boolean)
 
@@ -3892,23 +3893,25 @@ object SNAPSyncController {
   ): Boolean =
     snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted
 
-  /** Freshness gate for `refreshPivotInPlace`: reject candidate pivots whose source peer is
-    * more than `maxStaleness` blocks behind the CL-driven head.
+  /** Freshness gate for `refreshPivotInPlace`: reject candidate pivots whose source peer is more than `maxStaleness`
+    * blocks behind the CL-driven head.
     *
-    * Background: the post-merge SNAP refresh path used to take `max(snapPeer.maxBlockNumber)`
-    * as the new pivot with no comparison against the actual chain tip. When the only
-    * SNAP-capable peers left in the pool were lagging (e.g. one still reporting block
-    * 10_447_000 while sepolia's CL head was at 10_847_xxx — observed May 13 2026), the
-    * refresh kept picking the stuck-peer's block, then immediately tripped the same-root
-    * fallback and restart. This filter blocks that path: on post-merge chains we know the
-    * authoritative tip (via `clPivotHint`), so we require pivot sources to be within
-    * `maxStaleness` of it. Pre-merge chains pass through unchanged (clHeadNumber=None).
+    * Background: the post-merge SNAP refresh path used to take `max(snapPeer.maxBlockNumber)` as the new pivot with no
+    * comparison against the actual chain tip. When the only SNAP-capable peers left in the pool were lagging (e.g. one
+    * still reporting block 10_447_000 while sepolia's CL head was at 10_847_xxx — observed May 13 2026), the refresh
+    * kept picking the stuck-peer's block, then immediately tripped the same-root fallback and restart. This filter
+    * blocks that path: on post-merge chains we know the authoritative tip (via `clPivotHint`), so we require pivot
+    * sources to be within `maxStaleness` of it. Pre-merge chains pass through unchanged (clHeadNumber=None).
     *
-    * @param networkBest  the best SNAP peer's maxBlockNumber
-    * @param clHeadNumber the consensus-layer head block number, when available
-    * @param maxStaleness configured `maxPivotStalenessBlocks` (default 4096)
-    * @return Right(()) if the candidate is fresh enough, Left(floor) with the rejected
-    *         freshness floor for diagnostic logging on the call site
+    * @param networkBest
+    *   the best SNAP peer's maxBlockNumber
+    * @param clHeadNumber
+    *   the consensus-layer head block number, when available
+    * @param maxStaleness
+    *   configured `maxPivotStalenessBlocks` (default 4096)
+    * @return
+    *   Right(()) if the candidate is fresh enough, Left(floor) with the rejected freshness floor for diagnostic logging
+    *   on the call site
     */
   private[snap] def pivotPassesFreshnessFloor(
       networkBest: BigInt,
@@ -4009,15 +4012,12 @@ case class SNAPSyncConfig(
     snapServerPeers: List[java.net.URI] = Nil,
     /** Phase 2 of the SNAP rewrite (`snap-stacktrie-port` plan).
       *
-      * When `true`, the SNAP write path uses streaming `SnapHashTrie`
-      * (one per AccountTask, one per storage contract) instead of the legacy
-      * `MerklePatriciaTrie` + `DeferredWriteMptStorage` approach. Memory is
-      * bounded by trie depth rather than account count; the multi-GiB
-      * in-memory pivot trie and its 13.6-minute collapse are eliminated.
+      * When `true`, the SNAP write path uses streaming `SnapHashTrie` (one per AccountTask, one per storage contract)
+      * instead of the legacy `MerklePatriciaTrie` + `DeferredWriteMptStorage` approach. Memory is bounded by trie depth
+      * rather than account count; the multi-GiB in-memory pivot trie and its 13.6-minute collapse are eliminated.
       *
-      * Default `false` — opt in via `sync.snap-sync.use-stack-trie = true`
-      * in sync.conf for testing. Will become the default once Sepolia +
-      * Mordor validation completes (Step 5 of the plan).
+      * Default `false` — opt in via `sync.snap-sync.use-stack-trie = true` in sync.conf for testing. Will become the
+      * default once Sepolia + Mordor validation completes (Step 5 of the plan).
       */
     useStackTrie: Boolean = false
 )

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1251,6 +1251,16 @@ class SNAPSyncController(
         }
       }
 
+      // Real wire TD from the best SNAP-capable peer's ETH/68 handshake.
+      // Sorted by TD descending so we pick the peer with the highest known cumulative difficulty.
+      val bestSnapPeerTD: Option[BigInt] =
+        peersToDownloadFrom.values.toList
+          .filter(p => p.peerInfo.remoteStatus.supportsSnap && p.peerInfo.forkAccepted && p.peerInfo.maxBlockNumber > 0)
+          .sortBy(_.peerInfo.chainWeight.totalDifficulty)(Ordering[BigInt].reverse)
+          .headOption
+          .map(_.peerInfo.chainWeight.totalDifficulty)
+          .filter(_ > BigInt(0))
+
       pivotHeaderOpt match {
         case Some(header) =>
           val targetPivot = header.number
@@ -1265,7 +1275,7 @@ class SNAPSyncController(
               .putSnapSyncPivotBlock(targetPivot)
               .and(appStateStorage.putSnapSyncStateRoot(header.stateRoot))
               .commit()
-            updateBestBlockForPivot(header, targetPivot)
+            updateBestBlockForPivot(header, targetPivot, bestSnapPeerTD)
 
             SNAPSyncMetrics.setPivotBlockNumber(targetPivot)
 
@@ -1304,7 +1314,7 @@ class SNAPSyncController(
                       .putSnapSyncPivotBlock(targetPivot)
                       .and(appStateStorage.putSnapSyncStateRoot(header.stateRoot))
                       .commit()
-                    updateBestBlockForPivot(header, targetPivot)
+                    updateBestBlockForPivot(header, targetPivot, bestSnapPeerTD)
 
                     SNAPSyncMetrics.setPivotBlockNumber(targetPivot)
 
@@ -3120,11 +3130,16 @@ class SNAPSyncController(
     * incompatible forkId (e.g. Frontier vs Spiral). This stores the pivot header, chain weight, and best block info so
     * that createStatusMsg() in EthNodeStatus64ExchangeState can build a valid status message referencing the pivot.
     */
-  private def updateBestBlockForPivot(header: BlockHeader, pivotBlockNumber: BigInt): Unit = {
+  private def updateBestBlockForPivot(
+      header: BlockHeader,
+      pivotBlockNumber: BigInt,
+      peerTD: Option[BigInt] = None
+  ): Unit = {
     val pivotHash = header.hash
-    val estimatedTotalDifficulty =
+    val estimatedTotalDifficulty = peerTD.filter(_ > BigInt(0)).getOrElse {
       if (pivotBlockNumber == BigInt(0)) header.difficulty
       else header.difficulty * pivotBlockNumber
+    }
     // Store header so getBestBlockHeader() -> getBlockHeaderByNumber(pivot) finds it
     blockchainWriter.storeBlockHeader(header).commit()
     blockchainWriter
@@ -3135,7 +3150,7 @@ class SNAPSyncController(
       .commit()
     log.info(
       s"Updated best block for ETH status: block=$pivotBlockNumber, hash=${pivotHash.toHex.take(16)}..., " +
-        s"estimatedTD=$estimatedTotalDifficulty"
+        s"estimatedTD=$estimatedTotalDifficulty (source=${if (peerTD.exists(_ > 0)) "PEER_WIRE_TD" else "LINEAR_ESTIMATE"})"
     )
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrie.scala
@@ -8,51 +8,43 @@ import com.chipprbots.ethereum.mpt.StackTrie
 
 /** Hash-scheme RocksDB-batching wrapper around [[StackTrie]] for SNAP sync.
   *
-  * The StackTrie itself is strictly write-only and emits finalised nodes via a
-  * callback. This wrapper owns the batching policy:
+  * The StackTrie itself is strictly write-only and emits finalised nodes via a callback. This wrapper owns the batching
+  * policy:
   *
   *   - each emitted `(hash, RLP blob)` pair is appended to an in-memory buffer;
-  *   - when the buffer crosses `batchSizeThreshold` total bytes, the entire
-  *     buffer is handed to the `writeBatch` callback (a single batched RocksDB
-  *     write) and cleared;
+  *   - when the buffer crosses `batchSizeThreshold` total bytes, the entire buffer is handed to the `writeBatch`
+  *     callback (a single batched RocksDB write) and cleared;
   *   - `commit()` finalises the right-boundary path and flushes the remainder.
   *
-  * The `writeBatch` callback is the integration boundary. Callers pass in a
-  * function adapted from their storage layer — typically `mptStorage.storeRawNodes`
-  * for the SNAP path, which goes through `FastSyncNodeStorage` and picks up the
+  * The `writeBatch` callback is the integration boundary. Callers pass in a function adapted from their storage layer —
+  * typically `mptStorage.storeRawNodes` for the SNAP path, which goes through `FastSyncNodeStorage` and picks up the
   * pivot-block-number tag for pruning automatically.
   *
-  * == Why this is so simple ==
+  * ==Why this is so simple==
   *
-  * geth's equivalent (`pathTrie` / `hashTrie` in `eth/protocols/snap/gentrie.go`)
-  * carries non-trivial boundary logic — left-boundary skip on resume, ancestor
-  * deletion, right-boundary discard. Almost all of that complexity is
-  * path-scheme-specific: in path scheme, exactly one node exists at each trie
-  * path, so stale partial state from a prior session must be cleaned up to
-  * avoid structural conflicts.
+  * geth's equivalent (`pathTrie` / `hashTrie` in `eth/protocols/snap/gentrie.go`) carries non-trivial boundary logic —
+  * left-boundary skip on resume, ancestor deletion, right-boundary discard. Almost all of that complexity is
+  * path-scheme-specific: in path scheme, exactly one node exists at each trie path, so stale partial state from a prior
+  * session must be cleaned up to avoid structural conflicts.
   *
-  * Fukuii uses hash scheme — nodes are keyed by their keccak256 hash, so two
-  * nodes with different contents can never collide. Re-emitting an already-
-  * written node is a no-op (RocksDB just overwrites the same key with the same
-  * value). The boundary problem dissolves.
+  * Fukuii uses hash scheme — nodes are keyed by their keccak256 hash, so two nodes with different contents can never
+  * collide. Re-emitting an already- written node is a no-op (RocksDB just overwrites the same key with the same value).
+  * The boundary problem dissolves.
   *
-  * If we later need to recover bytes wasted by re-emitting already-committed
-  * nodes on resume, a `skipLeftBoundary` mode can be added — but it's a perf
-  * optimisation, not a correctness requirement.
+  * If we later need to recover bytes wasted by re-emitting already-committed nodes on resume, a `skipLeftBoundary` mode
+  * can be added — but it's a perf optimisation, not a correctness requirement.
   *
-  * == Concurrency ==
+  * ==Concurrency==
   *
-  * Not thread-safe. The expected usage is one wrapper instance per
-  * `AccountTask` (or per per-contract storage trie), with all `update` and
-  * `commit` calls dispatched from a single actor or thread.
+  * Not thread-safe. The expected usage is one wrapper instance per `AccountTask` (or per per-contract storage trie),
+  * with all `update` and `commit` calls dispatched from a single actor or thread.
   *
-  * @param writeBatch        called with `(nodeHash, rlpBlob)` pairs when the
-  *                          batch threshold is reached or on `commit()`. The
-  *                          caller owns the actual disk write semantics
-  *                          (synchronous vs queued, fsync vs not, etc.).
-  * @param batchSizeThreshold flush the batch when the accumulated blob bytes
-  *                           reach this size. 8 MiB matches geth's
-  *                           `batchSizeThreshold` in `eth/protocols/snap/sync.go`.
+  * @param writeBatch
+  *   called with `(nodeHash, rlpBlob)` pairs when the batch threshold is reached or on `commit()`. The caller owns the
+  *   actual disk write semantics (synchronous vs queued, fsync vs not, etc.).
+  * @param batchSizeThreshold
+  *   flush the batch when the accumulated blob bytes reach this size. 8 MiB matches geth's `batchSizeThreshold` in
+  *   `eth/protocols/snap/sync.go`.
   */
 final class SnapHashTrie(
     writeBatch: Seq[(ByteString, Array[Byte])] => Unit,
@@ -64,17 +56,15 @@ final class SnapHashTrie(
 
   private val stackTrie = new StackTrie((_, hash, blob) => emit(hash, blob))
 
-  /** Insert `value` under `key`. Keys must arrive in strictly-ascending
-    * hex-nibble order (after `HexPrefix.bytesToNibbles`). The underlying
-    * StackTrie enforces this; violations throw.
+  /** Insert `value` under `key`. Keys must arrive in strictly-ascending hex-nibble order (after
+    * `HexPrefix.bytesToNibbles`). The underlying StackTrie enforces this; violations throw.
     */
   def update(key: Array[Byte], value: Array[Byte]): Unit =
     stackTrie.update(key, value)
 
   /** Finalise the right-boundary path and flush any pending batch.
     *
-    * Returns the 32-byte trie root hash. After commit, the wrapper must be
-    * `reset()` before any further `update` calls.
+    * Returns the 32-byte trie root hash. After commit, the wrapper must be `reset()` before any further `update` calls.
     */
   def commit(): ByteString = {
     val root = stackTrie.hash()
@@ -82,12 +72,10 @@ final class SnapHashTrie(
     root
   }
 
-  /** Discard any in-memory state without flushing. Used when a range is being
-    * abandoned (pivot roll, abort, shutdown).
+  /** Discard any in-memory state without flushing. Used when a range is being abandoned (pivot roll, abort, shutdown).
     *
-    * Note: emissions already flushed to disk during the doomed run are NOT
-    * rolled back — they're still valid hash-content-addressed trie nodes and
-    * will simply be unreferenced until pruning cleans them up.
+    * Note: emissions already flushed to disk during the doomed run are NOT rolled back — they're still valid
+    * hash-content-addressed trie nodes and will simply be unreferenced until pruning cleans them up.
     */
   def reset(): Unit = {
     stackTrie.reset()
@@ -110,24 +98,22 @@ final class SnapHashTrie(
     if (pendingBytes >= batchSizeThreshold) flush()
   }
 
-  private def flush(): Unit = {
+  private def flush(): Unit =
     if (pending.nonEmpty) {
       // toSeq creates an immutable snapshot before clearing.
       writeBatch(pending.toSeq)
       pending.clear()
       pendingBytes = 0L
     }
-  }
 }
 
 object SnapHashTrie {
 
   /** 8 MiB, matching geth's `batchSizeThreshold` in `eth/protocols/snap/sync.go`.
     *
-    * Sized so that the 16 active account tasks plus their per-contract storage
-    * tries cumulatively bound in-flight buffered state to ~128-256 MiB worst
-    * case — large enough to amortise RocksDB write overhead, small enough to
-    * keep heap pressure manageable.
+    * Sized so that the 16 active account tasks plus their per-contract storage tries cumulatively bound in-flight
+    * buffered state to ~128-256 MiB worst case — large enough to amortise RocksDB write overhead, small enough to keep
+    * heap pressure manageable.
     */
   val DefaultBatchSizeBytes: Int = 8 * 1024 * 1024
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -72,17 +72,14 @@ class AccountRangeCoordinator(
     accountTrieEcOverride: Option[ExecutionContext] = None,
     /** Phase 2 of the SNAP rewrite (Step 3 of `snap-stacktrie-port` plan).
       *
-      * When `true`, accounts arriving in each `AccountTask` are inserted into
-      * a per-task [[com.chipprbots.ethereum.blockchain.sync.snap.SnapHashTrie]]
-      * (which wraps a streaming `StackTrie`) rather than into the shared
-      * `MerklePatriciaTrie` over `DeferredWriteMptStorage`. The single 4 GiB
-      * in-memory pivot trie and its multi-minute flush are eliminated; memory
-      * is bounded to ~8 MiB write batches per task.
+      * When `true`, accounts arriving in each `AccountTask` are inserted into a per-task
+      * [[com.chipprbots.ethereum.blockchain.sync.snap.SnapHashTrie]] (which wraps a streaming `StackTrie`) rather than
+      * into the shared `MerklePatriciaTrie` over `DeferredWriteMptStorage`. The single 4 GiB in-memory pivot trie and
+      * its multi-minute flush are eliminated; memory is bounded to ~8 MiB write batches per task.
       *
-      * When `false` (default), the legacy MPT-put-then-deferred-flush path is
-      * used unchanged. This gives operators an opt-in migration path; the
-      * legacy path will be removed in Step 5 of the plan once the StackTrie
-      * path is validated on Sepolia + Mordor.
+      * When `false` (default), the legacy MPT-put-then-deferred-flush path is used unchanged. This gives operators an
+      * opt-in migration path; the legacy path will be removed in Step 5 of the plan once the StackTrie path is
+      * validated on Sepolia + Mordor.
       */
     useStackTrie: Boolean = false
 ) extends Actor
@@ -184,9 +181,8 @@ class AccountRangeCoordinator(
     maybeRequestPivotRefresh()
   }
 
-  /** Reset the strike counter for a peer that has just produced a useful response (real
-    * accounts OR a boundary proof). Cheap to over-invoke; the goal is "any forward progress
-    * from this peer wipes prior strikes."
+  /** Reset the strike counter for a peer that has just produced a useful response (real accounts OR a boundary proof).
+    * Cheap to over-invoke; the goal is "any forward progress from this peer wipes prior strikes."
     */
   private def recordPeerSuccess(peerId: com.chipprbots.ethereum.network.PeerId): Unit =
     emptyResponseStrikes.remove(peerId)
@@ -415,10 +411,9 @@ class AccountRangeCoordinator(
   // without waiting for the next PeerAvailable message.
   private val knownAvailablePeers = mutable.Set[Peer]()
 
-  /** Number of active (non-stateless, non-snapless, non-cooling-down) snap-capable peers.
-    * Returns the actual count — no floor — so the progress log truthfully reports 0 when
-    * all peers are demoted (the case that drives the account stall). Previously this had
-    * `.max(1)` which masked the stall: progress log said "1 peers" while dispatch was
+  /** Number of active (non-stateless, non-snapless, non-cooling-down) snap-capable peers. Returns the actual count — no
+    * floor — so the progress log truthfully reports 0 when all peers are demoted (the case that drives the account
+    * stall). Previously this had `.max(1)` which masked the stall: progress log said "1 peers" while dispatch was
     * starving on zero eligible peers. See PR-1 of `this-is-the-same-fluttering-eagle.md`.
     */
   private def activePeerCount: Int =
@@ -902,10 +897,9 @@ class AccountRangeCoordinator(
   /** Dispatch up to maxInFlightPerPeer tasks to the given peer (pipelining). Mirrors
     * ByteCodeCoordinator.dispatchIfPossible — the proven pattern for SNAP sync.
     *
-    * No-op while any downstream coordinator (storage OR bytecode) is over its high-water mark.
-    * Workers already in flight always run to completion, so existing work continues to drain, but
-    * we stop producing new tasks (which would in turn enqueue more storage / bytecode work) until
-    * every signalling downstream has released.
+    * No-op while any downstream coordinator (storage OR bytecode) is over its high-water mark. Workers already in
+    * flight always run to completion, so existing work continues to drain, but we stop producing new tasks (which would
+    * in turn enqueue more storage / bytecode work) until every signalling downstream has released.
     */
   private def dispatchIfPossible(peer: Peer): Unit = {
     if (pendingTasks.isEmpty) return
@@ -928,9 +922,9 @@ class AccountRangeCoordinator(
     }
   }
 
-  /** Internal: record a back-pressure transition from one named downstream and re-engage dispatch
-    * once every signalling source has released. ANY-OF semantics: pause while at least one source
-    * is engaged; resume only when the set is fully empty.
+  /** Internal: record a back-pressure transition from one named downstream and re-engage dispatch once every signalling
+    * source has released. ANY-OF semantics: pause while at least one source is engaged; resume only when the set is
+    * fully empty.
     */
   private def applyBackpressureChange(source: String, paused: Boolean): Unit = {
     val wasActive = downstreamBackpressureActive
@@ -1359,12 +1353,10 @@ class AccountRangeCoordinator(
     }
   }
 
-  /** Get-or-create the per-task `SnapHashTrie` for the StackTrie path. Each
-    * task gets its own streaming trie keyed by `task.last` (the end-of-range
-    * boundary, unique per task). Nodes emitted by the wrapper flush to
-    * `mptStorage` via `storeRawNodes` — which routes through the existing
-    * `FastSyncNodeStorage` and picks up pivot-block-number tagging for
-    * pruning automatically.
+  /** Get-or-create the per-task `SnapHashTrie` for the StackTrie path. Each task gets its own streaming trie keyed by
+    * `task.last` (the end-of-range boundary, unique per task). Nodes emitted by the wrapper flush to `mptStorage` via
+    * `storeRawNodes` — which routes through the existing `FastSyncNodeStorage` and picks up pivot-block-number tagging
+    * for pruning automatically.
     */
   private def getOrCreateTaskStackTrie(task: AccountTask): SnapHashTrie =
     taskStackTries.getOrElseUpdate(
@@ -1379,8 +1371,8 @@ class AccountRangeCoordinator(
     * Used directly only from `finalizeTrie` (where the actor is in `finalizing` and no concurrent puts can race).
     * Periodic flushes during account download go through `spawnFlushTrieAsync`.
     *
-    * NOTE: legacy MPT path only. The StackTrie path flushes per-task at task completion via
-    * `SnapHashTrie.commit()`; no global flush is needed.
+    * NOTE: legacy MPT path only. The StackTrie path flushes per-task at task completion via `SnapHashTrie.commit()`; no
+    * global flush is needed.
     */
   private def flushTrieToStorage(): Unit =
     deferredStorage.flush().foreach { rootHash =>
@@ -1527,7 +1519,9 @@ class AccountRangeCoordinator(
         // finished after its `isTaskRangeComplete` branch was missed).
         if (taskStackTries.nonEmpty) {
           log.warning(s"Finalising ${taskStackTries.size} uncommitted task StackTries (unexpected)")
-          taskStackTries.values.foreach { trie => val _ = trie.commit() }
+          taskStackTries.values.foreach { trie =>
+            val _ = trie.commit()
+          }
           taskStackTries.clear()
         }
         // Use the pivot's claimed root as the "finalized root". With per-task fragments

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -364,10 +364,9 @@ class ByteCodeCoordinator(
       sender() ! ByteCodeProgress(progress, bytecodesDownloaded, bytesDownloaded)
   }
 
-  /** Emit a ByteCodeBackpressureChanged transition when the pending-task queue depth crosses a
-    * watermark. Forwarded by SNAPSyncController to AccountRangeCoordinator as
-    * `ByteCodeQueuePressure` so account workers stop producing new bytecode tasks during
-    * back-pressure. Mirrors `StorageRangeCoordinator.notifyBackpressureIfChanged` (#1233).
+  /** Emit a ByteCodeBackpressureChanged transition when the pending-task queue depth crosses a watermark. Forwarded by
+    * SNAPSyncController to AccountRangeCoordinator as `ByteCodeQueuePressure` so account workers stop producing new
+    * bytecode tasks during back-pressure. Mirrors `StorageRangeCoordinator.notifyBackpressureIfChanged` (#1233).
     */
   private def notifyBackpressureIfChanged(): Unit = {
     val pending = pendingTasks.size

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -72,19 +72,18 @@ object Messages {
   case object RecoverStalledAccountTasks extends AccountRangeCoordinatorMessage
 
   /** Sent by `StorageRangeCoordinator` (via `SNAPSyncController`) when its pending-task queue depth crosses a
-    * watermark. `paused = true` is emitted on the high-water transition: AccountRangeCoordinator should stop dispatching
-    * new account-range requests so it stops producing new storage tasks. `paused = false` is emitted on the low-water
-    * transition once the storage queue drains: AccountRangeCoordinator resumes dispatching.
+    * watermark. `paused = true` is emitted on the high-water transition: AccountRangeCoordinator should stop
+    * dispatching new account-range requests so it stops producing new storage tasks. `paused = false` is emitted on the
+    * low-water transition once the storage queue drains: AccountRangeCoordinator resumes dispatching.
     *
     * Workers already in flight continue to completion regardless — this only gates the next-dispatch decision.
     */
   case class StorageQueuePressure(paused: Boolean) extends AccountRangeCoordinatorMessage
 
-  /** Same shape as `StorageQueuePressure`, emitted by `ByteCodeCoordinator`. Account-range
-    * completions enqueue both storage tasks AND bytecode tasks, so either downstream coordinator
-    * can independently trigger back-pressure on the account dispatcher. AccountRangeCoordinator
-    * pauses dispatch whenever *any* downstream is over its high-water mark and only resumes once
-    * all sources have released.
+  /** Same shape as `StorageQueuePressure`, emitted by `ByteCodeCoordinator`. Account-range completions enqueue both
+    * storage tasks AND bytecode tasks, so either downstream coordinator can independently trigger back-pressure on the
+    * account dispatcher. AccountRangeCoordinator pauses dispatch whenever *any* downstream is over its high-water mark
+    * and only resumes once all sources have released.
     */
   case class ByteCodeQueuePressure(paused: Boolean) extends AccountRangeCoordinatorMessage
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -60,10 +60,9 @@ class StorageRangeCoordinator(
     flatBatchEcOverride: Option[ExecutionContext] = None,
     /** Phase 2 of the SNAP rewrite (Step 4 of `snap-stacktrie-port` plan).
       *
-      * When `true`, per-contract storage tries are built with a streaming
-      * `SnapHashTrie` instead of `MerklePatriciaTrie` + `DeferredWriteMptStorage`.
-      * Each contract's trie is constructed in O(depth) memory rather than
-      * holding the whole trie in memory until flush. Same opt-in semantics as
+      * When `true`, per-contract storage tries are built with a streaming `SnapHashTrie` instead of
+      * `MerklePatriciaTrie` + `DeferredWriteMptStorage`. Each contract's trie is constructed in O(depth) memory rather
+      * than holding the whole trie in memory until flush. Same opt-in semantics as
       * `AccountRangeCoordinator.useStackTrie`.
       */
     useStackTrie: Boolean = false,
@@ -84,7 +83,7 @@ class StorageRangeCoordinator(
   private var maxInFlightPerPeer: Int = initialMaxInFlightPerPeer
 
   // Task management
-  private val tasks = mutable.Queue[StorageTask]()
+  private[actors] val tasks = mutable.Queue[StorageTask]()
   // Dedup gate: (accountHash, next) uniquely identifies a pending task. Prevents duplicate
   // enqueues when concurrent timeout re-queues overlap (two timeouts for the same batch).
   private val pendingTaskKeys = mutable.Set[(ByteString, ByteString)]()
@@ -653,19 +652,19 @@ class StorageRangeCoordinator(
       }
     }
 
-  /** Aggregate-counter sink for completed StorageTask objects. Previously this appended into an
-    * unbounded `mutable.ArrayBuffer[StorageTask]` (one of the leak vectors behind the May 13 sepolia
-    * OOM at ~22M completed tasks). All downstream consumers — progress %, SyncStatistics.tasksCompleted,
-    * the completion check — only ever read the count, never the task data itself.
+  /** Aggregate-counter sink for completed StorageTask objects. Previously this appended into an unbounded
+    * `mutable.ArrayBuffer[StorageTask]` (one of the leak vectors behind the May 13 sepolia OOM at ~22M completed
+    * tasks). All downstream consumers — progress %, SyncStatistics.tasksCompleted, the completion check — only ever
+    * read the count, never the task data itself.
     */
   private def recordCompletedTask(task: StorageTask): Unit = {
     val _ = task // explicitly unused; kept in the signature to make call-site intent unambiguous
     completedTaskCount += 1L
   }
 
-  /** Emit a StorageQueuePressure transition if the pending-task queue depth has just crossed a
-    * watermark. Called after every enqueue and dequeue. Forwarded to AccountRangeCoordinator via
-    * SNAPSyncController so account workers stop producing new storage tasks during back-pressure.
+  /** Emit a StorageQueuePressure transition if the pending-task queue depth has just crossed a watermark. Called after
+    * every enqueue and dequeue. Forwarded to AccountRangeCoordinator via SNAPSyncController so account workers stop
+    * producing new storage tasks during back-pressure.
     */
   private def notifyBackpressureIfChanged(): Unit = {
     val pending = tasks.size
@@ -1501,10 +1500,9 @@ class StorageRangeCoordinator(
       accountsReadyForBuild.isEmpty && accountsInTrieConstruction.isEmpty && pendingAccountSlots.isEmpty &&
       pendingFlatBatchAccounts.isEmpty && inFlightFlatBatches == 0
 
-  /** Update contract completion counts and send progress to controller. The counter is incremented
-    * at the two "account fully done" sites (small-contract flat write + TrieConstructionComplete);
-    * we just broadcast its current value, avoiding the previous O(N) rebuild over completedTasks
-    * that ran on every progress check.
+  /** Update contract completion counts and send progress to controller. The counter is incremented at the two "account
+    * fully done" sites (small-contract flat write + TrieConstructionComplete); we just broadcast its current value,
+    * avoiding the previous O(N) rebuild over completedTasks that ran on every progress check.
     */
   private var lastReportedCompletedAccountCount: Long = 0L
   private def updateContractProgress(): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -267,8 +267,14 @@ class TrieNodeHealingCoordinator(
         Future {
           val frontier = mutable.Buffer.empty[HealingEntry]
           val visited = mutable.Set.empty[ByteString]
-          rebuildFrontierDFS(root, Seq(emptyPath), isStor = false, frontier, visited,
-            batch => selfRef ! FrontierRebuilt(batch))
+          rebuildFrontierDFS(
+            root,
+            Seq(emptyPath),
+            isStor = false,
+            frontier,
+            visited,
+            batch => selfRef ! FrontierRebuilt(batch)
+          )
           if (frontier.nonEmpty) selfRef ! FrontierRebuilt(frontier.toSeq)
         }(ec)
       } else {
@@ -287,7 +293,9 @@ class TrieNodeHealingCoordinator(
           s"— resuming healing from crash-recovery frontier"
       )
       if (entries.isEmpty)
-        log.warning("[HEAL-RESTART] Frontier is empty after BFS — trie may already be fully healed or storage is corrupt")
+        log.warning(
+          "[HEAL-RESTART] Frontier is empty after BFS — trie may already be fully healed or storage is corrupt"
+        )
       queueNodes(entries.map(e => (e.pathset, e.hash)))
       lastHealedAtMs = System.currentTimeMillis()
       tryRedispatchPendingTasks()
@@ -844,17 +852,16 @@ class TrieNodeHealingCoordinator(
 
   /** Rebuild the healing frontier from locally-stored trie nodes after a crash/restart.
     *
-    * Iterative DFS (depth-first via ArrayDeque stack). Mirrors go-ethereum trie.Sync's
-    * depth-prioritized queue: drilling deep finds frontier nodes immediately, keeping the
-    * working stack O(depth × branching_factor) ≈ O(1024) rather than the O(frontier_width)
-    * growth that a BFS queue exhibits on ETC mainnet. Runs on healingWriterEc.
+    * Iterative DFS (depth-first via ArrayDeque stack). Mirrors go-ethereum trie.Sync's depth-prioritized queue:
+    * drilling deep finds frontier nodes immediately, keeping the working stack O(depth × branching_factor) ≈ O(1024)
+    * rather than the O(frontier_width) growth that a BFS queue exhibits on ETC mainnet. Runs on healingWriterEc.
     *
     * For each node hash:
-    *   - in local storage  → already healed; push children onto the DFS stack
-    *   - not in storage    → missing; buffer and emit via onBatch every FrontierBatchSize entries
+    *   - in local storage → already healed; push children onto the DFS stack
+    *   - not in storage → missing; buffer and emit via onBatch every FrontierBatchSize entries
     *
-    * onBatch is called inline whenever the buffer reaches FrontierBatchSize. The caller is
-    * responsible for emitting any remaining buffered entries after this method returns.
+    * onBatch is called inline whenever the buffer reaches FrontierBatchSize. The caller is responsible for emitting any
+    * remaining buffered entries after this method returns.
     */
   private def rebuildFrontierDFS(
       startHash: ByteString,
@@ -886,7 +893,9 @@ class TrieNodeHealingCoordinator(
               s"stack depth ${stack.size}"
           )
 
-        val nodeOpt = try Some(mptStorage.get(hash.toArray)) catch { case _: Exception => None }
+        val nodeOpt =
+          try Some(mptStorage.get(hash.toArray))
+          catch { case _: Exception => None }
         nodeOpt match {
           case None =>
             // Not in storage — missing node, buffer for healing
@@ -901,7 +910,7 @@ class TrieNodeHealingCoordinator(
             // Already healed — push children onto the DFS stack
             val compact = pathset.last.toArray
             val nibbles = HexPrefix.decode(compact)._1
-            try {
+            try
               node match {
                 case branch: BranchNode =>
                   for (i <- 0 until 16)
@@ -954,7 +963,7 @@ class TrieNodeHealingCoordinator(
 
                 case _ => // storage trie leaf, NullNode, HashNode inline — no children to traverse
               }
-            } catch {
+            catch {
               case NonFatal(e) =>
                 log.debug(
                   s"[HEAL-RESTART-DFS] Cannot traverse stored node ${Hex.toHexString(hash.take(4).toArray)}: " +

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiService.scala
@@ -1175,13 +1175,13 @@ object BlobGasUtils {
     else total - target
   }
 
-  /** EIP-7918 (Osaka) excess-blob-gas calculation. Geth reference: `eip4844.calcExcessBlobGas` —
-    * post-Osaka, when `reservePrice > blobPrice`, the protocol uses an alternate formula that
-    * preserves a fraction of `parent.blobGasUsed` instead of subtracting `target`. This prevents
-    * the blob fee from collapsing in low-utilisation regimes.
+  /** EIP-7918 (Osaka) excess-blob-gas calculation. Geth reference: `eip4844.calcExcessBlobGas` — post-Osaka, when
+    * `reservePrice > blobPrice`, the protocol uses an alternate formula that preserves a fraction of
+    * `parent.blobGasUsed` instead of subtracting `target`. This prevents the blob fee from collapsing in
+    * low-utilisation regimes.
     *
     * Formula:
-    *   {{{
+    * {{{
     *   total = parent.excess + parent.used
     *   if (total < target) return 0
     *   if (isOsaka && reservePrice > blobPrice(parent.excess)) {
@@ -1189,10 +1189,10 @@ object BlobGasUtils {
     *     return parent.excess + scaled                       // in GAS units
     *   }
     *   return total - target
-    *   }}}
+    * }}}
     *
-    * `reservePrice = BLOB_BASE_COST * parent.baseFee` (in wei)
-    * `blobPrice    = fakeExponential(1, parent.excess, updateFraction) * GAS_PER_BLOB` (in wei)
+    * `reservePrice = BLOB_BASE_COST * parent.baseFee` (in wei) `blobPrice = fakeExponential(1, parent.excess,
+    * updateFraction) * GAS_PER_BLOB` (in wei)
     */
   def calcExcessBlobGasOsaka(
       parentExcessBlobGas: BigInt,
@@ -1234,9 +1234,9 @@ object BlobGasUtils {
     fakeExponential(MIN_BLOB_BASE_FEE, excessBlobGas, fraction)
   }
 
-  /** Fork-aware blob-base-fee update fraction. Each BPO bumps the fraction proportional to
-    * its MAX, matching geth's `params.config.go` `Default{Cancun,Prague,Osaka,BPO1,BPO2}BlobConfig.UpdateFraction`.
-    * Osaka itself reuses the Prague value (Osaka's blob params are unchanged from Prague).
+  /** Fork-aware blob-base-fee update fraction. Each BPO bumps the fraction proportional to its MAX, matching geth's
+    * `params.config.go` `Default{Cancun,Prague,Osaka,BPO1,BPO2}BlobConfig.UpdateFraction`. Osaka itself reuses the
+    * Prague value (Osaka's blob params are unchanged from Prague).
     */
   def updateFractionFor(
       blockTimestamp: Long,
@@ -1247,12 +1247,12 @@ object BlobGasUtils {
     else if (blockchainConfig.isPragueTimestamp(blockTimestamp)) PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION
     else BLOB_BASE_FEE_UPDATE_FRACTION
 
-  /** Compute the expected `excessBlobGas` of a child block given its parent and timestamp.
-    * Routes through the EIP-7918 alternate formula post-Osaka. This is the single canonical
-    * entry point for Engine-API payload validation and BlockHeaderValidator.
+  /** Compute the expected `excessBlobGas` of a child block given its parent and timestamp. Routes through the EIP-7918
+    * alternate formula post-Osaka. This is the single canonical entry point for Engine-API payload validation and
+    * BlockHeaderValidator.
     *
-    * `parentBaseFee` is required post-Osaka (used in the reserve-price comparison). Pass
-    * `BigInt(0)` for pre-Osaka chains; it's ignored.
+    * `parentBaseFee` is required post-Osaka (used in the reserve-price comparison). Pass `BigInt(0)` for pre-Osaka
+    * chains; it's ignored.
     */
   def expectedExcessBlobGas(
       parentExcessBlobGas: BigInt,

--- a/src/main/scala/com/chipprbots/ethereum/mpt/StackTrie.scala
+++ b/src/main/scala/com/chipprbots/ethereum/mpt/StackTrie.scala
@@ -4,32 +4,25 @@ import org.apache.pekko.util.ByteString
 
 import com.chipprbots.ethereum.crypto
 
-/** Streaming Merkle Patricia Trie builder, ported from go-ethereum's
-  * `trie/stacktrie.go`.
+/** Streaming Merkle Patricia Trie builder, ported from go-ethereum's `trie/stacktrie.go`.
   *
-  * The StackTrie is optimised for one specific access pattern: keys arrive in
-  * strictly-ascending hex-nibble order and the trie is built in a single
-  * left-to-right pass. As each new key is inserted, any unhashed elder sibling
-  * on the rightmost path of the trie is finalised (RLP-encoded, hashed if its
-  * encoded form is >= 32 bytes) and emitted via the `onTrieNode` callback. The
-  * finalised subtree becomes a single `Hashed` placeholder, so the live
-  * non-hashed nodes form only the path from root to the most-recent leaf.
+  * The StackTrie is optimised for one specific access pattern: keys arrive in strictly-ascending hex-nibble order and
+  * the trie is built in a single left-to-right pass. As each new key is inserted, any unhashed elder sibling on the
+  * rightmost path of the trie is finalised (RLP-encoded, hashed if its encoded form is >= 32 bytes) and emitted via the
+  * `onTrieNode` callback. The finalised subtree becomes a single `Hashed` placeholder, so the live non-hashed nodes
+  * form only the path from root to the most-recent leaf.
   *
-  * Memory bound: O(trie depth). For an account trie of 10M accounts the depth
-  * is ~6 + extensions, so total live `StNode` count is at most ~16 regardless
-  * of how many keys have been inserted.
+  * Memory bound: O(trie depth). For an account trie of 10M accounts the depth is ~6 + extensions, so total live
+  * `StNode` count is at most ~16 regardless of how many keys have been inserted.
   *
-  * `update` is the only mutating method; `hash` finalises the right boundary
-  * and returns the root hash. After `hash` the StackTrie cannot be updated
-  * again unless `reset` is called first.
+  * `update` is the only mutating method; `hash` finalises the right boundary and returns the root hash. After `hash`
+  * the StackTrie cannot be updated again unless `reset` is called first.
   *
-  * The `onTrieNode(path, hash, blob)` callback is invoked once per finalised
-  * non-inlined node. Receivers must deep-copy `path` and `blob` if they want
-  * to retain them: the StackTrie reuses internal buffers across calls.
+  * The `onTrieNode(path, hash, blob)` callback is invoked once per finalised non-inlined node. Receivers must deep-copy
+  * `path` and `blob` if they want to retain them: the StackTrie reuses internal buffers across calls.
   *
-  * Boundary handling (left-skip on resume, right-discard on abort, RocksDB
-  * batch ownership) is the wrapper's responsibility. This class is strictly
-  * write-only: it never reads from any backing storage.
+  * Boundary handling (left-skip on resume, right-discard on abort, RocksDB batch ownership) is the wrapper's
+  * responsibility. This class is strictly write-only: it never reads from any backing storage.
   */
 final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit) {
   import StackTrie._
@@ -38,9 +31,8 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
   // last hex key seen, for strict-ascending sort enforcement
   private var last: Array[Byte] = Array.emptyByteArray
 
-  /** Insert `value` under `key`. Keys must arrive in strictly ascending order
-    * after conversion to hex nibbles. Empty values are rejected (use a real
-    * "delete" model if you need removals — SNAP sync never deletes).
+  /** Insert `value` under `key`. Keys must arrive in strictly ascending order after conversion to hex nibbles. Empty
+    * values are rejected (use a real "delete" model if you need removals — SNAP sync never deletes).
     */
   def update(key: Array[Byte], value: Array[Byte]): Unit = {
     require(value.length > 0, "StackTrie does not accept empty values")
@@ -53,8 +45,8 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
 
   /** Finalise the right-boundary path and return the trie root hash.
     *
-    * After this call, the StackTrie's root is a `Hashed` placeholder. Further
-    * `update` calls will fail until `reset()` is invoked.
+    * After this call, the StackTrie's root is a `Hashed` placeholder. Further `update` calls will fail until `reset()`
+    * is invoked.
     */
   def hash(): ByteString = {
     hashNode(root, EmptyPath)
@@ -75,9 +67,8 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
 
   // ---- internals ----
 
-  /** Recursive descent insertion. Returns the (possibly new) node that should
-    * replace `node` at this position. Always returns either `node` (mutated in
-    * place) or a fresh node; never returns Empty unless `node` was Empty.
+  /** Recursive descent insertion. Returns the (possibly new) node that should replace `node` at this position. Always
+    * returns either `node` (mutated in place) or a fresh node; never returns Empty unless `node` was Empty.
     */
   private def insert(node: StNode, key: Array[Byte], value: Array[Byte], path: Array[Byte]): StNode = {
     node.typ match {
@@ -185,10 +176,9 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
     }
   }
 
-  /** Finalise `node` recursively: hash any unhashed children, RLP-encode this
-    * node, then either store the encoded blob in `node.value` (if < 32 bytes
-    * and not at the root) or compute keccak256 and store the hash (emitting
-    * via `onTrieNode`).
+  /** Finalise `node` recursively: hash any unhashed children, RLP-encode this node, then either store the encoded blob
+    * in `node.value` (if < 32 bytes and not at the root) or compute keccak256 and store the hash (emitting via
+    * `onTrieNode`).
     *
     * No-op if `node` is already `Hashed` or `Empty`.
     */
@@ -225,8 +215,8 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
 
   /** Apply the inline-or-hash rule to a finalised node's encoded blob.
     *
-    * The root (empty `path`) is always hashed even if its encoded blob is
-    * smaller than 32 bytes, because callers depend on a 32-byte root hash.
+    * The root (empty `path`) is always hashed even if its encoded blob is smaller than 32 bytes, because callers depend
+    * on a 32-byte root hash.
     */
   private def finalise(node: StNode, blob: Array[Byte], path: Array[Byte]): Unit = {
     if (blob.length < 32 && path.length > 0) {
@@ -259,9 +249,8 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
     encodeListOf2(encodeBytes(hp), childRef)
   }
 
-  /** Encode a Branch as `RLP([c0, c1, ..., c15, terminator])`. SNAP sync
-    * branches never carry a terminator value (keys are fixed-length 32-byte
-    * hashes), so slot 17 is always the empty string.
+  /** Encode a Branch as `RLP([c0, c1, ..., c15, terminator])`. SNAP sync branches never carry a terminator value (keys
+    * are fixed-length 32-byte hashes), so slot 17 is always the empty string.
     */
   private def encodeBranch(node: StNode): Array[Byte] = {
     val refs = new Array[Array[Byte]](17)
@@ -289,12 +278,11 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
 
   /** Encode a single child reference for inclusion in a parent's RLP list.
     *
-    *  - null / Empty → RLP empty string (`0x80`)
-    *  - Hashed with 32-byte hash → RLP string of 32 bytes (`0xa0 || hash`)
-    *  - Hashed with inline <32B blob → the blob bytes spliced in raw
-    *    (the blob IS its own RLP encoding)
+    *   - null / Empty → RLP empty string (`0x80`)
+    *   - Hashed with 32-byte hash → RLP string of 32 bytes (`0xa0 || hash`)
+    *   - Hashed with inline <32B blob → the blob bytes spliced in raw (the blob IS its own RLP encoding)
     */
-  private def encodeChildRef(child: StNode): Array[Byte] = {
+  private def encodeChildRef(child: StNode): Array[Byte] =
     if (child == null || child.typ == Empty) {
       EmptyBytesRlp
     } else if (child.typ == Hashed) {
@@ -305,7 +293,6 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
         s"StackTrie: encoding non-Hashed/non-Empty child (typ=${typeName(child.typ)})"
       )
     }
-  }
 
   /** RLP-encode a single byte string. Standard RLP rules. */
   private def encodeBytes(b: Array[Byte]): Array[Byte] = {
@@ -340,7 +327,7 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
     out
   }
 
-  private def listHeader(contentLen: Int): Array[Byte] = {
+  private def listHeader(contentLen: Int): Array[Byte] =
     if (contentLen < 56) {
       val out = new Array[Byte](1)
       out(0) = (0xc0 + contentLen).toByte
@@ -352,7 +339,6 @@ final class StackTrie(onTrieNode: (Array[Byte], ByteString, Array[Byte]) => Unit
       System.arraycopy(lenBytes, 0, out, 1, lenBytes.length)
       out
     }
-  }
 
   /** Big-endian, minimum-length encoding of a non-negative length. */
   private def lengthAsBytes(n: Int): Array[Byte] = {
@@ -384,15 +370,12 @@ object StackTrie {
   /** A node in the StackTrie. Mutable by design — geth's `stNode` is the same.
     *
     * Field meanings depend on `typ`:
-    *  - Empty: all fields ignored.
-    *  - Leaf: `key` holds the remaining hex-nibble suffix; `value` holds the
-    *    raw account/slot value.
-    *  - Ext: `key` holds the shared hex-nibble prefix; `children(0)` is the
-    *    single child.
-    *  - Branch: `children(0..15)` are the 16 nibble slots; `key` is empty.
-    *  - Hashed: `value` is either a 32-byte hash (parent encodes as
-    *    `RLPValue(hash)`) or a < 32 byte RLP blob (parent splices raw);
-    *    `key` and `children` are cleared for GC.
+    *   - Empty: all fields ignored.
+    *   - Leaf: `key` holds the remaining hex-nibble suffix; `value` holds the raw account/slot value.
+    *   - Ext: `key` holds the shared hex-nibble prefix; `children(0)` is the single child.
+    *   - Branch: `children(0..15)` are the 16 nibble slots; `key` is empty.
+    *   - Hashed: `value` is either a 32-byte hash (parent encodes as `RLPValue(hash)`) or a < 32 byte RLP blob (parent
+    *     splices raw); `key` and `children` are cleared for GC.
     */
   final class StNode(
       var typ: NodeType,
@@ -423,8 +406,8 @@ object StackTrie {
 
   // ---- small utilities (package-private for tests) ----
 
-  /** Index of the first differing nibble between `a` and `b`, capped at the
-    * shorter length. If one is a prefix of the other, returns the shorter length.
+  /** Index of the first differing nibble between `a` and `b`, capped at the shorter length. If one is a prefix of the
+    * other, returns the shorter length.
     */
   private[mpt] def diffIndex(a: Array[Byte], b: Array[Byte]): Int = {
     val n = math.min(a.length, b.length)
@@ -477,7 +460,7 @@ object StackTrie {
   }
 
   /** Append the slice `nibbles(from until from+count)` to a path. */
-  private[mpt] def appendNibbles(path: Array[Byte], nibbles: Array[Byte], from: Int, count: Int): Array[Byte] = {
+  private[mpt] def appendNibbles(path: Array[Byte], nibbles: Array[Byte], from: Int, count: Int): Array[Byte] =
     if (count <= 0) {
       if (path.length == 0) EmptyPath else path
     } else {
@@ -486,7 +469,6 @@ object StackTrie {
       System.arraycopy(nibbles, from, out, path.length, count)
       out
     }
-  }
 
   private[mpt] def hexStr(arr: Array[Byte]): String = {
     val sb = new StringBuilder(arr.length)

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -56,10 +56,6 @@ class NetworkPeerManagerActor(
 
   // Maximum length for hex string in debug logs (to avoid very long log lines)
 
-  // ETH/69: reject BlockRangeUpdate whose latestBlock is this many blocks beyond local best.
-  // Mirrors go-ethereum's maxFutureBlockTime heuristic translated to block-number space.
-  private val FutureBlockTolerance: BigInt = 100
-
   // Mutable reference to SNAPSyncController that can be set after initialization
   private var snapSyncControllerOpt: Option[ActorRef] = initialSnapSyncControllerOpt
 
@@ -302,6 +298,12 @@ class NetworkPeerManagerActor(
             }
           }
       }
+
+    // SNAPSyncController sends ConnectToPeer to networkPeerManager — forward to PeerManagerActor
+    // which is the only actor that handles it. Without this, the message is silently dropped.
+    case PeerManagerActor.ConnectToPeer(uri) =>
+      log.info("Forwarding ConnectToPeer({}) to PeerManagerActor", uri)
+      peerManagerActor ! PeerManagerActor.ConnectToPeer(uri)
   }
 
   /** Processes events and updating the information about each peer
@@ -326,52 +328,27 @@ class NetworkPeerManagerActor(
       handleGetByteCodes(msg, peerId, peersWithInfo.get(peerId))
 
     case MessageFromPeer(message, peerId) if peersWithInfo.contains(peerId) =>
-      // ETH/69: future-block validation for BlockRangeUpdate (go-ethereum handler.go alignment).
-      // Disconnect peers that claim a latestBlock far beyond our chain head — likely invalid or
-      // malicious. Lagging peers (latestBlock behind our head) are valid and pass through.
-      val futureBlockDisconnect = message match {
-        case bru: ETH69.BlockRangeUpdate =>
-          val localBest = appStateStorage.getBestBlockNumber()
-          // Only validate future-block when we have a meaningful chain head (> 0).
-          // At genesis/initial sync localBest=0, so any peer block would be rejected —
-          // skip the check until we've actually synced some chain state.
-          if (localBest > 0 && bru.latestBlock > localBest + FutureBlockTolerance) {
-            log.warning(
-              s"BlockRangeUpdate from peer ${peerId.value}: latestBlock=${bru.latestBlock} " +
-                s"is ${bru.latestBlock - localBest} blocks ahead of local best=$localBest " +
-                s"(tolerance=$FutureBlockTolerance). Disconnecting (BreachOfProtocol)."
-            )
-            peersWithInfo(peerId).peer.ref ! DisconnectPeer(Disconnect.Reasons.BreachOfProtocol)
-            true
-          } else false
-        case _ => false
+      // Route SNAP protocol responses (from peers we're syncing from) to SNAPSyncController
+      message match {
+        case msg @ (_: AccountRange | _: StorageRanges | _: TrieNodes | _: ByteCodes) =>
+          log.debug("Routing {} message to SNAPSyncController from peer {}", msg.getClass.getSimpleName, peerId)
+          snapSyncControllerOpt.foreach(_ ! msg)
+
+        case _ => // ETH protocol messages - no special routing needed
       }
 
-      if (futureBlockDisconnect) {
-        context.become(handleMessages(peersWithInfo - peerId))
-      } else {
-        // Route SNAP protocol responses (from peers we're syncing from) to SNAPSyncController
-        message match {
-          case msg @ (_: AccountRange | _: StorageRanges | _: TrieNodes | _: ByteCodes) =>
-            log.debug("Routing {} message to SNAPSyncController from peer {}", msg.getClass.getSimpleName, peerId)
-            snapSyncControllerOpt.foreach(_ ! msg)
-
-          case _ => // ETH protocol messages - no special routing needed
-        }
-
-        // Track per-peer block-height signals so the periodic re-probe (RefreshPeerBestBlocks)
-        // can skip ETH/69 peers that are actively pushing BlockRangeUpdate.
-        message match {
-          case _: ETH69.BlockRangeUpdate | _: ETH62BlockHeaders | _: ETH66BlockHeaders |
-              _: BaseETH6XMessages.NewBlock | _: NewBlockHashes =>
-            lastBlockSignalMs(peerId) = System.currentTimeMillis()
-          case _ => // not a block-height signal
-        }
-
-        val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message, handleReceivedMessage)
-        NetworkMetrics.ReceivedMessagesCounter.increment()
-        context.become(handleMessages(newPeersWithInfo))
+      // Track per-peer block-height signals so the periodic re-probe (RefreshPeerBestBlocks)
+      // can skip ETH/69 peers that are actively pushing BlockRangeUpdate.
+      message match {
+        case _: ETH69.BlockRangeUpdate | _: ETH62BlockHeaders | _: ETH66BlockHeaders |
+            _: BaseETH6XMessages.NewBlock | _: NewBlockHashes =>
+          lastBlockSignalMs(peerId) = System.currentTimeMillis()
+        case _ => // not a block-height signal
       }
+
+      val newPeersWithInfo = updatePeersWithInfo(peersWithInfo, peerId, message, handleReceivedMessage)
+      NetworkMetrics.ReceivedMessagesCounter.increment()
+      context.become(handleMessages(newPeersWithInfo))
 
     case PeerHandshakeSuccessful(peer, peerInfo: PeerInfo) =>
       val chainInfoDisplay =
@@ -390,48 +367,76 @@ class NetworkPeerManagerActor(
           s"$chainInfoDisplay forkAccepted=${peerInfo.forkAccepted} " +
           s"supportsSnap=${peerInfo.remoteStatus.supportsSnap}"
       )
-      peerEventBusActor ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
-      peerEventBusActor ! Subscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peer.id)))
-
-      // Besu-style eager best-block probe.
-      // ETH/64-/68 STATUS carries `bestHash` but not the peer's best block *number* — only
-      // ETH/61 (long gone) and ETH/69 do. Without the number, fast-sync `PivotBlockSelector`
-      // sees `peer.maxBlockNumber == 0`, picks pivot = 0, and never converges (the loop
-      // we hit on Barad-dûr 2026-04-29). Geth resolves this lazily inside the downloader by
-      // probing the chosen peer's bestHash; besu and nethermind do it eagerly the moment
-      // STATUS completes. We follow the eager pattern: one `GetBlockHeaders(bestHash, 1)`
-      // immediately after handshake, the response routes through `updateMaxBlock` via the
-      // existing `BlockHeadersCode` subscription and populates `PeerInfo.maxBlockNumber`.
-      //
-      // Skip the probe for:
-      //  * ETH/69 — STATUS already carries latestBlock (stuffed into chainWeight.totalDifficulty
-      //    by the handshaker), so maxBlockNumber is set on construction.
-      //  * Peers at genesis (`bestHash == genesisHash`) — they're block 0 by definition;
-      //    `peerHasUpdatedBestBlock` already accepts them as `isAtGenesis`.
-      //
-      // Peers that don't reply to the probe simply stay at maxBlockNumber=0 and get filtered
-      // by `peerHasUpdatedBestBlock` — no disconnect, since Mordor peers can be flaky and
-      // we don't want to throw away connections for one missed reply (Bug 26 lesson).
-      if (peerInfo.remoteStatus.capability != Capability.ETH69 && !peerInfo.isAtGenesis) {
-        val bestHash = peerInfo.remoteStatus.bestHash
-        val probe: MessageSerializable =
-          if (Capability.usesRequestId(peerInfo.remoteStatus.capability))
-            ETH66.GetBlockHeaders(ETH66.nextRequestId, Right(bestHash), 1, 0, reverse = false)
-          else
-            ETH62.GetBlockHeaders(Right(bestHash), 1, 0, reverse = false)
-        log.debug(
-          "BEST_BLOCK_PROBE: peer={} cap={} bestHash={} — asking for header at bestHash to discover block number",
-          peer.id,
-          peerInfo.remoteStatus.capability,
-          ByteStringUtils.hash2string(bestHash)
+      if (peersWithInfo.contains(peer.id)) {
+        val old = peersWithInfo(peer.id)
+        // Keep the EXISTING entry — don't overwrite with the duplicate.
+        // PeerManagerActor will drop the loser via AlreadyConnected; with the PeerDisconnected
+        // gate fix, the loser's termination no longer evicts the winner. Overwriting here with
+        // the duplicate (which may be the about-to-die loser) would leave a stale ref in
+        // peersWithInfo — mirroring Besu's registerDisconnect guard which only updates
+        // activeConnections when peer.getConnection().equals(connection) (the primary connection).
+        log.warning(
+          s"DUPLICATE_HANDSHAKE_DROPPED: ${peer.id} already in peersWithInfo " +
+            s"(existing=${old.peer.remoteAddress} inbound=${old.peer.incomingConnection}, " +
+            s"duplicate=${peer.remoteAddress} inbound=${peer.incomingConnection}) — " +
+            s"keeping existing entry, duplicate will be dropped by PeerManagerActor"
         )
-        peerManagerActor ! PeerManagerActor.SendMessage(probe, peer.id)
+        // No update to peersWithInfo, no double-count in metrics
+        context.become(handleMessages(peersWithInfo))
+      } else {
+        peerEventBusActor ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
+        peerEventBusActor ! Subscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peer.id)))
+        // Besu-style eager best-block probe.
+        // ETH/64-/68 STATUS carries `bestHash` but not the peer's best block *number* — only
+        // ETH/61 (long gone) and ETH/69 do. Without the number, fast-sync `PivotBlockSelector`
+        // sees `peer.maxBlockNumber == 0`, picks pivot = 0, and never converges (the loop
+        // we hit on Barad-dûr 2026-04-29). Geth resolves this lazily inside the downloader by
+        // probing the chosen peer's bestHash; besu and nethermind do it eagerly the moment
+        // STATUS completes. We follow the eager pattern: one `GetBlockHeaders(bestHash, 1)`
+        // immediately after handshake, the response routes through `updateMaxBlock` via the
+        // existing `BlockHeadersCode` subscription and populates `PeerInfo.maxBlockNumber`.
+        //
+        // Skip the probe for:
+        //  * ETH/69 — STATUS already carries latestBlock (stuffed into chainWeight.totalDifficulty
+        //    by the handshaker), so maxBlockNumber is set on construction.
+        //  * Peers at genesis (`bestHash == genesisHash`) — they're block 0 by definition;
+        //    `peerHasUpdatedBestBlock` already accepts them as `isAtGenesis`.
+        //
+        // Peers that don't reply to the probe simply stay at maxBlockNumber=0 and get filtered
+        // by `peerHasUpdatedBestBlock` — no disconnect, since Mordor peers can be flaky and
+        // we don't want to throw away connections for one missed reply (Bug 26 lesson).
+        if (peerInfo.remoteStatus.capability != Capability.ETH69 && !peerInfo.isAtGenesis) {
+          val bestHash = peerInfo.remoteStatus.bestHash
+          val probe: MessageSerializable =
+            if (Capability.usesRequestId(peerInfo.remoteStatus.capability))
+              ETH66.GetBlockHeaders(ETH66.nextRequestId, Right(bestHash), 1, 0, reverse = false)
+            else
+              ETH62.GetBlockHeaders(Right(bestHash), 1, 0, reverse = false)
+          log.debug(
+            "BEST_BLOCK_PROBE: peer={} cap={} bestHash={} — asking for header at bestHash to discover block number",
+            peer.id,
+            peerInfo.remoteStatus.capability,
+            ByteStringUtils.hash2string(bestHash)
+          )
+          peerManagerActor ! PeerManagerActor.SendMessage(probe, peer.id)
+        }
+        NetworkMetrics.registerAddHandshakedPeer(peer)
+        context.become(handleMessages(peersWithInfo + (peer.id -> PeerWithInfo(peer, peerInfo))))
       }
 
-      NetworkMetrics.registerAddHandshakedPeer(peer)
-      context.become(handleMessages(peersWithInfo + (peer.id -> PeerWithInfo(peer, peerInfo))))
+    case PeerDisconnected(peerId) if !peersWithInfo.contains(peerId) =>
+      log.debug(
+        "PEER_DISCONNECTED_IGNORED: {} not in peersWithInfo — likely suppressed duplicate or already removed",
+        peerId
+      )
 
     case PeerDisconnected(peerId) if peersWithInfo.contains(peerId) =>
+      val pw = peersWithInfo(peerId)
+      log.info(
+        s"PEER_DISCONNECTED: ${peerId.value} " +
+          s"addr=${pw.peer.remoteAddress} cap=${pw.peerInfo.remoteStatus.capability} " +
+          s"inbound=${pw.peer.incomingConnection}"
+      )
       peerEventBusActor ! Unsubscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peerId)))
       peerEventBusActor ! Unsubscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peerId)))
       NetworkMetrics.registerRemoveHandshakedPeer(peersWithInfo(peerId).peer)

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -258,18 +258,21 @@ class NetworkPeerManagerActor(
             )
           } else {
             val laggingFloor = clHead - LaggingPeerLagThreshold
-            val candidates = peersWithInfo.iterator.flatMap { case (peerId, PeerWithInfo(peer, peerInfo)) =>
-              if (peerInfo.maxBlockNumber > 0 && peerInfo.maxBlockNumber < laggingFloor) {
-                val firstSeen = laggingPeerSince.getOrElseUpdate(peerId, now)
-                val laggedFor = now - firstSeen
-                if (laggedFor >= LaggingPeerEvictAfter.toMillis) Some((peerId, peer, peerInfo, laggedFor))
-                else None
-              } else {
-                // Peer caught up (or never lagged) — reset hysteresis.
-                laggingPeerSince.remove(peerId)
-                None
+            val candidates = peersWithInfo.iterator
+              .flatMap { case (peerId, PeerWithInfo(peer, peerInfo)) =>
+                if (peerInfo.maxBlockNumber > 0 && peerInfo.maxBlockNumber < laggingFloor) {
+                  val firstSeen = laggingPeerSince.getOrElseUpdate(peerId, now)
+                  val laggedFor = now - firstSeen
+                  if (laggedFor >= LaggingPeerEvictAfter.toMillis) Some((peerId, peer, peerInfo, laggedFor))
+                  else None
+                } else {
+                  // Peer caught up (or never lagged) — reset hysteresis.
+                  laggingPeerSince.remove(peerId)
+                  None
+                }
               }
-            }.take(LaggingPeerMaxEvictionsPerCycle).toList
+              .take(LaggingPeerMaxEvictionsPerCycle)
+              .toList
 
             candidates.foreach { case (peerId, peer, peerInfo, laggedFor) =>
               log.info(
@@ -340,8 +343,8 @@ class NetworkPeerManagerActor(
       // Track per-peer block-height signals so the periodic re-probe (RefreshPeerBestBlocks)
       // can skip ETH/69 peers that are actively pushing BlockRangeUpdate.
       message match {
-        case _: ETH69.BlockRangeUpdate | _: ETH62BlockHeaders | _: ETH66BlockHeaders |
-            _: BaseETH6XMessages.NewBlock | _: NewBlockHashes =>
+        case _: ETH69.BlockRangeUpdate | _: ETH62BlockHeaders | _: ETH66BlockHeaders | _: BaseETH6XMessages.NewBlock |
+            _: NewBlockHashes =>
           lastBlockSignalMs(peerId) = System.currentTimeMillis()
         case _ => // not a block-height signal
       }
@@ -1088,67 +1091,59 @@ object NetworkPeerManagerActor {
   /** Self-message that drives the lagging-peer-eviction loop. */
   private[network] case object CheckLaggingPeers
 
-  /** Sent by `SNAPSyncController` whenever it ingests a new CL forkchoice head. Lets the
-    * peer manager evict chronically-lagging peers (more than `LaggingPeerLagThreshold`
-    * blocks below the CL head) so discovery can refill the connection slot with a fresh
-    * peer. Without this signal the actor has no notion of "actual chain tip" — pre-merge
-    * chains never send it and lagging-peer eviction is correctly disabled.
+  /** Sent by `SNAPSyncController` whenever it ingests a new CL forkchoice head. Lets the peer manager evict
+    * chronically-lagging peers (more than `LaggingPeerLagThreshold` blocks below the CL head) so discovery can refill
+    * the connection slot with a fresh peer. Without this signal the actor has no notion of "actual chain tip" —
+    * pre-merge chains never send it and lagging-peer eviction is correctly disabled.
     */
   case class UpdateClHead(blockNumber: BigInt)
 
-  /** How often to send each handshaked peer a one-shot `GetBlockHeaders(bestHash, 1)` to
-    * refresh `PeerInfo.maxBlockNumber`. Defaults to 5 minutes — small fraction of typical
-    * peer connection lifetimes (~30+ min) and small fraction of pivot-refresh cadence.
+  /** How often to send each handshaked peer a one-shot `GetBlockHeaders(bestHash, 1)` to refresh
+    * `PeerInfo.maxBlockNumber`. Defaults to 5 minutes — small fraction of typical peer connection lifetimes (~30+ min)
+    * and small fraction of pivot-refresh cadence.
     */
   private[network] val BestBlockRefreshInterval: FiniteDuration = 5.minutes
 
-  /** Window after which we re-probe an ETH/69 peer even though it has already had a
-    * `BlockRangeUpdate` opportunity. ETH/69 peers that don't actively push BRUs would
-    * otherwise never get re-probed. Half of the re-probe interval so a quiet peer gets
-    * polled within 2.5 minutes regardless of its push cadence.
+  /** Window after which we re-probe an ETH/69 peer even though it has already had a `BlockRangeUpdate` opportunity.
+    * ETH/69 peers that don't actively push BRUs would otherwise never get re-probed. Half of the re-probe interval so a
+    * quiet peer gets polled within 2.5 minutes regardless of its push cadence.
     */
   private[network] val BlockSignalStaleAfter: FiniteDuration = 150.seconds
 
-  /** Lagging-peer eviction parameters. Together: a peer that has been ≥ 4096 blocks
-    * behind the CL head continuously for 10 minutes is disconnected (and IP-blacklisted
-    * for 2 minutes to prevent immediate re-dial). 4096 matches the pivot freshness floor
-    * default (`snap-sync.max-pivot-staleness-blocks`, see #1234) so the same peer that
-    * fails pivot selection is the one we evict.
+  /** Lagging-peer eviction parameters. Together: a peer that has been ≥ 4096 blocks behind the CL head continuously for
+    * 10 minutes is disconnected (and IP-blacklisted for 2 minutes to prevent immediate re-dial). 4096 matches the pivot
+    * freshness floor default (`snap-sync.max-pivot-staleness-blocks`, see #1234) so the same peer that fails pivot
+    * selection is the one we evict.
     *
-    * Per-cycle cap of 5 evictions prevents the pool from collapsing if a sweep catches
-    * many peers at once; the 10-minute hysteresis prevents catching peers that are merely
-    * catching up.
+    * Per-cycle cap of 5 evictions prevents the pool from collapsing if a sweep catches many peers at once; the
+    * 10-minute hysteresis prevents catching peers that are merely catching up.
     */
   private[network] val LaggingPeerCheckInterval: FiniteDuration = 2.minutes
   private[network] val LaggingPeerEvictAfter: FiniteDuration = 10.minutes
   private[network] val LaggingPeerLagThreshold: BigInt = BigInt(4096)
   private[network] val LaggingPeerMaxEvictionsPerCycle: Int = 5
 
-  /** Below this floor of handshaked peers, skip eviction — better to keep a stale peer
-    * than to crater the connection pool on a small network. The floor is intentionally
-    * low (2): on thin testnets like sepolia we often see only 3-5 SNAP-capable peers
-    * total, and the lagging-peer pathology is most acute exactly there. A floor of 5
-    * would skip eviction entirely and the stuck peers would never recycle out. Two is
-    * still enough to prevent a single sweep from leaving us peerless mid-sync; the
-    * per-cycle cap of 5 plus the 10-minute hysteresis provide the heavier-weight
+  /** Below this floor of handshaked peers, skip eviction — better to keep a stale peer than to crater the connection
+    * pool on a small network. The floor is intentionally low (2): on thin testnets like sepolia we often see only 3-5
+    * SNAP-capable peers total, and the lagging-peer pathology is most acute exactly there. A floor of 5 would skip
+    * eviction entirely and the stuck peers would never recycle out. Two is still enough to prevent a single sweep from
+    * leaving us peerless mid-sync; the per-cycle cap of 5 plus the 10-minute hysteresis provide the heavier-weight
     * safeties.
     */
   private[network] val LaggingPeerMinPoolFloor: Int = 2
 
-  /** IP-blacklist applied to a peer that just failed the 10-minute lagging-peer hysteresis.
-    * Distinct from PR #1235's short-tier UselessPeer mapping (also 2 min): that's right for
-    * transient "rejected by remote" signals, but a peer we *chose* to evict for chronic lag
-    * has already proven it can't keep up. 30 minutes is long enough to break the immediate
-    * re-dial cycle (discovery has time to surface a fresh peer), short enough that a peer
-    * whose operator restarts and resyncs can reconnect within the hour.
+  /** IP-blacklist applied to a peer that just failed the 10-minute lagging-peer hysteresis. Distinct from PR #1235's
+    * short-tier UselessPeer mapping (also 2 min): that's right for transient "rejected by remote" signals, but a peer
+    * we *chose* to evict for chronic lag has already proven it can't keep up. 30 minutes is long enough to break the
+    * immediate re-dial cycle (discovery has time to surface a fresh peer), short enough that a peer whose operator
+    * restarts and resyncs can reconnect within the hour.
     */
   private[network] val LaggingPeerBlacklistDuration: FiniteDuration = 30.minutes
 
-  /** Delay before applying the override blacklist. PeerClosedConnection takes a network
-    * round-trip to propagate; we need the override to land AFTER PeerManagerActor processes
-    * that close path (which applies the short-tier 2-min blacklist), otherwise the short
-    * entry overrides ours. 5 seconds is comfortably above typical disconnect propagation
-    * without delaying the eviction so long that the peer could reconnect first.
+  /** Delay before applying the override blacklist. PeerClosedConnection takes a network round-trip to propagate; we
+    * need the override to land AFTER PeerManagerActor processes that close path (which applies the short-tier 2-min
+    * blacklist), otherwise the short entry overrides ours. 5 seconds is comfortably above typical disconnect
+    * propagation without delaying the eviction so long that the peer could reconnect first.
     */
   private[network] val LaggingPeerBlacklistOverrideDelay: FiniteDuration = 5.seconds
 

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -479,15 +479,30 @@ class PeerManagerActor(
       val (terminatedPeersIds, newConnectedPeers) = connectedPeers.removeTerminatedPeer(ref)
       terminatedPeersIds.foreach { peerId =>
         peerStatusCache = peerStatusCache - peerId
-        peerEventBus ! Publish(PeerEvent.PeerDisconnected(peerId))
-        // Reconnect maintained peers — mirrors Besu's checkMaintainedConnectionPeers scheduler.
-        // NB-8: If an inbound connection from this peer is already in newConnectedPeers (AlreadyConnected
-        // race resolved in our favour), skip the reconnect timer — the inbound covers it.
-        // Fix C: 30s → 5s so we close the gap window when inbound reconnects in ~10s.
+        // Pending peers have path-based IDs (non-hex). Only handshaked peers have real hex node
+        // IDs so we can check whether the winner is still alive in connectedPeers.
+        // Gate PeerDisconnected on stillConnected — mirrors Besu's registerDisconnect guard
+        // (peer.getConnection().equals(connection)) and go-ethereum's d.peers[id] tracking:
+        // when a duplicate connection (the loser of a simultaneous-dial collision) terminates,
+        // the winner is still alive in connectedPeers so stillConnected=true. Publishing
+        // PeerDisconnected unconditionally was causing NetworkPeerManagerActor to evict the
+        // live winner entry, creating an infinite reconnect cycle with core-geth.
+        val stillConnected = scala.util.Try(ByteString(Hex.decode(peerId.value)))
+          .map(newConnectedPeers.hasHandshakedWith)
+          .getOrElse(false)
+        if (stillConnected) {
+          log.info(
+            "DUPLICATE_TERMINATED: suppressing PeerDisconnected for {} — winner still connected, loser ref={} dropped",
+            peerId,
+            ref
+          )
+        } else {
+          log.info("GENUINE_DISCONNECT: publishing PeerDisconnected for {} ref={}", peerId, ref)
+          peerEventBus ! Publish(PeerEvent.PeerDisconnected(peerId))
+        }
         maintainedPeersByNodeId.get(peerId.value).foreach { uri =>
-          val nodeIdBytes = ByteString(Hex.decode(peerId.value))
-          if (newConnectedPeers.hasHandshakedWith(nodeIdBytes)) {
-            log.debug("Maintained peer {} already connected via inbound — skipping reconnect", uri)
+          if (stillConnected) {
+            log.debug("Maintained peer {} already connected via winner — skipping reconnect", uri)
           } else {
             log.debug("Maintained peer {} disconnected — scheduling reconnect in 5s", uri)
             context.system.scheduler.scheduleOnce(5.seconds, self, ConnectToPeer(uri))(context.dispatcher)

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -487,7 +487,8 @@ class PeerManagerActor(
         // the winner is still alive in connectedPeers so stillConnected=true. Publishing
         // PeerDisconnected unconditionally was causing NetworkPeerManagerActor to evict the
         // live winner entry, creating an infinite reconnect cycle with core-geth.
-        val stillConnected = scala.util.Try(ByteString(Hex.decode(peerId.value)))
+        val stillConnected = scala.util
+          .Try(ByteString(Hex.decode(peerId.value)))
           .map(newConnectedPeers.hasHandshakedWith)
           .getOrElse(false)
         if (stillConnected) {
@@ -863,8 +864,8 @@ object PeerManagerActor {
     *     `AlreadyConnected`, `ClientQuitting`, `TcpSubsystemError`, `DisconnectRequested`,
     *     `TimeoutOnReceivingAMessage`. Long blacklist on these classes destroys the peer pool during initial sync:
     *     peers reject us as uninteresting (we're at genesis / mid-SNAP-sync), we IP-blacklist them, and by the time
-    *     they'd accept us again we still can't re-dial. Sepolia 2026-05-13: 100+ peers blacklisted within 5 min,
-    *     pool collapsed to one peer; ETC mainnet has the same pattern.
+    *     they'd accept us again we still can't re-dial. Sepolia 2026-05-13: 100+ peers blacklisted within 5 min, pool
+    *     collapsed to one peer; ETC mainnet has the same pattern.
     *   - **Long** for anything else (catch-all).
     *
     * The classification of `UselessPeer` as a SHORT-tier rejection (was: LONG, via the `_` wildcard) is the substantive

--- a/src/main/scala/com/chipprbots/ethereum/network/discovery/DnsDiscovery.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/discovery/DnsDiscovery.scala
@@ -55,10 +55,10 @@ object DnsDiscovery extends Logger {
     * @param domain
     *   DNS domain hosting the ENR tree (e.g., "all.mordor.blockd.info")
     * @param forkIdFilter
-    *   Optional EIP-2124 fork ID filter. When provided, ENR entries carrying an `eth` key
-    *   with an incompatible fork ID are skipped (no outbound dial attempted). ENRs without
-    *   an `eth` key are accepted optimistically — the wire-protocol STATUS handshake makes
-    *   the authoritative check. Mirrors the logic in [[ForkIdTag]] used by discv4 routing.
+    *   Optional EIP-2124 fork ID filter. When provided, ENR entries carrying an `eth` key with an incompatible fork ID
+    *   are skipped (no outbound dial attempted). ENRs without an `eth` key are accepted optimistically — the
+    *   wire-protocol STATUS handshake makes the authoritative check. Mirrors the logic in [[ForkIdTag]] used by discv4
+    *   routing.
     * @return
     *   set of enode:// URL strings, empty on any failure
     */
@@ -157,7 +157,7 @@ object DnsDiscovery extends Logger {
 
       case Some(record) if record.startsWith("enr:") =>
         parseEnrToEnode(record, forkIdFilter) match {
-          case Right(enode)        => enodes += enode
+          case Right(enode) => enodes += enode
           case Left(reason) if reason.startsWith("fork-id mismatch") =>
             skipped += subdomain
           case Left(_) =>
@@ -182,9 +182,8 @@ object DnsDiscovery extends Logger {
     * "enr:" prefix.
     *
     * @param forkIdFilter
-    *   When provided, the ENR's `eth` key (EIP-2124) is validated against the local fork ID.
-    *   Returns `Left("fork-id mismatch: ...")` to signal a clean reject (not a parse failure)
-    *   so callers can log it differently.
+    *   When provided, the ENR's `eth` key (EIP-2124) is validated against the local fork ID. Returns `Left("fork-id
+    *   mismatch: ...")` to signal a clean reject (not a parse failure) so callers can log it differently.
     */
   private[discovery] def parseEnrToEnode(
       enrRecord: String,
@@ -207,8 +206,9 @@ object DnsDiscovery extends Logger {
           forkIdFilter match {
             case Some(filter) =>
               attrs.get("eth").foreach { ethBytes =>
-                val maybeForkId = try Some(decode[ForkId](rawDecode(ethBytes)))
-                catch { case _: Exception => None }
+                val maybeForkId =
+                  try Some(decode[ForkId](rawDecode(ethBytes)))
+                  catch { case _: Exception => None }
                 maybeForkId.foreach { remoteForkId =>
                   if (!filter.accepts(remoteForkId)) {
                     return Left(s"fork-id mismatch: $remoteForkId")
@@ -342,15 +342,13 @@ object DnsDiscovery extends Logger {
         None
     }
 
-  /** ENR fork-ID filter used during DNS discovery to skip nodes on incompatible chains.
-    * Mirrors the logic in [[ForkIdTag]] used by discv4 routing-table filtering, but applies
-    * at DNS-resolution time so the rejected ENRs never become dial candidates in the first
-    * place.
+  /** ENR fork-ID filter used during DNS discovery to skip nodes on incompatible chains. Mirrors the logic in
+    * [[ForkIdTag]] used by discv4 routing-table filtering, but applies at DNS-resolution time so the rejected ENRs
+    * never become dial candidates in the first place.
     *
-    * Without this, sepolia's `all.sepolia.ethdisco.net` (or equivalent) tree could include
-    * mis-tagged entries, and on shared infrastructure we observed peers from BSC (networkId
-    * 56), ETH mainnet (1), Core Chain (1116), etc. burning our outbound dial slots before
-    * the wire-protocol STATUS check could reject them. See PR #1249.
+    * Without this, sepolia's `all.sepolia.ethdisco.net` (or equivalent) tree could include mis-tagged entries, and on
+    * shared infrastructure we observed peers from BSC (networkId 56), ETH mainnet (1), Core Chain (1116), etc. burning
+    * our outbound dial slots before the wire-protocol STATUS check could reject them. See PR #1249.
     */
   class EnrForkIdFilter(
       genesisHash: () => ByteString,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -25,10 +25,10 @@ case class EthNodeStatus64ExchangeState(
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: ETH64.Status =>
     import ForkIdValidator.syncIoLogger
     log.info(
-      "STATUS_EXCHANGE: Received status from peer - protocolVersion={}, networkId={}, totalDifficulty={}, bestHash={}, genesisHash={}, forkId={}",
+      "ETH{}_STATUS: Received - totalDifficulty={}, networkId={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
-      status.networkId,
       status.totalDifficulty,
+      status.networkId,
       status.bestHash,
       status.genesisHash,
       status.forkId
@@ -44,7 +44,8 @@ case class EthNodeStatus64ExchangeState(
     val localForkId = ForkId.create(localGenesisHash, blockchainConfig)(localBestBlock, localBestTimestamp)
 
     log.info(
-      "STATUS_EXCHANGE: Local state - bestBlock={}, genesisHash={}, localForkId={}",
+      "ETH{}_STATUS: Local state - bestBlock={}, genesisHash={}, localForkId={}",
+      status.protocolVersion,
       localBestBlock,
       localGenesisHash,
       localForkId
@@ -52,14 +53,16 @@ case class EthNodeStatus64ExchangeState(
 
     if (status.networkId != peerConfiguration.networkId) {
       log.debug(
-        "STATUS_EXCHANGE: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
+        "ETH{}_STATUS: NetworkId mismatch - local={}, remote={} - disconnecting",
+        status.protocolVersion,
         peerConfiguration.networkId,
         status.networkId
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
       log.debug(
-        "STATUS_EXCHANGE: Peer genesis hash mismatch! Local: {}, Remote: {} - disconnecting peer",
+        "ETH{}_STATUS: Genesis mismatch - local={}, remote={} - disconnecting",
+        status.protocolVersion,
         localGenesisHash,
         status.genesisHash
       )
@@ -76,7 +79,10 @@ case class EthNodeStatus64ExchangeState(
         validationResult match {
           case Connect =>
             log.info(
-              "STATUS_EXCHANGE: ForkId validation passed - accepting peer connection (skipping fork block exchange per EIP-2124)"
+              "ETH{}_STATUS: Accepted - totalDifficulty={}, latestBlock={} (forkId ok)",
+              status.protocolVersion,
+              status.totalDifficulty,
+              status.bestHash
             )
             ConnectedState(
               PeerInfo.withForkAccepted(RemoteStatus(status, negotiatedCapability, supportsSnap, peerCapabilities))
@@ -157,10 +163,10 @@ case class EthNodeStatus64ExchangeState(
     )
 
     log.info(
-      "STATUS_EXCHANGE: Sending status - protocolVersion={}, networkId={}, totalDifficulty={}, bestBlock={}, bestHash={}, genesisHash={}, forkId={}",
+      "ETH{}_STATUS: Sending - totalDifficulty={}, networkId={}, bestBlock={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
-      status.networkId,
       status.totalDifficulty,
+      status.networkId,
       bestBlockNumber,
       bestBlockHeader.hash,
       genesisHash,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -102,10 +102,13 @@ case class EthNodeStatus69ExchangeState(
                     ChainWeight.totalDifficultyOnly(status.latestBlock)
                   }
                 }
-            log.debug(
-              "ETH69_STATUS: chainWeight for peer latestBlockHash {}: {} (localLookup={}, powEstimate={})",
-              status.latestBlockHash,
-              resolvedChainWeight,
+            log.info(
+              "ETH69_STATUS: TD resolved - totalDifficulty={}, latestBlock={}, source={} (localLookup={}, powEstimate={})",
+              resolvedChainWeight.totalDifficulty,
+              status.latestBlock,
+              if (blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined) "DB_LOOKUP"
+              else if (blockchainConfig.terminalTotalDifficulty.isEmpty) "POW_SCALING"
+              else "POS_PROXY",
               blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined,
               blockchainConfig.terminalTotalDifficulty.isEmpty
             )
@@ -121,7 +124,7 @@ case class EthNodeStatus69ExchangeState(
               )
             )
           case other =>
-            log.debug("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
+            log.info("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
             DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
         }
       }).unsafeRunSync()

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrapSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/PivotHeaderBootstrapSpec.scala
@@ -134,13 +134,42 @@ class PivotHeaderBootstrapSpec
     val parent = TestProbe()
     mkBootstrap(peersClient, parent, preferSnapPeers = true)
 
-    // First request uses BestSnapPeer — no SNAP peer available
-    peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
+    // First request uses BestSnapPeerWithMinBlockExcluding(target, {}) — no SNAP peer available at all
+    val req1 = peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
+    req1.peerSelector shouldBe PeersClient.BestSnapPeerWithMinBlockExcluding(targetBlock, Set.empty)
     peersClient.reply(PeersClient.NoSuitablePeer)
 
-    // Fallback request uses BestPeerWithMinBlock — peer responds with the correct header
+    // Fallback request uses BestPeerWithMinBlockExcluding — peer responds with the correct header
     peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
     peersClient.reply(PeersClient.Response(testPeer, ETH66.BlockHeaders(0, Seq(correctHeader))))
+
+    parent.expectMsg(3.seconds, PivotHeaderBootstrap.Completed(targetBlock, correctHeader))
+  }
+
+  it should "exclude a SNAP peer that returned empty headers and fall through to the next peer (Besu ETH69 monopoly fix)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in {
+    val peersClient = TestProbe()
+    val parent = TestProbe()
+    // maxAttempts=3 so budget isn't consumed by the empty-header WaitForPeer path
+    mkBootstrap(peersClient, parent, preferSnapPeers = true, maxAttempts = 3, waitForPeerDelay = 50.millis)
+
+    // Attempt 1: BestSnapPeerWithMinBlockExcluding(target, {}) picks testPeer (e.g. Besu with synthetic high TD).
+    // testPeer returns empty headers → testPeer added to triedPeers, WaitForPeer issued.
+    val req1 = peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
+    req1.peerSelector shouldBe PeersClient.BestSnapPeerWithMinBlockExcluding(targetBlock, Set.empty)
+    peersClient.reply(PeersClient.Response(testPeer, ETH66.BlockHeaders(0, Seq.empty)))
+
+    // WaitForPeer fires → retry: BestSnapPeerWithMinBlockExcluding(target, {testPeer}) → no SNAP peers left → NoSuitablePeer.
+    // flatMap catches NoSuitablePeer and issues fallback: BestPeerWithMinBlockExcluding(target, {testPeer}).
+    val req2 = peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
+    req2.peerSelector shouldBe PeersClient.BestSnapPeerWithMinBlockExcluding(targetBlock, Set(testPeer.id))
+    peersClient.reply(PeersClient.NoSuitablePeer)
+
+    // Fallback: testPeer2 (e.g. core-geth, non-SNAP or lower-TD SNAP) returns the correct header.
+    peersClient.expectMsgType[PeersClient.Request[ETH66.GetBlockHeaders]](3.seconds)
+    peersClient.reply(PeersClient.Response(testPeer2, ETH66.BlockHeaders(0, Seq(correctHeader))))
 
     parent.expectMsg(3.seconds, PivotHeaderBootstrap.Completed(targetBlock, correctHeader))
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrieSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SnapHashTrieSpec.scala
@@ -15,8 +15,8 @@ import com.chipprbots.ethereum.testing.Tags._
 
 /** Tests for [[SnapHashTrie]] — the batching wrapper around [[StackTrie]].
   *
-  * The StackTrie itself is already validated against `MerklePatriciaTrie` in
-  * `StackTrieSpec`. This spec focuses on the wrapper's responsibilities:
+  * The StackTrie itself is already validated against `MerklePatriciaTrie` in `StackTrieSpec`. This spec focuses on the
+  * wrapper's responsibilities:
   *
   *   - emissions flow through the `writeBatch` callback,
   *   - batching honours the size threshold,
@@ -28,17 +28,16 @@ class SnapHashTrieSpec extends AnyFlatSpec with Matchers {
 
   // ---- helpers ----
 
-  private implicit val byteArraySerializer: ByteArraySerializable[Array[Byte]] =
+  implicit private val byteArraySerializer: ByteArraySerializable[Array[Byte]] =
     new ByteArraySerializable[Array[Byte]] {
       def toBytes(input: Array[Byte]): Array[Byte] = input
       def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
     }
 
-  /** A recording `writeBatch` callback. Each invocation appends its batch to
-    * the list of recorded batches, and every (hash, blob) pair is added to a
-    * cumulative map for later inspection.
+  /** A recording `writeBatch` callback. Each invocation appends its batch to the list of recorded batches, and every
+    * (hash, blob) pair is added to a cumulative map for later inspection.
     */
-  private final class RecordingWriter {
+  final private class RecordingWriter {
     val batches: mutable.ArrayBuffer[Seq[(ByteString, Array[Byte])]] = mutable.ArrayBuffer.empty
     val combined: mutable.LinkedHashMap[ByteString, Array[Byte]] = mutable.LinkedHashMap.empty
     var totalBytes: Long = 0L

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -629,30 +629,34 @@ class AccountRangeCoordinatorSpec
   it should "mark a peer SNAPLESS only after EmptyResponseStrikeThreshold consecutive empty-proof responses (#1197)" taggedAs UnitTest in {
     // The previous policy promoted on the FIRST empty-proof response, which on sepolia
     // 2026-05-13 collapsed the snap-peer pool from 3-8 connected → 1 dispatched-to. The
-    // new policy requires 3 consecutive strikes (no intervening successful response) to
-    // mark the peer. Reference clients: geth has no explicit counter (uses throughput
-    // tracking); nethermind uses 5; we pick 3 as a balance.
+    // new policy requires EmptyResponseStrikeThreshold (5) consecutive strikes before
+    // marking the peer. Mirrors Nethermind's threshold; gives peers more rope on small
+    // testnets where a few transient empty responses are expected.
     val stateRoot = kec256(ByteString("trie-async-test-root"))
     val coord = newCoordinator(stateRoot = stateRoot)
     val ua = coord.underlyingActor
     val pendingProbe = TestProbe()
     val peer = PeerTestHelpers.createTestPeer("snapless-peer", pendingProbe.ref)
 
-    // Strikes 1 and 2 — peer still eligible.
+    // Strikes 1-4 — peer still eligible (below threshold of 5).
     seedActiveTask(coord, BigInt(701), peer, rootHash = stateRoot)
     coord ! Messages.TaskFailed(BigInt(701), "Missing proof for empty account range")
     seedActiveTask(coord, BigInt(702), peer, rootHash = stateRoot)
     coord ! Messages.TaskFailed(BigInt(702), "Missing proof for empty account range")
+    seedActiveTask(coord, BigInt(703), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(703), "Missing proof for empty account range")
+    seedActiveTask(coord, BigInt(704), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(704), "Missing proof for empty account range")
     coord ! Messages.GetProgress
     expectMsgType[AccountRangeStats](2.seconds)
 
     ua.statelessPeers should not contain peer.id
     ua.snaplessPeers should not contain peer.id
-    ua.emptyResponseStrikes.get(peer.id) shouldBe Some(2)
+    ua.emptyResponseStrikes.get(peer.id) shouldBe Some(4)
 
-    // Strike 3 — promoted to confirmed snapless + stateless.
-    seedActiveTask(coord, BigInt(703), peer, rootHash = stateRoot)
-    coord ! Messages.TaskFailed(BigInt(703), "Missing proof for empty account range")
+    // Strike 5 — promoted to confirmed snapless + stateless.
+    seedActiveTask(coord, BigInt(705), peer, rootHash = stateRoot)
+    coord ! Messages.TaskFailed(BigInt(705), "Missing proof for empty account range")
     coord ! Messages.GetProgress
     expectMsgType[AccountRangeStats](2.seconds)
 
@@ -696,7 +700,12 @@ class AccountRangeCoordinatorSpec
     system.stop(coord)
   }
 
-  it should "leave snaplessPeers untouched on PivotRefreshed (#1197)" taggedAs UnitTest in {
+  it should "clear snaplessPeers on PivotRefreshed (#1255)" taggedAs UnitTest in {
+    // PR #1255 changed the policy: snaplessPeers is now cleared on PivotRefreshed.
+    // Previous PR #1197 preserved it across pivots, but that stalled small peer pools
+    // (sepolia 2026-05-14: eligible=0 when all peers accumulated snapless across pivots).
+    // Clearing gives peers a fresh slate at the new root at the cost of ~5 re-test
+    // dispatches per peer per pivot; acceptable vs indefinite stall.
     val coord = newCoordinator()
     val ua = coord.underlyingActor
     val pendingProbe = TestProbe()
@@ -710,11 +719,9 @@ class AccountRangeCoordinatorSpec
     coord ! Messages.GetProgress
     expectMsgType[AccountRangeStats](2.seconds)
 
-    // statelessPeers is for stale-root failures and clears on PivotRefreshed.
+    // Both statelessPeers and snaplessPeers are cleared on PivotRefreshed (#1255).
     ua.statelessPeers shouldBe empty
-    // snaplessPeers tracks structural snapshot absence; survives so the peer doesn't
-    // go back into dispatch and immediately re-classify.
-    ua.snaplessPeers should contain(peer.id)
+    ua.snaplessPeers shouldBe empty
 
     system.stop(coord)
   }
@@ -885,7 +892,7 @@ class AccountRangeCoordinatorSpec
     val peerA = PeerTestHelpers.createTestPeer("dedup-peer-A", peerAProbe.ref)
     val peerB = PeerTestHelpers.createTestPeer("dedup-peer-B", peerBProbe.ref)
 
-    val coordinator = system.actorOf(
+    val coordinator = TestActorRef[AccountRangeCoordinator](
       AccountRangeCoordinator.props(
         stateRoot = stateRoot,
         networkPeerManager = networkPeerManager.ref,
@@ -896,6 +903,7 @@ class AccountRangeCoordinatorSpec
         initialMaxInFlightPerPeer = 1
       )
     )
+    val ua = coordinator.underlyingActor
 
     coordinator ! Messages.StartAccountRangeSync(stateRoot)
     coordinator ! Messages.PeerAvailable(peerA)
@@ -904,7 +912,12 @@ class AccountRangeCoordinatorSpec
     val reqId1 = sendMsg1.message.asInstanceOf[GetAccountRangeEnc].underlyingMsg.requestId
     val workerRef = networkPeerManager.lastSender
 
-    // peerA returns empty proof → marked stateless → all known peers stateless → PivotStateUnservable
+    // Pre-seed 4 strikes so the next TaskFailed is strike 5 (EmptyResponseStrikeThreshold).
+    // Avoids repeating 4 full request cycles; the coordinator still processes the final
+    // strike normally, marks peerA stateless/snapless, and sends PivotStateUnservable.
+    ua.emptyResponseStrikes(peerA.id) = 4
+
+    // peerA returns empty proof → strike 5 of 5 → marked stateless → PivotStateUnservable
     coordinator ! Messages.TaskFailed(reqId1, "Missing proof for empty account range")
     snapSyncController.expectMsgType[SNAPSyncController.PivotStateUnservable](2.seconds)
 
@@ -967,7 +980,7 @@ class AccountRangeCoordinatorSpec
     val peerProbe = TestProbe()
     val peer = PeerTestHelpers.createTestPeer("pivot-clear-peer", peerProbe.ref)
 
-    val coordinator = system.actorOf(
+    val coordinator = TestActorRef[AccountRangeCoordinator](
       AccountRangeCoordinator.props(
         stateRoot = rootR1,
         networkPeerManager = networkPeerManager.ref,
@@ -978,6 +991,7 @@ class AccountRangeCoordinatorSpec
         initialMaxInFlightPerPeer = 1
       )
     )
+    val ua = coordinator.underlyingActor
 
     coordinator ! Messages.StartAccountRangeSync(rootR1)
     coordinator ! Messages.PeerAvailable(peer)
@@ -986,7 +1000,10 @@ class AccountRangeCoordinatorSpec
     val reqId1 = sendMsg1.message.asInstanceOf[GetAccountRangeEnc].underlyingMsg.requestId
     val workerRef = networkPeerManager.lastSender
 
-    // Peer becomes stateless → coordinator requests pivot refresh from controller
+    // Pre-seed 4 strikes; the next TaskFailed is strike 5 (EmptyResponseStrikeThreshold).
+    ua.emptyResponseStrikes(peer.id) = 4
+
+    // Peer becomes stateless (strike 5 of 5) → coordinator requests pivot refresh
     coordinator ! Messages.TaskFailed(reqId1, "Missing proof for empty account range")
     snapSyncController.expectMsgType[SNAPSyncController.PivotStateUnservable](2.seconds)
 
@@ -1178,8 +1195,8 @@ class AccountRangeCoordinatorSpec
     (ref, storage)
   }
 
-  /** Build a strict-ascending sequence of (accountHash, Account) pairs starting
-    * at `task.next` so insertion order satisfies the StackTrie's sort invariant.
+  /** Build a strict-ascending sequence of (accountHash, Account) pairs starting at `task.next` so insertion order
+    * satisfies the StackTrie's sort invariant.
     */
   private def stackTrieFixtureAccounts(
       task: AccountTask,
@@ -1206,7 +1223,9 @@ class AccountRangeCoordinatorSpec
       rootHash = root
     )
     val accounts = stackTrieFixtureAccounts(task, 8)
-    val nodesBefore = storage.synchronized { /* peek size via decode-then-count */ 0 }
+    val nodesBefore = storage.synchronized { /* peek size via decode-then-count */
+      0
+    }
 
     // Drive the chunk-store path directly. isTaskRangeComplete = false (more responses
     // could follow for this range), so the per-task SnapHashTrie should remain in the map.
@@ -1214,7 +1233,7 @@ class AccountRangeCoordinatorSpec
     coord ! Messages.GetProgress
     expectMsgType[AccountRangeStats](2.seconds)
 
-    ua.taskStackTries should contain key task.last
+    (ua.taskStackTries should contain).key(task.last)
     // No global stateTrie touch — its root should still be the empty-root hash.
     ByteString(ua.getStateRoot.toArray) shouldEqual ByteString(MerklePatriciaTrie.EmptyRootHash)
     val _ = nodesBefore // suppress unused warning while the storage poking is a no-op

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -846,11 +846,7 @@ class StorageRangeCoordinatorSpec
     snapSyncController.expectMsg(3.seconds, SNAPSyncController.StorageBackpressureChanged(paused = true))
 
     // Drain the underlying queue to 2 entries (≤ low-water mark) and trigger a check.
-    val underlying = coordinator.underlyingActor
-    val pendingQueue =
-      classOf[StorageRangeCoordinator].getDeclaredFields.find(_.getName == "tasks").get
-    pendingQueue.setAccessible(true)
-    val q = pendingQueue.get(underlying).asInstanceOf[mutable.Queue[StorageTask]]
+    val q = coordinator.underlyingActor.tasks
     while (q.size > 2) q.dequeue()
 
     coordinator ! Messages.StorageCheckCompletion

--- a/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/engine/EngineApiServiceSpec.scala
@@ -552,13 +552,11 @@ class EngineApiServiceSpec extends AnyWordSpec with Matchers {
 
     /** Regression for cold-start sync bootstrap (post-merge chains).
       *
-      * Pre-fix, `engine_forkchoiceUpdated` short-circuited to SYNCING for unknown heads
-      * **without** invoking `forkChoiceManager.applyForkChoiceState`, which is the only path
-      * that publishes `BeaconHead` to the ForkChoiceManager listener. SyncController's
-      * BeaconHead handler is the trigger that forwards `CLPivotHint` to SNAPSyncController;
-      * without it, SNAP sync sat in `[CL-PIVOT] waiting for engine_forkchoiceUpdated` forever
-      * — fukuii accepted every newPayload as `ACCEPTED (parent unknown)` but never started
-      * actually syncing.
+      * Pre-fix, `engine_forkchoiceUpdated` short-circuited to SYNCING for unknown heads **without** invoking
+      * `forkChoiceManager.applyForkChoiceState`, which is the only path that publishes `BeaconHead` to the
+      * ForkChoiceManager listener. SyncController's BeaconHead handler is the trigger that forwards `CLPivotHint` to
+      * SNAPSyncController; without it, SNAP sync sat in `[CL-PIVOT] waiting for engine_forkchoiceUpdated` forever —
+      * fukuii accepted every newPayload as `ACCEPTED (parent unknown)` but never started actually syncing.
       */
     "publish BeaconHead to ForkChoiceManager listener even when the head is unknown (SYNCING short-circuit)"
       .taggedAs(UnitTest) in new EngineApiTestSetup {

--- a/src/test/scala/com/chipprbots/ethereum/mpt/StackTrieSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/mpt/StackTrieSpec.scala
@@ -14,18 +14,16 @@ import com.chipprbots.ethereum.testing.Tags._
 
 /** Tests for [[StackTrie]].
   *
-  * The bedrock invariant: for any set of (key, value) pairs inserted in
-  * strictly-ascending hex-nibble order, `StackTrie.hash()` must produce the
-  * same 32-byte root hash as inserting the same pairs into a
-  * [[MerklePatriciaTrie]] backed by an arbitrary `MptStorage`. The
-  * MerklePatriciaTrie is the reference oracle.
+  * The bedrock invariant: for any set of (key, value) pairs inserted in strictly-ascending hex-nibble order,
+  * `StackTrie.hash()` must produce the same 32-byte root hash as inserting the same pairs into a [[MerklePatriciaTrie]]
+  * backed by an arbitrary `MptStorage`. The MerklePatriciaTrie is the reference oracle.
   */
 class StackTrieSpec extends AnyFlatSpec with Matchers {
 
   // ---- helpers ----
 
   /** Implicit serializer used by the reference MerklePatriciaTrie tests below. */
-  private implicit val byteArraySerializer: com.chipprbots.ethereum.mpt.ByteArraySerializable[Array[Byte]] =
+  implicit private val byteArraySerializer: com.chipprbots.ethereum.mpt.ByteArraySerializable[Array[Byte]] =
     new com.chipprbots.ethereum.mpt.ByteArraySerializable[Array[Byte]] {
       def toBytes(input: Array[Byte]): Array[Byte] = input
       def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
@@ -51,10 +49,10 @@ class StackTrieSpec extends AnyFlatSpec with Matchers {
       pairs: Seq[(Array[Byte], Array[Byte])]
   ): (Array[Byte], Map[ByteString, Array[Byte]]) = {
     val collected = mutable.LinkedHashMap.empty[ByteString, Array[Byte]]
-    val st = new StackTrie((_, hash, blob) => {
+    val st = new StackTrie((_, hash, blob) =>
       // Defensive: callers must deep-copy if they want to retain the blob.
       collected += hash -> blob.clone()
-    })
+    )
     pairs.foreach { case (k, v) => st.update(k, v) }
     val root = st.hash().toArray
     (root, collected.toMap)

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/DnsDiscoveryEnrSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/DnsDiscoveryEnrSpec.scala
@@ -81,7 +81,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
 
   "parseEnrToEnode" should "parse a minimal valid IPv4 ENR" taggedAs UnitTest in {
     val enr = buildEnr()
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     result.get should startWith("enode://")
     result.get should include("@127.0.0.1:8080")
@@ -94,7 +94,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       tcp = Array(0x76.toByte, 0x51.toByte), // 30289
       udp = Some(Array(0x76.toByte, 0x52.toByte)) // 30290
     )
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     result.get should include(":30289?discport=30290")
   }
@@ -102,7 +102,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
   it should "not include ?discport when udp equals tcp" taggedAs UnitTest in {
     val port = Array(0x76.toByte, 0x51.toByte) // 30289
     val enr = buildEnr(tcp = port, udp = Some(port))
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     (result.get should not).include("discport")
   }
@@ -119,7 +119,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None when tcp field is missing" taggedAs UnitTest in {
@@ -134,7 +134,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None when secp256k1 field is missing" taggedAs UnitTest in {
@@ -149,36 +149,36 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None when tcp port is 0" taggedAs UnitTest in {
     val enr = buildEnr(tcp = Array(0, 0).map(_.toByte))
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None for a 32-byte (uncompressed-coordinate-only) public key" taggedAs UnitTest in {
     val shortKey = validCompressedKey.drop(1) // drop prefix → 32 bytes
     val enr = buildEnr(pubkey = shortKey)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None for a 65-byte (uncompressed) public key" taggedAs UnitTest in {
     val expandedKey = Array(0x04.toByte) ++ Array.fill(64)(0x00.toByte)
     val enr = buildEnr(pubkey = expandedKey)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None for invalid base64 ENR" taggedAs UnitTest in {
-    DnsDiscovery.parseEnrToEnode("enr:invalid-base64!!!") shouldBe None
+    DnsDiscovery.parseEnrToEnode("enr:invalid-base64!!!").toOption shouldBe None
   }
 
   it should "return None for empty ENR payload" taggedAs UnitTest in {
-    DnsDiscovery.parseEnrToEnode("enr:") shouldBe None
+    DnsDiscovery.parseEnrToEnode("enr:").toOption shouldBe None
   }
 
   it should "return None for truncated (non-list) RLP" taggedAs UnitTest in {
-    DnsDiscovery.parseEnrToEnode("enr:AAAA") shouldBe None
+    DnsDiscovery.parseEnrToEnode("enr:AAAA").toOption shouldBe None
   }
 
   it should "return None for RLP list with fewer than 4 items" taggedAs UnitTest in {
@@ -189,12 +189,12 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "return None for 3-byte ip (wrong length)" taggedAs UnitTest in {
     val enr = buildEnr(ip = Array(127, 0, 0).map(_.toByte))
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe None
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe None
   }
 
   it should "handle URL-safe base64 characters (- and _) correctly" taggedAs UnitTest in {
@@ -204,7 +204,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
     val withPadding = enr.replace('-', '+').replace('_', '/')
     // Standard base64 should not parse (DnsDiscovery expects URL-safe)
     // but our ENR should still parse fine (the URL-safe one)
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe defined
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe defined
   }
 
   it should "ignore unknown key-value fields in ENR" taggedAs UnitTest in {
@@ -214,7 +214,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
         RLPValue(Array(0xde.toByte, 0xad.toByte, 0xbe.toByte, 0xef.toByte))
       )
     )
-    DnsDiscovery.parseEnrToEnode(enr) shouldBe defined
+    DnsDiscovery.parseEnrToEnode(enr).toOption shouldBe defined
   }
 
   it should "prefer IPv4 over IPv6 when both present" taggedAs UnitTest in {
@@ -237,7 +237,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     result.get should include("10.0.0.1") // IPv4 wins
     (result.get should not).include("::1")
@@ -259,7 +259,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
       )
     )
     val enr = "enr:" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     // Java's InetAddress.getHostAddress() returns "0:0:0:0:0:0:0:1" or "::1" depending on JVM version.
     // Both are valid representations of the loopback IPv6 address; check for the bracket notation only.
@@ -270,7 +270,7 @@ class DnsDiscoveryEnrSpec extends AnyFlatSpec with Matchers {
 
   it should "produce a 128-hex-char node ID (64 uncompressed pubkey bytes)" taggedAs UnitTest in {
     val enr = buildEnr()
-    val result = DnsDiscovery.parseEnrToEnode(enr)
+    val result = DnsDiscovery.parseEnrToEnode(enr).toOption
     result shouldBe defined
     val nodeId = result.get.stripPrefix("enode://").takeWhile(_ != '@')
     (nodeId should have).length(128)

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/DnsDiscoverySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/DnsDiscoverySpec.scala
@@ -69,16 +69,16 @@ class DnsDiscoverySpec extends AnyFlatSpec with Matchers {
 
   "parseEnrToEnode" should "return None for invalid base64 ENR" taggedAs UnitTest in {
     val result = DnsDiscovery.parseEnrToEnode("enr:invalid-base64!!!")
-    result shouldBe None
+    result.toOption shouldBe None
   }
 
   it should "return None for empty ENR payload" taggedAs UnitTest in {
     val result = DnsDiscovery.parseEnrToEnode("enr:")
-    result shouldBe None
+    result.toOption shouldBe None
   }
 
   it should "return None for truncated ENR" taggedAs UnitTest in {
     val result = DnsDiscovery.parseEnrToEnode("enr:AAAA")
-    result shouldBe None
+    result.toOption shouldBe None
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/network/discovery/codecs/ENRCodecsSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/discovery/codecs/ENRCodecsSpec.scala
@@ -90,25 +90,16 @@ class ENRCodecsSpec extends AnyFlatSpec with Matchers {
         // Ignoring the signature, taking items up to where "tcp" would be.
         compare(list.items.drop(1).take(7), enrRLP.items.drop(1).take(7))
 
-        // The example is encoded differently because it uses the minimum
-        // length for the port, whereas the one in Scalanet just converts the
-        // Int to BigEndian bytes and includes them in the attributes.
-        //
-        // This should be fine from signature checking perspective as
-        // that is still carried out on the byte content of the attribute map,
-        // and nodes should be able to deserialize what we send.
-        //
-        // We might have problems if someone sends 0 for port as that
-        // would serialize to an empty byte array in RLP. But we can't
-        // address such nodes anyway, so it should be enough to check
-        // that we can deal with the shorter bytes (done below in a test).
+        // Ports are now encoded with RLP minimal length (no leading zero bytes),
+        // matching the ENR reference example and standard RLP encoding rules.
+        // tcp=0 → empty byte array; udp=30303 → 2-byte minimal (0x765f).
         compare(
           list.items.drop(8),
           RLPList(
             "tcp",
-            hex"00000000",
+            hex"",
             "udp",
-            hex"0000765f"
+            hex"765f"
           ).items
         )
 

--- a/src/test/scala/com/chipprbots/ethereum/nodebuilder/PortForwardingBuilderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/nodebuilder/PortForwardingBuilderSpec.scala
@@ -252,6 +252,7 @@ class PortForwardingBuilderSpec extends AnyFlatSpec with Matchers with BeforeAnd
       simulateDelay: Long = 0
   ) extends PortForwardingBuilder
       with DiscoveryConfigBuilder
+      with ActorSystemBuilder
       with com.chipprbots.ethereum.TestInstanceConfigProvider {
 
     implicit override lazy val ioRuntime: IORuntime = IORuntime.global

--- a/src/test/scala/com/chipprbots/ethereum/utils/VersionInfoSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/utils/VersionInfoSpec.scala
@@ -10,7 +10,7 @@ class VersionInfoSpec extends AnyFlatSpec with Matchers {
   it should "match ethstats expected structure and preserve major and minor Java version" taggedAs (UnitTest) in {
     (VersionInfo
       .nodeName() should fullyMatch)
-      .regex("""fukuii/v\d(\.\d+)*(-SNAPSHOT)?-[a-z0-9]{7}/[^/]+-[^/]+/[^/]+-.[^/]+-java-\d+\.\d+[._0-9]*""")
+      .regex("""fukuii/v\d(\.\d+)*(-SNAPSHOT)?-[a-z0-9]{7,}/[^/]+-[^/]+/[^/]+-.[^/]+-java-\d+\.\d+[._0-9]*""")
   }
 
   it should "augment the name with an identity" taggedAs (UnitTest) in {


### PR DESCRIPTION
## Summary

Four fixes across SNAP sync and P2P: the most impactful is a PoW chain TD bug that caused Fukuii to advertise a false chain-tip weight, winning every peer comparison and preventing best-peer selection from working correctly. The other three address a silent chain-weight corruption in backfill, several P2P lifecycle correctness gaps, and ETH68/69 status log visibility.

Also included: test suite alignment with upstream PRs #1237, #1255, and #1249 that left seven specs failing to compile or assert correctly after those merges.

---

## PoW pivot chain weight — wrong TD advertised in ETH STATUS

`updateBestBlockForPivot()` computed pivot TD as `header.difficulty × pivotBlockNumber` — a linear estimate using the current block's single-block difficulty rather than the real cumulative sum. On ETC at block 24.5M (current difficulty ≈ 2.64×10¹⁵) this produces ~64T vs the real wire TD ~24T.

Consequence: after bootstrapping the pivot, `ChainWeightStorage` for the pivot hash held the inflated estimate. Every subsequent ETH/68 STATUS message advertised TD ~64T, making Fukuii appear as the best chain tip to every connected peer. Peers respond by requesting headers from Fukuii rather than serving them, and `BestPeer` selection on the Fukuii side never picks any peer (all remote TDs appear lower).

Fix: at `BootstrapComplete` time, take the highest `chainWeight.totalDifficulty` from connected SNAP-capable, fork-accepted peers — the real ETH/68 wire value — and pass it to `updateBestBlockForPivot` via a new `peerTD: Option[BigInt] = None` parameter. The linear estimate is retained as a fallback for genesis and pivot-refresh paths where no peer TD is available yet.

---

## Backfill abort on missing parent chain weight

`ChainDownloader` used `getOrElse(ChainWeight.totalDifficultyOnly(0))` when a backfill batch's parent chain weight was absent from storage — silently writing TD=0 for that block and corrupting all subsequent accumulations in the batch. This caused the chain to appear to start from zero difficulty at the missing block, which in turn caused ETH STATUS to advertise TD values that reset mid-chain.

Fix: replace the silent fallback with an explicit abort. The cursor stays at the last committed safe position and the next request retries cleanly from there.

---

## P2P lifecycle — correctness fixes

| Fix | Root cause | File |
|-----|-----------|------|
| `BlockchainHostActor` silent drop on unknown start | `GetBlockHeaders` with an unknown start hash was silently dropped rather than returning an empty list. core-geth times out the pending request and drops the peer. | `BlockchainHostActor.scala` |
| Remove PRIO-8 future-block disconnect | Blocks within 100 of chain head are valid; reference clients do not disconnect here. The check was producing false positives near the pivot. | `NetworkPeerManagerActor.scala` |
| `ConnectToPeer` forwarding | `SNAPSyncController` needs to initiate outbound connections; without forwarding the message was silently dropped. | `NetworkPeerManagerActor.scala` |
| Duplicate handshake guard | When both outbound and inbound handshakes complete for the same peer, the second `HandshakedPeer` was processed normally — adding the peer twice, doubling metrics, and causing a double-disconnect on teardown. | `NetworkPeerManagerActor.scala` |
| `PeerDisconnected` `stillConnected` gate | `PeerManagerActor` did not check whether the disconnecting peer was still in the live-connection map before processing. A duplicate disconnect could evict the live-winner entry and trigger an infinite reconnect cycle. Mirrors Besu's `registerDisconnect` guard. | `PeerManagerActor.scala` |
| `BestSnapPeerWithMinBlockExcluding` in `PeersClient` | Pre-filters SNAP peers by `maxBlockNumber ≥ target` before TD comparison. `PivotHeaderBootstrap` uses it so a peer behind the pivot target cannot be selected regardless of synthetic TD. | `PeersClient.scala`, `PivotHeaderBootstrap.scala` |

---

## ETH68/69 status log visibility

ETH/68 and ETH/69 STATUS log lines were missing consistent prefixes and the TD field was logged at DEBUG, making it invisible in production INFO logs. Added `ETH{version}_STATUS:` prefixes to all STATUS Received/Sending/Accepted/Rejected lines and promoted TD resolution logging in ETH/69 to INFO with a `source=DB_LOOKUP|POW_SCALING|POS_PROXY` label.

---

## Upstream test suite alignment

Seven test failures left by upstream PRs #1237, #1255, and #1249:

| Spec | Upstream PR | Issue |
|------|------------|-------|
| `AccountRangeCoordinatorSpec` — strike threshold | #1237 | Comment said "3 consecutive strikes" but `EmptyResponseStrikeThreshold=5` in source. Updated test to send 5 strikes. |
| `AccountRangeCoordinatorSpec` — `PivotRefreshed` snapless | #1255 | Test expected `snaplessPeers` to survive `PivotRefreshed` (#1197 policy) but #1255 now clears it. Renamed test and inverted assertion. |
| `AccountRangeCoordinatorSpec` — two `PivotStateUnservable` timeouts | #1237 | Tests assumed 1-shot stateless promotion. Converted to `TestActorRef` and pre-seeded `emptyResponseStrikes=4` before the triggering `TaskFailed`. |
| `StorageRangeCoordinatorSpec` — back-pressure reflection | #1233 | Reflection lookup for field `"tasks"` failed because Scala 3 mangles private field names. Changed field to `private[actors]`; replaced reflection with direct access. |
| `DnsDiscovery{,Enr}Spec` + `PortForwardingBuilderSpec` | #1249 | `parseEnrToEnode` return type changed `Option[String]→Either[String,String]`; added `.toOption` at call sites. `DiscoveryConfigBuilder` self type gained `ActorSystemBuilder`; added mixin to `TestPortForwardingBuilder`. |
| `ENRCodecsSpec` | upstream codec | Port RLP encoding switched to minimal length. Updated expected bytes from 4-byte padded to minimal. |
| `VersionInfoSpec` | commit hash length | `nodeName` commit hash can be 8 chars; regex required exactly `{7}`. Widened to `{7,}`. |

---

## Test plan

- [x] `sbt test` — 3,157 tests, 0 failures
- [x] `scalafmtAll` — 17 files reformatted, no functional changes
- [x] Live sepolia run confirmed TD fix: `estimatedTD=24237106011164622751844 (source=PEER_WIRE_TD)` in STATUS logs
- [ ] Full ETC mainnet SNAP sync to head

🤖 Generated with [Claude Code](https://claude.com/claude-code)