### PR TITLE
fix(metrics): wire peer-demotion + blacklist metrics into call sites

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/Blacklist.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/Blacklist.scala
@@ -350,14 +350,26 @@ final case class CacheBasedBlacklist(cache: Cache[BlacklistId, BlacklistReasonTy
       case "RegularSyncBlacklistGroup" => NetworkMetrics.BlacklistedReasonsRegularSyncGroup.increment()
       case "P2PBlacklistGroup"         => NetworkMetrics.BlacklistedReasonsP2PGroup.increment()
     }
+    // Top-level total counter — increments on every blacklist event, regardless of group.
+    // Dashboards key off this to compute blacklists/min via rate(). The per-group counters
+    // above remain for cause attribution. The snapsync-domain duplicate kept for the SNAP
+    // dashboard panel that scopes itself to snapsync.* metrics.
+    com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.incrementPeerBlacklisted()
     cache.policy().expireVariably().toScala match {
       case Some(varExpiration) => varExpiration.put(id, reason.reasonType, duration.toJava)
       case None =>
         log.warn(customExpirationError(id))
         cache.put(id, reason.reasonType)
     }
+    // Refresh the size gauge after the new entry settles in cache. Without this, the gauge
+    // only updates when PeerManagerActor's periodic peer-discovery cycle calls keys.size,
+    // which on high-churn nets can lag the actual blacklist by 10s+ and undercount peaks.
+    NetworkMetrics.BlacklistedPeersSize.set(cache.underlying.estimatedSize())
   }
-  override def remove(id: BlacklistId): Unit = cache.invalidate(id)
+  override def remove(id: BlacklistId): Unit = {
+    cache.invalidate(id)
+    NetworkMetrics.BlacklistedPeersSize.set(cache.underlying.estimatedSize())
+  }
 
   override def keys: Set[BlacklistId] = {
     cache.cleanUp() // Remove expired entries before returning keys

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -171,8 +171,12 @@ class AccountRangeCoordinator(
     // Threshold reached — promote to confirmed snapless + stateless. Snapless is sticky
     // (root-independent, survives PivotRefreshed per #1197); stateless clears on the next
     // PivotRefreshed.
+    val wasSnapless = snaplessPeers.contains(peer.id)
+    val wasStateless = statelessPeers.contains(peer.id)
     snaplessPeers.add(peer.id)
     statelessPeers.add(peer.id)
+    if (!wasSnapless) com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.incrementSnaplessPeerConfirmed()
+    if (!wasStateless) com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.incrementStatelessPeerConfirmed()
     log.info(
       s"Peer ${peer.id.value} marked SNAPLESS after $strikes consecutive empty-proof responses " +
         s"— will skip for GetAccountRange this session. Bytecode/healing remain available. " +

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -204,7 +204,9 @@ class StorageRangeCoordinator(
       return
     }
 
+    val wasStateless = statelessPeers.contains(id)
     statelessPeers.add(id)
+    if (!wasStateless) com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.incrementStatelessPeerConfirmed()
     log.info(
       s"Peer $id marked stateless after $strikes consecutive empty storage responses for root " +
         s"${stateRoot.take(4).toHex} (${statelessPeers.size}/${knownAvailablePeers.size} stateless)"


### PR DESCRIPTION
## Summary

The SNAP sync Grafana dashboard shows **0** for four panels:
- Lagging peers evicted (works on some networks, see below)
- Snapless demoted
- Stateless confirmed
- Blacklisted (gauge + total)

Diagnosed against the running ETC mainnet primary: **the metrics are registered and scraped — Prometheus has them, value=0** — but the increment/set methods in `SNAPSyncMetrics` and `NetworkMetrics` had **zero call sites in production code**. Defined-but-dead since they were introduced.

## Wiring

| Metric | Hooked into |
|---|---|
| `snapsync.peers.snapless.confirmed.total` | `AccountRangeCoordinator` demotion (strike-threshold reached, first time only) |
| `snapsync.peers.stateless.confirmed.total` | `AccountRangeCoordinator` + `StorageRangeCoordinator` demotion (first entry only) |
| `snapsync.peers.blacklisted.total` | `CacheBasedBlacklist.add` (every event) |
| `network.peers.blacklisted.gauge` | `CacheBasedBlacklist.add` + `remove` (was: only PeerManagerActor's discovery loop, ~30s lag) |

The "first entry only" guards avoid double-counting when a peer briefly clears stateless then re-enters within the same pivot window.

## Evidence the metrics were dead

Direct Prometheus query against running ETC primary (651 blacklist events in the last 5 minutes of logs):

```
app_network_peers_blacklisted_gauge         = 0
app_network_lagging_peer_evicted_total      = 0   (single caller exists, untriggered on ETC)
app_snapsync_peers_blacklisted_total        = 0
app_snapsync_peers_snapless_confirmed_total = 0
app_snapsync_peers_stateless_confirmed_total = 0
```

The metric machinery works; the call sites were missing.

## Test plan

- [x] `sbt compile` clean
- [x] `sbt scalafmtAll` clean
- [ ] Verify in Prometheus after merge + image rebuild: scrape the primary's `/metrics` endpoint, see non-zero values for all four

No new metrics, no behavior change. Pure observability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)