### PR TITLE
fix(checkpoint): unwrap reference-counted nodes during export (Bug 33)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointCli.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointCli.scala
@@ -87,7 +87,7 @@ object CheckpointCli extends Logger {
     }
     val chainId = builder.blockchainConfig.chainId
     val exporter = new CheckpointExporter(
-      storages.nodeStorage,
+      storages.stateStorage,
       storages.evmCodeStorage,
       reader,
       chainId

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointCli.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointCli.scala
@@ -92,7 +92,16 @@ object CheckpointCli extends Logger {
       reader,
       chainId
     )
-    exporter.exportArchive(blockNumber, args.output, gzip = args.gzip)
+    // Auto-append .gz when --gzip is set and the operator didn't already include it.
+    // The CheckpointImporter also magic-byte-sniffs, but the conventional extension
+    // makes the file self-describing for ops tooling.
+    val output =
+      if (args.gzip && !args.output.toString.endsWith(".gz"))
+        args.output.resolveSibling(args.output.getFileName.toString + ".gz")
+      else args.output
+    if (output != args.output)
+      log.info(s"--gzip set, appending .gz: writing to $output")
+    exporter.exportArchive(blockNumber, output, gzip = args.gzip)
   }
 
   /** Minimal cake mix for read-only state access. No actors, no validators, no sync — just storage and BlockchainConfig.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporter.scala
@@ -10,13 +10,15 @@ import org.apache.pekko.util.ByteString
 import org.slf4j.LoggerFactory
 
 import com.chipprbots.ethereum.db.storage.EvmCodeStorage
-import com.chipprbots.ethereum.db.storage.NodeStorage
+import com.chipprbots.ethereum.db.storage.MptStorage
+import com.chipprbots.ethereum.db.storage.StateStorage
 import com.chipprbots.ethereum.domain.Account
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.mpt.BranchNode
 import com.chipprbots.ethereum.mpt.ExtensionNode
 import com.chipprbots.ethereum.mpt.HashNode
 import com.chipprbots.ethereum.mpt.LeafNode
+import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.mpt.MptTraversals
 import com.chipprbots.ethereum.mpt.NullNode
@@ -37,7 +39,7 @@ import com.chipprbots.ethereum.mpt.NullNode
   * size).
   */
 final class CheckpointExporter(
-    nodeStorage: NodeStorage,
+    stateStorage: StateStorage,
     evmCodeStorage: EvmCodeStorage,
     blockchainReader: BlockchainReader,
     chainId: BigInt
@@ -56,6 +58,10 @@ final class CheckpointExporter(
     }
 
     val start = System.currentTimeMillis()
+    // Read through the StateStorage abstraction so per-chain wrapping (e.g.,
+    // ReferenceCountNodeStorage on BasicPruning chains) is unwrapped automatically.
+    // Using raw NodeStorage would surface ref-counted bytes here — see Bug 33.
+    val mpt = stateStorage.getReadOnlyStorage
     val raw = new FileOutputStream(output.toFile)
     val out =
       if (gzip) new GZIPOutputStream(new BufferedOutputStream(raw, 65536), 65536)
@@ -87,6 +93,7 @@ final class CheckpointExporter(
       walkTrie(
         rootHash = header.stateRoot,
         isMainTrie = true,
+        mpt = mpt,
         writer = writer,
         visited = visited,
         codeHashes = codeHashes,
@@ -113,6 +120,7 @@ final class CheckpointExporter(
           walkTrie(
             rootHash = sroot,
             isMainTrie = false,
+            mpt = mpt,
             writer = writer,
             visited = visited,
             codeHashes = codeHashes,
@@ -169,6 +177,7 @@ final class CheckpointExporter(
   private def walkTrie(
       rootHash: ByteString,
       isMainTrie: Boolean,
+      mpt: MptStorage,
       writer: CheckpointArchive.Writer,
       visited: java.util.HashSet[ByteString],
       codeHashes: java.util.HashSet[ByteString],
@@ -180,14 +189,16 @@ final class CheckpointExporter(
     while (stack.nonEmpty) {
       val h = stack.pop()
       if (visited.add(h)) {
-        nodeStorage.get(h) match {
-          case None      => return Left(MissingTrieNode(h, isMainTrie))
-          case Some(rlp) =>
-            writer.writeNode(h, rlp)
-            onNodeEmitted()
-            val decoded = MptTraversals.decodeNode(rlp)
-            collectChildren(decoded, isMainTrie, stack, codeHashes, storageRoots)
-        }
+        val decoded =
+          try mpt.get(h.toArray)
+          catch { case _: MerklePatriciaTrie.MissingNodeException => return Left(MissingTrieNode(h, isMainTrie)) }
+        // The MptStorage path decodes once and caches the raw RLP it parsed. Prefer that —
+        // it round-trips byte-identically and matches the content-addressed hash. Fall back
+        // to re-encoding for the rare case a node lacks a cached RLP (in-memory test fixtures).
+        val rlp = decoded.cachedRlpEncoded.getOrElse(MptTraversals.encodeNode(decoded))
+        writer.writeNode(h, rlp)
+        onNodeEmitted()
+        collectChildren(decoded, isMainTrie, stack, codeHashes, storageRoots)
       }
     }
     Right(())

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporter.scala
@@ -89,6 +89,16 @@ final class CheckpointExporter(
         output
       )
 
+      def abortLog(err: ExportError): Unit =
+        log.error(
+          "[CHECKPOINT EXPORT] ABORTED after nodes={} bytecodes={}: {}. " +
+            "Archive at {} is incomplete (missing end-of-stream marker + CRC) and unusable.",
+          nodesEmitted,
+          bytecodesEmitted,
+          err,
+          output
+        )
+
       // Phase 1: account trie
       walkTrie(
         rootHash = header.stateRoot,
@@ -109,8 +119,10 @@ final class CheckpointExporter(
             )
         }
       ) match {
-        case Right(_)  => ()
-        case Left(err) => return Left(err)
+        case Right(_) => ()
+        case Left(err) =>
+          abortLog(err)
+          return Left(err)
       }
 
       // Phase 2: per-account storage tries
@@ -136,8 +148,10 @@ final class CheckpointExporter(
                 )
             }
           ) match {
-            case Right(_)  => ()
-            case Left(err) => return Left(err)
+            case Right(_) => ()
+            case Left(err) =>
+              abortLog(err)
+              return Left(err)
           }
         }
       }
@@ -152,7 +166,9 @@ final class CheckpointExporter(
               writer.writeBytecode(ch, code.toArray)
               bytecodesEmitted += 1
             case None =>
-              return Left(MissingBytecode(ch))
+              val err = MissingBytecode(ch)
+              abortLog(err)
+              return Left(err)
           }
         }
       }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporter.scala
@@ -36,13 +36,28 @@ final class CheckpointImporter(
   import CheckpointImporter._
   private val log = LoggerFactory.getLogger(getClass)
 
-  /** Import from a file. A `.gz` suffix is decoded transparently. */
+  /** Import from a file. Gzip-wrapped archives are auto-detected by either:
+    *   - file path ending in `.gz` (operator convention), OR
+    *   - first 2 bytes being the gzip magic `0x1F 0x8B` (peeked via a PushbackInputStream)
+    *
+    * The magic sniff covers Bug 35: an operator using `--gzip` who didn't add the `.gz` extension to
+    * the output path still gets a working import.
+    */
   def importFromFile(path: Path, expectedChainId: Option[Long] = None): Either[ImportError, ImportResult] = {
     val raw = new FileInputStream(path.toFile)
     try {
+      val pushback = new java.io.PushbackInputStream(raw, 2)
+      val b0 = pushback.read()
+      val b1 = pushback.read()
+      val isGzipped =
+        path.toString.endsWith(".gz") ||
+          (b0 == 0x1f && b1 == 0x8b)
+      // Put the two peeked bytes back so the decoder sees them.
+      if (b1 >= 0) pushback.unread(b1)
+      if (b0 >= 0) pushback.unread(b0)
       val in: InputStream =
-        if (path.toString.endsWith(".gz")) new GZIPInputStream(raw, 65536)
-        else raw
+        if (isGzipped) new GZIPInputStream(pushback, 65536)
+        else pushback
       try importFromStream(in, expectedChainId)
       finally in.close()
     } finally raw.close()

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporterSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointExporterSpec.scala
@@ -84,7 +84,7 @@ class CheckpointExporterSpec
       // Export
       val outputPath = tmpRoot.resolve("export.checkpoint")
       val exporter = new CheckpointExporter(
-        sourceStorages.storages.nodeStorage,
+        sourceStorages.storages.stateStorage,
         sourceStorages.storages.evmCodeStorage,
         sourceReader,
         chainId = 1337L
@@ -137,13 +137,66 @@ class CheckpointExporterSpec
 
     "fail cleanly when the requested block is missing" taggedAs UnitTest in new Setup {
       val exporter = new CheckpointExporter(
-        sourceStorages.storages.nodeStorage,
+        sourceStorages.storages.stateStorage,
         sourceStorages.storages.evmCodeStorage,
         sourceReader,
         chainId = 1L
       )
       val r = exporter.exportArchive(blockNumber = 9999, output = tmpRoot.resolve("nope.checkpoint"))
       r shouldBe Left(CheckpointExporter.NoSuchBlock(9999))
+    }
+
+    // Regression for Bug 33 — exporter must unwrap ReferenceCountNodeStorage wrapper bytes.
+    // Reading raw nodeStorage bytes on a BasicPruning chain surfaces the ref-count metadata,
+    // which fails to decode as an MPT node. Exporter now goes through StateStorage so the
+    // wrapper is transparent.
+    "round-trip state stored under BasicPruning (ref-counted) without MPT decode failure" taggedAs UnitTest in new BasicPruningSetup {
+      val codeA: ByteString = ByteString("contract-A-bytecode")
+      val codeAHash: ByteString = crypto.kec256(codeA)
+      sourceStorages.storages.evmCodeStorage.put(codeAHash, codeA).commit()
+
+      import MerklePatriciaTrie.defaultByteArraySerializable
+      val addr1 = Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477")
+      val addr2 = Hex.decode("11111111111111111111111111111111111111aa")
+      // Use a non-zero block number so ReferenceCountNodeStorage tags writes properly.
+      val sourceBackingStorage = sourceStorages.storages.stateStorage.getBackingStorage(100)
+      val accountTrie = MerklePatriciaTrie[Array[Byte], Account](sourceBackingStorage)
+        .put(crypto.kec256(addr1), Account(nonce = UInt256(0), balance = UInt256(100), codeHash = codeAHash))
+        .put(crypto.kec256(addr2), Account(nonce = UInt256(1), balance = UInt256(1)))
+      val stateRoot = ByteString(accountTrie.getRootHash)
+
+      val header = Fixtures.Blocks.Block3125369.header.copy(stateRoot = stateRoot, number = 100)
+      val weight = ChainWeight(BigInt(42))
+      sourceWriter.storeBlockHeader(header).and(sourceWriter.storeChainWeight(header.hash, weight)).commit()
+
+      // Export — must NOT throw MPTException(Invalid Node) when nodes are wrapped.
+      val outputPath = tmpRoot.resolve("export.checkpoint")
+      val exporter = new CheckpointExporter(
+        sourceStorages.storages.stateStorage,
+        sourceStorages.storages.evmCodeStorage,
+        sourceReader,
+        chainId = 1L
+      )
+      val exportResult = exporter.exportArchive(header.number, outputPath).value
+      exportResult.nodesExported should be > 0L
+
+      // Import into a fresh (ArchivePruning) storage and re-derive the same trie.
+      val importer = new CheckpointImporter(
+        targetWriter,
+        targetStorages.storages.stateStorage,
+        targetStorages.storages.evmCodeStorage,
+        targetStorages.storages.appStateStorage
+      )
+      val importResult = importer.importFromFile(outputPath, Some(1L)).value
+      importResult.blockNumber shouldBe header.number
+
+      val importedTrie = MerklePatriciaTrie[Array[Byte], Account](
+        stateRoot.toArray,
+        targetStorages.storages.stateStorage.getBackingStorage(100)
+      )
+      importedTrie.get(crypto.kec256(addr1)).value.balance shouldBe UInt256(100)
+      importedTrie.get(crypto.kec256(addr2)).value.nonce shouldBe UInt256(1)
+      targetStorages.storages.evmCodeStorage.get(codeAHash).map(_.toArray.toSeq) shouldBe Some(codeA.toArray.toSeq)
     }
   }
 
@@ -161,6 +214,35 @@ class CheckpointExporterSpec
 
   private trait Setup extends EphemBlockchainTestSetup {
     val sourceStorages = getNewStorages
+    val targetStorages = getNewStorages
+    val sourceWriter: BlockchainWriter = BlockchainWriter(sourceStorages.storages)
+    val targetWriter: BlockchainWriter = BlockchainWriter(targetStorages.storages)
+    val sourceReader: BlockchainReader = BlockchainReader(sourceStorages.storages)
+    val targetReader: BlockchainReader = BlockchainReader(targetStorages.storages)
+  }
+
+  /** Source uses BasicPruning so trie nodes go through ReferenceCountNodeStorage's ref-count wrapping
+    * — the path that exposed Bug 33. Target stays ArchivePruning (matches the default `Setup`).
+    */
+  private trait BasicPruningSetup extends EphemBlockchainTestSetup {
+    import com.chipprbots.ethereum.db.components.EphemDataSourceComponent
+    import com.chipprbots.ethereum.db.components.Storages
+    import com.chipprbots.ethereum.db.storage.pruning.BasicPruning
+    import com.chipprbots.ethereum.db.storage.pruning.PruningMode
+    import com.chipprbots.ethereum.nodebuilder.PruningConfigBuilder
+
+    trait BasicPruningConfigBuilder
+        extends PruningConfigBuilder
+        with com.chipprbots.ethereum.TestInstanceConfigProvider {
+      override val pruningMode: PruningMode = BasicPruning(history = 1000)
+    }
+
+    val sourceStorages: EphemDataSourceComponent with BasicPruningConfigBuilder with Storages.DefaultStorages =
+      new EphemDataSourceComponent
+        with BasicPruningConfigBuilder
+        with Storages.DefaultStorages
+        with com.chipprbots.ethereum.TestInstanceConfigProvider
+
     val targetStorages = getNewStorages
     val sourceWriter: BlockchainWriter = BlockchainWriter(sourceStorages.storages)
     val targetWriter: BlockchainWriter = BlockchainWriter(targetStorages.storages)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporterSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/checkpoint/CheckpointImporterSpec.scala
@@ -109,6 +109,35 @@ class CheckpointImporterSpec extends AnyWordSpec with Matchers with EitherValues
       freshStorage.storages.appStateStorage.isSnapSyncDone() shouldBe false
       freshStorage.storages.appStateStorage.getBestBlockNumber() shouldBe 0
     }
+
+    // Regression for Bug 35 — operator-supplied output path without `.gz` extension
+    // shouldn't break the import. importFromFile sniffs the gzip magic bytes.
+    "import a gzipped archive even when the file path lacks .gz extension" taggedAs UnitTest in new Setup {
+      import java.nio.file.Files
+      import java.util.zip.GZIPOutputStream
+
+      val header = checkpointHeader
+      val nodes = Seq((hash("rootNode"), Array.fill[Byte](32)(0xaa.toByte)))
+      val bytes = encodeArchive(header, nodes, Nil)
+
+      // Write the archive to a temp file WITH gzip compression but WITHOUT .gz suffix
+      val tmp = Files.createTempFile("checkpoint-bug35", ".checkpoint")
+      try {
+        val out = new GZIPOutputStream(Files.newOutputStream(tmp))
+        try out.write(bytes)
+        finally out.close()
+
+        val importer = new CheckpointImporter(
+          writer,
+          freshStorage.storages.stateStorage,
+          freshStorage.storages.evmCodeStorage,
+          freshStorage.storages.appStateStorage
+        )
+        val result = importer.importFromFile(tmp, Some(checkpointChainId)).value
+        result.blockNumber shouldBe header.blockHeader.number
+        result.nodesImported shouldBe nodes.length
+      } finally Files.deleteIfExists(tmp)
+    }
   }
 
   private trait Setup extends EphemBlockchainTestSetup {


### PR DESCRIPTION
## Summary

`CheckpointExporter` (PR #1264) crashed with `MerklePatriciaTrie.MPTException: Invalid Node` when exporting from a chain that uses `BasicPruning` (e.g., Mordor, ETC mainnet). Root cause: it took raw `NodeStorage` and read trie nodes via `nodeStorage.get(hash)`. On `BasicPruning` chains the on-disk values are wrapped with reference-count metadata; only `ReferenceCountNodeStorage.get` (via the `MptStorage` abstraction) unwraps that to plain RLP.

Tests covered `ArchivePruning` (no wrapper) but not the wrapping path, so the bug shipped.

## Fix

- `CheckpointExporter` constructor now takes `StateStorage` instead of raw `NodeStorage`.
- `walkTrie` reads via `stateStorage.getReadOnlyStorage.get(hash)`, which dispatches through the correct `NodesKeyValueStorage` wrapper for the chain's pruning mode.
- Raw RLP is pulled from the returned `MptNode.cachedRlpEncoded` field (set by `MptStorage.decodeNode` to the post-unwrap bytes) so the archive stays byte-identical and content-addressed hashes match.
- `CheckpointCli.ExportBuilder` updated to pass `storages.stateStorage`.

## Test plan

- [x] `sbt 'testOnly *Checkpoint*'` — **18/18 pass**, including the new regression:
  - `should round-trip state stored under BasicPruning (ref-counted) without MPT decode failure` — exports from a `BasicPruning(history=1000)`-backed source storage and imports into a fresh `ArchivePruning` target, verifying the trie can be re-derived from the same `stateRoot`.
- [x] Discovered + reproduced live on Mordor secondary (`fukuii-secondary`) immediately after a legacy SNAP sync completed.
- [ ] Re-running export + import end-to-end on the synced Mordor datadir with this fix to confirm the live regression is gone — in progress in same session as this PR.

## Memory

[bug33_checkpoint_exporter_pruning.md](https://github.com/chippr-robotics/fukuii/blob/main/.memory/bug33.md) in operator notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)