### PR TITLE
feat(checkpoint): import bootstrap from .checkpoint archive (PR-1/3)

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -322,4 +322,14 @@ sync {
   # Maximum time to wait for the CL to push a head on post-merge chains before falling
   # back to peer-best-by-block-number. Only consulted when `engine-api-required = false`.
   cl-wait-timeout = 5.minutes
+
+  # Checkpoint sync: when set to a non-empty path AND the database is fresh (best-block == 0)
+  # AND SNAP is not already marked done, the node will import the referenced `.checkpoint`
+  # archive at startup instead of running SNAP. Use this on post-merge chains (sepolia,
+  # ETH mainnet) where SNAP-serving peers are scarce. A trailing `.gz` is decoded transparently.
+  # Empty string = disabled (the default).
+  #
+  # See `src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointArchive.scala`
+  # for the on-disk format.
+  checkpoint-sync-file = ""
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointArchive.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointArchive.scala
@@ -1,0 +1,251 @@
+package com.chipprbots.ethereum.blockchain.checkpoint
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.zip.CRC32
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.domain.BlockHeader
+import com.chipprbots.ethereum.domain.BlockHeaderImplicits.BlockHeaderByteArrayDec
+import com.chipprbots.ethereum.domain.BlockHeaderImplicits.BlockHeaderEnc
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.utils.ByteUtils
+
+/** Binary file format for an exported chain state — used by `CheckpointImporter` to bootstrap a fresh datadir at a known
+  * block without running SNAP. PR-2 adds an HTTP downloader; PR-3 adds the producer (`fukuii checkpoint export`).
+  *
+  * Layout:
+  * {{{
+  *   magic            : 4 bytes  (0xC4 0xC4 0xC4 0xC4)
+  *   version          : 1 byte   (currently 0x01)
+  *   chainId          : 8 bytes  (big-endian uint64)
+  *   blockHeaderLen   : 4 bytes  (big-endian uint32)
+  *   blockHeader      : <len> bytes (RLP(BlockHeader))
+  *   chainWeightLen   : 4 bytes  (big-endian uint32)
+  *   chainWeight      : <len> bytes (big-endian unsigned integer — totalDifficulty)
+  *   entries          : zero or more {tag:1, hashLen:1, hash:hashLen, dataLen:4, data:dataLen}
+  *                      tag=0x01 = trie node, tag=0x02 = bytecode
+  *   end-of-stream    : 1 byte (tag=0x00; no hash/data follow)
+  *   crc32            : 4 bytes  (CRC32 over every preceding byte; excludes this field itself)
+  * }}}
+  *
+  * Gzip wrapping is the operator's choice — pass a `GZIPInputStream`/`GZIPOutputStream` to `Reader`/`Writer` if desired.
+  * The codec itself doesn't compress, so a `.checkpoint.gz` is just gzip-of-uncompressed-checkpoint.
+  */
+object CheckpointArchive {
+
+  val Magic: Array[Byte] = Array(0xc4.toByte, 0xc4.toByte, 0xc4.toByte, 0xc4.toByte)
+  val Version: Byte = 1
+
+  val TagEnd: Byte = 0x00
+  val TagNode: Byte = 0x01
+  val TagBytecode: Byte = 0x02
+
+  private val MaxHeaderBytes: Int = 64 * 1024 // real headers are well under 1 KiB
+  private val MaxWeightBytes: Int = 64 // 256-bit unsigned int + slack
+  private val MaxEntryBytes: Int = 1 << 26 // 64 MiB — bytecodes capped at 24 KiB on-chain, trie nodes << 1 KiB
+
+  /** Header section of an archive — small, always loaded into memory. */
+  final case class Header(
+      chainId: Long,
+      blockHeader: BlockHeader,
+      chainWeight: ChainWeight
+  )
+
+  sealed trait Entry extends Product with Serializable
+  final case class NodeEntry(hash: ByteString, rlp: Array[Byte]) extends Entry
+  final case class BytecodeEntry(hash: ByteString, code: Array[Byte]) extends Entry
+  case object EndOfStream extends Entry
+
+  sealed trait DecodeError extends Product with Serializable
+  case object BadMagic extends DecodeError
+  final case class UnsupportedVersion(found: Byte) extends DecodeError
+  case object BadCrc extends DecodeError
+  final case class Truncated(where: String) extends DecodeError
+  final case class Malformed(reason: String) extends DecodeError
+
+  /** Stream-oriented writer. Caller owns the OutputStream and is responsible for closing it. */
+  final class Writer(rawOut: OutputStream) {
+    private val crc = new CRC32
+    // 64 KiB buffer matches geth's snapshot.diskLayer writeBufferSize — friendly to RocksDB downstream.
+    private val out = new BufferedOutputStream(rawOut, 65536)
+    private var headerWritten = false
+    private var finished = false
+
+    private def w(buf: Array[Byte]): Unit = {
+      out.write(buf)
+      crc.update(buf)
+    }
+    private def wb(b: Int): Unit = {
+      out.write(b)
+      crc.update(b)
+    }
+    private def wInt(v: Int): Unit = {
+      wb((v >>> 24) & 0xff)
+      wb((v >>> 16) & 0xff)
+      wb((v >>> 8) & 0xff)
+      wb(v & 0xff)
+    }
+    private def wLong(v: Long): Unit = {
+      wInt(((v >>> 32) & 0xffffffffL).toInt)
+      wInt((v & 0xffffffffL).toInt)
+    }
+
+    def writeHeader(h: Header): Unit = {
+      require(!headerWritten, "header already written")
+      headerWritten = true
+      w(Magic)
+      wb(Version.toInt & 0xff)
+      wLong(h.chainId)
+      val hdrBytes = h.blockHeader.toBytes
+      wInt(hdrBytes.length)
+      w(hdrBytes)
+      val weightBytes = ByteUtils.bigIntToUnsignedByteArray(h.chainWeight.totalDifficulty)
+      wInt(weightBytes.length)
+      w(weightBytes)
+    }
+
+    def writeNode(hash: ByteString, rlpBytes: Array[Byte]): Unit = {
+      require(headerWritten && !finished, "writer state invalid")
+      require(hash.length > 0 && hash.length <= 255, s"hash length out of range: ${hash.length}")
+      wb(TagNode.toInt & 0xff)
+      wb(hash.length & 0xff)
+      w(hash.toArray)
+      wInt(rlpBytes.length)
+      w(rlpBytes)
+    }
+
+    def writeBytecode(hash: ByteString, code: Array[Byte]): Unit = {
+      require(headerWritten && !finished, "writer state invalid")
+      require(hash.length > 0 && hash.length <= 255, s"hash length out of range: ${hash.length}")
+      wb(TagBytecode.toInt & 0xff)
+      wb(hash.length & 0xff)
+      w(hash.toArray)
+      wInt(code.length)
+      w(code)
+    }
+
+    /** Write the end-of-stream marker followed by the CRC32 trailer. The trailer is the only data that bypasses the
+      * running checksum.
+      */
+    def finish(): Unit = {
+      require(headerWritten && !finished, "writer state invalid")
+      finished = true
+      wb(TagEnd.toInt & 0xff)
+      val crcValue = crc.getValue.toInt
+      out.write((crcValue >>> 24) & 0xff)
+      out.write((crcValue >>> 16) & 0xff)
+      out.write((crcValue >>> 8) & 0xff)
+      out.write(crcValue & 0xff)
+      out.flush()
+    }
+  }
+
+  /** Stream-oriented reader. Caller owns the InputStream. */
+  final class Reader(rawIn: InputStream) {
+    private val crc = new CRC32
+    private val in = new BufferedInputStream(rawIn, 65536)
+    private var headerRead = false
+    private var endSeen = false
+
+    private def rb(): Int = {
+      val b = in.read()
+      if (b < 0) throw new EOFException("unexpected EOF")
+      crc.update(b)
+      b
+    }
+    private def r(n: Int): Array[Byte] = {
+      val buf = new Array[Byte](n)
+      var off = 0
+      while (off < n) {
+        val got = in.read(buf, off, n - off)
+        if (got < 0) throw new EOFException("unexpected EOF")
+        off += got
+      }
+      crc.update(buf)
+      buf
+    }
+    private def rInt(): Int =
+      ((rb() & 0xff) << 24) | ((rb() & 0xff) << 16) | ((rb() & 0xff) << 8) | (rb() & 0xff)
+    private def rLong(): Long =
+      ((rInt().toLong & 0xffffffffL) << 32) | (rInt().toLong & 0xffffffffL)
+
+    def readHeader(): Either[DecodeError, Header] =
+      try {
+        require(!headerRead, "header already read")
+        headerRead = true
+        val magicBuf = r(4)
+        if (!magicBuf.sameElements(Magic)) Left(BadMagic)
+        else {
+          val version = rb().toByte
+          if (version != Version) Left(UnsupportedVersion(version))
+          else {
+            val chainId = rLong()
+            val hdrLen = rInt()
+            if (hdrLen < 0 || hdrLen > MaxHeaderBytes) Left(Malformed(s"hdrLen=$hdrLen"))
+            else {
+              val hdrBytes = r(hdrLen)
+              val header =
+                try hdrBytes.toBlockHeader
+                catch { case e: Exception => return Left(Malformed(s"blockHeader: ${e.getMessage}")) }
+              val weightLen = rInt()
+              if (weightLen < 0 || weightLen > MaxWeightBytes) Left(Malformed(s"weightLen=$weightLen"))
+              else {
+                val weightBytes = r(weightLen)
+                val totalDifficulty = if (weightBytes.isEmpty) BigInt(0) else BigInt(1, weightBytes)
+                Right(Header(chainId, header, ChainWeight(totalDifficulty)))
+              }
+            }
+          }
+        }
+      } catch {
+        case _: EOFException => Left(Truncated("header-section"))
+      }
+
+    def nextEntry(): Either[DecodeError, Entry] =
+      try {
+        require(headerRead, "must read header first")
+        require(!endSeen, "stream already ended")
+        val tag = rb().toByte
+        tag match {
+          case TagEnd =>
+            endSeen = true
+            Right(EndOfStream)
+          case TagNode | TagBytecode =>
+            val hashLen = rb() & 0xff
+            if (hashLen == 0 || hashLen > 64) Left(Malformed(s"hashLen=$hashLen"))
+            else {
+              val hash = r(hashLen)
+              val dataLen = rInt()
+              if (dataLen < 0 || dataLen > MaxEntryBytes) Left(Malformed(s"dataLen=$dataLen"))
+              else {
+                val data = r(dataLen)
+                if (tag == TagNode) Right(NodeEntry(ByteString(hash), data))
+                else Right(BytecodeEntry(ByteString(hash), data))
+              }
+            }
+          case other => Left(Malformed(s"unknown tag=0x${(other.toInt & 0xff).toHexString}"))
+        }
+      } catch {
+        case _: EOFException => Left(Truncated("entry"))
+      }
+
+    /** Read the 4-byte CRC trailer and compare against the running checksum. Bytes read here are not folded into the
+      * checksum. Must be called only after `nextEntry()` returned `EndOfStream`.
+      */
+    def verifyCrc(): Either[DecodeError, Unit] = {
+      require(endSeen, "must reach end-of-stream first")
+      val expected = crc.getValue.toInt
+      val b0 = in.read(); val b1 = in.read(); val b2 = in.read(); val b3 = in.read()
+      if ((b0 | b1 | b2 | b3) < 0) Left(Truncated("crc-trailer"))
+      else {
+        val found = ((b0 & 0xff) << 24) | ((b1 & 0xff) << 16) | ((b2 & 0xff) << 8) | (b3 & 0xff)
+        if (found == expected) Right(()) else Left(BadCrc)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporter.scala
@@ -1,0 +1,190 @@
+package com.chipprbots.ethereum.blockchain.checkpoint
+
+import java.io.FileInputStream
+import java.io.InputStream
+import java.nio.file.Path
+import java.util.zip.GZIPInputStream
+
+import org.apache.pekko.util.ByteString
+
+import org.slf4j.LoggerFactory
+
+import com.chipprbots.ethereum.db.storage.AppStateStorage
+import com.chipprbots.ethereum.db.storage.EvmCodeStorage
+import com.chipprbots.ethereum.db.storage.StateStorage
+import com.chipprbots.ethereum.domain.BlockchainWriter
+import com.chipprbots.ethereum.domain.appstate.BlockInfo
+
+/** Bootstrap a fresh datadir from a `.checkpoint` archive (see [[CheckpointArchive]] for the on-disk format).
+  *
+  * After a successful import the database holds:
+  *   - the checkpoint block's header (no body — the archive intentionally omits transactions/receipts)
+  *   - all state trie nodes reachable from the header's stateRoot
+  *   - all referenced contract bytecodes
+  *   - the chain weight (totalDifficulty) at the checkpoint block
+  *   - AppState pointers: bestBlock = checkpoint block; snap/bytecode/storage recovery all marked done so the SNAP
+  *     coordinator is never spawned on the next start
+  *
+  * Regular sync resumes from `checkpoint.number + 1` driven by the Engine API (post-merge chains).
+  */
+final class CheckpointImporter(
+    blockchainWriter: BlockchainWriter,
+    stateStorage: StateStorage,
+    evmCodeStorage: EvmCodeStorage,
+    appStateStorage: AppStateStorage
+) {
+  import CheckpointImporter._
+  private val log = LoggerFactory.getLogger(getClass)
+
+  /** Import from a file. A `.gz` suffix is decoded transparently. */
+  def importFromFile(path: Path, expectedChainId: Option[Long] = None): Either[ImportError, ImportResult] = {
+    val raw = new FileInputStream(path.toFile)
+    try {
+      val in: InputStream =
+        if (path.toString.endsWith(".gz")) new GZIPInputStream(raw, 65536)
+        else raw
+      try importFromStream(in, expectedChainId)
+      finally in.close()
+    } finally raw.close()
+  }
+
+  def importFromStream(in: InputStream, expectedChainId: Option[Long]): Either[ImportError, ImportResult] = {
+    val reader = new CheckpointArchive.Reader(in)
+    reader.readHeader() match {
+      case Left(err) => Left(BadFormat(err))
+      case Right(h) =>
+        expectedChainId match {
+          case Some(want) if want != h.chainId => Left(ChainIdMismatch(want, h.chainId))
+          case _                               => streamEntries(reader, h)
+        }
+    }
+  }
+
+  private def streamEntries(
+      reader: CheckpointArchive.Reader,
+      header: CheckpointArchive.Header
+  ): Either[ImportError, ImportResult] = {
+    val startMs = System.currentTimeMillis()
+    val blockNum = header.blockHeader.number
+    val blockHash = header.blockHeader.hash
+    // Pass the checkpoint block number so ReferenceCountNodeStorage tags nodes at the
+    // imported block height — matches what SNAP healing does at pivot, so post-import
+    // pruning math stays sane.
+    val mpt = stateStorage.getBackingStorage(blockNum)
+    val nodeBuf = scala.collection.mutable.ArrayBuffer.empty[(ByteString, Array[Byte])]
+    val codeBuf = scala.collection.mutable.ArrayBuffer.empty[(ByteString, Array[Byte])]
+    var totalNodes = 0L
+    var totalBytecodes = 0L
+    var nodeBytes = 0L
+    var codeBytes = 0L
+
+    log.info(
+      "[CHECKPOINT IMPORT] starting block={} chainId={} stateRoot={}",
+      blockNum,
+      header.chainId,
+      hex8(header.blockHeader.stateRoot)
+    )
+
+    def flushNodes(): Unit =
+      if (nodeBuf.nonEmpty) {
+        mpt.storeRawNodes(nodeBuf.toSeq)
+        nodeBuf.clear()
+      }
+
+    def flushCodes(): Unit =
+      if (codeBuf.nonEmpty) {
+        var batch = evmCodeStorage.emptyBatchUpdate
+        var i = 0
+        while (i < codeBuf.length) {
+          val (h, code) = codeBuf(i)
+          batch = batch.and(evmCodeStorage.put(h, ByteString(code)))
+          i += 1
+        }
+        batch.commit()
+        codeBuf.clear()
+      }
+
+    var done = false
+    while (!done) {
+      reader.nextEntry() match {
+        case Left(err) =>
+          flushNodes(); flushCodes()
+          return Left(BadFormat(err))
+        case Right(CheckpointArchive.NodeEntry(hash, rlpBytes)) =>
+          nodeBuf += ((hash, rlpBytes))
+          totalNodes += 1
+          nodeBytes += rlpBytes.length
+          if (nodeBuf.size >= NodeBatchSize) {
+            flushNodes()
+            if (totalNodes % LogInterval == 0)
+              log.info(
+                "[CHECKPOINT IMPORT] nodes={} ({} MiB), bytecodes={}",
+                totalNodes,
+                nodeBytes / (1024 * 1024),
+                totalBytecodes
+              )
+          }
+        case Right(CheckpointArchive.BytecodeEntry(hash, code)) =>
+          codeBuf += ((hash, code))
+          totalBytecodes += 1
+          codeBytes += code.length
+          if (codeBuf.size >= BytecodeBatchSize) flushCodes()
+        case Right(CheckpointArchive.EndOfStream) =>
+          flushNodes(); flushCodes()
+          done = true
+      }
+    }
+
+    reader.verifyCrc() match {
+      case Left(err) => return Left(BadFormat(err))
+      case Right(_)  => ()
+    }
+
+    // Header, chain weight, best-block pointer, and the done-markers all committed in a
+    // single atomic batch — partial state here would be worse than no state at all.
+    blockchainWriter
+      .storeBlockHeader(header.blockHeader)
+      .and(blockchainWriter.storeChainWeight(blockHash, header.chainWeight))
+      .and(appStateStorage.putBestBlockInfo(BlockInfo(blockHash, blockNum)))
+      .and(appStateStorage.snapSyncDone())
+      .and(appStateStorage.bytecodeRecoveryDone())
+      .and(appStateStorage.storageRecoveryDone())
+      .commit()
+
+    val elapsed = System.currentTimeMillis() - startMs
+    log.info(
+      "[CHECKPOINT IMPORT] complete: block={} nodes={} ({} MiB) bytecodes={} ({} MiB) elapsed={}s. " +
+        "RegularSync will resume from {}.",
+      blockNum,
+      totalNodes,
+      nodeBytes / (1024 * 1024),
+      totalBytecodes,
+      codeBytes / (1024 * 1024),
+      elapsed / 1000,
+      blockNum + 1
+    )
+
+    Right(ImportResult(blockNum, totalNodes, totalBytecodes, elapsed))
+  }
+
+  private def hex8(bs: ByteString): String =
+    bs.take(8).toArray.map("%02x".format(_)).mkString
+}
+
+object CheckpointImporter {
+  // 10k * ~500 B per node ≈ 5 MiB per write batch — comfortable for RocksDB's default write buffer.
+  val NodeBatchSize: Int = 10000
+  val BytecodeBatchSize: Int = 1000
+  val LogInterval: Long = 100000L
+
+  sealed trait ImportError extends Product with Serializable
+  final case class BadFormat(err: CheckpointArchive.DecodeError) extends ImportError
+  final case class ChainIdMismatch(expected: Long, found: Long) extends ImportError
+
+  final case class ImportResult(
+      blockNumber: BigInt,
+      nodesImported: Long,
+      bytecodesImported: Long,
+      elapsedMs: Long
+  )
+}

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -710,6 +710,43 @@ class SyncController(
       }
     }
 
+    // Checkpoint sync (PR-1): import a `.checkpoint` archive on first boot if configured.
+    // Only runs on a fresh datadir (best-block == 0 and SNAP not already done). On success
+    // the import marks SNAP/bytecode/storage as done; the match below routes to RegularSync.
+    // On failure we log and fall through to the normal SNAP/Fast/Regular path so the node
+    // still has a way forward.
+    syncConfig.checkpointSyncFile.foreach { path =>
+      if (appStateStorage.getBestBlockNumber() == 0 && !appStateStorage.isSnapSyncDone()) {
+        val chainIdBig = configBuilder.blockchainConfig.chainId
+        log.info("[CHECKPOINT IMPORT] starting from {} (chainId={})", path, chainIdBig)
+        val importer = new com.chipprbots.ethereum.blockchain.checkpoint.CheckpointImporter(
+          blockchainWriter,
+          stateStorage,
+          evmCodeStorage,
+          appStateStorage
+        )
+        importer.importFromFile(path, Some(chainIdBig.toLong)) match {
+          case Right(result) =>
+            log.info(
+              "[CHECKPOINT IMPORT] success: block={} nodes={} bytecodes={} elapsed={}s",
+              result.blockNumber,
+              result.nodesImported,
+              result.bytecodesImported,
+              result.elapsedMs / 1000
+            )
+          case Left(err) =>
+            log.error("[CHECKPOINT IMPORT] failed: {} — falling through to SNAP/Fast/Regular", err)
+        }
+      } else {
+        log.info(
+          "Checkpoint sync configured (file={}) but DB already initialized (bestBlock={}, snapDone={}); skipping import",
+          path,
+          appStateStorage.getBestBlockNumber(),
+          appStateStorage.isSnapSyncDone()
+        )
+      }
+    }
+
     // If fast sync is desired but the circuit-breaker is open, start regular sync for now and
     // schedule an in-process restart of fast sync once the cool-off expires.
     if (doFastSync && appStateStorage.isFastSyncCoolingOff(nowMillis)) {

--- a/src/main/scala/com/chipprbots/ethereum/utils/Config.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/Config.scala
@@ -86,7 +86,13 @@ object Config extends InstanceConfig(ConfigFactory.load().getConfig("fukuii"), "
       // `clPivotHint` is never set, and the existing TD-based path runs unchanged.
       // Closes #1207.
       engineApiRequired: Boolean,
-      clWaitTimeout: FiniteDuration
+      clWaitTimeout: FiniteDuration,
+      // Checkpoint sync (PR-1): bootstrap a fresh datadir by importing a pre-built `.checkpoint`
+      // archive instead of running SNAP. The file is read once at startup when best-block == 0 and
+      // SNAP isn't already done; on success, RegularSync resumes from `checkpoint.number + 1`.
+      // Both fields default to None (disabled). Optional `.gz` decompression is automatic.
+      // PR-2 adds `checkpointSyncUrl` as the HTTP fetch source for the same import path.
+      checkpointSyncFile: Option[java.nio.file.Path]
   )
 
   object SyncConfig {
@@ -186,7 +192,12 @@ object Config extends InstanceConfig(ConfigFactory.load().getConfig("fukuii"), "
               case _ => None
             }
           }
-        } else Seq.empty
+        } else Seq.empty,
+        checkpointSyncFile =
+          if (syncConfig.hasPath("checkpoint-sync-file")) {
+            val raw = syncConfig.getString("checkpoint-sync-file").trim
+            if (raw.isEmpty) None else Some(java.nio.file.Paths.get(raw))
+          } else None
       )
     }
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointArchiveSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointArchiveSpec.scala
@@ -1,0 +1,146 @@
+package com.chipprbots.ethereum.blockchain.checkpoint
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.testing.Tags.UnitTest
+
+class CheckpointArchiveSpec extends AnyWordSpec with Matchers with EitherValues {
+
+  private def sample: CheckpointArchive.Header =
+    CheckpointArchive.Header(
+      chainId = 61L,
+      blockHeader = Fixtures.Blocks.Block3125369.header,
+      chainWeight = ChainWeight(BigInt("123456789012345678901234567890"))
+    )
+
+  private def hex(s: String): ByteString = ByteString(s.getBytes("UTF-8"))
+
+  private def encodeFull(
+      header: CheckpointArchive.Header,
+      nodes: Seq[(ByteString, Array[Byte])],
+      bytecodes: Seq[(ByteString, Array[Byte])]
+  ): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    val w = new CheckpointArchive.Writer(baos)
+    w.writeHeader(header)
+    nodes.foreach { case (h, n) => w.writeNode(h, n) }
+    bytecodes.foreach { case (h, b) => w.writeBytecode(h, b) }
+    w.finish()
+    baos.toByteArray
+  }
+
+  "CheckpointArchive" should {
+
+    "round-trip a header with no entries" taggedAs UnitTest in {
+      val bytes = encodeFull(sample, Nil, Nil)
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      val decoded = r.readHeader().value
+      decoded.chainId shouldBe sample.chainId
+      decoded.blockHeader shouldBe sample.blockHeader
+      decoded.chainWeight shouldBe sample.chainWeight
+      r.nextEntry().value shouldBe CheckpointArchive.EndOfStream
+      r.verifyCrc() shouldBe Right(())
+    }
+
+    "round-trip a mix of nodes and bytecodes preserving order and bytes" taggedAs UnitTest in {
+      val n1 = (hex("nodeHash1____________________________"), "nodeA".getBytes("UTF-8"))
+      val n2 = (hex("nodeHash2____________________________"), Array.fill[Byte](2048)(0x42))
+      val b1 = (hex("codeHash1____________________________"), "bytecodeBlob".getBytes("UTF-8"))
+      val bytes = encodeFull(sample, Seq(n1, n2), Seq(b1))
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      r.readHeader().value
+
+      r.nextEntry().value match {
+        case CheckpointArchive.NodeEntry(h, b) =>
+          h shouldBe n1._1
+          b.toSeq shouldBe n1._2.toSeq
+        case other => fail(s"expected NodeEntry, got $other")
+      }
+      r.nextEntry().value match {
+        case CheckpointArchive.NodeEntry(h, b) =>
+          h shouldBe n2._1
+          b.toSeq shouldBe n2._2.toSeq
+        case other => fail(s"expected NodeEntry, got $other")
+      }
+      r.nextEntry().value match {
+        case CheckpointArchive.BytecodeEntry(h, b) =>
+          h shouldBe b1._1
+          b.toSeq shouldBe b1._2.toSeq
+        case other => fail(s"expected BytecodeEntry, got $other")
+      }
+      r.nextEntry().value shouldBe CheckpointArchive.EndOfStream
+      r.verifyCrc() shouldBe Right(())
+    }
+
+    "reject a bad magic value" taggedAs UnitTest in {
+      val bytes = encodeFull(sample, Nil, Nil)
+      bytes(0) = 0x00 // corrupt magic
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      r.readHeader() shouldBe Left(CheckpointArchive.BadMagic)
+    }
+
+    "reject an unsupported version" taggedAs UnitTest in {
+      val bytes = encodeFull(sample, Nil, Nil)
+      bytes(4) = 99 // version byte right after 4-byte magic
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      r.readHeader() shouldBe Left(CheckpointArchive.UnsupportedVersion(99.toByte))
+    }
+
+    "reject a corrupted entry payload (CRC mismatch)" taggedAs UnitTest in {
+      val n1 = (hex("nodeHash1____________________________"), Array.fill[Byte](64)(0xaa.toByte))
+      val bytes = encodeFull(sample, Seq(n1), Nil)
+      // Flip a byte in the node payload, after the header. The header section ends at a
+      // non-trivial offset; just find a byte well past the prefix and toggle it.
+      bytes(bytes.length - 16) = (bytes(bytes.length - 16) ^ 0xff).toByte
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      r.readHeader().value
+      // Drain entries — corruption may surface as a decode error or pass through to CRC check
+      var sawEnd = false
+      var decodeErr: Option[CheckpointArchive.DecodeError] = None
+      while (!sawEnd && decodeErr.isEmpty) {
+        r.nextEntry() match {
+          case Left(e)                                   => decodeErr = Some(e)
+          case Right(CheckpointArchive.EndOfStream)      => sawEnd = true
+          case Right(_)                                  => ()
+        }
+      }
+      if (sawEnd) {
+        r.verifyCrc() shouldBe Left(CheckpointArchive.BadCrc)
+      } else {
+        decodeErr should not be empty
+      }
+    }
+
+    "reject a corrupted CRC trailer" taggedAs UnitTest in {
+      val bytes = encodeFull(sample, Nil, Nil)
+      bytes(bytes.length - 1) = (bytes(bytes.length - 1) ^ 0xff).toByte
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(bytes))
+      r.readHeader().value
+      r.nextEntry().value shouldBe CheckpointArchive.EndOfStream
+      r.verifyCrc() shouldBe Left(CheckpointArchive.BadCrc)
+    }
+
+    "reject a truncated stream" taggedAs UnitTest in {
+      val bytes = encodeFull(sample, Nil, Nil)
+      val short = bytes.take(bytes.length / 2)
+      val r = new CheckpointArchive.Reader(new ByteArrayInputStream(short))
+      // Header may decode if first half is enough, else fails. Either way no successful CRC.
+      r.readHeader() match {
+        case Right(_) =>
+          // Header was short enough to fit; nextEntry should fail
+          r.nextEntry().isLeft shouldBe true
+        case Left(_) => succeed
+      }
+    }
+  }
+
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporterSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporterSpec.scala
@@ -1,0 +1,145 @@
+package com.chipprbots.ethereum.blockchain.checkpoint
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.EitherValues
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.domain.BlockchainWriter
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.testing.Tags.UnitTest
+
+class CheckpointImporterSpec extends AnyWordSpec with Matchers with EitherValues with OptionValues {
+
+  "CheckpointImporter" should {
+
+    "import a single-account archive end-to-end" taggedAs UnitTest in new Setup {
+      val header = checkpointHeader
+      val nodes = Seq(
+        (hash("rootNode"), Array.fill[Byte](48)(0xab.toByte)),
+        (hash("storageRoot"), Array.fill[Byte](64)(0xcd.toByte))
+      )
+      val bytecodes = Seq(
+        (hash("code1"), "bytecode1".getBytes("UTF-8")),
+        (hash("code2"), "bytecode2".getBytes("UTF-8"))
+      )
+      val bytes = encodeArchive(header, nodes, bytecodes)
+
+      val importer = new CheckpointImporter(
+        writer,
+        freshStorage.storages.stateStorage,
+        freshStorage.storages.evmCodeStorage,
+        freshStorage.storages.appStateStorage
+      )
+      val result =
+        importer.importFromStream(new ByteArrayInputStream(bytes), Some(checkpointChainId)).value
+
+      result.blockNumber shouldBe header.blockHeader.number
+      result.nodesImported shouldBe nodes.length
+      result.bytecodesImported shouldBe bytecodes.length
+
+      // Best-block pointers
+      val best = freshStorage.storages.appStateStorage.getBestBlockInfo()
+      best.number shouldBe header.blockHeader.number
+      best.hash shouldBe header.blockHeader.hash
+
+      // Phase flags set so SNAP isn't re-entered
+      freshStorage.storages.appStateStorage.isSnapSyncDone() shouldBe true
+      freshStorage.storages.appStateStorage.isBytecodeRecoveryDone() shouldBe true
+      freshStorage.storages.appStateStorage.isStorageRecoveryDone() shouldBe true
+
+      // Header retrievable
+      blockReader.getBlockHeaderByNumber(header.blockHeader.number).value shouldBe header.blockHeader
+
+      // SerializingMptStorage.get decodes RLP, so it can't verify our random-byte fixtures.
+      // Verify via the underlying NodeStorage directly.
+      nodes.foreach { case (h, rlp) =>
+        freshStorage.storages.nodeStorage.get(h).map(_.toSeq) shouldBe Some(rlp.toSeq)
+      }
+
+      // Bytecodes retrievable
+      bytecodes.foreach { case (h, code) =>
+        freshStorage.storages.evmCodeStorage.get(h).map(_.toArray.toSeq) shouldBe Some(code.toSeq)
+      }
+    }
+
+    "reject an archive with a mismatched chainId" taggedAs UnitTest in new Setup {
+      val header = checkpointHeader
+      val bytes = encodeArchive(header, Nil, Nil)
+
+      val importer = new CheckpointImporter(
+        writer,
+        freshStorage.storages.stateStorage,
+        freshStorage.storages.evmCodeStorage,
+        freshStorage.storages.appStateStorage
+      )
+      // expect chainId 9999; archive declares 61
+      val result = importer.importFromStream(new ByteArrayInputStream(bytes), Some(9999L))
+      result shouldBe Left(CheckpointImporter.ChainIdMismatch(9999L, checkpointChainId))
+
+      // Best block must remain at 0 on rejection
+      freshStorage.storages.appStateStorage.getBestBlockNumber() shouldBe 0
+      freshStorage.storages.appStateStorage.isSnapSyncDone() shouldBe false
+    }
+
+    "reject a corrupted archive without committing state" taggedAs UnitTest in new Setup {
+      val header = checkpointHeader
+      val nodes = Seq((hash("n1"), Array.fill[Byte](32)(0x11)))
+      val bytes = encodeArchive(header, nodes, Nil)
+      // Flip the CRC trailer to ensure a CRC error
+      bytes(bytes.length - 1) = (bytes(bytes.length - 1) ^ 0xff).toByte
+
+      val importer = new CheckpointImporter(
+        writer,
+        freshStorage.storages.stateStorage,
+        freshStorage.storages.evmCodeStorage,
+        freshStorage.storages.appStateStorage
+      )
+      val result = importer.importFromStream(new ByteArrayInputStream(bytes), None)
+      result.isLeft shouldBe true
+
+      // Phase flags must remain unset on failure (we want the next start to be able to retry)
+      freshStorage.storages.appStateStorage.isSnapSyncDone() shouldBe false
+      freshStorage.storages.appStateStorage.getBestBlockNumber() shouldBe 0
+    }
+  }
+
+  private trait Setup extends EphemBlockchainTestSetup {
+    val checkpointChainId: Long = 61L
+    val freshStorage = getNewStorages
+    val writer: BlockchainWriter = BlockchainWriter(freshStorage.storages)
+    val blockReader =
+      com.chipprbots.ethereum.domain.BlockchainReader(freshStorage.storages)
+
+    val checkpointHeader: CheckpointArchive.Header =
+      CheckpointArchive.Header(
+        chainId = checkpointChainId,
+        blockHeader = Fixtures.Blocks.Block3125369.header,
+        chainWeight = ChainWeight(BigInt("987654321"))
+      )
+
+    def hash(s: String): ByteString = ByteString(s.padTo(32, '_').getBytes("UTF-8"))
+
+    def encodeArchive(
+        header: CheckpointArchive.Header,
+        nodes: Seq[(ByteString, Array[Byte])],
+        bytecodes: Seq[(ByteString, Array[Byte])]
+    ): Array[Byte] = {
+      val baos = new ByteArrayOutputStream()
+      val w = new CheckpointArchive.Writer(baos)
+      w.writeHeader(header)
+      nodes.foreach { case (h, n) => w.writeNode(h, n) }
+      bytecodes.foreach { case (h, b) => w.writeBytecode(h, b) }
+      w.finish()
+      baos.toByteArray
+    }
+
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/TestSyncConfig.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/TestSyncConfig.scala
@@ -57,7 +57,8 @@ trait TestSyncConfig extends SyncConfigBuilder with com.chipprbots.ethereum.Test
     useBootstrapCheckpoints = false,
     bootstrapCheckpoints = Seq.empty,
     engineApiRequired = false,
-    clWaitTimeout = 5.minutes
+    clWaitTimeout = 5.minutes,
+    checkpointSyncFile = None
   )
 
   override lazy val syncConfig: SyncConfig = defaultSyncConfig


### PR DESCRIPTION
## Summary

- New self-delimiting binary archive format (`.checkpoint`) — magic + version + chainId + RLP(BlockHeader) + ChainWeight + stream of (node|bytecode) entries + CRC32 trailer. `.gz` is decoded transparently.
- New `CheckpointImporter` writes header + raw MPT nodes (via `MptStorage.storeRawNodes` at the checkpoint block number so ref-counting is sane) + bytecodes + chain weight + best-block info, then marks SNAP/bytecode/storage recovery as done in a single atomic commit so the existing `SyncController` match routes to `startRegularSync()`.
- Wired into `SyncController.start()` before the SNAP/Fast switch. Runs only when `checkpoint-sync-file` is set AND `best-block == 0` AND `!isSnapSyncDone`. On failure we log and fall through to the normal SNAP/Fast/Regular path.
- Config: new `checkpoint-sync-file` key in `sync.conf` (defaults to empty/disabled); `SyncConfig.checkpointSyncFile: Option[Path]`.

Unblocks post-merge testnets (sepolia, ETH mainnet) where SNAP-serving peers are scarce — once any operator has a checkpoint archive they can hand it to a fresh fukuii and skip SNAP entirely. PR-2 adds HTTP auto-fetch; PR-3 adds the exporter.

This is the **mechanism**. The first archive (where it comes from) is operational follow-up — see plan section _Bootstrap question_.

## Test plan

- [x] sbt testOnly Checkpoint specs — 10/10 pass
- [x] Full sbt compile clean (no warnings introduced)
- [x] Full sbt Test/compile clean
- [ ] Integration: produce a fixture checkpoint, place at configured path, boot fukuii from clean datadir, verify SNAP is skipped and RegularSync starts — deferred to PR-2/3 once we can produce real archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)