### PR TITLE
ci: bump Tier 1 test timeout 10 → 15 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,17 +76,17 @@ jobs:
       - name: Run Essential Tests (Tier 1)
         run: |
           echo "=========================================="
-          echo "Running Essential Tests (< 5 minutes)"
+          echo "Running Essential Tests (< 15 minutes)"
           echo "=========================================="
           set -o pipefail
-          sbt -v testEssential 2>&1 | tee /tmp/sbt-testEssential.log || { 
+          sbt -v testEssential 2>&1 | tee /tmp/sbt-testEssential.log || {
             echo "sbt testEssential failed — dumping 'last test'"
             sbt 'last test' 2>&1 | tee /tmp/sbt-last-test-essential.log || true
             exit 1
           }
         env:
           FUKUII_DEV: true
-        timeout-minutes: 10
+        timeout-minutes: 15
       
       - name: Run Standard Tests with Coverage (Tier 2)
         run: |


### PR DESCRIPTION
## Summary

Tier 1 essential tests now run 9-10 min on the GitHub runner; the 10-min timeout has zero headroom. The latest CI run on PR #1183 timed out at 10:00 with the 3023-test core suite completing in 9:52 — clean pass, zero test failures, pure timeout exhaustion.

Bumping `timeout-minutes: 10 → 15` to restore headroom. The documented "< 5 minutes" target in the step name was an aspiration from the test-tier ADR; the suite has grown significantly across recent merges.

## Test plan

- [x] Diff is one workflow file, three lines changed (timeout value + step description)
- [x] No test code or production code touched
- [ ] CI on this branch confirms it doesn't break anything else (this PR targets staging where ci.yml `pull_request` doesn't trigger — the proof comes from PR #1183 retrying after merge)

## Outstanding

PR #1183 has a second blocker: `run / sync` hive simulator reports 2 failing tests matching the `fukuii` gate. This is **pre-existing** — every staging push from May 14 onward has failed `hive-sync` (20 consecutive runs). That's a deeper issue out of scope for this CI tweak; needs separate investigation of the actual fukuii-specific sync simulator scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)