### PR TITLE
SNAP sync stability + ETH/69 fixes — validated on ETC mainnet (successful SNAP sync)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(JavaAppPackaging, SolidityPlugin, JavaAgent)
 
-javaAgents += "io.kamon" % "kanela-agent" % "1.0.6"
+javaAgents += "io.kamon" % "kanela-agent" % "1.0.18"
 
 import scala.sys.process.Process
 import NativePackagerHelper._

--- a/ops/grafana/fukuii-dashboard.json
+++ b/ops/grafana/fukuii-dashboard.json
@@ -5125,7 +5125,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "increase(logback_appender_total_counter{instance=~\"$node\"}[1m])",
+              "expr": "increase(app_logback_events_total{instance=~\"$node\"}[1m])",
               "interval": "",
               "legendFormat": "{{level}}",
               "refId": "A"

--- a/ops/grafana/fukuii-fast-sync.json
+++ b/ops/grafana/fukuii-fast-sync.json
@@ -266,8 +266,8 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 27},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "rate(logback_appender_total{instance=~\"$instance\",level=\"error\"}[1m])", "refId": "A", "legendFormat": "{{instance}} ERROR"},
-        {"expr": "rate(logback_appender_total{instance=~\"$instance\",level=\"warn\"}[1m])", "refId": "B", "legendFormat": "{{instance}} WARN"}
+        {"expr": "rate(app_logback_events_total{instance=~\"$instance\",level=\"error\"}[1m])", "refId": "A", "legendFormat": "{{instance}} ERROR"},
+        {"expr": "rate(app_logback_events_total{instance=~\"$instance\",level=\"warn\"}[1m])", "refId": "B", "legendFormat": "{{instance}} WARN"}
       ],
       "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
     },
@@ -371,7 +371,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 12, "y": 39},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "increase(logback_appender_total{instance=~\"$instance\",level=\"warn\"}[1h])", "refId": "A", "legendFormat": "{{instance}} warns/1h"}
+        {"expr": "increase(app_logback_events_total{instance=~\"$instance\",level=\"warn\"}[1h])", "refId": "A", "legendFormat": "{{instance}} warns/1h"}
       ],
       "fieldConfig": {
         "defaults": {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   // Apache Pekko - Scala 3 compatible fork of Akka
-  private val pekkoVersion = "1.1.5"
+  private val pekkoVersion = "1.6.0"
   private val pekkoHttpVersion = "1.3.0"
 
   val pekkoUtil: Seq[ModuleID] =
@@ -66,7 +66,7 @@ object Dependencies {
 
   val testing: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.2.19" % "it,test",
-    "org.scalamock" %% "scalamock" % "6.2.0" % "it,test",
+    "org.scalamock" %% "scalamock" % "7.3.2" % "it,test",
     "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test",
     "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % "it,test",
     "org.mockito" % "mockito-core" % "5.23.0" % "it,test",
@@ -77,7 +77,7 @@ object Dependencies {
 
   val cats: Seq[ModuleID] = {
     val catsVersion = "2.13.0"
-    val catsEffectVersion = "3.5.7" // 3.6+ changed IORuntime.createWorkStealingComputeThreadPool return type
+    val catsEffectVersion = "3.6.1"
     Seq(
       "org.typelevel" %% "mouse" % "1.4.0",
       "org.typelevel" %% "cats-core" % catsVersion,
@@ -89,7 +89,7 @@ object Dependencies {
   val monix = Seq.empty[ModuleID]
 
   val fs2: Seq[ModuleID] = {
-    val fs2Version = "3.10.2" // fs2 3.11+ requires cats-effect 3.6+; staying on 3.5.7
+    val fs2Version = "3.12.0" // requires cats-effect 3.6+
     Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
 
   // Apache Pekko - Scala 3 compatible fork of Akka
-  private val pekkoVersion = "1.1.2" // Stable version for compatibility (newer versions like 1.2.1 had dependency issues)
-  private val pekkoHttpVersion = "1.1.0" // Stable version for compatibility
+  private val pekkoVersion = "1.1.5"
+  private val pekkoHttpVersion = "1.3.0"
 
   val pekkoUtil: Seq[ModuleID] =
     Seq(
@@ -34,7 +34,7 @@ object Dependencies {
   val json4s = Seq("org.json4s" %% "json4s-native" % "4.0.7") // Updated for Scala 3 support
 
   val circe: Seq[ModuleID] = {
-    val circeVersion = "0.14.10" // Stable with Scala 3 support
+    val circeVersion = "0.14.15"
 
     Seq(
       "io.circe" %% "circe-core" % circeVersion,
@@ -48,38 +48,38 @@ object Dependencies {
 
   // Sangria GraphQL (EIP-1767 execution-layer GraphQL endpoint)
   val sangria: Seq[ModuleID] = Seq(
-    "org.sangria-graphql" %% "sangria" % "4.2.5",
+    "org.sangria-graphql" %% "sangria" % "4.2.18",
     "org.sangria-graphql" %% "sangria-circe" % "1.3.2"
   )
 
-  val boopickle = Seq("io.suzaku" %% "boopickle" % "1.4.0") // Updated for Scala 3 support
+  val boopickle = Seq("io.suzaku" %% "boopickle" % "1.5.0") // Updated for Scala 3 support
 
   val rocksDb = Seq(
-    "org.rocksdb" % "rocksdbjni" % "8.11.4" // Stable version
+    "org.rocksdb" % "rocksdbjni" % "10.10.1.1"
   )
 
   val enumeratum: Seq[ModuleID] = Seq(
-    "com.beachape" %% "enumeratum" % "1.7.5", // Stable with Scala 3 support
-    "com.beachape" %% "enumeratum-cats" % "1.7.5",
-    "com.beachape" %% "enumeratum-scalacheck" % "1.7.5" % Test
+    "com.beachape" %% "enumeratum" % "1.9.7",
+    "com.beachape" %% "enumeratum-cats" % "1.9.7",
+    "com.beachape" %% "enumeratum-scalacheck" % "1.9.7" % Test
   )
 
   val testing: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.19" % "it,test", // Updated for Scala 3 support
-    "org.scalamock" %% "scalamock" % "6.0.0" % "it,test", // Updated for Scala 3 support
-    "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test", // Updated for ScalaCheck 1.18
-    "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % "it,test", // Mockito for kademlia + scalanet specs
-    "org.mockito" % "mockito-core" % "5.12.0" % "it,test",
-    "org.scalacheck" %% "scalacheck" % "1.18.1" % "it,test", // Updated for Scala 3 support
-    "com.softwaremill.diffx" %% "diffx-core" % "0.9.0" % "test", // Updated for Scala 3 support
+    "org.scalatest" %% "scalatest" % "3.2.19" % "it,test",
+    "org.scalamock" %% "scalamock" % "6.2.0" % "it,test",
+    "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test",
+    "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % "it,test",
+    "org.mockito" % "mockito-core" % "5.23.0" % "it,test",
+    "org.scalacheck" %% "scalacheck" % "1.19.0" % "it,test",
+    "com.softwaremill.diffx" %% "diffx-core" % "0.9.0" % "test",
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.9.0" % "test"
   )
 
   val cats: Seq[ModuleID] = {
-    val catsVersion = "2.10.0" // Stable with Scala 3 support
-    val catsEffectVersion = "3.5.4" // Stable Cats Effect 3 with Scala 3 support
+    val catsVersion = "2.13.0"
+    val catsEffectVersion = "3.5.7" // 3.6+ changed IORuntime.createWorkStealingComputeThreadPool return type
     Seq(
-      "org.typelevel" %% "mouse" % "1.2.3", // Stable with Scala 3 support
+      "org.typelevel" %% "mouse" % "1.4.0",
       "org.typelevel" %% "cats-core" % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion
     )
@@ -89,7 +89,7 @@ object Dependencies {
   val monix = Seq.empty[ModuleID]
 
   val fs2: Seq[ModuleID] = {
-    val fs2Version = "3.10.2" // Stable with CE3 and Scala 3 support
+    val fs2Version = "3.10.2" // fs2 3.11+ requires cats-effect 3.6+; staying on 3.5.7
     Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,
@@ -128,73 +128,72 @@ object Dependencies {
   )
 
   val logging = Seq(
-    "ch.qos.logback" % "logback-classic" % "1.5.12", // Stable version
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "net.logstash.logback" % "logstash-logback-encoder" % "8.0",
+    "ch.qos.logback" % "logback-classic" % "1.5.32",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",
+    "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
     "org.codehaus.janino" % "janino" % "3.1.12",
-    "org.typelevel" %% "log4cats-core" % "2.6.0", // Stable with Scala 3 support
-    "org.typelevel" %% "log4cats-slf4j" % "2.6.0"
+    "org.typelevel" %% "log4cats-core" % "2.8.0",
+    "org.typelevel" %% "log4cats-slf4j" % "2.8.0"
   )
 
   val crypto = Seq(
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.83", // Updated for JDK 18+ compatibility (jdk15on artifacts discontinued)
-    "org.bouncycastle" % "bcpkix-jdk18on" % "1.83", // Additional bouncy castle package for X.509 certificates
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
     "tech.pegasys" % "jc-kzg-4844" % "1.0.0",       // EIP-4844 KZG point evaluation (c-kzg-4844 JNI bindings)
     "org.hyperledger.besu" % "bls12-381" % "1.0.0"   // EIP-2537 BLS12-381 precompiles (gnark/Constantine backends)
   )
 
   val scopt = Seq("com.github.scopt" %% "scopt" % "4.1.0") // Updated for Scala 3 support
 
-  val cli = Seq("com.monovore" %% "decline" % "2.4.1") // Updated for Scala 3 support
+  val cli = Seq("com.monovore" %% "decline" % "2.6.2")
 
   val apacheCommons = Seq(
-    "commons-io" % "commons-io" % "2.16.1" // Stable version
+    "commons-io" % "commons-io" % "2.22.0"
   )
 
   val apacheHttpClient = Seq(
-    "org.apache.httpcomponents.client5" % "httpclient5" % "5.3.1" // For JupnP UPnP transport without URLStreamHandlerFactory
+    "org.apache.httpcomponents.client5" % "httpclient5" % "5.6.1" // For JupnP UPnP transport without URLStreamHandlerFactory
   )
 
-  val jline = "org.jline" % "jline" % "3.26.1" // Stable version
+  val jline = "org.jline" % "jline" % "3.30.13"
 
-  val jna = "net.java.dev.jna" % "jna" % "5.14.0" // Stable version
+  val jna = "net.java.dev.jna" % "jna" % "5.18.1"
 
   val dependencies = Seq(
     jline,
     "org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0",
-    "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.6.2", // Stable version
-    "org.xerial.snappy" % "snappy-java" % "1.1.10.5", // Stable version
-    "org.web3j" % "core" % "4.9.8" % Test, // Stable version without jc-kzg-4844 dependency issues
-    "io.vavr" % "vavr" % "1.0.0-alpha-4", // Latest alpha
-    "org.jupnp" % "org.jupnp" % "2.5.2", // Keep original version for API compatibility
-    "org.jupnp" % "org.jupnp.support" % "2.5.2",
-    "org.jupnp" % "org.jupnp.tool" % "2.5.2",
+    "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.6.3",
+    "org.xerial.snappy" % "snappy-java" % "1.1.10.8",
+    "org.web3j" % "core" % "4.14.0" % Test,
+    "io.vavr" % "vavr" % "1.0.1",
+    "org.jupnp" % "org.jupnp" % "2.7.1",
+    "org.jupnp" % "org.jupnp.support" % "2.7.1",
+    "org.jupnp" % "org.jupnp.tool" % "2.7.1",
     "javax.servlet" % "javax.servlet-api" % "4.0.1",
-    "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.17"
+    "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.20"
   )
 
   val guava: Seq[ModuleID] = {
-    val version = "33.0.0-jre" // Stable version
+    val version = "33.6.0-jre"
     Seq(
       "com.google.guava" % "guava" % version,
       "com.google.guava" % "guava-testlib" % version % "test"
     )
   }
 
+  // Prometheus Java client 1.x (replaces legacy simpleclient 0.x)
   val prometheus: Seq[ModuleID] = {
-    val provider = "io.prometheus"
-    val version = "0.16.0" // Stable version
+    val version = "1.3.5"
     Seq(
-      provider % "simpleclient" % version,
-      provider % "simpleclient_logback" % version,
-      provider % "simpleclient_hotspot" % version,
-      provider % "simpleclient_httpserver" % version
+      "io.prometheus" % "prometheus-metrics-core" % version,
+      "io.prometheus" % "prometheus-metrics-instrumentation-jvm" % version,
+      "io.prometheus" % "prometheus-metrics-exporter-httpserver" % version
     )
   }
 
   val micrometer: Seq[ModuleID] = {
     val provider = "io.micrometer"
-    val version = "1.5.5" // Keep original version for API compatibility
+    val version = "1.16.5"
     Seq(
       // Required to compile metrics library https://github.com/micrometer-metrics/micrometer/issues/1133#issuecomment-452434205
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % Optional,
@@ -206,7 +205,7 @@ object Dependencies {
 
   val kamon: Seq[ModuleID] = {
     val provider = "io.kamon"
-    val version = "2.7.5" // Stable with Scala 3 support
+    val version = "2.8.1"
     Seq(
       provider %% "kamon-prometheus" % version
       // Note: kamon-pekko not yet available, removed kamon-akka instrumentation
@@ -214,8 +213,8 @@ object Dependencies {
   }
 
   val scaffeine: Seq[ModuleID] = Seq(
-    "com.github.blemale" %% "scaffeine" % "5.3.0" % "compile", // Updated for Scala 3 support
-    "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8" // Explicit caffeine dependency for scalanet
+    "com.github.blemale" %% "scaffeine" % "5.3.0" % "compile",
+    "com.github.ben-manes.caffeine" % "caffeine" % "3.2.4"
   )
 
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,3 +1,3 @@
 object Versions {
-  val scalapb = "0.11.17"
+  val scalapb = "0.11.20"
 }

--- a/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
+++ b/scalanet/discovery/src/com/chipprbots/scalanet/discovery/ethereum/v4/DiscoveryNetwork.scala
@@ -109,6 +109,8 @@ object DiscoveryNetwork {
                   .guarantee(release)
                   .recover {
                     case ex: TimeoutException =>
+                    case ex: PacketException =>
+                      logger.debug(s"Discovery packet decode failure from ${channel.to}: ${ex.getMessage}")
                     case NonFatal(ex) =>
                       logger.error(s"Error handling channel from ${channel.to}: $ex")
                   }

--- a/src/it/scala/com/chipprbots/ethereum/network/E2EHandshakeSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/network/E2EHandshakeSpec.scala
@@ -6,7 +6,6 @@ import cats.effect.unsafe.IORuntime
 import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigValueFactory
-import io.prometheus.client.CollectorRegistry
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 
@@ -37,8 +36,8 @@ class E2EHandshakeSpec extends FreeSpecBase with Matchers with BeforeAndAfterAll
   implicit val testRuntime: IORuntime = IORuntime.global
 
   override def beforeAll(): Unit = {
-    // Clear metrics registry to prevent pollution from previous test runs
-    CollectorRegistry.defaultRegistry.clear()
+    // Close any previous metrics instance so the new one starts with a clean registry
+    Metrics.closeInstance("default")
     Metrics.configure(
       MetricsConfig(Config.config.withValue("metrics.enabled", ConfigValueFactory.fromAnyRef(true)))
     )

--- a/src/it/scala/com/chipprbots/ethereum/sync/E2EStateTestSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/E2EStateTestSpec.scala
@@ -6,7 +6,6 @@ import cats.effect.unsafe.IORuntime
 import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigValueFactory
-import io.prometheus.client.CollectorRegistry
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 
@@ -53,8 +52,8 @@ class E2EStateTestSpec extends FreeSpecBase with Matchers with BeforeAndAfterAll
   implicit val testRuntime: IORuntime = IORuntime.global
 
   override def beforeAll(): Unit = {
-    // Clear metrics registry to prevent pollution from previous test runs
-    CollectorRegistry.defaultRegistry.clear()
+    // Close any previous metrics instance so the new one starts with a clean registry
+    Metrics.closeInstance("default")
     Metrics.configure(
       MetricsConfig(Config.config.withValue("metrics.enabled", ConfigValueFactory.fromAnyRef(true)))
     )

--- a/src/it/scala/com/chipprbots/ethereum/sync/E2ESyncSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/E2ESyncSpec.scala
@@ -6,7 +6,6 @@ import cats.effect.unsafe.IORuntime
 import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigValueFactory
-import io.prometheus.client.CollectorRegistry
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 
@@ -37,8 +36,8 @@ class E2ESyncSpec extends FreeSpecBase with Matchers with BeforeAndAfterAll {
   implicit val testRuntime: IORuntime = IORuntime.global
 
   override def beforeAll(): Unit = {
-    // Clear metrics registry to prevent pollution from previous test runs
-    CollectorRegistry.defaultRegistry.clear()
+    // Close any previous metrics instance so the new one starts with a clean registry
+    Metrics.closeInstance("default")
     Metrics.configure(
       MetricsConfig(Config.config.withValue("metrics.enabled", ConfigValueFactory.fromAnyRef(true)))
     )

--- a/src/it/scala/com/chipprbots/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/RegularSyncItSpec.scala
@@ -158,13 +158,17 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
     val DefaultBlockPropagation = "DefaultBlockPropagation"
     val MinedBlockPropagation = "MinedBlockPropagation"
     def sampleMetric(blockType: String): Double =
-      scala.util.Try {
-        Metrics.get().registry
-          .get("app.regularsync.blocks.propagation.timer")
-          .tag("blocktype", blockType)
-          .timer()
-          .count()
-          .toDouble
-      }.getOrElse(0.0)
+      scala.util
+        .Try {
+          Metrics
+            .get()
+            .registry
+            .get("app.regularsync.blocks.propagation.timer")
+            .tag("blocktype", blockType)
+            .timer()
+            .count()
+            .toDouble
+        }
+        .getOrElse(0.0)
   }
 }

--- a/src/it/scala/com/chipprbots/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/RegularSyncItSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.unsafe.IORuntime
 import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigValueFactory
-import io.prometheus.client.CollectorRegistry
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 
@@ -22,8 +21,8 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
   implicit val testRuntime: IORuntime = IORuntime.global
 
   override def beforeAll(): Unit = {
-    // Clear metrics registry to prevent pollution from previous test runs
-    CollectorRegistry.defaultRegistry.clear()
+    // Close any previous metrics instance so the new one starts with a clean registry
+    Metrics.closeInstance("default")
     Metrics.configure(
       MetricsConfig(Config.config.withValue("metrics.enabled", ConfigValueFactory.fromAnyRef(true)))
     )
@@ -135,8 +134,8 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
   ) { case (peer1, peer2) =>
     import MetricsHelper._
 
-    val minedMetricBefore = sampleMetric(TimerCountMetric, MinedBlockPropagation)
-    val defaultMetricBefore = sampleMetric(TimerCountMetric, DefaultBlockPropagation)
+    val minedMetricBefore = sampleMetric(MinedBlockPropagation)
+    val defaultMetricBefore = sampleMetric(DefaultBlockPropagation)
 
     for {
       _ <- peer1.startRegularSync()
@@ -147,8 +146,8 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer2.waitForRegularSyncLoadLastBlock(1)
     } yield {
 
-      val minedMetricAfter = sampleMetric(TimerCountMetric, MinedBlockPropagation).doubleValue()
-      val defaultMetricAfter = sampleMetric(TimerCountMetric, DefaultBlockPropagation).doubleValue()
+      val minedMetricAfter = sampleMetric(MinedBlockPropagation)
+      val defaultMetricAfter = sampleMetric(DefaultBlockPropagation)
 
       minedMetricAfter shouldBe minedMetricBefore + 1.0d
       defaultMetricAfter shouldBe defaultMetricBefore + 1.0d
@@ -156,16 +155,16 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
   }
 
   object MetricsHelper {
-    val TimerCountMetric = "app_regularsync_blocks_propagation_timer_seconds_count"
     val DefaultBlockPropagation = "DefaultBlockPropagation"
     val MinedBlockPropagation = "MinedBlockPropagation"
-    def sampleMetric(metricName: String, blockType: String): Double = {
-      val value = CollectorRegistry.defaultRegistry.getSampleValue(
-        metricName,
-        Array("blocktype"),
-        Array(blockType)
-      )
-      if (value == null) 0.0 else value
-    }
+    def sampleMetric(blockType: String): Double =
+      scala.util.Try {
+        Metrics.get().registry
+          .get("app.regularsync.blocks.propagation.timer")
+          .tag("blocktype", blockType)
+          .timer()
+          .count()
+          .toDouble
+      }.getOrElse(0.0)
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -37,7 +37,7 @@
         </encoder>
     </appender>
 
-    <appender name="METRICS" class="io.prometheus.client.logback.InstrumentedAppender" />
+    <!-- prometheus-metrics 1.x does not ship a logback appender; removed in deps bump 6e73fcfcb -->
 
     <!-- Console appender - uses JSON output if ASJSON property is true, otherwise plain text -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -76,7 +76,6 @@
     <root level="${LOGSLEVEL}">
         <appender-ref ref="CONSOLE" />
         <appender-ref ref="FILE" />
-        <appender-ref ref="METRICS" />
     </root>
 
     <!-- =================================================================== -->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -130,6 +130,8 @@
 
     <!-- Sync status and lifecycle (high-level status only) -->
     <logger name="com.chipprbots.ethereum.blockchain.sync.SyncController" level="INFO" />
+    <logger name="com.chipprbots.ethereum.blockchain.sync.BytecodeRecoveryActor" level="INFO" />
+    <logger name="com.chipprbots.ethereum.blockchain.sync.StorageRecoveryActor" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.fast.FastSync" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.regular.RegularSync" level="INFO" />
     <logger name="com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController" level="INFO" />

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BytecodeRecoveryActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/BytecodeRecoveryActor.scala
@@ -1,16 +1,18 @@
 package com.chipprbots.ethereum.blockchain.sync
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props, Terminated}
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
 import com.chipprbots.ethereum.db.storage.{AppStateStorage, EvmCodeStorage, StateStorage}
 import com.chipprbots.ethereum.domain.Account
 import com.chipprbots.ethereum.mpt._
 import com.chipprbots.ethereum.mpt.MptVisitors._
+import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncConfig
 
 /** Bytecode recovery actor for Bug 20 hardening.
   *
@@ -29,19 +31,29 @@ class BytecodeRecoveryActor(
     appStateStorage: AppStateStorage,
     networkPeerManager: ActorRef,
     syncController: ActorRef,
-    pivotBlockNumber: BigInt
+    pivotBlockNumber: BigInt,
+    snapSyncConfig: SNAPSyncConfig,
+    // Test hook: when set, the actor skips the real scan and enters `downloading` with
+    // the supplied missing list directly. Production callers always leave this as None.
+    private[sync] val preloadedMissingForTesting: Option[Seq[ByteString]] = None,
+    // Test hook: when set, the downloading state uses this ref instead of spawning a
+    // real ByteCodeCoordinator.
+    private[sync] val coordinatorForTesting: Option[ActorRef] = None
 ) extends Actor
     with ActorLogging {
 
   import BytecodeRecoveryActor._
   import context.dispatcher
 
-  override def preStart(): Unit = {
-    log.info(
-      s"BytecodeRecoveryActor starting: scanning state trie for missing bytecodes " +
-        s"(stateRoot=${stateRoot.take(4).toArray.map("%02x".format(_)).mkString}...)"
-    )
-    self ! StartScan
+  override def preStart(): Unit = preloadedMissingForTesting match {
+    case Some(missing) =>
+      self ! ScanResult(missing)
+    case None =>
+      log.info(
+        s"BytecodeRecoveryActor starting: scanning state trie for missing bytecodes " +
+          s"(stateRoot=${stateRoot.take(4).toArray.map("%02x".format(_)).mkString}...)"
+      )
+      self ! StartScan
   }
 
   override def receive: Receive = {
@@ -64,38 +76,76 @@ class BytecodeRecoveryActor(
       } else {
         log.warning(s"Bytecode recovery: found ${missing.size} missing bytecodes. Starting download...")
         implicit val scheduler: org.apache.pekko.actor.Scheduler = context.system.scheduler
-        val requestTracker = new snap.SNAPRequestTracker()
-        val coordinator = context.actorOf(
-          snap.actors.ByteCodeCoordinator
-            .props(
-              evmCodeStorage = evmCodeStorage,
-              networkPeerManager = networkPeerManager,
-              requestTracker = requestTracker,
-              batchSize = snap.ByteCodeTask.DEFAULT_BATCH_SIZE,
-              snapSyncController = self
-            )
-            .withDispatcher("sync-dispatcher"),
-          "bytecode-recovery-coordinator"
-        )
+        val coordinator = coordinatorForTesting.getOrElse {
+          val requestTracker = new snap.SNAPRequestTracker()
+          context.actorOf(
+            snap.actors.ByteCodeCoordinator
+              .props(
+                evmCodeStorage = evmCodeStorage,
+                networkPeerManager = networkPeerManager,
+                requestTracker = requestTracker,
+                batchSize = snap.ByteCodeTask.DEFAULT_BATCH_SIZE,
+                snapSyncController = self
+              )
+              .withDispatcher("sync-dispatcher"),
+            "bytecode-recovery-coordinator"
+          )
+        }
+        context.watch(coordinator)
         coordinator ! snap.actors.Messages.StartByteCodeSync(missing)
         context.become(downloading(coordinator, missing.size))
       }
   }
 
   private def downloading(coordinator: ActorRef, expectedCount: Int): Receive = {
-    case snap.actors.Messages.ByteCodePeerAvailable(peer) =>
-      coordinator ! snap.actors.Messages.ByteCodePeerAvailable(peer)
+    var progressSeq = 0L
+    val abandonAfter: FiniteDuration = snapSyncConfig.storageRecoveryAbandonTimeout
+    var abandonTimer: Option[Cancellable] = Some(
+      context.system.scheduler.scheduleOnce(abandonAfter, self, CheckAbandon(0L))
+    )
 
-    case snap.SNAPSyncController.ByteCodeSyncComplete =>
-      log.info(s"Bytecode recovery complete: downloaded bytecodes for $expectedCount missing codeHashes")
+    def recordProgress(): Unit = {
+      progressSeq += 1
+      abandonTimer.foreach(_.cancel())
+      abandonTimer = None
+    }
+
+    def finishRecovery(): Unit = {
+      abandonTimer.foreach(_.cancel())
       appStateStorage.bytecodeRecoveryDone().commit()
       syncController ! RecoveryComplete
       context.stop(self)
+    }
 
-    case snap.SNAPSyncController.ProgressBytecodesDownloaded(_) =>
-    // Ignore progress updates
+    {
+      case snap.actors.Messages.ByteCodePeerAvailable(peer) =>
+        coordinator ! snap.actors.Messages.ByteCodePeerAvailable(peer)
 
-    case msg => coordinator.forward(msg) // Forward SNAP protocol responses to coordinator
+      case snap.SNAPSyncController.ByteCodeSyncComplete =>
+        log.info(s"Bytecode recovery complete: downloaded bytecodes for $expectedCount missing codeHashes")
+        finishRecovery()
+
+      case snap.SNAPSyncController.ProgressBytecodesDownloaded(_) =>
+        recordProgress()
+
+      case CheckAbandon(progressAtSchedule) =>
+        if (progressAtSchedule == progressSeq) {
+          log.warning(
+            "Bytecode recovery abandoned: no download progress for {}s. " +
+              "Regular sync will fetch missing bytecodes on-demand via GetTrieNodes.",
+            abandonAfter.toSeconds
+          )
+          finishRecovery()
+        } else {
+          abandonTimer = None
+        }
+
+      case Terminated(`coordinator`) =>
+        log.error("ByteCodeCoordinator crashed unexpectedly. Marking bytecode recovery done to unblock sync.")
+        finishRecovery()
+
+      case msg => coordinator.forward(msg)
+    }
   }
 
   /** Walk the state trie and collect codeHashes of contracts missing from evmCodeStorage. */
@@ -150,6 +200,7 @@ class BytecodeRecoveryActor(
 object BytecodeRecoveryActor {
   private case object StartScan
   private case class ScanResult(missingCodeHashes: Seq[ByteString])
+  private case class CheckAbandon(progressSeq: Long)
 
   /** Sent to SyncController when recovery is complete (or skipped) */
   case object RecoveryComplete
@@ -161,7 +212,8 @@ object BytecodeRecoveryActor {
       appStateStorage: AppStateStorage,
       networkPeerManager: ActorRef,
       syncController: ActorRef,
-      pivotBlockNumber: BigInt
+      pivotBlockNumber: BigInt,
+      snapSyncConfig: SNAPSyncConfig
   ): Props =
     Props(
       new BytecodeRecoveryActor(
@@ -171,7 +223,8 @@ object BytecodeRecoveryActor {
         appStateStorage,
         networkPeerManager,
         syncController,
-        pivotBlockNumber
+        pivotBlockNumber,
+        snapSyncConfig
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeerRequestHandler.scala
@@ -48,17 +48,6 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
   private def timeTakenSoFar(): Long = System.currentTimeMillis() - startTime
 
   override def preStart(): Unit = {
-    log.debug(
-      "PEER_REQUEST: Starting request to peer={}, reqType={}, respCode=0x{}, timeout={}ms",
-      peer.id,
-      requestMsg.getClass.getSimpleName,
-      responseMsgCode.toHexString,
-      responseTimeout.toMillis
-    )
-    log.debug(
-      "PEER_REQUEST: Request details: {}",
-      requestMsg.toShortString
-    )
     networkPeerManager ! NetworkPeerManagerActor.SendMessage(toSerializable(requestMsg), peer.id)
     peerEventBus ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
     peerEventBus ! Subscribe(subscribeMessageClassifier)
@@ -83,14 +72,6 @@ class PeerRequestHandler[RequestMsg <: Message, ResponseMsg <: Message: ClassTag
 
   def handleResponseMsg(responseMsg: ResponseMsg): Unit = {
     val elapsed = timeTakenSoFar()
-    log.debug(
-      "PEER_REQUEST_SUCCESS: peer={}, reqType={}, respType={}, elapsed={}ms",
-      peer.id,
-      requestMsg.getClass.getSimpleName,
-      responseMsg.getClass.getSimpleName,
-      elapsed
-    )
-    log.debug("PEER_REQUEST_SUCCESS: Response details: {}", responseMsg.toShortString)
     cleanupAndStop()
     initiator ! ResponseReceived(peer, responseMsg, timeTaken = elapsed)
   }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/StorageRecoveryActor.scala
@@ -1,6 +1,6 @@
 package com.chipprbots.ethereum.blockchain.sync
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props, Terminated}
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
@@ -107,6 +107,8 @@ class StorageRecoveryActor(
           )
         }
 
+        context.watch(coordinator)
+
         // Send tasks in batches of 10K (same as SNAPSyncController)
         val batchSize = 10000
         var totalSent = 0
@@ -199,6 +201,13 @@ class StorageRecoveryActor(
           // Progress happened between scheduling and firing — reset.
           abandonTimer = None
         }
+
+      case Terminated(`coordinator`) =>
+        log.error("StorageRangeCoordinator crashed unexpectedly. Marking storage recovery done to unblock sync.")
+        abandonTimer.foreach(_.cancel())
+        appStateStorage.storageRecoveryDone().commit()
+        syncController ! RecoveryComplete
+        context.stop(self)
 
       case msg => coordinator.forward(msg) // Forward SNAP protocol responses to coordinator
     }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -326,9 +326,10 @@ class SyncController(
     case SyncProtocol.HealingImpossible =>
       snapSync ! PoisonPill
       log.warning(
-        "SNAP finalization aborted (state root mismatch). Clearing SnapSyncDone and restarting SNAP with a fresh pivot."
+        "SNAP finalization aborted (state root mismatch). Clearing sync state and restarting SNAP with a fresh pivot."
       )
       appStateStorage.clearSnapSyncDone().commit()
+      appStateStorage.clearFastSyncDone().commit()
       startSnapSync()
 
     case SyncProtocol.Status.Progress(_, _) =>
@@ -343,6 +344,9 @@ class SyncController(
 
   def runningRegularSync(regularSync: ActorRef): Receive = { case other =>
     other match {
+      case Terminated(actor) if actor == regularSync =>
+        log.error("RegularSync actor terminated unexpectedly — restarting regular sync.")
+        startRegularSync(resumeBackfill = false)
       case SyncProtocol.ResetFastSync =>
         handleResetFastSync()
       case SyncProtocol.RestartFastSync =>
@@ -388,6 +392,12 @@ class SyncController(
     case Terminated(actor) if actor == snapSync =>
       log.warning("SNAPSyncController died while regular sync was running; chain backfill aborted.")
       context.become(runningRegularSync(regularSync))
+
+    case Terminated(actor) if actor == regularSync =>
+      log.error("RegularSync actor terminated unexpectedly during backfill — restarting regular sync.")
+      context.unwatch(snapSync)
+      snapSync ! PoisonPill
+      startRegularSync(resumeBackfill = false)
 
     case msg if isRestartTrigger(msg) =>
       log.info("Restart triggered while SNAP backfill was running; poison-pilling SNAP backfill actor first.")
@@ -848,6 +858,32 @@ class SyncController(
                   header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
                 )
             }
+          } else {
+            // Symmetric case (Run-26): pivot root EXISTS in MPT but differs from snapStateRoot.
+            // The downloaded account trie is stored under snapStateRoot; update the pivot header
+            // to match so the startup diagnostic passes and regular sync reads the correct trie.
+            snapStateRoot.foreach { snapRoot =>
+              if (snapRoot != header.stateRoot) {
+                val snapRootExists =
+                  try { mptStorage.get(snapRoot.toArray); true }
+                  catch { case _: Exception => false }
+                log.info(
+                  "snapStateRoot({}) availability: {}",
+                  snapRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                  if (snapRootExists) "EXISTS" else "MISSING"
+                )
+                if (snapRootExists) {
+                  log.warning(
+                    "snapStateRoot({}) differs from pivotHeader.stateRoot({}) — " +
+                      "updating pivot block header to use downloaded state root.",
+                    snapRoot.take(8).toArray.map("%02x".format(_)).mkString,
+                    header.stateRoot.take(8).toArray.map("%02x".format(_)).mkString
+                  )
+                  val updatedHeader = header.copy(stateRoot = snapRoot)
+                  blockchainWriter.storeBlockHeader(updatedHeader).commit()
+                }
+              }
+            }
           }
         }
         val needBytecode = !appStateStorage.isBytecodeRecoveryDone()
@@ -979,6 +1015,7 @@ class SyncController(
       s"regular-sync-$syncGeneration"
     )
     regularSync ! SyncProtocol.Start
+    context.watch(regularSync)
     context.become(runningRegularSync(regularSync))
     // After SNAP completes, chain backfill (#1162) writes headers / bodies / receipts in the
     // background. If the node was killed mid-backfill, persisted cursors (#1169) tell us how

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -369,7 +369,7 @@ class SyncController(
         regularSync ! PoisonPill
         appStateStorage.clearSnapSyncDone().commit()
         appStateStorage.clearFastSyncDone().commit()
-        startSnapSync()
+        startSnapSync(minPivotBlock = Some(blockNumber))
       case msg =>
         regularSync.forward(msg)
     }
@@ -938,7 +938,7 @@ class SyncController(
     context.become(runningFastSync(fastSync))
   }
 
-  def startSnapSync(): Unit = {
+  def startSnapSync(minPivotBlock: Option[BigInt] = None): Unit = {
     log.info("Starting SNAP sync mode")
     syncGeneration += 1
 
@@ -979,6 +979,10 @@ class SyncController(
       }
     }
 
+    minPivotBlock.foreach { minBlock =>
+      log.info("Sending MinPivotBlock({}) to new SNAP sync actor", minBlock)
+      snapSync ! SNAPSyncController.MinPivotBlock(minBlock)
+    }
     snapSync ! SNAPSyncController.Start
     context.become(runningSnapSync(snapSync))
   }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -1118,6 +1118,8 @@ class SyncController(
             s"stateRoot=${stateRoot.take(4).toArray.map("%02x".format(_)).mkString}..., pivotBlock=$pivotBlock)"
         )
 
+        val snapSyncConfig = loadSnapSyncConfig()
+
         val bytecodeActor = if (needBytecode) {
           Some(
             context.actorOf(
@@ -1129,7 +1131,8 @@ class SyncController(
                   appStateStorage = appStateStorage,
                   networkPeerManager = networkPeerManager,
                   syncController = self,
-                  pivotBlockNumber = pivotBlock
+                  pivotBlockNumber = pivotBlock,
+                  snapSyncConfig = snapSyncConfig
                 )
                 .withDispatcher("sync-dispatcher"),
               s"bytecode-recovery-$syncGeneration"
@@ -1138,7 +1141,6 @@ class SyncController(
         } else None
 
         val storageActor = if (needStorage) {
-          val snapSyncConfig = loadSnapSyncConfig()
           Some(
             context.actorOf(
               StorageRecoveryActor
@@ -1157,6 +1159,9 @@ class SyncController(
             )
           )
         } else None
+
+        bytecodeActor.foreach(context.watch)
+        storageActor.foreach(context.watch)
 
         // Register self for SNAP message routing so responses reach coordinators
         networkPeerManager ! com.chipprbots.ethereum.network.NetworkPeerManagerActor.RegisterSnapSyncController(self)
@@ -1234,6 +1239,34 @@ class SyncController(
           bytecodeActor.foreach(_ ! snap.actors.Messages.ByteCodePeerAvailable(peer))
           storageActor.foreach(_ ! snap.actors.Messages.StoragePeerAvailable(peer))
         }
+      }
+
+    case Terminated(actor) if bytecodeActor.contains(actor) =>
+      log.error("BytecodeRecoveryActor terminated unexpectedly. Treating as complete to unblock sync.")
+      if (storageComplete) {
+        peerPoller.cancel()
+        networkPeerManager ! com.chipprbots.ethereum.network.NetworkPeerManagerActor.RegisterSnapSyncController(
+          context.system.deadLetters
+        )
+        startRegularSync()
+      } else {
+        context.become(
+          runningRecovery(bytecodeActor = None, storageActor, bytecodeComplete = true, storageComplete, peerPoller)
+        )
+      }
+
+    case Terminated(actor) if storageActor.contains(actor) =>
+      log.error("StorageRecoveryActor terminated unexpectedly. Treating as complete to unblock sync.")
+      if (bytecodeComplete) {
+        peerPoller.cancel()
+        networkPeerManager ! com.chipprbots.ethereum.network.NetworkPeerManagerActor.RegisterSnapSyncController(
+          context.system.deadLetters
+        )
+        startRegularSync()
+      } else {
+        context.become(
+          runningRecovery(bytecodeActor, storageActor = None, bytecodeComplete, storageComplete = true, peerPoller)
+        )
       }
 
     case msg =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/FastSync.scala
@@ -772,7 +772,13 @@ class FastSync(
       requestedBlockBodies = requestedBlockBodies - handler
       requestedReceipts = requestedReceipts - handler
 
-      blacklistIfHandshaked(peer.id, blacklistDuration, reason)
+      // Peers that close the connection before answering (PEER_REQUEST_DISCONNECTED) get a longer
+      // cooldown so they don't immediately rejoin and trigger another GetReceipts dispatch cycle.
+      val effectiveDuration = reason match {
+        case FastSyncRequestFailed("connection closed") => 10.minutes
+        case _                                          => blacklistDuration
+      }
+      blacklistIfHandshaked(peer.id, effectiveDuration, reason)
     }
 
     /** Restarts download from a few blocks behind the current best block header, as an unexpected DB error happened

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -116,7 +116,7 @@ class BlockFetcher(
   private def processFetchCommands(state: BlockFetcherState): Behavior[FetchCommand] =
     Behaviors.receiveMessage {
       case PrintStatus =>
-        log.info("BlockFetcher status: {}", state.status)
+        log.info("BlockFetcher: readyBlocks={} knownTop={} onTop={}", state.readyBlocks.size, state.knownTop, state.isOnTop)
         log.debug("BlockFetcher detailed status: {}", state.statusDetailed)
         log.debug(
           "Current state - last block: {}, known top: {}, is on top: {}, ready blocks: {}, waiting headers: {}",

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -43,6 +43,7 @@ import com.chipprbots.ethereum.network.p2p.messages.ETH62._
 import com.chipprbots.ethereum.network.p2p.messages.ETH62.{BlockHeaders => ETH62BlockHeaders}
 import com.chipprbots.ethereum.network.p2p.messages.ETH63.NodeData
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{BlockHeaders => ETH66BlockHeaders}
+import com.chipprbots.ethereum.network.p2p.messages.ETH69
 import com.chipprbots.ethereum.utils.ByteStringUtils
 import com.chipprbots.ethereum.utils.Config.SyncConfig
 import com.chipprbots.ethereum.utils.FunctorOps._
@@ -99,7 +100,7 @@ class BlockFetcher(
         peerEventBus.tell(
           Subscribe(
             MessageClassifier(
-              Set(Codes.NewBlockCode, Codes.NewBlockHashesCode, Codes.BlockHeadersCode),
+              Set(Codes.NewBlockCode, Codes.NewBlockHashesCode, Codes.BlockHeadersCode, Codes.BlockRangeUpdateCode),
               PeerSelector.AllPeers
             )
           ),
@@ -126,7 +127,13 @@ class BlockFetcher(
           state.readyBlocks.size,
           state.waitingHeaders.size
         )
-        Behaviors.same
+        // Defense-in-depth: if stuck at chain head with no peer gossip (e.g., ETH/69 peers that
+        // sent BlockRangeUpdate before we subscribed, or a quiet period), probe speculatively.
+        // withPossibleNewTopAt(knownTop + 1) exits isOnTop and triggers tryFetchHeaders.
+        if (state.isOnTop) {
+          log.debug("BlockFetcher: isOnTop at knownTop={}, probing for next block", state.knownTop)
+          fetchBlocks(state.withPossibleNewTopAt(state.knownTop + 1))
+        } else Behaviors.same
 
       case PickBlocks(amount, replyTo) =>
         log.debug("PickBlocks request for {} blocks (ready blocks: {})", amount, state.readyBlocks.size)
@@ -235,8 +242,9 @@ class BlockFetcher(
                   headers.size,
                   updatedState.waitingHeaders.size
                 )
-                // If we received a full batch, the peer likely has more blocks.
-                // Bump knownTop to force another fetch cycle (prevents premature isOnTop).
+                // Full batch only: peer likely has more blocks — eagerly advance knownTop to
+                // prevent premature isOnTop. Partial batch = chain tip; leave knownTop at
+                // lastHeader.number so isOnTop fires correctly.
                 val finalState = if (headers.size.toLong >= syncConfig.blockHeadersPerRequest) {
                   val lastHeader = headers.maxBy(_.number)
                   updatedState.withPossibleNewTopAt(lastHeader.number + 1)
@@ -395,6 +403,12 @@ class BlockFetcher(
             )
             state.withPossibleNewTopAt(validHashes.lastOption.map(_.number))
         }
+        supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
+        fetchBlocks(newState)
+
+      case AdaptedMessageFromEventBus(msg: ETH69.BlockRangeUpdate, _) =>
+        log.debug("Received BlockRangeUpdate earliest={} latest={}", msg.earliestBlock, msg.latestBlock)
+        val newState = state.withPossibleNewTopAt(msg.latestBlock)
         supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
         fetchBlocks(newState)
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -199,6 +199,7 @@ class BlockImporter(
       // Retry the same blocks directly — don't PickBlocks, which would fetch from wherever the
       // fetcher is now (potentially far beyond the pivot). After SNAP sync, only the pivot header
       // has a number→hash mapping, so branch resolution would fail for any other starting point.
+      consecutiveExhausts += 1
       importBlocks(blocksToRetry, blockImportType)(state)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -252,7 +252,7 @@ class BlockImporter(
               b.body.transactionList.size,
               b.header.gasUsed
             )
-          case _ => log.info("Imported blocks {} - {}", importedBlocks.head.number, importedBlocks.last.number)
+          case _ => log.info("Imported blocks {} - {}", importedBlocks.last.number, importedBlocks.head.number)
         }
 
         errorOpt match {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -243,7 +243,15 @@ class BlockImporter(
         val (importedBlocks, errorOpt) = value
         importedBlocks.size match {
           case 0 => log.debug("Imported no blocks")
-          case 1 => log.info("Imported block {}", importedBlocks.head.number)
+          case 1 =>
+            val b = importedBlocks.head
+            log.info(
+              "Imported block {} ({}) txs={} gas={}",
+              b.number,
+              b.header.hashAsHexString.take(10),
+              b.body.transactionList.size,
+              b.header.gasUsed
+            )
           case _ => log.info("Imported blocks {} - {}", importedBlocks.head.number, importedBlocks.last.number)
         }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -64,18 +64,22 @@ class BlockImporter(
 
   context.setReceiveTimeout(syncConfig.syncRetryInterval)
 
-  // Counts consecutive state-node-fetch exhausts since the last successful state-node delivery.
-  // Don't key on block number: branch resolution walks the chain back one block per backoff
-  // cycle (24428221 → 24428220 → ...), so per-block tracking would never reach the threshold.
-  // After [[StuckEscapeThreshold]] consecutive exhausts anywhere, regular sync is deemed
-  // terminally stuck and we signal SyncController to re-trigger SNAP from a recent pivot.
-  private var consecutiveExhausts: Int = 0
   private var pendingStateNodeHash: Option[ByteString] = None
+
+  // Reset the companion-object exhaust counter on fresh actor creation.
+  // On Pekko Restart, only postRestart() fires — preStart() is skipped — so
+  // survivedExhausts is preserved across restarts and only zeroed for a new
+  // BlockImporter actor (new regular-sync session).
+  override def preStart(): Unit = {
+    super.preStart()
+    BlockImporter.survivedExhausts = 0
+  }
 
   override def receive: Receive = idle
 
   override def postRestart(reason: Throwable): Unit = {
-    super.postRestart(reason)
+    // Intentionally skip super.postRestart() — that would call preStart() and
+    // reset survivedExhausts, defeating its purpose of surviving Pekko Restarts.
     start()
   }
 
@@ -139,10 +143,10 @@ class BlockImporter(
       // can serve it via SNAP GetTrieNodes (typical: pivot fell out of the 128-block serve window
       // on every connected peer).
       val blockNum = blocksToRetry.head.number
-      consecutiveExhausts += 1
+      BlockImporter.survivedExhausts += 1
       val missingHashStr = pendingStateNodeHash.map(ByteStringUtils.hash2string).getOrElse("<unknown>")
 
-      if (consecutiveExhausts >= BlockImporter.StuckEscapeThreshold) {
+      if (BlockImporter.survivedExhausts >= BlockImporter.StuckEscapeThreshold) {
         // Multiple consecutive exhausts mean peers genuinely don't have our parent state and
         // never will (we're far behind their snap-serve window). The only recovery is to re-pivot
         // via SNAP. Reset our local counter so we don't re-fire if SyncController bounces us back
@@ -150,10 +154,10 @@ class BlockImporter(
         log.error(
           "Regular sync stuck on block {} after {} consecutive state-node exhausts (missing {}); requesting SNAP re-sync",
           blockNum,
-          consecutiveExhausts,
+          BlockImporter.survivedExhausts,
           missingHashStr
         )
-        consecutiveExhausts = 0
+        BlockImporter.survivedExhausts = 0
         pendingStateNodeHash = None
         supervisor ! SyncProtocol.RegularSyncStuck(blockNum, missingHashStr)
         // Don't transition further — SyncController will PoisonPill regular sync.
@@ -161,7 +165,7 @@ class BlockImporter(
         log.error(
           "State node recovery failed after max retries for block {} (consecutive exhausts: {}/{}) — backing off {}s before retry",
           blockNum,
-          consecutiveExhausts,
+          BlockImporter.survivedExhausts,
           BlockImporter.StuckEscapeThreshold,
           5.minutes.toSeconds
         )
@@ -190,7 +194,7 @@ class BlockImporter(
       catch { case _: Exception => () }
       // Successful state-node delivery — reset stuck-counter so a later transient failure on a
       // different block doesn't escalate to SNAP re-sync prematurely.
-      consecutiveExhausts = 0
+      BlockImporter.survivedExhausts = 0
       pendingStateNodeHash = None
       importBlocks(blocksToRetry, blockImportType)(state)
 
@@ -199,7 +203,7 @@ class BlockImporter(
       // Retry the same blocks directly — don't PickBlocks, which would fetch from wherever the
       // fetcher is now (potentially far beyond the pivot). After SNAP sync, only the pivot header
       // has a number→hash mapping, so branch resolution would fail for any other starting point.
-      consecutiveExhausts += 1
+      BlockImporter.survivedExhausts += 1
       importBlocks(blocksToRetry, blockImportType)(state)
   }
 
@@ -599,6 +603,11 @@ object BlockImporter {
   // is deemed terminally stuck and we escalate to SNAP re-sync via SyncProtocol.RegularSyncStuck.
   // 3 × 5-min backoff = ~15 minutes of bounded retry before invoking the escape valve.
   val StuckEscapeThreshold: Int = 3
+
+  // Exhaust counter that outlives individual actor instances so Pekko Restarts don't reset
+  // the progress toward StuckEscapeThreshold. Zeroed by preStart() (fresh regular-sync session)
+  // but NOT by postRestart() (same logical actor restarted after a crash).
+  private[regular] var survivedExhausts: Int = 0
 
   // scalastyle:off parameter.number
   def props(

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -26,6 +26,8 @@ import com.chipprbots.ethereum.ledger.BranchResolution
 import com.chipprbots.ethereum.nodebuilder.BlockchainConfigBuilder
 import com.chipprbots.ethereum.utils.Config.SyncConfig
 
+import scala.concurrent.duration._
+
 class RegularSync(
     peersClient: ActorRef,
     networkPeerManager: ActorRef,
@@ -92,6 +94,11 @@ class RegularSync(
       BlockFetcher.PrintStatus
     )(context.dispatcher, self)
 
+  val printStatusSchedule: Cancellable =
+    scheduler.scheduleWithFixedDelay(
+      60.seconds, 60.seconds, self, RegularSync.PrintStatus
+    )(context.dispatcher, self)
+
   override def receive: Receive = running(
     ProgressState(startedFetching = false, initialBlock = 0, currentBlock = 0, bestKnownNetworkBlock = 0)
   )
@@ -139,6 +146,15 @@ class RegularSync(
         msg.missingHash
       )
       context.parent ! msg
+
+    case RegularSync.PrintStatus =>
+      val lag = progressState.bestKnownNetworkBlock - progressState.currentBlock
+      log.info(
+        "RegularSync following head: current={} best={} lag={}",
+        progressState.currentBlock,
+        progressState.bestKnownNetworkBlock,
+        lag
+      )
   }
 
   override def supervisorStrategy: SupervisorStrategy = AllForOneStrategy()(SupervisorStrategy.defaultDecider)
@@ -146,9 +162,12 @@ class RegularSync(
   override def postStop(): Unit = {
     log.info("Regular Sync stopped")
     printFetcherSchedule.cancel()
+    printStatusSchedule.cancel()
   }
 }
 object RegularSync {
+  private[regular] case object PrintStatus
+
   // scalastyle:off parameter.number
   def props(
       peersClient: ActorRef,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -215,7 +215,7 @@ object RegularSync {
     def toStatus: SyncProtocol.Status =
       if (startedFetching && bestKnownNetworkBlock != 0 && currentBlock < bestKnownNetworkBlock) {
         Status.Syncing(initialBlock, Progress(currentBlock, bestKnownNetworkBlock), None)
-      } else if (startedFetching && currentBlock >= bestKnownNetworkBlock) {
+      } else if (startedFetching && bestKnownNetworkBlock != 0 && currentBlock >= bestKnownNetworkBlock) {
         Status.SyncDone
       } else {
         Status.NotSyncing

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -78,6 +78,10 @@ class ChainDownloader(
   private var bodyRequestPeers: Map[ActorRef, (Peer, Seq[ByteString])] = Map.empty
   private var receiptRequestPeers: Map[ActorRef, (Peer, Seq[ByteString])] = Map.empty
 
+  // go-ethereum behavioural backoff: peers that returned empty headers are excluded from
+  // header dispatch (capacity-to-zero equivalent). Bodies/receipts/SNAP unaffected.
+  private var emptyHeaderPeers: Set[PeerId] = Set.empty
+
   // Stats
   private var headersDownloaded: BigInt = 0
   private var bodiesDownloaded: BigInt = 0
@@ -90,6 +94,7 @@ class ChainDownloader(
   // Visible to tests in the same package: lets ChainDownloaderSpec assert YieldToRegularSync clamping
   // without relying on log-output scraping or reflection.
   private[snap] def currentMaxConcurrentRequests: Int = maxConcurrentRequests
+  private[snap] def isHeaderExcluded(peerId: PeerId): Boolean = emptyHeaderPeers.contains(peerId)
 
   // Dispatch timer
   private var dispatchTask: Option[org.apache.pekko.actor.Cancellable] = None
@@ -182,7 +187,11 @@ class ChainDownloader(
     case ResponseReceived(peer, ETH66.BlockHeaders(_, headers), _) =>
       headerRequestPeers -= peer.id
       if (headers.nonEmpty) {
+        emptyHeaderPeers -= peer.id
         handleHeaders(peer, headers)
+      } else {
+        emptyHeaderPeers += peer.id
+        log.debug("Empty headers from {} — excluding from header dispatch", peer.id)
       }
       dispatchRequests()
 
@@ -223,7 +232,8 @@ class ChainDownloader(
       headerRequestPeers.contains(peerId) ||
       bodyRequestPeers.values.exists(_._1.id == peerId) ||
       receiptRequestPeers.values.exists(_._1.id == peerId) ||
-      p.peer.nodeId.exists(snapServerPeerNodeIds.contains)
+      p.peer.nodeId.exists(snapServerPeerNodeIds.contains) ||
+      emptyHeaderPeers.contains(peerId)
     }
 
     if (available.isEmpty) return

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloader.scala
@@ -53,7 +53,8 @@ class ChainDownloader(
     val syncConfig: SyncConfig,
     val scheduler: Scheduler,
     initialMaxConcurrentRequests: Int,
-    requestTimeout: FiniteDuration = 10.seconds
+    requestTimeout: FiniteDuration = 10.seconds,
+    snapServerPeerNodeIds: Set[ByteString] = Set.empty
 )(implicit ec: ExecutionContext)
     extends Actor
     with ActorLogging
@@ -218,10 +219,11 @@ class ChainDownloader(
     val inFlightCount = headerRequestPeers.size + bodyRequestPeers.size + receiptRequestPeers.size
     if (inFlightCount >= maxConcurrentRequests) return
 
-    val available = peersToDownloadFrom.filterNot { case (peerId, _) =>
+    val available = peersToDownloadFrom.filterNot { case (peerId, p) =>
       headerRequestPeers.contains(peerId) ||
       bodyRequestPeers.values.exists(_._1.id == peerId) ||
-      receiptRequestPeers.values.exists(_._1.id == peerId)
+      receiptRequestPeers.values.exists(_._1.id == peerId) ||
+      p.peer.nodeId.exists(snapServerPeerNodeIds.contains)
     }
 
     if (available.isEmpty) return
@@ -716,7 +718,8 @@ object ChainDownloader {
       syncConfig: SyncConfig,
       scheduler: Scheduler,
       maxConcurrentRequests: Int = 4,
-      requestTimeout: FiniteDuration = 10.seconds
+      requestTimeout: FiniteDuration = 10.seconds,
+      snapServerPeerNodeIds: Set[ByteString] = Set.empty
   )(implicit ec: ExecutionContext): Props =
     Props(
       new ChainDownloader(
@@ -729,7 +732,8 @@ object ChainDownloader {
         syncConfig,
         scheduler,
         maxConcurrentRequests,
-        requestTimeout
+        requestTimeout,
+        snapServerPeerNodeIds
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
@@ -5,7 +5,6 @@ import org.apache.pekko.util.ByteString
 import com.chipprbots.ethereum.domain.Account
 import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.mpt.MptTraversals
-import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.mpt.LeafNode
 import com.chipprbots.ethereum.mpt.ExtensionNode
 import com.chipprbots.ethereum.mpt.BranchNode
@@ -53,10 +52,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
   ): Either[String, Unit] = {
 
     if (proof.isEmpty && accounts.isEmpty) {
-      if (rootHash == ByteString(MerklePatriciaTrie.EmptyRootHash)) {
-        return Right(())
-      }
-      return Left("Missing proof for empty account range")
+      return Right(())
     }
 
     // If we have accounts, we need a proof

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3138,23 +3138,36 @@ class SNAPSyncController(
       peerTD: Option[BigInt] = None
   ): Unit = {
     val pivotHash = header.hash
-    val estimatedTotalDifficulty = peerTD.filter(_ > BigInt(0)).getOrElse {
-      if (pivotBlockNumber == BigInt(0)) header.difficulty
-      else header.difficulty * pivotBlockNumber
-    }
+    // Priority: (1) real cumulative TD from ChainDownloader already in DB — never overwrite it;
+    // (2) ETH68 peer wire TD passed in — accurate bootstrap during rough period;
+    // (3) pivotBlockNumber as proxy — non-inflating fallback so fukuii never appears
+    //     as the highest-TD peer while SNAP syncing (low TD is harmless; inflated TD is not).
+    val (estimatedTotalDifficulty, tdSource) =
+      blockchainReader
+        .getChainWeightByHash(pivotHash)
+        .map(cw => (cw.totalDifficulty, "REAL_PIVOT_TD"))
+        .orElse(peerTD.filter(_ > BigInt(0)).map(td => (td, "ETH68_BOOTSTRAP")))
+        .getOrElse {
+          val proxy = if (pivotBlockNumber == BigInt(0)) header.difficulty else pivotBlockNumber
+          (proxy, "BLOCK_NUMBER_PROXY")
+        }
     // Store header so getBestBlockHeader() -> getBlockHeaderByNumber(pivot) finds it
     blockchainWriter.storeBlockHeader(header).commit()
     blockchainWriter
       .storeChainWeight(pivotHash, ChainWeight.totalDifficultyOnly(estimatedTotalDifficulty))
       .commit()
-    appStateStorage
-      .putBestBlockInfo(com.chipprbots.ethereum.domain.appstate.BlockInfo(pivotHash, pivotBlockNumber))
-      .commit()
+    // Only advance the self-reported best-block pointer when we have a real TD.
+    // BLOCK_NUMBER_PROXY must not overwrite a real ETH68_BOOTSTRAP anchor — if it did,
+    // resolveETH69ChainWeight's POW_SCALING would read block-number as ourBestTD and produce
+    // a wrong-magnitude TD for every ETH/69 peer until the next restart.
+    if (tdSource != "BLOCK_NUMBER_PROXY") {
+      appStateStorage
+        .putBestBlockInfo(com.chipprbots.ethereum.domain.appstate.BlockInfo(pivotHash, pivotBlockNumber))
+        .commit()
+    }
     log.info(
       s"Updated best block for ETH status: block=$pivotBlockNumber, hash=${pivotHash.toHex.take(16)}..., " +
-        s"estimatedTD=$estimatedTotalDifficulty (source=${
-            if (peerTD.exists(_ > 0)) "PEER_WIRE_TD" else "LINEAR_ESTIMATE"
-          })"
+        s"estimatedTD=$estimatedTotalDifficulty (source=$tdSource)"
     )
   }
 
@@ -3605,14 +3618,17 @@ class SNAPSyncController(
           blockchainWriter.storeBlock(Block(pivotHeader, BlockBody.empty)).commit()
 
           // Store a ChainWeight so compareBranch() can evaluate new blocks.
-          // We estimate totalDifficulty ≈ difficulty × blockNumber. This doesn't need
-          // to be exact — it just needs to exist so branch resolution doesn't error,
-          // and subsequent blocks will accumulate from this baseline.
-          val estimatedTotalDifficulty = pivotHeader.difficulty * pivot
+          // Prefer real cumulative TD from ChainDownloader if already in DB;
+          // fall to pivot block number as a non-inflating proxy otherwise.
+          val finalTD =
+            blockchainReader
+              .getChainWeightByHash(pivotHash)
+              .map(_.totalDifficulty)
+              .getOrElse(pivot)
           blockchainWriter
             .storeChainWeight(
               pivotHash,
-              ChainWeight.totalDifficultyOnly(estimatedTotalDifficulty)
+              ChainWeight.totalDifficultyOnly(finalTD)
             )
             .commit()
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -189,6 +189,12 @@ class SNAPSyncController(
   // arrives in the syncing state, the refresh is completed.
   private var pendingPivotRefresh: Option[(BigInt, String)] = None
 
+  // Debounce rapid PeerDisconnected bursts — collect peer IDs and flush after a 3 s quiet window.
+  // Prevents a burst of TCP failures (e.g. 15 in 33 s) from draining all coordinator task queues
+  // simultaneously, which would deplete the peer pool and trigger a cascade pivot refresh.
+  private var pendingDisconnectedPeers: Set[String] = Set.empty
+  private var disconnectFlushTask: Option[Cancellable] = None
+
   // Scheduled tasks for periodic peer requests
   private var accountRangeRequestTask: Option[Cancellable] = None
   private var bytecodeRequestTask: Option[Cancellable] = None
@@ -264,12 +270,22 @@ class SNAPSyncController(
       }
 
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
-      handlePeerListMessages(msg)
-      requestTracker.rateTracker.removePeer(peerId.value)
-      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
-      storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePeerUnavailable(peerId.value))
-      bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePeerUnavailable(peerId.value))
-      trieNodeHealingCoordinator.foreach(_ ! actors.Messages.HealingPeerUnavailable(peerId.value))
+      handlePeerListMessages(msg)                          // immediate: keeps handshakedPeers current
+      requestTracker.rateTracker.removePeer(peerId.value)  // immediate: rate tracking
+      pendingDisconnectedPeers += peerId.value
+      disconnectFlushTask.foreach(_.cancel())
+      disconnectFlushTask = Some(scheduler.scheduleOnce(3.seconds)(self ! FlushPeerDisconnects)(ec))
+
+    case FlushPeerDisconnects =>
+      disconnectFlushTask = None
+      val ids = pendingDisconnectedPeers
+      pendingDisconnectedPeers = Set.empty
+      ids.foreach { id =>
+        accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(id))
+        storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePeerUnavailable(id))
+        bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePeerUnavailable(id))
+        trieNodeHealingCoordinator.foreach(_ ! actors.Messages.HealingPeerUnavailable(id))
+      }
   }
 
   /** Wrap handlePeerListMessages to also update the PeerRateTracker when peers connect/disconnect. Tracks previous peer
@@ -290,12 +306,22 @@ class SNAPSyncController(
       }
 
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
-      handlePeerListMessages(msg) // removes from handshakedPeers
-      requestTracker.rateTracker.removePeer(peerId.value)
-      accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(peerId.value))
-      storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePeerUnavailable(peerId.value))
-      bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePeerUnavailable(peerId.value))
-      trieNodeHealingCoordinator.foreach(_ ! actors.Messages.HealingPeerUnavailable(peerId.value))
+      handlePeerListMessages(msg)                          // immediate: keeps handshakedPeers current
+      requestTracker.rateTracker.removePeer(peerId.value)  // immediate: rate tracking
+      pendingDisconnectedPeers += peerId.value
+      disconnectFlushTask.foreach(_.cancel())
+      disconnectFlushTask = Some(scheduler.scheduleOnce(3.seconds)(self ! FlushPeerDisconnects)(ec))
+
+    case FlushPeerDisconnects =>
+      disconnectFlushTask = None
+      val ids = pendingDisconnectedPeers
+      pendingDisconnectedPeers = Set.empty
+      ids.foreach { id =>
+        accountRangeCoordinator.foreach(_ ! actors.Messages.PeerUnavailable(id))
+        storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePeerUnavailable(id))
+        bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePeerUnavailable(id))
+        trieNodeHealingCoordinator.foreach(_ ! actors.Messages.HealingPeerUnavailable(id))
+      }
   }
 
   // Storage stagnation watchdog: if storage stops advancing while tasks remain, repivot/restart.
@@ -3853,7 +3879,8 @@ object SNAPSyncController {
   final case class PivotBootstrapFailed(
       reason: String
   ) // Signal from SyncController that pivot header bootstrap exhausted retries
-  private case object RetrySnapSyncStart // Internal message to retry SNAP sync start after bootstrap
+  private case object RetrySnapSyncStart   // Internal message to retry SNAP sync start after bootstrap
+  private case object FlushPeerDisconnects // Debounce flush: forward batched PeerUnavailable to coordinators
   case object AccountRangeSyncComplete
   case object ByteCodeSyncComplete
   case object StorageRangeSyncComplete

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -200,7 +200,6 @@ class SNAPSyncController(
   private var bytecodeRequestTask: Option[Cancellable] = None
   private var storageRangeRequestTask: Option[Cancellable] = None
   private var accountStagnationCheckTask: Option[Cancellable] = None
-  private var storageStagnationCheckTask: Option[Cancellable] = None
   private var healingRequestTask: Option[Cancellable] = None
   private var snapServerPeersScheduler: Option[Cancellable] = None
   private var storageStagnationRefreshAttempted: Boolean = false
@@ -334,6 +333,8 @@ class SNAPSyncController(
     10.minutes // CFG-2: 20→10min; second stall force-completes after 30s anyway
   private val AccountStagnationThreshold: FiniteDuration = snapSyncConfig.accountStagnationTimeout
   private var lastStorageProgressMs: Long = System.currentTimeMillis()
+  private var lastBytecodeProgressMs: Long = System.currentTimeMillis()
+  private var lastBytecodeProgressCount: Long = 0L
   private var lastAccountProgressMs: Long = System.currentTimeMillis()
   private var lastAccountTasksCompleted: Int = 0
   private var lastAccountsDownloaded: Long = 0
@@ -363,7 +364,6 @@ class SNAPSyncController(
     bytecodeRequestTask.foreach(_.cancel())
     storageRangeRequestTask.foreach(_.cancel())
     accountStagnationCheckTask.foreach(_.cancel())
-    storageStagnationCheckTask.foreach(_.cancel())
     healingRequestTask.foreach(_.cancel())
     bootstrapCheckTask.foreach(_.cancel())
     pivotBootstrapRetryTask.foreach(_.cancel())
@@ -579,6 +579,7 @@ class SNAPSyncController(
 
     case ProgressBytecodesDownloaded(count) =>
       progressMonitor.incrementBytecodesDownloaded(count)
+      lastBytecodeProgressMs = System.currentTimeMillis()
 
     case ProgressStorageSlotsSynced(count) =>
       progressMonitor.incrementStorageSlotsSynced(count)
@@ -827,8 +828,10 @@ class SNAPSyncController(
         // Cancel account stagnation checks (no longer relevant)
         accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
 
-        // Start storage stagnation watchdog now that accounts are done
+        // Start storage + bytecode stagnation watchdogs now that accounts are done
         lastStorageProgressMs = System.currentTimeMillis()
+        lastBytecodeProgressMs = System.currentTimeMillis()
+        lastBytecodeProgressCount = 0L
         scheduleStagnationChecks()
 
         checkAllDownloadsComplete()
@@ -862,13 +865,21 @@ class SNAPSyncController(
       checkAllDownloadsComplete()
 
     case StorageRangeSyncForceCompleted if !storagePhaseComplete =>
-      storagePhaseComplete = true
-      storagePhaseForceCompleted = true
-      log.warning(
-        s"Storage range sync was force-completed. ByteCode: $bytecodePhaseComplete, Accounts: $accountsComplete. " +
-          "SNAP will run healing/validation before regular sync handoff."
-      )
-      checkAllDownloadsComplete()
+      if (currentPhase == ByteCodeAndStorageSync || currentPhase == StateHealing) {
+        storagePhaseComplete = true
+        storagePhaseForceCompleted = true
+        log.warning(
+          s"Storage range sync was force-completed. ByteCode: $bytecodePhaseComplete, " +
+            s"Accounts: $accountsComplete. SNAP will run healing/validation before handoff."
+        )
+        checkAllDownloadsComplete()
+      } else {
+        log.warning(
+          s"StorageRangeSyncForceCompleted received during phase $currentPhase " +
+            s"(consecutive-failures transient path) — ignoring storagePhaseComplete flag. " +
+            s"Storage stagnation recovery remains active for ByteCodeAndStorageSync phase."
+        )
+      }
 
     case HealingAllPeersStateless if currentPhase == StateHealing =>
       log.warning("All healing peers stateless — refreshing pivot in-place for healing")
@@ -1097,10 +1108,10 @@ class SNAPSyncController(
   private case object CheckDownloadStagnation
   private case class AccountCoordinatorProgress(progress: actors.AccountRangeStats)
   private case class StorageCoordinatorProgress(stats: actors.StorageRangeCoordinator.SyncStatistics)
+  private case class ByteCodeCoordinatorProgress(progress: actors.Messages.ByteCodeProgress)
 
   private def scheduleStagnationChecks(): Unit = {
     accountStagnationCheckTask.foreach(_.cancel())
-    storageStagnationCheckTask.foreach(_.cancel())
     val interval = DownloadStagnationCheckInterval
     accountStagnationCheckTask = Some(
       scheduler.scheduleWithFixedDelay(interval, interval, self, CheckDownloadStagnation)(ec, self)
@@ -1138,7 +1149,6 @@ class SNAPSyncController(
             s"(stalled ${stalledForMs / 1000}s). Trie construction likely stuck. Force-completing."
         )
         storageRangeRequestTask.foreach(_.cancel()); storageRangeRequestTask = None
-        storageStagnationCheckTask.foreach(_.cancel()); storageStagnationCheckTask = None
         storageRangeCoordinator.foreach(_ ! actors.Messages.ForceCompleteStorage)
       }
       return
@@ -1170,9 +1180,32 @@ class SNAPSyncController(
           s"Promoting to healing phase (preserving downloaded state)."
       )
       storageRangeRequestTask.foreach(_.cancel()); storageRangeRequestTask = None
-      storageStagnationCheckTask.foreach(_.cancel()); storageStagnationCheckTask = None
       storageRangeCoordinator.foreach(_ ! actors.Messages.ForceCompleteStorage)
     }
+  }
+
+  private val BytecodeStagnationThreshold: FiniteDuration = 10.minutes
+
+  /** Force-complete bytecode sync if no progress for BytecodeStagnationThreshold.
+    *
+    * Only fires during ByteCodeAndStorageSync when noMoreTasksExpected is set (post-AccountRange). Missing bytecodes
+    * are recovered per-block during import via BytecodeRecoveryActor.
+    */
+  private def maybeForceCompleteIfBytecodeStagnant(progress: actors.Messages.ByteCodeProgress): Unit = {
+    if (currentPhase != ByteCodeAndStorageSync || bytecodePhaseComplete) return
+    if (progress.bytecodesDownloaded > lastBytecodeProgressCount) {
+      lastBytecodeProgressCount = progress.bytecodesDownloaded
+      lastBytecodeProgressMs = System.currentTimeMillis()
+      return
+    }
+    val stalledForMs = System.currentTimeMillis() - lastBytecodeProgressMs
+    if (stalledForMs < BytecodeStagnationThreshold.toMillis) return
+    log.warning(
+      s"ByteCode sync stalled: no progress for ${stalledForMs / 1000}s " +
+        s"(threshold=${BytecodeStagnationThreshold.toSeconds}s, downloaded=${progress.bytecodesDownloaded}). " +
+        s"Force-completing — missing bytecodes deferred to import-time recovery."
+    )
+    bytecodeCoordinator.foreach(_ ! actors.Messages.ForceCompleteByteCodes)
   }
 
   /** Geth-aligned: check if all 3 concurrent download phases are complete. Only transitions to healing when accounts +
@@ -2693,6 +2726,19 @@ class SNAPSyncController(
               }
               .pipeTo(self)
           }
+          if (!bytecodePhaseComplete) {
+            bytecodeCoordinator.foreach { coordinator =>
+              (coordinator ? actors.Messages.ByteCodeGetProgress)
+                .mapTo[actors.Messages.ByteCodeProgress]
+                .map(ByteCodeCoordinatorProgress.apply)
+                .recover { case _ =>
+                  ByteCodeCoordinatorProgress(
+                    actors.Messages.ByteCodeProgress(0.0, 0L, 0L)
+                  )
+                }
+                .pipeTo(self)
+            }
+          }
         case _ => // No stagnation check needed in other phases
       }
       super.aroundReceive(receive, msg)
@@ -2711,6 +2757,14 @@ class SNAPSyncController(
           s"refreshAttempted=$storageStagnationRefreshAttempted"
       )
       maybeRestartIfStorageStagnant(stats)
+      super.aroundReceive(receive, msg)
+
+    case ByteCodeCoordinatorProgress(progress) if currentPhase == ByteCodeAndStorageSync =>
+      log.info(
+        s"ByteCode stagnation check: downloaded=${progress.bytecodesDownloaded}, " +
+          s"stalledMs=${System.currentTimeMillis() - lastBytecodeProgressMs}"
+      )
+      maybeForceCompleteIfBytecodeStagnant(progress)
       super.aroundReceive(receive, msg)
 
     case _ =>
@@ -3366,7 +3420,6 @@ class SNAPSyncController(
     bytecodeRequestTask.foreach(_.cancel()); bytecodeRequestTask = None
     storageRangeRequestTask.foreach(_.cancel()); storageRangeRequestTask = None
     accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
-    storageStagnationCheckTask.foreach(_.cancel()); storageStagnationCheckTask = None
     healingRequestTask.foreach(_.cancel()); healingRequestTask = None
     bootstrapCheckTask.foreach(_.cancel()); bootstrapCheckTask = None
     pivotBootstrapRetryTask.foreach(_.cancel()); pivotBootstrapRetryTask = None

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -202,6 +202,7 @@ class SNAPSyncController(
   private var accountStagnationCheckTask: Option[Cancellable] = None
   private var storageStagnationCheckTask: Option[Cancellable] = None
   private var healingRequestTask: Option[Cancellable] = None
+  private var snapServerPeersScheduler: Option[Cancellable] = None
   private var storageStagnationRefreshAttempted: Boolean = false
   private var trieWalkInProgress: Boolean = false
   private var healingRoundCount: Int = 0
@@ -369,6 +370,8 @@ class SNAPSyncController(
     snapCapabilityCheckTask.foreach(_.cancel())
     snapPeerEvictionTask.foreach(_.cancel())
     rateTrackerTuneTask.foreach(_.cancel())
+    snapServerPeersScheduler.foreach(_.cancel())
+    snapServerPeersScheduler = None
     progressMonitor.stopPeriodicLogging()
   }
 
@@ -1719,6 +1722,7 @@ class SNAPSyncController(
 
             // Start parallel chain download during recovery too
             startChainDownloader()
+            startSnapServerPeersScheduler()
 
             context.become(syncing)
             // If both phases were already complete, advance to healing immediately
@@ -2232,9 +2236,11 @@ class SNAPSyncController(
     preservedRangeProgress = Map.empty
     preservedAtPivotBlock = None
 
-    // Stop chain downloader
+    // Stop chain downloader and peer scheduler
     chainDownloader.foreach(context.stop)
     chainDownloader = None
+    snapServerPeersScheduler.foreach(_.cancel())
+    snapServerPeersScheduler = None
 
     // Notify parent controller to switch to fast sync
     context.parent ! FallbackToFastSync
@@ -2338,6 +2344,11 @@ class SNAPSyncController(
     // Start parallel chain download (headers, bodies, receipts from genesis to pivot)
     // Follows the Geth/Nethermind pattern of overlapping chain + state download.
     startChainDownloader()
+
+    // Start proactive outbound dials to snap-server-peers so they are connected throughout ALL
+    // phases (not only at StateHealing). core-geth's StaticNode dial to fukuii fails silently;
+    // fukuii must initiate the connection itself.
+    startSnapServerPeersScheduler()
   }
 
   private def launchAccountRangeWorkers(rootHash: ByteString, concurrency: Int): Unit = {
@@ -2800,17 +2811,8 @@ class SNAPSyncController(
       // Periodically send peer availability notifications (cancel any existing scheduler first)
       startHealingRequestScheduler()
 
-      // Ensure configured snap-server-peers are connected, checked periodically.
-      // Initial delay of 15s gives inbound connections time to complete STATUS exchange and
-      // appear in handshakedPeers (STATUS < 1s + peersScanInterval = 5s) before we ever
-      // send an outbound ConnectToPeer. Firing immediately was causing AlreadyConnected on
-      // go-ethereum: core-geth connects inbound → we immediately dial outbound → both killed.
-      scheduler.scheduleWithFixedDelay(
-        15.seconds,
-        30.seconds,
-        self,
-        EnsureSnapServerPeersConnected
-      )(ec)
+      // Ensure snap-server-peers scheduler is running (idempotent — already started at account sync).
+      startSnapServerPeersScheduler()
 
       progressMonitor.startPhase(StateHealing)
     }
@@ -2871,6 +2873,17 @@ class SNAPSyncController(
     healingRequestTask = Some(
       scheduler.scheduleWithFixedDelay(0.seconds, 1.second, self, RequestTrieNodeHealing)(ec, self)
     )
+  }
+
+  // Start (or re-use) the snap-server-peers reconnect scheduler.
+  // Idempotent: does nothing if already running. 15s initial delay lets inbound connections
+  // complete STATUS exchange before we fire an outbound ConnectToPeer (avoids AlreadyConnected races).
+  private def startSnapServerPeersScheduler(): Unit = {
+    if (snapSyncConfig.snapServerPeers.nonEmpty && snapServerPeersScheduler.isEmpty) {
+      snapServerPeersScheduler = Some(
+        scheduler.scheduleWithFixedDelay(15.seconds, 30.seconds, self, EnsureSnapServerPeersConnected)(ec)
+      )
+    }
   }
 
   // Internal message for periodic healing requests
@@ -3750,6 +3763,9 @@ class SNAPSyncController(
       if (chainDownloader.isEmpty) {
         log.info("Starting parallel chain download from genesis to pivot block {}", pivot)
         coordinatorGeneration += 1
+        val snapServerNodeIds = snapSyncConfig.snapServerPeers.flatMap { uri =>
+          scala.util.Try(ByteString(org.bouncycastle.util.encoders.Hex.decode(uri.getUserInfo))).toOption
+        }.toSet
         val downloader = context.actorOf(
           ChainDownloader
             .props(
@@ -3761,7 +3777,8 @@ class SNAPSyncController(
               syncConfig,
               scheduler,
               snapSyncConfig.chainDownloadMaxConcurrentRequests,
-              snapSyncConfig.chainDownloadTimeout
+              snapSyncConfig.chainDownloadTimeout,
+              snapServerNodeIds
             )
             .withDispatcher("sync-dispatcher"),
           s"chain-downloader-$coordinatorGeneration"

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -77,6 +77,10 @@ class SNAPSyncController(
   // from `SyncController`. Consumed by `startSnapSync()` to skip TD-based pivot selection
   // on post-merge chains. Only meaningful when `isPostMergeChain == true`. Closes #1207.
   private var clPivotHint: Option[CLPivotHint] = None
+
+  // Minimum pivot block enforced when re-entering SNAP from a RegularSyncStuck escape.
+  // Prevents re-selecting the same pivot that caused the regular-sync stall.
+  private var minPivotHint: BigInt = BigInt(0)
   private var clHintArrivedAtMs: Option[Long] = None
 
   // Captured once at construction. ETC mainnet has TTD=None and never goes down the
@@ -396,6 +400,10 @@ class SNAPSyncController(
   override def receive: Receive = idle
 
   def idle: Receive = {
+    case MinPivotBlock(minBlock) =>
+      log.info("Received MinPivotBlock hint: pivot must be >= {}", minBlock)
+      minPivotHint = minBlock
+
     case Start =>
       log.info("Starting SNAP sync...")
       startSnapSync()
@@ -1957,7 +1965,14 @@ class SNAPSyncController(
         (localBestBlock, LocalPivot)
     }
 
-    val pivotBlockNumber = baseBlockForPivot - snapSyncConfig.pivotBlockOffset
+    val rawPivot = baseBlockForPivot - snapSyncConfig.pivotBlockOffset
+    val pivotBlockNumber = rawPivot.max(minPivotHint)
+    if (pivotBlockNumber > rawPivot) {
+      log.warning(
+        s"SNAP pivot raised from $rawPivot to $pivotBlockNumber to satisfy MinPivotBlock constraint " +
+          s"(regular sync was stuck near that block)"
+      )
+    }
 
     log.info(
       s"SNAP pivot selection: localBest=$localBestBlock, networkBest=${networkBestBlockOpt.getOrElse("none")}, " +
@@ -3950,6 +3965,11 @@ object SNAPSyncController {
     * `StartRegularSyncBootstrap` to fetch the header from peers). Closes #1207.
     */
   final case class CLPivotHint(headHash: ByteString, knownHeader: Option[BlockHeader])
+
+  /** Minimum block number the pivot must be at or above. Sent by SyncController when regular sync
+    * was stuck at a specific block, so re-SNAP can't re-select the same pivot that caused the stall.
+    */
+  final case class MinPivotBlock(minBlock: BigInt)
 
   /** Bootstrap-by-hash variant of `StartRegularSyncBootstrap`. Used when the CL drives sync and we know the head hash
     * but not its block number — `PivotHeaderBootstrap` then fetches by `GetBlockHeaders(Right(hash))`. Closes #1207.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -271,8 +271,8 @@ class SNAPSyncController(
       }
 
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
-      handlePeerListMessages(msg)                          // immediate: keeps handshakedPeers current
-      requestTracker.rateTracker.removePeer(peerId.value)  // immediate: rate tracking
+      handlePeerListMessages(msg) // immediate: keeps handshakedPeers current
+      requestTracker.rateTracker.removePeer(peerId.value) // immediate: rate tracking
       pendingDisconnectedPeers += peerId.value
       disconnectFlushTask.foreach(_.cancel())
       disconnectFlushTask = Some(scheduler.scheduleOnce(3.seconds)(self ! FlushPeerDisconnects)(ec))
@@ -307,8 +307,8 @@ class SNAPSyncController(
       }
 
     case msg @ com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected(peerId) =>
-      handlePeerListMessages(msg)                          // immediate: keeps handshakedPeers current
-      requestTracker.rateTracker.removePeer(peerId.value)  // immediate: rate tracking
+      handlePeerListMessages(msg) // immediate: keeps handshakedPeers current
+      requestTracker.rateTracker.removePeer(peerId.value) // immediate: rate tracking
       pendingDisconnectedPeers += peerId.value
       disconnectFlushTask.foreach(_.cancel())
       disconnectFlushTask = Some(scheduler.scheduleOnce(3.seconds)(self ! FlushPeerDisconnects)(ec))
@@ -2878,13 +2878,12 @@ class SNAPSyncController(
   // Start (or re-use) the snap-server-peers reconnect scheduler.
   // Idempotent: does nothing if already running. 15s initial delay lets inbound connections
   // complete STATUS exchange before we fire an outbound ConnectToPeer (avoids AlreadyConnected races).
-  private def startSnapServerPeersScheduler(): Unit = {
+  private def startSnapServerPeersScheduler(): Unit =
     if (snapSyncConfig.snapServerPeers.nonEmpty && snapServerPeersScheduler.isEmpty) {
       snapServerPeersScheduler = Some(
         scheduler.scheduleWithFixedDelay(15.seconds, 30.seconds, self, EnsureSnapServerPeersConnected)(ec)
       )
     }
-  }
 
   // Internal message for periodic healing requests
   private case object RequestTrieNodeHealing
@@ -3896,7 +3895,7 @@ object SNAPSyncController {
   final case class PivotBootstrapFailed(
       reason: String
   ) // Signal from SyncController that pivot header bootstrap exhausted retries
-  private case object RetrySnapSyncStart   // Internal message to retry SNAP sync start after bootstrap
+  private case object RetrySnapSyncStart // Internal message to retry SNAP sync start after bootstrap
   private case object FlushPeerDisconnects // Debounce flush: forward batched PeerUnavailable to coordinators
   case object AccountRangeSyncComplete
   case object ByteCodeSyncComplete

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -823,7 +823,14 @@ class SNAPSyncController(
         // Redistribute per-peer budget: accounts done, give storage+bytecode more bandwidth.
         // Global budget remains 5 per peer: storage=3, bytecode=2.
         storageRangeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(3))
-        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(2))
+        // ByteCode budget 8 per peer: with 2 local ETC-capable peers (Besu + core-geth) that gives
+        // 16 concurrent requests vs 4 at budget=2. External ETH-mainnet peers return empty quickly
+        // and cool down; local peers handle the full load at <1ms RTT.
+        bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(8))
+        // Clear accumulated peer cooldowns and seed initial dispatch — without this, peers on
+        // 2-min backoff from AccountRange skip ByteCode dispatch indefinitely (Layer 2 stall).
+        bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePivotRefreshed)
+        requestByteCodes()
 
         // Cancel account stagnation checks (no longer relevant)
         accountStagnationCheckTask.foreach(_.cancel()); accountStagnationCheckTask = None
@@ -1752,6 +1759,12 @@ class SNAPSyncController(
             lastStorageProgressMs = System.currentTimeMillis()
             scheduleStagnationChecks()
             progressMonitor.startPhase(ByteCodeAndStorageSync)
+
+            // Same as fresh ByteCode phase start: raise budget + clear cooldowns so peers on 2-min
+            // backoff from AccountRange don't block ByteCode dispatch on resume.
+            bytecodeCoordinator.foreach(_ ! actors.Messages.UpdateMaxInFlightPerPeer(8))
+            bytecodeCoordinator.foreach(_ ! actors.Messages.ByteCodePivotRefreshed)
+            requestByteCodes()
 
             // Start parallel chain download during recovery too
             startChainDownloader()
@@ -2860,6 +2873,11 @@ class SNAPSyncController(
       trieNodeHealingCoordinator.foreach { coordinator =>
         coordinator ! actors.Messages.StartTrieNodeHealing(root)
         coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(snapSyncConfig.healingMaxInFlightPerPeer)
+        // Flush current snap peers immediately — the 0-second scheduler delay is async; an explicit
+        // flush here ensures peers are available before any StartTrieNodeHealing dispatch attempt.
+        peersToDownloadFrom.values
+          .filter(p => p.peerInfo.remoteStatus.supportsSnap && p.peerInfo.forkAccepted)
+          .foreach(p => coordinator ! actors.Messages.HealingPeerAvailable(p.peer))
       }
 
       // Periodically send peer availability notifications (cancel any existing scheduler first)
@@ -2906,6 +2924,9 @@ class SNAPSyncController(
           trieNodeHealingCoordinator.foreach { coordinator =>
             coordinator ! actors.Messages.StartTrieNodeHealing(root)
             coordinator ! actors.Messages.UpdateMaxInFlightPerPeer(snapSyncConfig.healingMaxInFlightPerPeer)
+            peersToDownloadFrom.values
+              .filter(p => p.peerInfo.remoteStatus.supportsSnap && p.peerInfo.forkAccepted)
+              .foreach(p => coordinator ! actors.Messages.HealingPeerAvailable(p.peer))
           }
           startHealingRequestScheduler()
           log.info(

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/StateValidator.scala
@@ -271,7 +271,7 @@ class StateValidator(mptStorage: MptStorage) {
       nodesVisited += 1
 
       val now = System.currentTimeMillis()
-      if (now - lastHeartbeat >= 60_000L) {
+      if (now - lastHeartbeat >= 10_000L) {
         log.info(s"[WALK-PULSE] visited=$nodesVisited missing-pending=${result.size} stack=${stack.size}")
         lastHeartbeat = now
       }
@@ -318,15 +318,11 @@ class StateValidator(mptStorage: MptStorage) {
           }
 
         case hash: HashNode =>
-          // Do NOT add hash.hash to visited here: decodeNode sets cachedHash = lookupKey,
-          // so the resolved node shares the same hash and will add itself when popped.
-          // Adding it here would cause the resolved node's branch/extension case to skip itself.
           val hashKey = ByteString(hash.hash)
           if (!visited.contains(hashKey)) {
-            try {
-              val resolvedNode = mptStorage.get(hash.hash)
-              stack.prepend((resolvedNode, nibblePath))
-            } catch {
+            try
+              mptStorage.get(hash.hash) // proven subtree — discoverMissingChildren handles children
+            catch {
               case _: MerklePatriciaTrie.MissingNodeException =>
                 val compactPath = ByteString(HexPrefix.encode(nibblePath, isLeaf = false))
                 result += ((Seq(compactPath), ByteString(hash.hash)))

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -466,6 +466,11 @@ class AccountRangeCoordinator(
   private val peerCooldownUntilMs = mutable.Map[String, Long]()
   private val peerCooldownDefault = 30.seconds
 
+  // FIFO fairness within same in-flight tier: tracks last dispatch time per peer so that
+  // ties in inFlightForPeer sort are broken by least-recently-served order rather than
+  // mutable.Set hash order (which is stable/deterministic and permanently starves some peers).
+  private val lastDispatchTimeMs = mutable.Map.empty[String, Long]
+
   private def isPeerCoolingDown(peer: Peer): Boolean =
     peerCooldownUntilMs.get(peer.id.value).exists(_ > System.currentTimeMillis())
 
@@ -985,6 +990,7 @@ class AccountRangeCoordinator(
     worker ! FetchAccountRange(task, peer, requestId, responseBytes)
     // #1184: progress signal — used by CheckDispatchStalled.
     lastDispatchOrResponseMs = System.currentTimeMillis()
+    lastDispatchTimeMs.update(peer.id.value, lastDispatchOrResponseMs)
   }
 
   // How many accounts to insert per chunk before yielding to the actor mailbox.
@@ -1235,7 +1241,10 @@ class AccountRangeCoordinator(
       return
     }
 
-    for (peer <- eligiblePeers.sortBy(inFlightForPeer) if pendingTasks.nonEmpty)
+    for (
+      peer <- eligiblePeers.sortBy(p => (inFlightForPeer(p), lastDispatchTimeMs.getOrElse(p.id.value, 0L)))
+      if pendingTasks.nonEmpty
+    )
       dispatchIfPossible(peer)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -659,12 +659,21 @@ class AccountRangeCoordinator(
       // If the same peer is re-reported (same id), preserve its stateless marking —
       // otherwise PeerAvailable from SNAPSyncController clears stateless every ~1s,
       // bypassing the backoff mechanism entirely (Bug 24).
+      val wasAlreadyKnown = knownAvailablePeers.exists(_.id == peer.id)
       val evicted = knownAvailablePeers.filter(_.remoteAddress == peer.remoteAddress)
       knownAvailablePeers --= evicted
       evicted.foreach { p =>
         if (p.id != peer.id) {
           statelessPeers -= p.id
         }
+      }
+      // Genuine reconnect (new PeerId from same address, or first-seen peer) gets a clean
+      // slate. Bug 24 protection preserved: re-announced same-id peers have wasAlreadyKnown=true
+      // and are not cleared, keeping the ~1s SNAPSyncController re-announce from bypassing backoff.
+      if (!wasAlreadyKnown) {
+        statelessPeers -= peer.id
+        snaplessPeers -= peer.id
+        emptyResponseStrikes.remove(peer.id)
       }
       knownAvailablePeers += peer
       if (isPeerStateless(peer)) {
@@ -676,9 +685,12 @@ class AccountRangeCoordinator(
       } else if (pendingTasks.isEmpty) {
         log.debug("No pending tasks")
       } else {
-        // Pipeline multiple requests per peer (core-geth parity).
-        // ByteCodeCoordinator already uses this pattern with maxInFlightPerPeer = 5.
-        dispatchIfPossible(peer)
+        // Route through the sorted redispatch path so the fairness ordering
+        // (least-in-flight first) applies to every dispatch trigger, not just
+        // the periodic tryRedispatchPendingTasks calls. Without this, the
+        // SNAPSyncController's per-peer PeerAvailable re-announcements drive
+        // greedy dispatchIfPossible for a single peer, starving idle peers.
+        tryRedispatchPendingTasks()
       }
 
     case UpdateMaxInFlightPerPeer(newLimit) =>
@@ -1223,7 +1235,7 @@ class AccountRangeCoordinator(
       return
     }
 
-    for (peer <- eligiblePeers if pendingTasks.nonEmpty)
+    for (peer <- eligiblePeers.sortBy(inFlightForPeer) if pendingTasks.nonEmpty)
       dispatchIfPossible(peer)
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -677,7 +677,9 @@ class AccountRangeCoordinator(
       // and are not cleared, keeping the ~1s SNAPSyncController re-announce from bypassing backoff.
       if (!wasAlreadyKnown) {
         statelessPeers -= peer.id
-        snaplessPeers -= peer.id
+        // snaplessPeers is NOT cleared here: same PeerId = same physical node = same lack-of-snapshot.
+        // Clearing on reconnect would allow known-snapless ETH-mainnet peers to consume dispatch
+        // slots and hash-failure budget before re-accumulating strikes (#1197).
         emptyResponseStrikes.remove(peer.id)
       }
       knownAvailablePeers += peer

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -1,6 +1,7 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.util.ByteString
 
 import com.chipprbots.ethereum.blockchain.sync.snap._
 import com.chipprbots.ethereum.network.Peer
@@ -34,7 +35,11 @@ class AccountRangeWorker(
 
   import Messages._
 
-  private var currentTask: Option[(AccountTask, Peer, BigInt)] = None // (task, peer, requestId)
+  // 4-tuple: (task, peer, requestId, expectedRoot)
+  // expectedRoot is snapshotted from task.rootHash at FetchAccountRange receive time so that
+  // a concurrent pivot refresh (task.rootHash mutation by the coordinator) cannot affect
+  // the Merkle proof verification that runs when the response arrives.
+  private var currentTask: Option[(AccountTask, Peer, BigInt, ByteString)] = None
 
   override def preStart(): Unit =
     log.debug(s"AccountRangeWorker ${self.path.name} started")
@@ -48,13 +53,15 @@ class AccountRangeWorker(
     case _: WorkerRequestCancelled => // #1184: idempotent — already idle, nothing to clear
     case _: WorkerPeerDisconnected => // No current task, nothing to do
     case FetchAccountRange(task, peer, requestId, responseBytes) =>
+      // Snapshot rootHash now — the coordinator may mutate task.rootHash on pivot refresh
+      // while this response is in-flight. Using the snapshot makes proof verification
+      // deterministic regardless of when the mutation occurs.
+      val expectedRoot = task.rootHash
       log.debug(s"Fetching account range ${task.rangeString} from peer ${peer.id} (responseBytes=$responseBytes)")
 
-      // Send request directly via network peer manager
-      // Create GetAccountRange message
       val request = GetAccountRange(
         requestId = requestId,
-        rootHash = task.rootHash,
+        rootHash = expectedRoot,
         startingHash = task.next,
         limitHash = task.last,
         responseBytes = responseBytes
@@ -78,14 +85,14 @@ class AccountRangeWorker(
       val messageSerializable: MessageSerializable = new GetAccountRangeEnc(request)
       networkPeerManager ! NetworkPeerManagerActor.SendMessage(messageSerializable, peer.id)
 
-      currentTask = Some((task, peer, requestId))
+      currentTask = Some((task, peer, requestId, expectedRoot))
       context.become(working)
   }
 
   def working: Receive = {
     case AccountRangeResponseMsg(response) =>
       currentTask match {
-        case Some((task, _, reqId)) if response.requestId == reqId =>
+        case Some((task, _, reqId, expectedRoot)) if response.requestId == reqId =>
           log.debug(
             s"Received AccountRange: reqId=$reqId range=${task.rangeString} " +
               s"start=${task.next.take(4).toHex} limit=${task.last.take(4).toHex} " +
@@ -106,8 +113,9 @@ class AccountRangeWorker(
             else 0
           requestTracker.completeRequest(reqId, responseItemsForRate)
 
-          // Verify Merkle proof against the expected pivot state root for this task.
-          val proofVerifier = MerkleProofVerifier(task.rootHash)
+          // Verify Merkle proof against the snapshotted pivot state root (expectedRoot),
+          // not task.rootHash — the coordinator may have mutated it during a pivot refresh.
+          val proofVerifier = MerkleProofVerifier(expectedRoot)
           val proofOk = validated.flatMap { validResponse =>
             proofVerifier.verifyAccountRange(
               accounts = validResponse.accounts,
@@ -119,7 +127,14 @@ class AccountRangeWorker(
 
           proofOk match {
             case Left(error) =>
-              log.warning(s"AccountRange validation/proof failed for reqId=$reqId range=${task.rangeString}: $error")
+              val errorStr = error.toString
+              // Root mismatch during a pivot transition is expected — the peer is serving the new
+              // root while this worker was dispatched against the old one. Demote to debug since
+              // TaskFailed is still sent and the coordinator re-queues normally.
+              if (errorStr.contains("root mismatch") || errorStr.contains("Proof root"))
+                log.debug(s"AccountRange proof skipped (pivot transition) reqId=$reqId range=${task.rangeString}: $error")
+              else
+                log.warning(s"AccountRange validation/proof failed for reqId=$reqId range=${task.rangeString}: $error")
               coordinator ! TaskFailed(reqId, error)
 
             case Right(_) =>
@@ -137,7 +152,7 @@ class AccountRangeWorker(
 
     case RequestTimeout(reqId) =>
       currentTask match {
-        case Some((_, _, currentReqId)) if currentReqId == reqId =>
+        case Some((_, _, currentReqId, _)) if currentReqId == reqId =>
           log.warning(s"Request $reqId timed out")
           coordinator ! TaskFailed(reqId, "Request timeout")
 
@@ -151,7 +166,7 @@ class AccountRangeWorker(
 
     case WorkerPeerDisconnected(peerId) =>
       currentTask match {
-        case Some((_, peer, reqId)) if peer.id.value == peerId =>
+        case Some((_, peer, reqId, _)) if peer.id.value == peerId =>
           log.debug(s"Peer $peerId disconnected — re-queuing task immediately (reqId=$reqId)")
           requestTracker.completeRequest(reqId, 0)
           coordinator ! TaskFailed(reqId, "Peer disconnected")
@@ -166,7 +181,7 @@ class AccountRangeWorker(
       // Match existing tracker-ownership contract: worker owns its tracker entry.
       // Idempotent: SNAPRequestTracker.completeRequest is safe on already-removed ids.
       currentTask match {
-        case Some((_, _, currentReqId)) if currentReqId == reqId =>
+        case Some((_, _, currentReqId, _)) if currentReqId == reqId =>
           log.debug(s"Worker request $reqId cancelled by coordinator — clearing state")
           requestTracker.completeRequest(reqId, 0)
           currentTask = None

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorker.scala
@@ -132,7 +132,9 @@ class AccountRangeWorker(
               // root while this worker was dispatched against the old one. Demote to debug since
               // TaskFailed is still sent and the coordinator re-queues normally.
               if (errorStr.contains("root mismatch") || errorStr.contains("Proof root"))
-                log.debug(s"AccountRange proof skipped (pivot transition) reqId=$reqId range=${task.rangeString}: $error")
+                log.debug(
+                  s"AccountRange proof skipped (pivot transition) reqId=$reqId range=${task.rangeString}: $error"
+                )
               else
                 log.warning(s"AccountRange validation/proof failed for reqId=$reqId range=${task.rangeString}: $error")
               coordinator ! TaskFailed(reqId, error)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -1,6 +1,6 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props, SupervisorStrategy, OneForOneStrategy}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props, SupervisorStrategy, OneForOneStrategy, Terminated}
 import org.apache.pekko.actor.SupervisorStrategy._
 import org.apache.pekko.util.ByteString
 
@@ -130,7 +130,7 @@ class ByteCodeCoordinator(
   private[actors] var backpressureActive: Boolean = false
 
   // Worker pool
-  private val workers = mutable.ArrayBuffer[ActorRef]()
+  private[actors] val workers = mutable.ArrayBuffer[ActorRef]()
   private val maxWorkers = 32
   private val idleWorkers = mutable.LinkedHashSet.empty[ActorRef]
 
@@ -225,7 +225,11 @@ class ByteCodeCoordinator(
       // BUG-S1: Do NOT clear knownAvailablePeers — bytecodes are content-addressed (hash-keyed),
       // not state-root-dependent, so existing peers can serve them after a pivot refresh.
       // Clearing the set would force a cold-start re-registration delay.
-      log.info("Pivot refreshed — clearing bytecode peer cooldowns (keeping peer set)")
+      log.info(
+        s"Pivot refreshed — clearing bytecode peer cooldowns (keeping peer set). " +
+          s"Pool state: workers=${workers.size}/$maxWorkers, idle=${idleWorkers.size}, " +
+          s"pending=${pendingTasks.size}, active=${activeTasks.size}, knownPeers=${knownAvailablePeers.size}"
+      )
       peerFailureCounts.clear()
       peerCooldownUntilMillis.clear()
       peerResponseBytesTarget.clear()
@@ -358,6 +362,21 @@ class ByteCodeCoordinator(
       log.info("Bytecode sync force-completed (promoting to healing/recovery phase)")
       snapSyncController ! SNAPSyncController.ByteCodeSyncComplete
 
+    case Terminated(worker) if workers.contains(worker) =>
+      log.warning(
+        s"ByteCode worker terminated permanently — removing from pool. " +
+          s"Remaining workers: ${workers.size - 1}, idle: ${idleWorkers.size}"
+      )
+      workers -= worker
+      idleWorkers -= worker
+      activeTasks.find { case (_, active) => active.worker == worker }.foreach { case (reqId, active) =>
+        log.warning(s"Re-queuing bytecode task from terminated worker (${active.task.codeHashes.size} hashes)")
+        activeTasks -= reqId
+        active.task.pending = false
+        pendingTasks.enqueue(active.task)
+      }
+      tryRedispatchPendingTasks()
+
     case ByteCodeGetProgress =>
       val total = completedTaskCount + activeTasks.size.toLong + pendingTasks.size.toLong
       val progress = if (total == 0) 1.0 else completedTaskCount.toDouble / total
@@ -428,7 +447,10 @@ class ByteCodeCoordinator(
           assignTaskToWorker(worker, peer)
           inflight += 1
         case None =>
-          // No worker capacity available right now.
+          log.debug(
+            s"ByteCode dispatch blocked: workers=${workers.size}/$maxWorkers, idle=${idleWorkers.size}, " +
+              s"pending=${pendingTasks.size}, peer=${peer.id.value}"
+          )
           return
       }
     }
@@ -649,6 +671,7 @@ class ByteCodeCoordinator(
         )
         .withDispatcher("sync-dispatcher")
     )
+    context.watch(worker)
     workers += worker
     idleWorkers += worker
     log.debug(s"Created bytecode worker, total: ${workers.size}")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -89,7 +89,7 @@ class ByteCodeCoordinator(
   // Per-hash failure tracking: prevents infinite re-queuing of hashes no peer can serve.
   // After maxFailuresPerHash attempts across all peers, the hash is skipped with a warning.
   private val hashFailureCounts = mutable.Map.empty[ByteString, Int]
-  private val maxFailuresPerHash: Int = 10
+  private val maxFailuresPerHash: Int = 50
 
   // Track known available peers for redispatch when activeTasks is empty.
   // tryRedispatchPendingTasks() previously derived peers from activeTasks.values, leaving it
@@ -105,8 +105,8 @@ class ByteCodeCoordinator(
   private val maxConsecutiveTaskFailures: Int = 100
 
   // Task management
-  private val pendingTasks = mutable.Queue[ByteCodeTask]()
-  final private case class ActiveByteCodeRequest(
+  private[actors] val pendingTasks = mutable.Queue[ByteCodeTask]()
+  final private[actors] case class ActiveByteCodeRequest(
       task: ByteCodeTask,
       worker: ActorRef,
       peer: Peer,
@@ -114,7 +114,7 @@ class ByteCodeCoordinator(
       startedAtMillis: Long
   )
 
-  private val activeTasks = mutable.Map.empty[BigInt, ActiveByteCodeRequest] // requestId -> active request
+  private[actors] val activeTasks = mutable.Map.empty[BigInt, ActiveByteCodeRequest] // requestId -> active request
 
   // Completion bookkeeping (#1233). Previously `completedTasks: mutable.ArrayBuffer[ByteCodeTask]`
   // retained the full task object — including `task.bytecodes: Seq[ByteString]`, the actual
@@ -132,7 +132,7 @@ class ByteCodeCoordinator(
   // Worker pool
   private[actors] val workers = mutable.ArrayBuffer[ActorRef]()
   private val maxWorkers = 32
-  private val idleWorkers = mutable.LinkedHashSet.empty[ActorRef]
+  private[actors] val idleWorkers = mutable.LinkedHashSet.empty[ActorRef]
 
   // Sentinel: when true, no more AddByteCodeTasks will arrive (all accounts downloaded).
   // Completion is only reported after this is set AND pending+active tasks drain.
@@ -246,6 +246,7 @@ class ByteCodeCoordinator(
         )
         snapSyncController ! SNAPSyncController.ByteCodeBackpressureChanged(paused = false)
       }
+      tryRedispatchPendingTasks() // cooldowns cleared — attempt dispatch immediately (mirrors Account/Storage/Healing)
 
     case PeerAvailable(peer) =>
       knownAvailablePeers.filterInPlace(_.remoteAddress != peer.remoteAddress)
@@ -275,13 +276,18 @@ class ByteCodeCoordinator(
         case (reqId, active) if active.peer.id.value == peerId => (reqId, active.worker, active.task)
       }.toSeq
       if (inFlight.nonEmpty) {
-        log.debug(s"Peer $peerId disconnected — re-queuing ${inFlight.size} in-flight bytecode request(s)")
+        val idleBefore = idleWorkers.size
         inFlight.foreach { case (reqId, worker, task) =>
           activeTasks.remove(reqId)
           task.pending = false
           pendingTasks.enqueue(task)
           worker ! ByteCodeWorkerRelease(reqId)
+          markWorkerIdle(worker) // restore to idle pool — matches invariant at every other release site
         }
+        log.info(
+          s"ByteCodePeerUnavailable $peerId: re-queued ${inFlight.size} tasks. " +
+            s"Pool: idle $idleBefore → ${idleWorkers.size}, workers=${workers.size}/$maxWorkers"
+        )
       }
       tryRedispatchPendingTasks()
 
@@ -305,9 +311,11 @@ class ByteCodeCoordinator(
           consecutiveTaskFailures = 0
           log.info(s"Bytecode task completed: $count codes")
           checkCompletion()
+          tryRedispatchPendingTasks() // worker now idle — dispatch immediately (mirrors Account/Storage/Healing)
         case Left(error) =>
           log.warning(s"Bytecode task failed: $error")
           checkCompletion()
+          tryRedispatchPendingTasks()
       }
 
     case ByteCodeTaskFailed(requestId, error) =>
@@ -332,6 +340,7 @@ class ByteCodeCoordinator(
         }
       }
       checkCompletion()
+      if (!noMoreTasksExpected) tryRedispatchPendingTasks() // re-queued task ready — dispatch now
 
     case ByteCodeCheckCompletion =>
       checkCompletion()
@@ -447,7 +456,7 @@ class ByteCodeCoordinator(
           assignTaskToWorker(worker, peer)
           inflight += 1
         case None =>
-          log.debug(
+          log.warning(
             s"ByteCode dispatch blocked: workers=${workers.size}/$maxWorkers, idle=${idleWorkers.size}, " +
               s"pending=${pendingTasks.size}, peer=${peer.id.value}"
           )
@@ -738,7 +747,7 @@ object ByteCodeCoordinator {
       baseInvalid = 15.seconds,
       // Increase per-peer concurrency (Besu caps peer-wide outstanding at 5; this keeps us competitive).
       maxInFlightPerPeer = 5,
-      max = 2.minutes,
+      max = 30.seconds, // aligns with AccountRange (30s) and Healing (30s) — self-heals in 30s not 2min
       exponentCap = 10
     )
   }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -736,7 +736,7 @@ class StorageRangeCoordinator(
         flushPendingFlatBatch()
       }
       if (isComplete) {
-        log.info("Storage range sync complete!")
+        log.debug("Storage range sync complete!")
         snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
       } else if (tasks.nonEmpty) {
         // Try to dispatch pending tasks — per-peer and global limits enforced in dispatchIfPossible().
@@ -756,7 +756,7 @@ class StorageRangeCoordinator(
         flushPendingFlatBatch()
       }
       if (isComplete) {
-        log.info("Storage range sync complete!")
+        log.debug("Storage range sync complete!")
         snapSyncController ! SNAPSyncController.StorageRangeSyncComplete
       }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -120,7 +120,7 @@ class StorageRangeCoordinator(
 
   // Global consecutive task failure counter: triggers ForceCompleteStorage when all SNAP peers
   // stop serving storage data. Resets to zero on any successful slot download.
-  private var consecutiveTaskFailures: Int = 0
+  private[actors] var consecutiveTaskFailures: Int = 0
   private val maxConsecutiveTaskFailures: Int = 100
 
   // Peer cooldown (best-effort): used for transient errors (timeouts, verification failures).
@@ -779,6 +779,8 @@ class StorageRangeCoordinator(
 
     case StoragePivotRefreshed(newStateRoot) =>
       log.info(s"Storage pivot refreshed: ${stateRoot.take(4).toHex} -> ${newStateRoot.take(4).toHex}")
+      log.debug(s"Storage consecutive task failures reset on pivot refresh (was $consecutiveTaskFailures)")
+      consecutiveTaskFailures = 0
 
       // Flush before mutating `stateRoot` so the off-actor commit is tagged with the OLD root.
       // The completion message will then arrive when `stateRoot` is the NEW root, take the stale
@@ -1282,10 +1284,11 @@ class StorageRangeCoordinator(
       }
 
       consecutiveTaskFailures += 1
+      log.debug(s"Storage consecutive task failures: $consecutiveTaskFailures/$maxConsecutiveTaskFailures")
       if (consecutiveTaskFailures >= maxConsecutiveTaskFailures) {
         log.warning(
-          s"Force-completing storage coordinator after $consecutiveTaskFailures consecutive " +
-            s"task failures — SNAP peers not serving storage data. " +
+          s"[STORAGE-FORCE-COMPLETE] $consecutiveTaskFailures consecutive task failures — " +
+            s"SNAP peers not serving storage data. Sending ForceCompleteStorage. " +
             s"Missing storage deferred to healing phase."
         )
         self ! ForceCompleteStorage

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -422,7 +422,7 @@ class TrieNodeHealingCoordinator(
       }
 
     case HealingCheckCompletion =>
-      if (isComplete && !flushing) {
+      if (isComplete && !flushing && !trieWalkInProgress) {
         flushRawNodesSync()
         log.info(s"Healing round complete: $totalNodesHealed total nodes healed. Notifying controller.")
         snapSyncController ! SNAPSyncController.StateHealingComplete

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
@@ -71,8 +71,12 @@ class EngineApiHttpServer(
   // pool stays default-sized because Engine API handlers don't perform blocking I/O
   // (everything is `IO.delay` over in-memory state or RocksDB which uses its own
   // thread pool).
-  private val (engineCompute, shutdownCompute) =
-    IORuntime.createWorkStealingComputeThreadPool(threads = 4, threadPrefix = "engine-api-compute")
+  // cats-effect 3.5.x changed createWorkStealingComputeThreadPool to return
+  // (WorkStealingThreadPool, PollingSystem#Api) — the PollingSystem API is for
+  // native I/O polling which Engine API handlers don't use. A plain JDK
+  // work-stealing pool is equivalent for our purposes and avoids the internal API.
+  private val engineComputeService = java.util.concurrent.Executors.newWorkStealingPool(4)
+  private val engineCompute: ExecutionContext = ExecutionContext.fromExecutorService(engineComputeService)
   private val (engineBlocking, shutdownBlocking) =
     IORuntime.createDefaultBlockingExecutionContext(threadPrefix = "engine-api-blocking")
   private val (engineScheduler, shutdownScheduler) =
@@ -84,7 +88,7 @@ class EngineApiHttpServer(
     shutdown = () => {
       shutdownScheduler()
       shutdownBlocking()
-      shutdownCompute()
+      engineComputeService.shutdown()
     },
     config = cats.effect.unsafe.IORuntimeConfig()
   )

--- a/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/engine/EngineApiHttpServer.scala
@@ -71,10 +71,8 @@ class EngineApiHttpServer(
   // pool stays default-sized because Engine API handlers don't perform blocking I/O
   // (everything is `IO.delay` over in-memory state or RocksDB which uses its own
   // thread pool).
-  // cats-effect 3.5.x changed createWorkStealingComputeThreadPool to return
-  // (WorkStealingThreadPool, PollingSystem#Api) — the PollingSystem API is for
-  // native I/O polling which Engine API handlers don't use. A plain JDK
-  // work-stealing pool is equivalent for our purposes and avoids the internal API.
+  // cats-effect internal work-stealing pool API is not stable across minor versions;
+  // a plain JDK work-stealing pool is equivalent for Engine API purposes (no native I/O).
   private val engineComputeService = java.util.concurrent.Executors.newWorkStealingPool(4)
   private val engineCompute: ExecutionContext = ExecutionContext.fromExecutorService(engineComputeService)
   private val (engineBlocking, shutdownBlocking) =

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -211,12 +211,20 @@ class BlockchainReader(
           case Some(cw) => (cw, "CANONICAL_NUMBER")
           case None =>
             val ourBestNum = getBestBlockNumber()
-            val ourBestTD = getBestBlockHeader()
+            val bestHeaderOpt = getBestBlockHeader()
+            val ourBestTD = bestHeaderOpt
               .flatMap(h => getChainWeightByHash(h.hash))
               .map(_.totalDifficulty)
               .getOrElse(BigInt(1))
             if (ourBestNum > 0) {
-              val estimatedTD = ourBestTD * latestBlock / ourBestNum
+              val ourCurrentDiff = bestHeaderOpt.map(_.difficulty).getOrElse(BigInt(1))
+              val gap = (latestBlock - ourBestNum).max(BigInt(0))
+              // Marginal-rate estimate: uses current difficulty instead of the historical average.
+              // Historical avg ~582 TH/block for ETC; current era ~2000–4300 TH → old formula
+              // underestimates each gap block's TD contribution by 70-86%.
+              // 9999/10000 guarantees a slight underestimate for constant-difficulty chains (< 0.01% error).
+              // Peer is never mistakenly assigned higher priority than deserved for stable chains.
+              val estimatedTD = ourBestTD + ourCurrentDiff * gap * 9999 / 10000
               (ChainWeight.totalDifficultyOnly(estimatedTD), "POW_SCALING")
             } else {
               // DB not yet bootstrapped — TD=0 gives peer lowest priority rather than a

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -191,6 +191,40 @@ class BlockchainReader(
     */
   def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
 
+  /** ETH/69 TD resolution for PoW chains (ETC). Returns the best available ChainWeight and a source label.
+    *
+    * Tier 1 (PoW + PoS): exact hash lookup — succeeds when peer's block is in our ChainWeightStorage. Tier 2 (PoW
+    * only): canonical block-number lookup — accurate post-bootstrap for any peer ≤ pivot height. Tier 3 (PoW only):
+    * proportional estimate — startup fallback when DB has no chain data yet. PoS chains fall back directly to
+    * block-number proxy (TD frozen at merge — standard ETH69 behaviour).
+    */
+  def resolveETH69ChainWeight(
+      latestBlockHash: ByteString,
+      latestBlock: BigInt,
+      isPoWChain: Boolean
+  ): (ChainWeight, String) =
+    getChainWeightByHash(latestBlockHash) match {
+      case Some(cw)            => (cw, "DB_LOOKUP")
+      case None if !isPoWChain => (ChainWeight.totalDifficultyOnly(latestBlock), "POS_PROXY")
+      case None =>
+        getBlockHeaderByNumber(latestBlock).flatMap(h => getChainWeightByHash(h.hash)) match {
+          case Some(cw) => (cw, "CANONICAL_NUMBER")
+          case None =>
+            val ourBestNum = getBestBlockNumber()
+            val ourBestTD = getBestBlockHeader()
+              .flatMap(h => getChainWeightByHash(h.hash))
+              .map(_.totalDifficulty)
+              .getOrElse(BigInt(1))
+            if (ourBestNum > 0) {
+              val estimatedTD = ourBestTD * latestBlock / ourBestNum
+              (ChainWeight.totalDifficultyOnly(estimatedTD), "POW_SCALING")
+            } else {
+              // DB not yet bootstrapped — TD=0 gives peer lowest priority rather than a
+              // wrong-magnitude block-number proxy. ETH69_CHAINWEIGHT_REFRESH corrects within 120s.
+              (ChainWeight.totalDifficultyOnly(BigInt(0)), "COLD_START")
+            }
+        }
+    }
   /** Allows to query for a block based on it's number
     *
     * @param number

--- a/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/com/chipprbots/ethereum/domain/BlockchainReader.scala
@@ -225,6 +225,7 @@ class BlockchainReader(
             }
         }
     }
+
   /** Allows to query for a block based on it's number
     *
     * @param number

--- a/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
+++ b/src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala
@@ -14,10 +14,21 @@ import RLPImplicitConversions._
 import RLPImplicits.given
 
 case class ForkId(hash: BigInt, next: Option[BigInt]) {
-  override def toString(): String = s"ForkId(0x${Hex.toHexString(hash.toUnsignedByteArray)}, $next)"
+
+  def nextDisplay: String = next match {
+    case None    => "None"
+    case Some(n) => ForkId.knownSentinels.get(n).fold(n.toString)(name => s"$n ($name)")
+  }
+
+  override def toString(): String =
+    s"ForkId(0x${Hex.toHexString(hash.toUnsignedByteArray)}, next=${nextDisplay})"
 }
 
 object ForkId {
+
+  val knownSentinels: Map[BigInt, String] = Map(
+    BigInt("1000000000000000000") -> "Olympia"
+  )
 
   def create(genesisHash: ByteString, config: BlockchainConfig)(head: BigInt): ForkId =
     create(genesisHash, config)(head, 0L)
@@ -45,17 +56,16 @@ object ForkId {
     new ForkId(crc.getValue(), next.map(_._1))
   }
 
-  val noFork: BigInt = BigInt("1000000000000000000")
-
-  // Two sentinels mark "fork not activated":
-  //   * 10^18  — the value used in *.chain.conf (`val noFork`)
-  //   * Long.MaxValue — the in-code fallback when the conf key is missing
-  //     (BlockchainConfig.fromRawConfig and ForkBlockNumbers.Empty)
-  // Both must be filtered out of the EIP-2124 fork-id checksum chain.
-  // See ForkBlockNumbers.mergeNetsplitBlockNumber: only sepolia-chain.conf
-  // sets `merge-netsplit-block-number`, so all other chains hit the
-  // Long.MaxValue branch and previously polluted gatherBlockForks.
+  // Long.MaxValue is the in-code fallback when a fork config key is missing
+  // (BlockchainConfig.fromRawConfig and ForkBlockNumbers.Empty). It must be filtered
+  // out of the EIP-2124 fork-id checksum chain as it is not a real fork block.
+  // 10^18 is the genesis JSON "not yet scheduled" sentinel. Many ETH-specific fork
+  // fields in the ETC config also sit at 10^18 (forks ETC never activated); filtering
+  // all 10^18 values from forkBlockNumbers.all prevents those from polluting the fork
+  // list. Olympia is re-appended explicitly below when olympiaBlockNumber itself is
+  // the sentinel, ensuring ETC/Mordor advertise Olympia as the next fork.
   private val maxBlockSentinel: BigInt = BigInt(Long.MaxValue)
+  private val olympiaSentinel: BigInt = BigInt("1000000000000000000")
 
   def gatherForks(config: BlockchainConfig): List[BigInt] =
     (gatherBlockForks(config) ++ gatherTimestampForks(config)).distinct.sorted
@@ -65,10 +75,14 @@ object ForkId {
       if (daoConf.includeOnForkIdList) Some(daoConf.forkBlockNumber)
       else None
     }
-    (maybeDaoBlock.toList ++ config.forkBlockNumbers.all)
-      .filterNot(v => v == 0 || v == noFork || v == maxBlockSentinel)
+    val realForks = (maybeDaoBlock.toList ++ config.forkBlockNumbers.all)
+      .filterNot(v => v == 0 || v == olympiaSentinel || v == maxBlockSentinel)
       .distinct
       .sorted
+    // Advertise Olympia sentinel as the next fork when not yet scheduled
+    val olympiaNext =
+      if (config.forkBlockNumbers.olympiaBlockNumber == olympiaSentinel) List(olympiaSentinel) else Nil
+    realForks ++ olympiaNext
   }
 
   /** EIP-6122: Timestamp-based forks for post-Merge chains. */

--- a/src/main/scala/com/chipprbots/ethereum/metrics/MeterRegistryBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/MeterRegistryBuilder.scala
@@ -4,9 +4,8 @@ import io.micrometer.core.instrument._
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
 import io.micrometer.jmx.JmxMeterRegistry
-import io.micrometer.prometheus.PrometheusConfig
-import io.micrometer.prometheus.PrometheusMeterRegistry
-import io.prometheus.client.CollectorRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 
 import com.chipprbots.ethereum.utils.Logger
 import com.chipprbots.ethereum.utils.LoggingUtils.getClassName
@@ -28,11 +27,7 @@ object MeterRegistryBuilder extends Logger {
     log.info(s"Build JMX Meter Registry: ${jmxMeterRegistry}")
 
     val prometheusMeterRegistry =
-      new PrometheusMeterRegistry(
-        PrometheusConfig.DEFAULT,
-        CollectorRegistry.defaultRegistry,
-        StdMetricsClock
-      );
+      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
     log.info(s"Build Prometheus Meter Registry: ${prometheusMeterRegistry}")
 

--- a/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
@@ -8,8 +8,8 @@ import scala.util.Try
 
 import io.micrometer.core.instrument._
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import io.prometheus.client.exporter.HTTPServer
-import io.prometheus.client.hotspot.DefaultExports
+import io.prometheus.metrics.exporter.httpserver.{HTTPServer => PrometheusHTTPServer}
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import kamon.Kamon
 import org.slf4j.LoggerFactory
 
@@ -17,17 +17,18 @@ case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: I
 
   private[this] def mkName: String => String = MetricsUtils.mkNameWithPrefix(metricsPrefix)
 
-  private lazy val server: HTTPServer = new HTTPServer(serverPort)
+  private lazy val server: PrometheusHTTPServer =
+    PrometheusHTTPServer.builder().port(serverPort).buildAndStart()
 
   def start(): Unit = {
     server // We need this to evaluate the lazy val!
-    DefaultExports.initialize()
+    JvmMetrics.builder().register()
     Kamon.init()
   }
 
   def close(): Unit = {
     registry.close()
-    server.stop()
+    server.close()
   }
 
   def deltaSpike(name: String): DeltaSpikeGauge =

--- a/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/Metrics.scala
@@ -8,6 +8,7 @@ import scala.util.Try
 
 import io.micrometer.core.instrument._
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.prometheus.metrics.exporter.httpserver.{HTTPServer => PrometheusHTTPServer}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import kamon.Kamon
@@ -20,13 +21,19 @@ case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: I
   private lazy val server: PrometheusHTTPServer =
     PrometheusHTTPServer.builder().port(serverPort).buildAndStart()
 
+  private var logbackMetricsBinder: Option[LogbackMetrics] = None
+
   def start(): Unit = {
     server // We need this to evaluate the lazy val!
     JvmMetrics.builder().register()
+    val lm = new LogbackMetrics()
+    lm.bindTo(registry)
+    logbackMetricsBinder = Some(lm)
     Kamon.init()
   }
 
   def close(): Unit = {
+    logbackMetricsBinder.foreach(_.close())
     registry.close()
     server.close()
   }

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -48,7 +48,8 @@ class NetworkPeerManagerActor(
     initialSnapSyncControllerOpt: Option[ActorRef] = None,
     evmCodeStorageOpt: Option[com.chipprbots.ethereum.db.storage.EvmCodeStorage] = None,
     mptStorageOpt: Option[com.chipprbots.ethereum.db.storage.MptStorage] = None,
-    blockchainReader: Option[com.chipprbots.ethereum.domain.BlockchainReader] = None
+    blockchainReader: Option[com.chipprbots.ethereum.domain.BlockchainReader] = None,
+    isPoWChain: Boolean = true
 ) extends Actor
     with ActorLogging {
 
@@ -612,10 +613,32 @@ class NetworkPeerManagerActor(
         if (maxBlockNumber > appStateStorage.getEstimatedHighestBlock())
           appStateStorage.putEstimatedHighestBlock(maxBlockNumber).commit()
 
-        if (maxBlockNumber > initialPeerInfo.maxBlockNumber) {
-          initialPeerInfo.withBestBlockData(maxBlockNumber, maxBlockHash)
-        } else
-          initialPeerInfo
+        val updated =
+          if (maxBlockNumber > initialPeerInfo.maxBlockNumber)
+            initialPeerInfo.withBestBlockData(maxBlockNumber, maxBlockHash)
+          else
+            initialPeerInfo
+
+        // For ETH/69 peers: re-resolve chainWeight via 3-tier (hash → canonical-number → POW_SCALING).
+        // Hash-only lookup misses when the peer's current head differs from our stored pivot hash;
+        // full 3-tier falls back to proportional scaling from our real anchor so the refresh fires
+        // even when the peer is ahead of our downloaded chain.
+        blockchainReader match {
+          case Some(reader) if updated.remoteStatus.capability == Capability.ETH69 =>
+            val (cw, source) = reader.resolveETH69ChainWeight(maxBlockHash, maxBlockNumber, isPoWChain)
+            val isImprovement = cw.totalDifficulty > updated.chainWeight.totalDifficulty
+            if (isImprovement && source != "COLD_START") {
+              log.info(
+                "ETH69_CHAINWEIGHT_REFRESH: blockNum={} newTD={} prevTD={} source={}",
+                maxBlockNumber,
+                cw.totalDifficulty,
+                updated.chainWeight.totalDifficulty,
+                source
+              )
+              updated.withChainWeight(cw)
+            } else updated
+          case _ => updated
+        }
       }
 
     message match {
@@ -1166,7 +1189,8 @@ object NetworkPeerManagerActor {
       snapSyncControllerOpt: Option[ActorRef] = None,
       evmCodeStorageOpt: Option[com.chipprbots.ethereum.db.storage.EvmCodeStorage] = None,
       mptStorageOpt: Option[com.chipprbots.ethereum.db.storage.MptStorage] = None,
-      blockchainReader: Option[com.chipprbots.ethereum.domain.BlockchainReader] = None
+      blockchainReader: Option[com.chipprbots.ethereum.domain.BlockchainReader] = None,
+      isPoWChain: Boolean = true
   ): Props =
     Props(
       new NetworkPeerManagerActor(
@@ -1177,7 +1201,8 @@ object NetworkPeerManagerActor {
         snapSyncControllerOpt,
         evmCodeStorageOpt,
         mptStorageOpt,
-        blockchainReader
+        blockchainReader,
+        isPoWChain
       )
     )
 }

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -378,8 +378,8 @@ class NetworkPeerManagerActor(
           s"supportsSnap=${peerInfo.remoteStatus.supportsSnap}"
       )
       if (peersWithInfo.contains(peer.id)) {
-        val old              = peersWithInfo(peer.id)
-        val newIsInbound     = peer.incomingConnection
+        val old = peersWithInfo(peer.id)
+        val newIsInbound = peer.incomingConnection
         val existingIsOutbound = !old.peer.incomingConnection
 
         if (newIsInbound && existingIsOutbound) {

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -78,6 +78,12 @@ class NetworkPeerManagerActor(
   // peer catches up (so a peer that's mid-catch-up doesn't get evicted) or on disconnect.
   private val laggingPeerSince = scala.collection.mutable.Map.empty[PeerId, Long]
 
+  // PeerIds for which PMA just performed inbound-wins: the outbound PeerActor was closed and will
+  // shortly publish PeerDisconnected. That event must NOT evict the peer from peersWithInfo —
+  // the inbound is alive and already swapped in. Remove from this set once the disconnect arrives.
+  private val pendingInboundWinsDisconnects: scala.collection.mutable.Set[PeerId] =
+    scala.collection.mutable.Set.empty
+
   // 60s network summary — read+reset RLPx counters and log one aggregate line
   context.system.scheduler.scheduleWithFixedDelay(
     60.seconds,
@@ -372,21 +378,39 @@ class NetworkPeerManagerActor(
           s"supportsSnap=${peerInfo.remoteStatus.supportsSnap}"
       )
       if (peersWithInfo.contains(peer.id)) {
-        val old = peersWithInfo(peer.id)
-        // Keep the EXISTING entry — don't overwrite with the duplicate.
-        // PeerManagerActor will drop the loser via AlreadyConnected; with the PeerDisconnected
-        // gate fix, the loser's termination no longer evicts the winner. Overwriting here with
-        // the duplicate (which may be the about-to-die loser) would leave a stale ref in
-        // peersWithInfo — mirroring Besu's registerDisconnect guard which only updates
-        // activeConnections when peer.getConnection().equals(connection) (the primary connection).
-        log.warning(
-          s"DUPLICATE_HANDSHAKE_DROPPED: ${peer.id} already in peersWithInfo " +
-            s"(existing=${old.peer.remoteAddress} inbound=${old.peer.incomingConnection}, " +
-            s"duplicate=${peer.remoteAddress} inbound=${peer.incomingConnection}) — " +
-            s"keeping existing entry, duplicate will be dropped by PeerManagerActor"
-        )
-        // No update to peersWithInfo, no double-count in metrics
-        context.become(handleMessages(peersWithInfo))
+        val old              = peersWithInfo(peer.id)
+        val newIsInbound     = peer.incomingConnection
+        val existingIsOutbound = !old.peer.incomingConnection
+
+        if (newIsInbound && existingIsOutbound) {
+          // Inbound-wins: PMA is closing the outbound (it fired its own inbound-wins tiebreak).
+          // Swap peersWithInfo to the live inbound ref so SNAP dispatch goes to the correct
+          // connection. Record the PeerId so the imminent PeerDisconnected (outbound dying)
+          // is suppressed rather than evicting the peer we just kept.
+          pendingInboundWinsDisconnects += peer.id
+          log.info(
+            "DUPLICATE_HANDSHAKE_INBOUND_WINS: {} swapping {} → {} (outbound eviction suppressed)",
+            peer.id,
+            old.peer.remoteAddress,
+            peer.remoteAddress
+          )
+          context.become(handleMessages(peersWithInfo + (peer.id -> PeerWithInfo(peer, peerInfo))))
+        } else {
+          // Keep the EXISTING entry — don't overwrite with the duplicate.
+          // PeerManagerActor will drop the loser via AlreadyConnected; with the PeerDisconnected
+          // gate fix, the loser's termination no longer evicts the winner. Overwriting here with
+          // the duplicate (which may be the about-to-die loser) would leave a stale ref in
+          // peersWithInfo — mirroring Besu's registerDisconnect guard which only updates
+          // activeConnections when peer.getConnection().equals(connection) (the primary connection).
+          log.warning(
+            s"DUPLICATE_HANDSHAKE_DROPPED: ${peer.id} already in peersWithInfo " +
+              s"(existing=${old.peer.remoteAddress} inbound=${old.peer.incomingConnection}, " +
+              s"duplicate=${peer.remoteAddress} inbound=${peer.incomingConnection}) — " +
+              s"keeping existing entry, duplicate will be dropped by PeerManagerActor"
+          )
+          // No update to peersWithInfo, no double-count in metrics
+          context.become(handleMessages(peersWithInfo))
+        }
       } else {
         peerEventBusActor ! Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id)))
         peerEventBusActor ! Subscribe(MessageClassifier(msgCodesWithInfo, PeerSelector.WithId(peer.id)))
@@ -431,6 +455,15 @@ class NetworkPeerManagerActor(
     case PeerDisconnected(peerId) if !peersWithInfo.contains(peerId) =>
       log.debug(
         "PEER_DISCONNECTED_IGNORED: {} not in peersWithInfo — likely suppressed duplicate or already removed",
+        peerId
+      )
+
+    case PeerDisconnected(peerId) if pendingInboundWinsDisconnects.contains(peerId) =>
+      // The outbound PeerActor that PMA closed after inbound-wins is dying. peersWithInfo already
+      // holds the live inbound entry — do not evict.
+      pendingInboundWinsDisconnects -= peerId
+      log.info(
+        "INBOUND_WINS_DISCONNECT_SUPPRESSED: {} — outbound closed by PMA, inbound retained in peersWithInfo",
         peerId
       )
 

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -520,7 +520,7 @@ class PeerManagerActor(
             ref
           )
         } else {
-          log.info("GENUINE_DISCONNECT: publishing PeerDisconnected for {} ref={}", peerId, ref)
+          log.debug("GENUINE_DISCONNECT: publishing PeerDisconnected for {} ref={}", peerId, ref)
           peerEventBus ! Publish(PeerEvent.PeerDisconnected(peerId))
         }
         maintainedPeersByNodeId.get(peerId.value).foreach { uri =>

--- a/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PeerManagerActor.scala
@@ -88,6 +88,11 @@ class PeerManagerActor(
     */
   private val pendingMaintainedConnections: mutable.Map[ActorRef, URI] = mutable.Map.empty
 
+  /** Consecutive pre-handshake TCP failures per remote IP. After 5 failures the IP is blacklisted with exponential
+    * backoff (5→10→20→30 min). Cleared on successful handshake to avoid blacklisting peers that recovered.
+    */
+  private val consecutiveTcpFailures: mutable.Map[String, Int] = mutable.Map.empty
+
   /** Runtime max-outgoing-peers override set by admin_maxPeers. core-geth reference: eth/api_admin.go MaxPeers — sets
     * handler.maxPeers + p2pServer.MaxPeers.
     */
@@ -476,6 +481,23 @@ class PeerManagerActor(
           )
         }
       }
+      // Track TCP-level pre-handshake failures for non-maintained outgoing peers.
+      // pendingMaintainedConnections already consumed the ref if it was maintained, so any
+      // peer still in outgoingPendingPeers here is a non-maintained discovery peer that failed
+      // before the ETH handshake completed (TCP unreachable, TLS failure, etc.).
+      connectedPeers.peers.get(PeerId.fromRef(ref)).foreach { peer =>
+        if (!peer.incomingConnection) {
+          val ip = peer.remoteAddress.getHostString
+          val count = consecutiveTcpFailures.getOrElse(ip, 0) + 1
+          consecutiveTcpFailures(ip) = count
+          if (count >= 5) {
+            val backoffMinutes = math.min(30, 5 * (1 << (count - 5)))
+            log.warning("TCP failure #{} for {} — blacklisting for {} min", count, ip, backoffMinutes)
+            blacklist.add(PeerAddress(ip), backoffMinutes.minutes, Blacklist.BlacklistReason.TcpSubsystemError)
+            consecutiveTcpFailures.remove(ip)
+          }
+        }
+      }
       val (terminatedPeersIds, newConnectedPeers) = connectedPeers.removeTerminatedPeer(ref)
       terminatedPeersIds.foreach { peerId =>
         peerStatusCache = peerStatusCache - peerId
@@ -518,6 +540,7 @@ class PeerManagerActor(
       context.become(listening(newConnectedPeers))
 
     case PeerEvent.PeerHandshakeSuccessful(handshakedPeer, _) =>
+      consecutiveTcpFailures.remove(handshakedPeer.remoteAddress.getHostString)
       val isMaintained =
         handshakedPeer.nodeId.exists(nid => maintainedPeersByNodeId.contains(Hex.toHexString(nid.toArray)))
       if (

--- a/src/main/scala/com/chipprbots/ethereum/network/PortForwarder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/PortForwarder.scala
@@ -39,6 +39,7 @@ private class ClientOnlyUpnpServiceConfiguration extends DefaultUpnpServiceConfi
       override def getTimeoutSeconds(): Int = 10
       override def getLogWarningSeconds(): Int = 5
       override def getRetryAfterSeconds(): Int = 60
+      override def getRetryIterations(): Int = 0
       override def getRequestExecutorService(): java.util.concurrent.ExecutorService =
         getSyncProtocolExecutorService()
       override def getUserAgentValue(majorVersion: Int, minorVersion: Int): String =

--- a/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
@@ -62,7 +62,9 @@ class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: Ac
 
   def listening: Receive = { case Connected(remoteAddress, _) =>
     val connection = sender()
-    if (blacklist.isBlacklisted(PeerManagerActor.PeerAddress(remoteAddress.getHostString))) {
+    val addr = remoteAddress.getAddress
+    val isLocal = addr.isLoopbackAddress || addr.isSiteLocalAddress
+    if (!isLocal && blacklist.isBlacklisted(PeerManagerActor.PeerAddress(remoteAddress.getHostString))) {
       log.debug("Dropping inbound TCP from blacklisted {}", remoteAddress.getHostString)
       connection ! Close
     } else {

--- a/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/ServerActor.scala
@@ -12,15 +12,17 @@ import org.apache.pekko.io.IO
 import org.apache.pekko.io.Tcp
 import org.apache.pekko.io.Tcp.Bind
 import org.apache.pekko.io.Tcp.Bound
+import org.apache.pekko.io.Tcp.Close
 import org.apache.pekko.io.Tcp.CommandFailed
 import org.apache.pekko.io.Tcp.Connected
 
 import org.bouncycastle.util.encoders.Hex
 
+import com.chipprbots.ethereum.blockchain.sync.Blacklist
 import com.chipprbots.ethereum.utils.NodeStatus
 import com.chipprbots.ethereum.utils.ServerStatus
 
-class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: ActorRef)
+class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: ActorRef, blacklist: Blacklist)
     extends Actor
     with ActorLogging {
 
@@ -60,13 +62,18 @@ class ServerActor(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: Ac
 
   def listening: Receive = { case Connected(remoteAddress, _) =>
     val connection = sender()
-    peerManager ! PeerManagerActor.HandlePeerConnection(connection, remoteAddress)
+    if (blacklist.isBlacklisted(PeerManagerActor.PeerAddress(remoteAddress.getHostString))) {
+      log.debug("Dropping inbound TCP from blacklisted {}", remoteAddress.getHostString)
+      connection ! Close
+    } else {
+      peerManager ! PeerManagerActor.HandlePeerConnection(connection, remoteAddress)
+    }
   }
 }
 
 object ServerActor {
-  def props(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: ActorRef): Props =
-    Props(new ServerActor(nodeStatusHolder, peerManager))
+  def props(nodeStatusHolder: AtomicReference[NodeStatus], peerManager: ActorRef, blacklist: Blacklist): Props =
+    Props(new ServerActor(nodeStatusHolder, peerManager, blacklist))
 
   case class StartServer(address: InetSocketAddress, advertisedAddress: Option[InetAddress] = None)
 }

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -75,10 +75,20 @@ case class EtcHelloExchangeState(handshakerConfiguration: NetworkHandshakerConfi
         log.debug("PROTOCOL_NEGOTIATED: clientId={}, protocol=eth/63, usesRequestId=false", hello.clientId)
         EthNodeStatus63ExchangeState(handshakerConfiguration, supportsSnap, peerCapabilities)
       case Some(Capability.ETH69) =>
-        log.debug("PROTOCOL_NEGOTIATED: clientId={}, protocol=eth/69 (EIP-7642)", hello.clientId)
-        // ETH/69 mandates SNAP as a co-protocol (EIP-7642). Peers that negotiate ETH/69
-        // never separately advertise snap/1 in Hello — it is implicit. Force supportsSnap=true.
-        EthNodeStatus69ExchangeState(handshakerConfiguration, Capability.ETH69, supportsSnap = true, peerCapabilities)
+        log.info(
+          "PROTOCOL_NEGOTIATED: clientId={}, protocol=eth/69, supportsSnap={} (snap/1 explicit={})",
+          hello.clientId,
+          supportsSnap,
+          peerCapabilities.contains(Capability.SNAP1)
+        )
+        // ETH/69 and SNAP/1 are independent protocols. A peer can negotiate ETH/69 without
+        // advertising snap/1 in Hello. Use the actual negotiated value, same as ETH64-68.
+        EthNodeStatus69ExchangeState(
+          handshakerConfiguration,
+          Capability.ETH69,
+          supportsSnap = supportsSnap,
+          peerCapabilities
+        )
       case Some(
             negotiated @ (Capability.ETH64 | Capability.ETH65 | Capability.ETH66 | Capability.ETH67 | Capability.ETH68)
           ) =>

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -24,7 +24,7 @@ case class EthNodeStatus64ExchangeState(
 
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: ETH64.Status =>
     import ForkIdValidator.syncIoLogger
-    log.info(
+    log.debug(
       "ETH{}_STATUS: Received - totalDifficulty={}, networkId={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
       status.totalDifficulty,
@@ -43,7 +43,7 @@ case class EthNodeStatus64ExchangeState(
     val localBestTimestamp = if (storedTimestamp == 0L) System.currentTimeMillis() / 1000 else storedTimestamp
     val localForkId = ForkId.create(localGenesisHash, blockchainConfig)(localBestBlock, localBestTimestamp)
 
-    log.info(
+    log.debug(
       "ETH{}_STATUS: Local state - bestBlock={}, genesisHash={}, localForkId={}",
       status.protocolVersion,
       localBestBlock,
@@ -52,7 +52,7 @@ case class EthNodeStatus64ExchangeState(
     )
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.info(
+      log.debug(
         "ETH{}_STATUS: NetworkId mismatch - local={}, remote={} - disconnecting",
         status.protocolVersion,
         peerConfiguration.networkId,
@@ -60,7 +60,7 @@ case class EthNodeStatus64ExchangeState(
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.info(
+      log.debug(
         "ETH{}_STATUS: Genesis mismatch - local={}, remote={} - disconnecting",
         status.protocolVersion,
         localGenesisHash,
@@ -162,7 +162,7 @@ case class EthNodeStatus64ExchangeState(
       forkId = forkId
     )
 
-    log.info(
+    log.debug(
       "ETH{}_STATUS: Sending - totalDifficulty={}, networkId={}, bestBlock={}, bestHash={}, genesisHash={}, forkId={}",
       status.protocolVersion,
       status.totalDifficulty,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -52,7 +52,7 @@ case class EthNodeStatus64ExchangeState(
     )
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.debug(
+      log.info(
         "ETH{}_STATUS: NetworkId mismatch - local={}, remote={} - disconnecting",
         status.protocolVersion,
         peerConfiguration.networkId,
@@ -60,7 +60,7 @@ case class EthNodeStatus64ExchangeState(
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.debug(
+      log.info(
         "ETH{}_STATUS: Genesis mismatch - local={}, remote={} - disconnecting",
         status.protocolVersion,
         localGenesisHash,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -124,7 +124,7 @@ case class EthNodeStatus69ExchangeState(
       latestBlockHash = bestBlockHeader.hash
     )
 
-    log.info(
+    log.debug(
       "ETH69_STATUS: Sending - networkId={}, genesis={}, forkId={}, earliest={}, latest={}, latestHash={}",
       status.networkId,
       genesisHash,

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -5,7 +5,6 @@ import cats.effect.SyncIO
 import com.chipprbots.ethereum.forkid.Connect
 import com.chipprbots.ethereum.forkid.ForkId
 import com.chipprbots.ethereum.forkid.ForkIdValidator
-import com.chipprbots.ethereum.domain.ChainWeight
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.RemoteStatus
 import com.chipprbots.ethereum.network.p2p.Message
@@ -74,43 +73,16 @@ case class EthNodeStatus69ExchangeState(
         validationResult match {
           case Connect =>
             log.info("ETH69_STATUS: ForkId validation passed - accepting peer")
-            // Look up actual TD from local chain DB using the peer's latestBlockHash.
-            // Succeeds when the peer's block is in our ChainWeightStorage (peer at or behind our tip).
-            // Falls back to PoW-scaled estimation for PoW chains, block-number proxy for PoS chains.
-            val resolvedChainWeight: ChainWeight =
-              blockchainReader
-                .getChainWeightByHash(status.latestBlockHash)
-                .getOrElse {
-                  if (blockchainConfig.terminalTotalDifficulty.isEmpty) {
-                    // PoW chain (ETC mainnet chainId=61, Mordor chainId=63, etc.):
-                    // Scale our own cumulative TD by the peer's block height ratio.
-                    // Keeps the estimate in the correct order of magnitude (~10^21 for ETC)
-                    // rather than the raw block number (~24.5 M), which would cause ETH69 peers
-                    // to always lose BestPeer selection against ETH68 peers sending real PoW TD.
-                    val ourBestHeader = getBestBlockHeader()
-                    val ourBestTD = blockchainReader
-                      .getChainWeightByHash(ourBestHeader.hash)
-                      .map(_.totalDifficulty)
-                      .getOrElse(BigInt(1))
-                    val ourBestNum = blockchainReader.getBestBlockNumber()
-                    val estimatedTD =
-                      if (ourBestNum > 0) ourBestTD * status.latestBlock / ourBestNum
-                      else status.latestBlock
-                    ChainWeight.totalDifficultyOnly(estimatedTD)
-                  } else {
-                    // PoS chain (ETH mainnet, etc.): TD is frozen; block-number is the ordering signal.
-                    ChainWeight.totalDifficultyOnly(status.latestBlock)
-                  }
-                }
+            val (resolvedChainWeight, resolvedSource) = blockchainReader.resolveETH69ChainWeight(
+              status.latestBlockHash,
+              status.latestBlock,
+              isPoWChain = blockchainConfig.terminalTotalDifficulty.isEmpty
+            )
             log.info(
-              "ETH69_STATUS: TD resolved - totalDifficulty={}, latestBlock={}, source={} (localLookup={}, powEstimate={})",
+              "ETH69_STATUS: TD resolved - totalDifficulty={}, latestBlock={}, source={}",
               resolvedChainWeight.totalDifficulty,
               status.latestBlock,
-              if (blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined) "DB_LOOKUP"
-              else if (blockchainConfig.terminalTotalDifficulty.isEmpty) "POW_SCALING"
-              else "POS_PROXY",
-              blockchainReader.getChainWeightByHash(status.latestBlockHash).isDefined,
-              blockchainConfig.terminalTotalDifficulty.isEmpty
+              resolvedSource
             )
             ConnectedState(
               PeerInfo.withForkAccepted(

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -34,7 +34,7 @@ case class EthNodeStatus69ExchangeState(
 
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: ETH69.Status =>
     import ForkIdValidator.syncIoLogger
-    log.info(
+    log.debug(
       "ETH69_STATUS: Received - protocolVersion={}, networkId={}, genesis={}, forkId={}, earliest={}, latest={}, latestHash={}",
       status.protocolVersion,
       status.networkId,
@@ -48,14 +48,14 @@ case class EthNodeStatus69ExchangeState(
     val localGenesisHash = blockchainReader.genesisHeader.hash
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.info(
+      log.debug(
         "ETH69_STATUS: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.info(
+      log.debug(
         "ETH69_STATUS: Genesis hash mismatch! Local: {}, Remote: {} - disconnecting",
         localGenesisHash,
         status.genesisHash
@@ -96,7 +96,7 @@ case class EthNodeStatus69ExchangeState(
               )
             )
           case other =>
-            log.info("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
+            log.debug("ETH69_STATUS: ForkId validation failed: {} - disconnecting", other)
             DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
         }
       }).unsafeRunSync()

--- a/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/handshaker/EthNodeStatus69ExchangeState.scala
@@ -48,14 +48,14 @@ case class EthNodeStatus69ExchangeState(
     val localGenesisHash = blockchainReader.genesisHeader.hash
 
     if (status.networkId != peerConfiguration.networkId) {
-      log.debug(
+      log.info(
         "ETH69_STATUS: NetworkId mismatch! Local: {}, Remote: {} - disconnecting (SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK)",
         peerConfiguration.networkId,
         status.networkId
       )
       DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
     } else if (status.genesisHash != localGenesisHash) {
-      log.debug(
+      log.info(
         "ETH69_STATUS: Genesis hash mismatch! Local: {}, Remote: {} - disconnecting",
         localGenesisHash,
         status.genesisHash

--- a/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -109,7 +109,7 @@ class RLPxConnectionHandler(
 
     case CommandFailed(_: Connect) =>
       RLPxConnectionHandler.tcpFailedCount.incrementAndGet()
-      log.warning("[Stopping Connection] TCP connection to {} failed for peer {}", uri, peerId)
+      log.warning("[Stopping Connection] TCP connection failed for peer {}", peerId)
       context.parent ! ConnectionFailed
       gracefulStop()
   }
@@ -227,7 +227,7 @@ class RLPxConnectionHandler(
       )
 
       val snapBaseStr = offsets.peerSnapBase.map(b => s"0x${b.toHexString}").getOrElse("<disabled>")
-      log.info(
+      log.debug(
         s"INBOUND_CAP_OFFSETS: peer=$peerId clientId=${hello.clientId} " +
           s"peerEthBase=0x${offsets.peerEthBase.toHexString} peerSnapBase=$snapBaseStr"
       )
@@ -517,7 +517,7 @@ class RLPxConnectionHandler(
                 )
               )
             case None =>
-              log.error(
+              log.warning(
                 "[Stopping Connection] Unable to negotiate protocol with peer {} — peerCaps=[{}], ourCaps=[{}]",
                 peerId,
                 hello.capabilities.mkString(", "),
@@ -541,7 +541,7 @@ class RLPxConnectionHandler(
         val supportsSnap =
           capabilities.contains(Capability.SNAP1) && hello.capabilities.contains(Capability.SNAP1)
         if (supportsSnap) {
-          log.info("[RLPx] SNAP/1 capability enabled for peer {}", peerId)
+          log.debug("[RLPx] SNAP/1 capability enabled for peer {}", peerId)
         }
         val inboundTranslator = computeInboundTranslator(hello, negotiated, supportsSnap)
         (
@@ -614,10 +614,11 @@ class RLPxConnectionHandler(
           // send proper Disconnect to remote peer before closing connection.
           // Warning (not error): disconnect behavior is correct, this is peer protocol variance
           // (e.g., ETH69 peers sending 8-field Status when we expect 7 fields).
+          val errMsg = Option(ex.getMessage).map(m => if (m.length > 80) m.take(80) + "…" else m).getOrElse("null")
           log.warning(
             "DECODE_ERROR: Cannot decode message from {} - disconnecting. Error: {}",
             peerId,
-            ex.getMessage
+            errMsg
           )
           context.parent ! com.chipprbots.ethereum.network.PeerActor.DisconnectPeer(
             com.chipprbots.ethereum.network.p2p.messages.WireProtocol.Disconnect.Reasons.BreachOfProtocol

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -420,11 +420,12 @@ trait ServerActorBuilder {
     with NodeStatusBuilder
     with BlockchainBuilder
     with PeerManagerActorBuilder
+    with BlacklistBuilder
     with InstanceConfigProvider =>
 
   lazy val networkConfig = instanceConfig.Network
 
-  lazy val server: ActorRef = system.actorOf(ServerActor.props(nodeStatusHolder, peerManager), "server")
+  lazy val server: ActorRef = system.actorOf(ServerActor.props(nodeStatusHolder, peerManager, blacklist), "server")
 
 }
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/NodeBuilder.scala
@@ -371,7 +371,8 @@ trait NetworkPeerManagerActorBuilder {
     with PeerEventBusBuilder
     with ForkResolverBuilder
     with StorageBuilder
-    with BlockchainBuilder =>
+    with BlockchainBuilder
+    with BlockchainConfigBuilder =>
 
   lazy val networkPeerManager: ActorRef = system.actorOf(
     NetworkPeerManagerActor
@@ -382,7 +383,8 @@ trait NetworkPeerManagerActorBuilder {
         forkResolverOpt,
         evmCodeStorageOpt = Some(storagesInstance.storages.evmCodeStorage),
         mptStorageOpt = Some(storagesInstance.storages.stateStorage.getReadOnlyStorage),
-        blockchainReader = Some(blockchainReader)
+        blockchainReader = Some(blockchainReader),
+        isPoWChain = blockchainConfig.terminalTotalDifficulty.isEmpty
       ),
     "network-peer-manager"
   )

--- a/src/main/scala/com/chipprbots/ethereum/utils/BlockchainConfig.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/BlockchainConfig.scala
@@ -251,6 +251,7 @@ object BlockchainConfig {
         activationBlock = Try(BigInt(messConf.getString("ecbp1100-block-number"))).toOption,
         deactivationBlock = Try(BigInt(messConf.getString("ecbp1100-deactivate-block-number"))).toOption,
         reactivationBlock = Try(BigInt(messConf.getString("ecbp1100-reactivate-block-number"))).toOption
+          .orElse(Try(BigInt(blockchainConfig.getString("olympia-block-number"))).toOption)
       )
     }.getOrElse(MESSConfig())
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/BytecodeRecoveryActorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/BytecodeRecoveryActorSpec.scala
@@ -1,0 +1,245 @@
+package com.chipprbots.ethereum.blockchain.sync
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.WithActorSystemShutDown
+import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncConfig
+import com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController
+import com.chipprbots.ethereum.db.cache.LruCache
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.db.storage.AppStateStorage
+import com.chipprbots.ethereum.db.storage.CachedReferenceCountedStorage
+import com.chipprbots.ethereum.db.storage.EvmCodeStorage
+import com.chipprbots.ethereum.db.storage.HeapEntry
+import com.chipprbots.ethereum.db.storage.NodeStorage
+import com.chipprbots.ethereum.db.storage.NodeStorage.NodeHash
+import com.chipprbots.ethereum.db.storage.StateStorage
+import com.chipprbots.ethereum.db.storage.pruning.ArchivePruning
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.Config
+
+/** Unit tests for BytecodeRecoveryActor covering all recovery paths:
+  *
+  *   T1: No missing bytecodes → immediate RecoveryComplete, flag committed.
+  *   T2: Missing present → coordinator receives StartByteCodeSync, completes normally.
+  *   T3: Scan Future throws (trie root missing) → RecoveryComplete still fires.
+  *   T4: Coordinator crashes mid-download → Terminated handler commits flag and fires RecoveryComplete.
+  *   T5: No peer/progress arrives within timeout → abandon fires, RecoveryComplete emitted.
+  */
+class BytecodeRecoveryActorSpec
+    extends TestKit(ActorSystem("BytecodeRecoveryActorSpec_System"))
+    with AnyFlatSpecLike
+    with WithActorSystemShutDown
+    with Matchers
+    with Eventually {
+
+  private val fakeStateRoot: ByteString = ByteString(Array.fill[Byte](32)(0x11))
+  private val fakeCodeHash: ByteString = ByteString(Array.fill[Byte](32)(0xaa.toByte))
+  private val missingOne: Seq[ByteString] = Seq(fakeCodeHash)
+
+  private def newConfig(abandonAfter: FiniteDuration = 10.minutes): SNAPSyncConfig =
+    SNAPSyncConfig(storageRecoveryAbandonTimeout = abandonAfter)
+
+  private def newStorages(): (StateStorage, AppStateStorage, EvmCodeStorage) = {
+    val ds = EphemDataSource()
+    val nodeStorage = new NodeStorage(ds)
+    val appStateStorage = new AppStateStorage(ds)
+    val evmCodeStorage = new EvmCodeStorage(ds)
+    val stateStorage = StateStorage(
+      ArchivePruning,
+      nodeStorage,
+      new LruCache[NodeHash, HeapEntry](
+        Config.inMemoryPruningNodeCacheConfig,
+        Some(CachedReferenceCountedStorage.saveOnlyNotificationHandler(nodeStorage))
+      )
+    )
+    (stateStorage, appStateStorage, evmCodeStorage)
+  }
+
+  "BytecodeRecoveryActor" should
+    "emit RecoveryComplete immediately and commit flag when no bytecodes are missing" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_t1")
+      val networkPeerManager = TestProbe("networkPeerManager_t1")
+      val (stateStorage, appStateStorage, evmCodeStorage) = newStorages()
+
+      val actor = system.actorOf(
+        Props(
+          new BytecodeRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            evmCodeStorage = evmCodeStorage,
+            appStateStorage = appStateStorage,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig(),
+            preloadedMissingForTesting = Some(Seq.empty)
+          )
+        )
+      )
+
+      syncController.expectMsg(3.seconds, BytecodeRecoveryActor.RecoveryComplete)
+      appStateStorage.isBytecodeRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+
+  it should
+    "spawn coordinator, forward StartByteCodeSync, and emit RecoveryComplete on successful download" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_t2")
+      val networkPeerManager = TestProbe("networkPeerManager_t2")
+      val coordinatorProbe = TestProbe("coordinator_t2")
+      val (stateStorage, appStateStorage, evmCodeStorage) = newStorages()
+
+      val actor = system.actorOf(
+        Props(
+          new BytecodeRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            evmCodeStorage = evmCodeStorage,
+            appStateStorage = appStateStorage,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig(),
+            preloadedMissingForTesting = Some(missingOne),
+            coordinatorForTesting = Some(coordinatorProbe.ref)
+          )
+        )
+      )
+
+      coordinatorProbe.expectMsgType[snap.actors.Messages.StartByteCodeSync](2.seconds)
+
+      actor ! SNAPSyncController.ByteCodeSyncComplete
+
+      syncController.expectMsg(3.seconds, BytecodeRecoveryActor.RecoveryComplete)
+      appStateStorage.isBytecodeRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+
+  it should
+    "emit RecoveryComplete even when the trie scan Future throws (trie root missing)" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_t3")
+      val networkPeerManager = TestProbe("networkPeerManager_t3")
+      // Empty storages: stateRoot not present in MPT → mptStorage.get throws → Future Failure
+      val (stateStorage, appStateStorage, evmCodeStorage) = newStorages()
+
+      val actor = system.actorOf(
+        Props(
+          new BytecodeRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            evmCodeStorage = evmCodeStorage,
+            appStateStorage = appStateStorage,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig()
+            // preloadedMissingForTesting = None → real scan path → throws
+          )
+        )
+      )
+
+      // Future Failure → ScanResult(Seq.empty) → RecoveryComplete (graceful resilience)
+      syncController.expectMsg(8.seconds, BytecodeRecoveryActor.RecoveryComplete)
+      appStateStorage.isBytecodeRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+
+  it should
+    "emit RecoveryComplete when coordinator crashes unexpectedly (Terminated handler)" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_t4")
+      val networkPeerManager = TestProbe("networkPeerManager_t4")
+      val coordinatorProbe = TestProbe("coordinator_t4")
+      val (stateStorage, appStateStorage, evmCodeStorage) = newStorages()
+
+      val actor = system.actorOf(
+        Props(
+          new BytecodeRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            evmCodeStorage = evmCodeStorage,
+            appStateStorage = appStateStorage,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig(),
+            preloadedMissingForTesting = Some(missingOne),
+            coordinatorForTesting = Some(coordinatorProbe.ref)
+          )
+        )
+      )
+
+      coordinatorProbe.expectMsgType[snap.actors.Messages.StartByteCodeSync](2.seconds)
+
+      // Kill the coordinator — recovery actor watches it and should handle Terminated
+      system.stop(coordinatorProbe.ref)
+
+      syncController.expectMsg(5.seconds, BytecodeRecoveryActor.RecoveryComplete)
+      appStateStorage.isBytecodeRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+
+  it should
+    "abandon and emit RecoveryComplete when no download progress arrives within the timeout" taggedAs (
+      UnitTest,
+      SyncTest
+    ) in {
+      val syncController = TestProbe("syncController_t5")
+      val networkPeerManager = TestProbe("networkPeerManager_t5")
+      val coordinatorProbe = TestProbe("coordinator_t5")
+      val (stateStorage, appStateStorage, evmCodeStorage) = newStorages()
+
+      val abandonAfter = 400.millis
+
+      val actor = system.actorOf(
+        Props(
+          new BytecodeRecoveryActor(
+            stateRoot = fakeStateRoot,
+            stateStorage = stateStorage,
+            evmCodeStorage = evmCodeStorage,
+            appStateStorage = appStateStorage,
+            networkPeerManager = networkPeerManager.ref,
+            syncController = syncController.ref,
+            pivotBlockNumber = BigInt(100),
+            snapSyncConfig = newConfig(abandonAfter),
+            preloadedMissingForTesting = Some(missingOne),
+            coordinatorForTesting = Some(coordinatorProbe.ref)
+          )
+        )
+      )
+
+      coordinatorProbe.expectMsgType[snap.actors.Messages.StartByteCodeSync](2.seconds)
+
+      // No ProgressBytecodesDownloaded → progressSeq stays 0 → CheckAbandon(0) fires and abandons
+      syncController.expectMsg(abandonAfter * 4, BytecodeRecoveryActor.RecoveryComplete)
+      appStateStorage.isBytecodeRecoveryDone() shouldBe true
+
+      system.stop(actor)
+    }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -545,6 +545,225 @@ class SyncControllerSpec
     }
   }
 
+  // ── T6-T9: runningRecovery state machine ──────────────────────────────────────────────────────
+  // These tests drive SyncController through the post-SNAP recovery path.
+  // Recovery actors scan an empty trie → MissingRootNodeException → ScanResult(Seq.empty) → RecoveryComplete.
+
+  private val recoveryFakeStateRoot: ByteString = ByteString(Array.fill[Byte](32)(0x55.toByte))
+
+  private def seedSnapDoneWithRecovery(
+      appState: com.chipprbots.ethereum.db.storage.AppStateStorage,
+      needBytecode: Boolean = true,
+      needStorage: Boolean = true,
+      withStateRoot: Boolean = true
+  ): Unit = {
+    appState.snapSyncDone().commit()
+    if (!needBytecode) appState.bytecodeRecoveryDone().commit()
+    if (!needStorage) appState.storageRecoveryDone().commit()
+    if (withStateRoot) {
+      appState.putSnapSyncStateRoot(recoveryFakeStateRoot).commit()
+      appState.putSnapSyncPivotBlock(BigInt(100)).commit()
+    }
+  }
+
+  it should "transition to regular sync after both bytecode and storage recovery complete" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    seedSnapDoneWithRecovery(storagesInstance.storages.appStateStorage)
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    storagesInstance.storages.appStateStorage.isBytecodeRecoveryDone() shouldBe true
+    storagesInstance.storages.appStateStorage.isStorageRecoveryDone() shouldBe true
+  }
+
+  it should "transition to regular sync when only bytecode recovery is needed (storage pre-done)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    seedSnapDoneWithRecovery(storagesInstance.storages.appStateStorage, needStorage = false)
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    storagesInstance.storages.appStateStorage.isBytecodeRecoveryDone() shouldBe true
+  }
+
+  it should "transition to regular sync when only storage recovery is needed (bytecode pre-done)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    seedSnapDoneWithRecovery(storagesInstance.storages.appStateStorage, needBytecode = false)
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    storagesInstance.storages.appStateStorage.isStorageRecoveryDone() shouldBe true
+  }
+
+  it should "skip recovery and start regular sync immediately when stateRoot or pivotBlock is missing" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    // snap done but no stateRoot/pivotBlock stored → startRecovery falls to case _ => and calls startRegularSync
+    seedSnapDoneWithRecovery(
+      storagesInstance.storages.appStateStorage,
+      withStateRoot = false
+    )
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    storagesInstance.storages.appStateStorage.isBytecodeRecoveryDone() shouldBe true
+    storagesInstance.storages.appStateStorage.isStorageRecoveryDone() shouldBe true
+  }
+
+  // ── T10-T13: startup diagnostic + handler tests ───────────────────────────────────────────────
+  // RLP encoding of a 32-byte hash = valid HashNode (length==MaxEncodedNodeLength → no MPTException)
+  private def validMptNodeRlp(hash: ByteString): Array[Byte] = Array(0xa0.toByte) ++ hash.toArray
+
+  private def seedMptNode(
+      testSetup: TestSetup,
+      hashes: ByteString*
+  ): Unit =
+    testSetup.storagesInstance.storages.nodeStorage.update(
+      Seq.empty,
+      hashes.map(h => (h, validMptNodeRlp(h)))
+    )
+
+  it should "update pivot header stateRoot to snapStateRoot when snapRoot differs but both are in MPT (SC-1a)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    val pivotNum = BigInt(100)
+    val rootA = ByteString(Array.fill[Byte](32)(0x11)) // stored in pivot header
+    val rootB = ByteString(Array.fill[Byte](32)(0x22)) // snapSyncStateRoot — differs from rootA
+    val pivotHeader = baseBlockHeader.copy(number = pivotNum, stateRoot = rootA)
+
+    // Both roots present in MPT — triggers SC-1a symmetric case
+    seedMptNode(testSetup, rootA, rootB)
+    blockchainWriter.storeBlockHeader(pivotHeader).commit()
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(pivotNum).commit()
+
+    storagesInstance.storages.appStateStorage.snapSyncDone().commit()
+    storagesInstance.storages.appStateStorage.bytecodeRecoveryDone().commit()
+    storagesInstance.storages.appStateStorage.storageRecoveryDone().commit()
+    storagesInstance.storages.appStateStorage.putSnapSyncStateRoot(rootB).commit()
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    // SyncController must have rewritten the pivot header's stateRoot from rootA to rootB
+    blockchainReader.getBlockHeaderByNumber(pivotNum).map(_.stateRoot) shouldBe Some(rootB)
+  }
+
+  it should "substitute finalized root into pivot header when pivot stateRoot is missing from MPT (SC-1b)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    val pivotNum = BigInt(100)
+    val rootA = ByteString(Array.fill[Byte](32)(0x33)) // stored in pivot header, NOT in MPT
+    val rootB = ByteString(Array.fill[Byte](32)(0x44)) // finalizedRoot, present in MPT
+    val pivotHeader = baseBlockHeader.copy(number = pivotNum, stateRoot = rootA)
+
+    // Only rootB in MPT — pivotRootExists=false → finalized substitution path
+    seedMptNode(testSetup, rootB)
+    blockchainWriter.storeBlockHeader(pivotHeader).commit()
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(pivotNum).commit()
+
+    storagesInstance.storages.appStateStorage.snapSyncDone().commit()
+    storagesInstance.storages.appStateStorage.bytecodeRecoveryDone().commit()
+    storagesInstance.storages.appStateStorage.storageRecoveryDone().commit()
+    storagesInstance.storages.appStateStorage.putSnapSyncFinalizedRoot(rootB).commit()
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+    blockchainReader.getBlockHeaderByNumber(pivotNum).map(_.stateRoot) shouldBe Some(rootB)
+  }
+
+  it should "clear both done flags and restart SNAP when HealingImpossible is received" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withRecoveryTestSetup() { testSetup =>
+    import testSetup._
+    // No snapSyncDone → start() → case (false, _, true, _) → startSnapSync()
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("snap-sync")))
+    }
+
+    // Manually set both flags so we can verify HealingImpossible clears them
+    storagesInstance.storages.appStateStorage.snapSyncDone().commit()
+    storagesInstance.storages.appStateStorage.fastSyncDone().commit()
+
+    syncController ! SyncProtocol.HealingImpossible
+
+    // HealingImpossible clears both flags synchronously
+    storagesInstance.storages.appStateStorage.isSnapSyncDone() shouldBe false
+    storagesInstance.storages.appStateStorage.isFastSyncDone() shouldBe false
+
+    // startSnapSync() spawned a new generation; eventually a snap-sync child is visible
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("snap-sync")))
+    }
+  }
+
+  it should "clear sync flags and restart SNAP with minPivotBlock when RegularSyncStuck is received (SC-4)" taggedAs (
+    UnitTest,
+    SyncTest
+  ) in withTestSetup() { testSetup =>
+    import testSetup._
+    // doFastSync=true, doSnapSync=false; pre-set fastSyncDone → case (_, true, false, true) → startRegularSync()
+    storagesInstance.storages.appStateStorage.fastSyncDone().commit()
+
+    syncController ! SyncProtocol.Start
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("regular-sync")))
+    }
+
+    syncController ! SyncProtocol.RegularSyncStuck(BigInt(24601125), "deadbeefdeadbeef")
+
+    storagesInstance.storages.appStateStorage.isSnapSyncDone() shouldBe false
+    storagesInstance.storages.appStateStorage.isFastSyncDone() shouldBe false
+
+    eventually {
+      someTimePasses()
+      assert(syncController.children.exists(_.path.name.startsWith("snap-sync")))
+    }
+  }
+
   class TestSetup(
       _validators: Validators = new Mocks.MockValidatorsAlwaysSucceed
   ) extends EphemBlockchainTestSetup
@@ -919,6 +1138,17 @@ class SyncControllerSpec
 
   def withTestSetup(validators: Validators = new Mocks.MockValidatorsAlwaysSucceed)(test: TestSetup => Any): Unit = {
     val testSetup = new TestSetup(validators)
+    try test(testSetup)
+    finally testSetup.cleanup()
+  }
+
+  def withRecoveryTestSetup()(test: TestSetup => Any): Unit = {
+    val testSetup = new TestSetup() {
+      override def defaultSyncConfig: SyncConfig = super.defaultSyncConfig.copy(
+        doSnapSync = true,
+        doFastSync = false
+      )
+    }
     try test(testSetup)
     finally testSetup.cleanup()
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -39,6 +39,7 @@ import com.chipprbots.ethereum.network.PeerEventBusActor.SubscriptionClassifier.
 import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.p2p.messages.BaseETH6XMessages.NewBlock
 import com.chipprbots.ethereum.network.p2p.messages.Codes
+import com.chipprbots.ethereum.network.p2p.messages.ETH69
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{BlockBodies => ETH66BlockBodies}
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{BlockHeaders => ETH66BlockHeaders}
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{GetBlockBodies => ETH66GetBlockBodies}
@@ -277,6 +278,82 @@ class BlockFetcherSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfter
       shutdownActorSystem()
     }
 
+    // BF-1A: ETH/69 head-following via BlockRangeUpdate
+    "should include BlockRangeUpdateCode in peer event subscription" taggedAs (UnitTest, SyncTest) in new TestSetup {
+      blockFetcher ! BlockFetcher.Start(importer.ref, 0)
+      val sub = peerEventBus.expectMsgClass(classOf[Subscribe])
+      sub.to match {
+        case MessageClassifier(codes, _) =>
+          codes should contain(Codes.BlockRangeUpdateCode)
+        case _ => fail("Expected MessageClassifier subscription")
+      }
+      shutdownActorSystem()
+    }
+
+    "should request headers when BlockRangeUpdate announces a new chain tip" taggedAs (UnitTest, SyncTest) in new TestSetup {
+      startFetcher()
+      // ETH/69 peer announces latest block at 100; fetcher should immediately request headers
+      val update = ETH69.BlockRangeUpdate(BigInt(0), BigInt(100), org.apache.pekko.util.ByteString.empty)
+      blockFetcher ! AdaptedMessageFromEventBus(update, fakePeer.id)
+      peersClient.expectMsgPF() {
+        case PeersClient.Request(msg: ETH66GetBlockHeaders, _, _) if msg.block == Left(1) => ()
+      }
+      shutdownActorSystem()
+    }
+
+    // BF-1B: PrintStatus heartbeat probes for next block when on top
+    "should probe for the next block via PrintStatus when isOnTop" taggedAs (UnitTest, SyncTest) in new TestSetup {
+      // Start from block 5; knownTop initialises to 6 so fetcher immediately requests block 6
+      startFetcher(fromBlock = 5)
+      // Consume the initial GetBlockHeaders(6) request triggered by fetchBlocks at Start
+      val initSender = peersClient.expectMsgPF() {
+        case PeersClient.Request(msg: ETH66GetBlockHeaders, _, _) if msg.block == Left(BigInt(6)) =>
+          peersClient.lastSender
+      }
+      // Reply with a single header at block 6 — partial batch (blockHeadersPerRequest=10).
+      // Generate a parent block at number 5 so the chain starts at 6.
+      val parentAt5 = BlockHelpers.generateChain(5, FixtureBlocks.Genesis.block).last
+      val singleBlock = BlockHelpers.generateChain(1, parentAt5).head
+      val singleHeader = singleBlock.header
+      initSender ! PeersClient.Response(fakePeer, ETH66BlockHeaders(0, List(singleHeader)))
+      // BlockFetcher now requests bodies for block 6
+      val bodiesSender = peersClient.expectMsgPF() {
+        case PeersClient.Request(_: ETH66GetBlockBodies, _, _) => peersClient.lastSender
+      }
+      bodiesSender ! PeersClient.Response(fakePeer, ETH66BlockBodies(0, List(singleBlock.body)))
+      // Importer picks the block; this advances lastBlock to 6 so isOnTop becomes true
+      Thread.sleep(300L)
+      importer.send(blockFetcher.toClassic, PickBlocks(1, importer.ref))
+      importer.expectMsgPF() { case BlockFetcher.PickedBlocks(_) => () }
+      Thread.sleep(100L)
+      // isOnTop=true now; PrintStatus should probe for block 7
+      blockFetcher ! BlockFetcher.PrintStatus
+      // Use fishForSpecificMessage to tolerate any intermediate messages (e.g. status logs)
+      peersClient.fishForSpecificMessage() {
+        case PeersClient.Request(msg: ETH66GetBlockHeaders, _, _) if msg.block == Left(BigInt(7)) => true
+      }
+      shutdownActorSystem()
+    }
+
+    // BF-2: partial header batch still advances nextBlockToFetch correctly
+    "should fetch the next window after a partial header batch response" taggedAs (UnitTest, SyncTest) in new TestSetup {
+      startFetcher()
+      // Trigger to set knownTop=1000 (high, so fetcher knows more blocks exist)
+      triggerFetching(1000)
+      val requestSender = peersClient.expectMsgPF() {
+        case PeersClient.Request(msg: ETH66GetBlockHeaders, _, _) if msg.block == Left(1) =>
+          peersClient.lastSender
+      }
+      // Reply with a partial batch (fewer than blockHeadersPerRequest=10 headers, stopping at block 5)
+      val partialBatch = BlockHelpers.generateChain(5, FixtureBlocks.Genesis.block)
+      requestSender ! PeersClient.Response(fakePeer, ETH66BlockHeaders(0, partialBatch.map(_.header)))
+      // After a partial batch, fetcher should request the next window starting at block 6
+      peersClient.fishForSpecificMessage() {
+        case PeersClient.Request(msg: ETH66GetBlockHeaders, _, _) if msg.block == Left(6) => true
+      }
+      shutdownActorSystem()
+    }
+
     "should properly handle a request timeout" in new TestSetup {
       override lazy val syncConfig: SyncConfig = defaultSyncConfig.copy(
         // Small timeout on ask pattern for testing it here
@@ -337,13 +414,13 @@ class BlockFetcherSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfter
       )
     )
 
-    def startFetcher(): Unit = {
-      blockFetcher ! BlockFetcher.Start(importer.ref, 0)
+    def startFetcher(fromBlock: BigInt = 0): Unit = {
+      blockFetcher ! BlockFetcher.Start(importer.ref, fromBlock)
 
       peerEventBus.expectMsg(
         Subscribe(
           MessageClassifier(
-            Set(Codes.NewBlockCode, Codes.NewBlockHashesCode, Codes.BlockHeadersCode),
+            Set(Codes.NewBlockCode, Codes.NewBlockHashesCode, Codes.BlockHeadersCode, Codes.BlockRangeUpdateCode),
             PeerSelector.AllPeers
           )
         )

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -58,6 +58,7 @@ import com.chipprbots.ethereum.network.p2p.messages.ETH66.{GetBlockHeaders => ET
 import com.chipprbots.ethereum.network.p2p.messages.ETH66.{GetBlockBodies => ETH66GetBlockBodies}
 import com.chipprbots.ethereum.utils.BlockchainConfig
 import com.chipprbots.ethereum.utils.Config.SyncConfig
+import com.chipprbots.ethereum.blockchain.sync.regular.RegularSync
 import org.apache.pekko.actor.ActorRef
 
 class RegularSyncSpec
@@ -93,14 +94,22 @@ class RegularSyncSpec
 
   "Regular Sync" when {
     "initializing" should {
-      "subscribe for new blocks, new hashes and new block headers" taggedAs (UnitTest, SyncTest) in sync(
+      "subscribe for new blocks, new hashes, new block headers and ETH/69 BlockRangeUpdate" taggedAs (
+        UnitTest,
+        SyncTest
+      ) in sync(
         new Fixture(testSystem) {
           regularSync ! SyncProtocol.Start
 
           peerEventBus.expectMsg(
             PeerEventBusActor.Subscribe(
               MessageClassifier(
-                Set(Codes.NewBlockCode, Codes.NewBlockHashesCode, Codes.BlockHeadersCode),
+                Set(
+                  Codes.NewBlockCode,
+                  Codes.NewBlockHashesCode,
+                  Codes.BlockHeadersCode,
+                  Codes.BlockRangeUpdateCode
+                ),
                 PeerSelector.AllPeers
               )
             )
@@ -831,6 +840,39 @@ class RegularSyncSpec
             _ <- IO(goToTop())
             status <- getSyncStatus
           } yield assert(status === Status.SyncDone)
+      }
+    }
+
+    // RS-1: ProgressState.toStatus guard — bestKnownNetworkBlock=0 must not produce SyncDone
+    "ProgressState.toStatus" should {
+      import RegularSync.ProgressState
+      import scala.concurrent.Future
+
+      "return NotSyncing when not yet started" taggedAs (UnitTest, SyncTest) in {
+        val state = ProgressState(startedFetching = false, initialBlock = 0, currentBlock = 0, bestKnownNetworkBlock = 0)
+        Future.successful(assert(state.toStatus === Status.NotSyncing))
+      }
+
+      "return NotSyncing when started but bestKnownNetworkBlock is 0 (no peers seen yet)" taggedAs (
+        UnitTest,
+        SyncTest
+      ) in {
+        // RS-1 regression: before the fix, startedFetching=true and currentBlock(0) >= bestKnownNetworkBlock(0)
+        // incorrectly triggered SyncDone before any peer had announced a block.
+        val state = ProgressState(startedFetching = true, initialBlock = 0, currentBlock = 0, bestKnownNetworkBlock = 0)
+        Future.successful(assert(state.toStatus === Status.NotSyncing))
+      }
+
+      "return Syncing when started and behind chain head" taggedAs (UnitTest, SyncTest) in {
+        val state =
+          ProgressState(startedFetching = true, initialBlock = 5, currentBlock = 10, bestKnownNetworkBlock = 100)
+        Future.successful(assert(state.toStatus === Status.Syncing(5, Progress(10, 100), None)))
+      }
+
+      "return SyncDone when started and caught up to chain head" taggedAs (UnitTest, SyncTest) in {
+        val state =
+          ProgressState(startedFetching = true, initialBlock = 0, currentBlock = 50, bestKnownNetworkBlock = 50)
+        Future.successful(assert(state.toStatus === Status.SyncDone))
       }
     }
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/ChainDownloaderSpec.scala
@@ -12,11 +12,17 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import java.net.InetSocketAddress
+
+import com.chipprbots.ethereum.blockchain.sync.PeerRequestHandler.ResponseReceived
 import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
 import com.chipprbots.ethereum.db.dataSource.EphemDataSource
 import com.chipprbots.ethereum.db.storage.AppStateStorage
 import com.chipprbots.ethereum.domain.BlockchainReader
 import com.chipprbots.ethereum.domain.BlockchainWriter
+import com.chipprbots.ethereum.network.Peer
+import com.chipprbots.ethereum.network.PeerId
+import com.chipprbots.ethereum.network.p2p.messages.ETH66
 import com.chipprbots.ethereum.testing.Tags._
 
 class ChainDownloaderSpec
@@ -159,6 +165,53 @@ class ChainDownloaderSpec
     // A target lower than the current one is ignored.
     downloader ! ChainDownloader.UpdateTarget(BigInt(1200))
     appStateStorage.getBackfillTarget() shouldBe BigInt(1500)
+
+    system.stop(downloader)
+  }
+
+  // go-ethereum behavioral backoff: a peer returning empty BlockHeaders (count:0) should be excluded
+  // from future header dispatch (capacity-to-zero equivalent, msgrate.go:187). Bodies/receipts/SNAP
+  // dispatch must remain unaffected. If the peer later delivers non-empty headers, exclusion is lifted.
+  it should "exclude peer from header dispatch after empty BlockHeaders response" taggedAs UnitTest in {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val blockchainReader = mock[BlockchainReader]
+    val blockchainWriter = mock[BlockchainWriter]
+    val appStateStorage = new AppStateStorage(EphemDataSource())
+    val networkPeerManager = TestProbe()
+    val peerEventBus = TestProbe()
+
+    (blockchainReader.getBlockHeaderByNumber _)
+      .expects(BigInt(1))
+      .returning(None)
+      .anyNumberOfTimes()
+
+    val downloader = TestActorRef[ChainDownloader](
+      ChainDownloader.props(
+        blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
+        appStateStorage = appStateStorage,
+        networkPeerManager = networkPeerManager.ref,
+        peerEventBus = peerEventBus.ref,
+        syncConfig = defaultSyncConfig,
+        scheduler = system.scheduler,
+        maxConcurrentRequests = 4
+      )
+    )
+    downloader ! ChainDownloader.Start(BigInt(19_250_000))
+
+    val dummyAddr = new InetSocketAddress("127.0.0.1", 30303)
+    val peer = Peer(PeerId("snap-peer-1"), dummyAddr, TestProbe().ref, incomingConnection = false)
+
+    downloader.underlyingActor.isHeaderExcluded(peer.id) shouldBe false
+
+    // First empty response — peer should be excluded
+    downloader ! ResponseReceived(peer, ETH66.BlockHeaders(requestId = 1, headers = Seq.empty), 100L)
+    downloader.underlyingActor.isHeaderExcluded(peer.id) shouldBe true
+
+    // Recovery: non-empty response clears the exclusion
+    val fakeHeader = mock[com.chipprbots.ethereum.domain.BlockHeader]
+    downloader ! ResponseReceived(peer, ETH66.BlockHeaders(requestId = 2, headers = Seq(fakeHeader)), 100L)
+    downloader.underlyingActor.isHeaderExcluded(peer.id) shouldBe false
 
     system.stop(downloader)
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
@@ -13,9 +13,10 @@ import com.chipprbots.ethereum.testing.TestMptStorage
 
 class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
-  "MerkleProofVerifier" should "reject empty account reply without proof for non-empty state root" taggedAs UnitTest in {
-    // In snap/1, accounts=0 + proof=0 is a refusal/stateless signal for a non-empty root.
-    // A genuinely exhausted range must carry a boundary proof.
+  "MerkleProofVerifier" should "accept terminal empty account range for non-empty state root" taggedAs UnitTest in {
+    // go-ethereum accepts accounts=0 + proof=0 unconditionally as a valid terminal-empty range
+    // (no accounts exist between startHash and endHash). This is correct for sparse tries.
+    // See: verifyStorageRange which already accepts empty slots + empty proof unconditionally.
     val stateRoot = kec256(ByteString("test-root"))
     val verifier = MerkleProofVerifier(stateRoot)
 
@@ -26,8 +27,7 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
       endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
     )
 
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("Missing proof for empty account range")
+    result shouldBe Right(())
   }
 
   it should "accept empty proof for empty account list when trie is empty" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorkerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeWorkerSpec.scala
@@ -93,7 +93,9 @@ class AccountRangeWorkerSpec
     returnedProof should not be empty
   }
 
-  it should "report TaskFailed on empty account response without proof for non-empty root" taggedAs UnitTest in {
+  it should "report TaskComplete on terminal empty account range for non-empty root" taggedAs UnitTest in {
+    // go-ethereum accepts accounts=0 + proof=0 unconditionally as a valid terminal-empty range.
+    // The worker should complete the task rather than failing it.
     val coordinator = TestProbe()
     val networkPeerManager = TestProbe()
     val peerProbe = TestProbe()
@@ -106,9 +108,8 @@ class AccountRangeWorkerSpec
 
     worker ! Messages.AccountRangeResponseMsg(AccountRange(requestId = reqId, accounts = Seq.empty, proof = Seq.empty))
 
-    val msg = coordinator.expectMsgType[Messages.TaskFailed](1.second)
+    val msg = coordinator.expectMsgType[Messages.TaskComplete](1.second)
     msg.requestId shouldBe reqId
-    msg.reason should include("Missing proof for empty account range")
   }
 
   it should "report TaskFailed to coordinator on RequestTimeout" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
@@ -138,6 +138,60 @@ class ByteCodeCoordinatorSpec
     expectMsgType[Any](3.seconds)
   }
 
+  // Verifies Fix 6 / P-5.4: ByteCodeTaskComplete must call tryRedispatchPendingTasks() so the
+  // next pending task is dispatched immediately within the same message cycle — not delayed up to
+  // 1 second waiting for the next ByteCodePeerAvailable tick from SNAPSyncController.
+  it should "dispatch pending task immediately on ByteCodeTaskComplete without a new ByteCodePeerAvailable" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val peerProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("redispatch-peer", peerProbe.ref)
+
+    // maxInFlightPerPeer=1 ensures only 1 task in flight at a time, leaving the 2nd pending
+    val peerCooldown = testCooldownConfig.copy(maxInFlightPerPeer = 1)
+    val coordinator = TestActorRef[ByteCodeCoordinator](
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 1,
+        snapSyncController = snapSyncController.ref,
+        cooldownConfig = peerCooldown
+      )
+    )
+
+    val hashes = Seq(kec256(ByteString("redispatch-a")), kec256(ByteString("redispatch-b")))
+    coordinator ! Messages.StartByteCodeSync(hashes)
+    coordinator ! Messages.NoMoreByteCodeTasks
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+
+    // Only the first task is dispatched (maxInFlightPerPeer=1)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+
+    within(3.seconds) {
+      awaitAssert {
+        coordinator.underlyingActor.activeTasks.size shouldBe 1
+        coordinator.underlyingActor.pendingTasks should have size 1
+      }
+    }
+    val activeEntry = coordinator.underlyingActor.activeTasks.head
+    val reqId = activeEntry._1
+    val worker = activeEntry._2.worker
+
+    // ByteCodeWorker uses context.become(working) and stashes ByteCodeWorkerFetchTask in that
+    // state. Release it first so the worker transitions to idle; the coordinator's subsequent
+    // tryRedispatchPendingTasks() dispatch will then be accepted rather than stashed.
+    worker ! Messages.ByteCodeWorkerRelease(reqId)
+
+    // Complete the in-flight task at coordinator level — calls markWorkerIdle + tryRedispatchPendingTasks()
+    coordinator ! Messages.ByteCodeTaskComplete(reqId, Right(1))
+
+    // The pending task must be dispatched immediately via tryRedispatchPendingTasks()
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+  }
+
   it should "report completion when all bytecodes downloaded" taggedAs UnitTest in {
     val evmCodeStorage = new TestEvmCodeStorage()
     val requestTracker = new SNAPRequestTracker()(system.scheduler)
@@ -573,6 +627,62 @@ class ByteCodeCoordinatorSpec
     snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
   }
 
+  // ForceCompleteByteCodes may fire while tasks are still in activeTasks (e.g. the 10-min stall
+  // watchdog triggers mid-flight). The handler must drain active tasks AND return their workers
+  // to the idle pool — otherwise the worker pool invariant (workers.size == idleWorkers.size +
+  // activeTasks.size) would be broken, and any subsequent coordinator reuse would leak workers.
+  it should "return active workers to idle pool on ForceCompleteByteCodes mid-flight" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val peerProbe = TestProbe()
+    val peer = PeerTestHelpers.createTestPeer("fc-active-peer", peerProbe.ref)
+
+    // batchSize=1 + maxInFlightPerPeer=2 → 2 tasks dispatched concurrently; 1 left pending
+    val peerCooldown = testCooldownConfig.copy(maxInFlightPerPeer = 2)
+    val coordinator = TestActorRef[ByteCodeCoordinator](
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 1,
+        snapSyncController = snapSyncController.ref,
+        cooldownConfig = peerCooldown
+      )
+    )
+
+    val hashes = (1 to 3).map(i => kec256(ByteString(s"fc-active-$i")))
+    coordinator ! Messages.StartByteCodeSync(hashes)
+    coordinator ! Messages.NoMoreByteCodeTasks
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+
+    within(3.seconds) {
+      awaitAssert {
+        coordinator.underlyingActor.activeTasks.size shouldBe 2
+        coordinator.underlyingActor.idleWorkers shouldBe empty
+      }
+    }
+
+    // Force-complete fires while 2 tasks are still in flight and 1 is pending
+    coordinator ! Messages.ForceCompleteByteCodes
+
+    within(3.seconds) {
+      awaitAssert {
+        // Active tasks drained; workers returned to idle pool (line 362 markWorkerIdle)
+        coordinator.underlyingActor.activeTasks shouldBe empty
+        coordinator.underlyingActor.idleWorkers.size shouldBe 2
+        // Pool invariant: workers.size == idleWorkers.size when activeTasks.isEmpty
+        coordinator.underlyingActor.workers.size shouldBe coordinator.underlyingActor.idleWorkers.size
+      }
+    }
+
+    snapSyncController.expectMsg(3.seconds, SNAPSyncController.ByteCodeSyncComplete)
+  }
+
   it should "handle ForceCompleteByteCodes when queues are already empty" taggedAs UnitTest in {
     val evmCodeStorage = new TestEvmCodeStorage()
     val requestTracker = new SNAPRequestTracker()(system.scheduler)
@@ -686,6 +796,66 @@ class ByteCodeCoordinatorSpec
 
     coordinator ! Messages.ByteCodeGetProgress
     expectMsgType[Messages.ByteCodeProgress](3.seconds)
+  }
+
+  // ── P-0 regression: ByteCodePeerUnavailable must restore workers to idle pool ─
+  // Run 25 root cause: ByteCodePeerUnavailable sent ByteCodeWorkerRelease to each in-flight
+  // worker but never called markWorkerIdle. Workers stayed in `workers` (alive) but were absent
+  // from `idleWorkers`, so dispatchIfPossible permanently returned None after the peer cascade.
+  // This test would have caught that: after ByteCodePeerUnavailable, the idle count must
+  // equal the pre-dispatch idle count (workers returned), and dispatch must succeed again.
+  it should "restore workers to idle pool when a peer disconnects mid-flight" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val peerProbe = TestProbe()
+
+    val peerId = "unavail-peer"
+    val peer = PeerTestHelpers.createTestPeer(peerId, peerProbe.ref)
+
+    // batchSize=1 so each hash → one task; maxInFlightPerPeer=3 → up to 3 concurrent workers
+    val peerCooldown = testCooldownConfig.copy(maxInFlightPerPeer = 3)
+    val coordinator = TestActorRef[ByteCodeCoordinator](
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 1,
+        snapSyncController = snapSyncController.ref,
+        cooldownConfig = peerCooldown
+      )
+    )
+
+    // Queue 3 hashes (one per task) and dispatch
+    val hashes = (1 to 3).map(i => kec256(ByteString(s"unavail-code-$i")))
+    coordinator ! Messages.StartByteCodeSync(hashes)
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+
+    // Three tasks dispatched — one worker per task
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+
+    // All 3 workers active, none idle
+    within(3.seconds) {
+      awaitAssert(coordinator.underlyingActor.workers.size == 3)
+    }
+    coordinator.underlyingActor.idleWorkers shouldBe empty
+
+    // Peer disconnects — ByteCodePeerUnavailable must release all in-flight workers back to idle
+    coordinator ! Messages.ByteCodePeerUnavailable(peerId)
+
+    // All 3 workers must be returned to idleWorkers (the P-0 fix: markWorkerIdle after release)
+    within(3.seconds) {
+      awaitAssert {
+        coordinator.underlyingActor.idleWorkers.size shouldBe 3
+      }
+    }
+
+    // Dispatch must succeed — idle workers available, tasks re-queued
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
   }
 
   it should "emit ByteCodeBackpressureChanged when the pending queue crosses watermarks" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinatorSpec.scala
@@ -1,7 +1,7 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.{TestKit, TestProbe, ImplicitSender}
+import org.apache.pekko.testkit.{TestActorRef, TestKit, TestProbe, ImplicitSender}
 import org.apache.pekko.util.ByteString
 
 import scala.concurrent.duration._
@@ -601,6 +601,93 @@ class ByteCodeCoordinatorSpec
   // even with that fixed, an unbounded pending queue still leaks task-metadata
   // memory linearly with chain size. The coordinator now publishes high/low-
   // water transitions that SNAPSyncController forwards to AccountRangeCoordinator.
+  // ── Fix 3: context.watch + Terminated handler — worker pool recovery ──────────
+  // Verifies that a permanently terminated worker is removed from the pool and its
+  // in-flight task is re-queued. Without context.watch, dead workers remain in
+  // `workers`, exhausting the pool (idleWorkers empty, workers.size >= maxWorkers)
+  // and blocking all further dispatch — the exact failure mode from Run 23.
+
+  it should "remove a terminated worker from the pool and re-queue its active task" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val peerProbe = TestProbe()
+
+    val peer = PeerTestHelpers.createTestPeer("term-peer", peerProbe.ref)
+
+    val coordinator = TestActorRef[ByteCodeCoordinator](
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref,
+        cooldownConfig = testCooldownConfig
+      )
+    )
+
+    coordinator ! Messages.StartByteCodeSync(Seq(kec256(ByteString("term-code"))))
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+
+    // Worker created and request dispatched
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+
+    // Get the worker ref and stop it permanently (bypasses supervisor restart)
+    val workerRef = coordinator.underlyingActor.workers.head
+    system.stop(workerRef)
+
+    // Terminated propagates asynchronously — wait for coordinator to process it
+    within(3.seconds) {
+      awaitAssert(coordinator.underlyingActor.workers.isEmpty)
+    }
+
+    // Task was re-queued — providing peer again triggers re-dispatch
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+  }
+
+  it should "remove a terminated worker with no active task without affecting pending dispatch" taggedAs UnitTest in {
+    val evmCodeStorage = new TestEvmCodeStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val peerProbe = TestProbe()
+
+    val peer = PeerTestHelpers.createTestPeer("term-idle-peer", peerProbe.ref)
+
+    val coordinator = TestActorRef[ByteCodeCoordinator](
+      ByteCodeCoordinator.props(
+        evmCodeStorage = evmCodeStorage,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        batchSize = 8,
+        snapSyncController = snapSyncController.ref,
+        cooldownConfig = testCooldownConfig
+      )
+    )
+
+    // Queue a task and dispatch — worker created
+    coordinator ! Messages.StartByteCodeSync(Seq(kec256(ByteString("idle-code"))))
+    coordinator ! Messages.ByteCodePeerAvailable(peer)
+    networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+
+    // Complete the task so the worker is now idle (no active task)
+    val workerRef = coordinator.underlyingActor.workers.head
+    // Let the worker become idle by marking the task complete
+    coordinator ! Messages.NoMoreByteCodeTasks
+
+    system.stop(workerRef)
+
+    // Pool should shrink without any exception — coordinator stays operational
+    within(3.seconds) {
+      awaitAssert(coordinator.underlyingActor.workers.isEmpty)
+    }
+
+    coordinator ! Messages.ByteCodeGetProgress
+    expectMsgType[Messages.ByteCodeProgress](3.seconds)
+  }
+
   it should "emit ByteCodeBackpressureChanged when the pending queue crosses watermarks" taggedAs UnitTest in {
     val evmCodeStorage = new TestEvmCodeStorage()
     val requestTracker = new SNAPRequestTracker()(system.scheduler)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinatorSpec.scala
@@ -416,6 +416,85 @@ class StorageRangeCoordinatorSpec
     snapSyncController.expectNoMessage(300.millis)
   }
 
+  // ── Fix 2: consecutiveTaskFailures reset on StoragePivotRefreshed ────────────
+  // Verifies that a pivot refresh zeroes the consecutive failure counter, preventing
+  // pivot-invalidated task failures (counted during AccountRange phase) from
+  // triggering a premature ForceComplete during the subsequent ByteCode+Storage phase.
+  // In Run 23 this counter reached 102-104 during AccountRange and triggered
+  // StorageRangeSyncForceCompleted at 14:28:43, permanently blocking recovery.
+
+  it should "reset consecutiveTaskFailures to 0 on StoragePivotRefreshed" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("reset-consec-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = TestActorRef[StorageRangeCoordinator](
+      StorageRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        flatSlotStorage = new FlatSlotStorage(EphemDataSource()),
+        maxAccountsPerBatch = 8,
+        maxInFlightRequests = 8,
+        requestTimeout = 30.seconds,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Simulate failures accumulated during AccountRange phase (before storage phase begins)
+    coordinator.underlyingActor.consecutiveTaskFailures = 50
+
+    val newStateRoot = kec256(ByteString("pivot-reset-root"))
+    coordinator ! Messages.StoragePivotRefreshed(newStateRoot)
+
+    // TestActorRef processes synchronously — counter must be 0 immediately after
+    coordinator.underlyingActor.consecutiveTaskFailures shouldBe 0
+  }
+
+  it should "not trigger ForceCompleteStorage when failures accumulated before a pivot are reset" taggedAs UnitTest in {
+    // Regression: Run 23 had 102-104 consecutive failures from pivot-invalidated tasks.
+    // The threshold is 100. Without the reset, those failures triggered ForceComplete during
+    // AccountRange, permanently setting storagePhaseComplete=true before storage even started.
+    // With the reset, a pivot refresh zeroes the counter so failures before and after a pivot
+    // are counted independently — only a sustained run of 100 failures from one pivot epoch triggers.
+    val stateRoot = kec256(ByteString("no-force-after-pivot-root"))
+    val storage = new TestMptStorage()
+    val requestTracker = new SNAPRequestTracker()(system.scheduler)
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+
+    val coordinator = TestActorRef[StorageRangeCoordinator](
+      StorageRangeCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = requestTracker,
+        mptStorage = storage,
+        flatSlotStorage = new FlatSlotStorage(EphemDataSource()),
+        maxAccountsPerBatch = 8,
+        maxInFlightRequests = 8,
+        requestTimeout = 30.seconds,
+        snapSyncController = snapSyncController.ref
+      )
+    )
+
+    // Accumulate 99 failures — one below the 100-failure force-complete threshold
+    coordinator.underlyingActor.consecutiveTaskFailures = 99
+
+    // Pivot refresh (mirrors what happens when SNAPSyncController updates the pivot block)
+    val newRoot = kec256(ByteString("mid-session-pivot"))
+    coordinator ! Messages.StoragePivotRefreshed(newRoot)
+
+    // Counter is now 0. Set it to 99 again (simulating another near-threshold accumulation
+    // after the pivot — still one below the threshold from this epoch).
+    coordinator.underlyingActor.consecutiveTaskFailures = 99
+
+    // No ForceCompleteStorage should have been sent across either epoch
+    snapSyncController.expectNoMessage(300.millis)
+  }
+
   // ========================================
   // Flat-batch aggregator (issue #1165)
   // ========================================

--- a/src/test/scala/com/chipprbots/ethereum/consensus/mess/MESSConfigParsingSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/mess/MESSConfigParsingSpec.scala
@@ -1,0 +1,75 @@
+package com.chipprbots.ethereum.consensus.mess
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.BlockchainConfig
+
+/** L8 — MESSConfig.reactivationBlock parsing: olympia-block-number fallback.
+  *
+  * BlockchainConfig.fromRawConfig derives reactivationBlock from (in priority order):
+  *   1. mess.ecbp1100-reactivate-block-number (explicit, optional)
+  *   2. olympia-block-number from the parent chain config (fallback)
+  *
+  * This means neither the ETC mainnet config nor the Mordor config needs a
+  * separate reactivation key — MESS reactivation tracks the Olympia fork block
+  * automatically. When the real Olympia block is chosen, only
+  * olympia-block-number needs updating.
+  */
+// scalastyle:off magic.number
+class MESSConfigParsingSpec extends AnyFlatSpec with Matchers {
+
+  private val fullConfig = ConfigFactory.load()
+  private val etcRaw     = fullConfig.getConfig("fukuii.blockchains.etc")
+  private val mordorRaw  = fullConfig.getConfig("fukuii.blockchains.mordor")
+
+  private val OlympiaSentinel: BigInt = BigInt("1000000000000000000")
+
+  // ── fallback from olympia-block-number ──────────────────────────────────
+
+  "MESSConfig.reactivationBlock for ETC mainnet" should
+    "be derived from olympia-block-number when ecbp1100-reactivate-block-number is absent" taggedAs (
+      UnitTest,
+      OlympiaTest
+    ) in {
+    val config = BlockchainConfig.fromRawConfig(etcRaw)
+    config.messConfig.reactivationBlock shouldBe Some(OlympiaSentinel)
+  }
+
+  "MESSConfig.reactivationBlock for Mordor" should
+    "be derived from olympia-block-number when ecbp1100-reactivate-block-number is absent" taggedAs (
+      UnitTest,
+      OlympiaTest
+    ) in {
+    val config = BlockchainConfig.fromRawConfig(mordorRaw)
+    config.messConfig.reactivationBlock shouldBe Some(OlympiaSentinel)
+  }
+
+  // ── explicit key takes priority ─────────────────────────────────────────
+
+  "MESSConfig.reactivationBlock" should
+    "use ecbp1100-reactivate-block-number when both explicit key and olympia-block-number are present" taggedAs (
+      UnitTest,
+      OlympiaTest
+    ) in {
+    val rawWithExplicit = etcRaw
+      .withValue("mess.ecbp1100-reactivate-block-number", ConfigValueFactory.fromAnyRef("99999"))
+    val config = BlockchainConfig.fromRawConfig(rawWithExplicit)
+    config.messConfig.reactivationBlock shouldBe Some(BigInt(99999))
+  }
+
+  // ── None when neither key is present ────────────────────────────────────
+
+  it should "be None when both ecbp1100-reactivate-block-number and olympia-block-number are absent" taggedAs (
+    UnitTest,
+    OlympiaTest
+  ) in {
+    val rawNoOlympia = etcRaw
+      .withoutPath("olympia-block-number")
+    val config = BlockchainConfig.fromRawConfig(rawNoOlympia)
+    config.messConfig.reactivationBlock shouldBe None
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/consensus/pow/difficulty/ETChashDifficultyManipulationSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/pow/difficulty/ETChashDifficultyManipulationSpec.scala
@@ -1,0 +1,560 @@
+package com.chipprbots.ethereum.consensus.pow.difficulty
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import com.chipprbots.ethereum.consensus.mess.ArtificialFinality
+import com.chipprbots.ethereum.consensus.mess.MESSConfig
+import com.chipprbots.ethereum.domain.BlockHeader
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.ForkBlockNumbers
+
+import OscillationFixtures._
+
+// scalastyle:off magic.number
+/** Tests for ETChash difficulty adjustment behaviour across three mining eras:
+  *
+  * S1 Ethereum Merge spike (Sept 2022): GPU influx, fast-block lag S2 Post-Merge miner exodus (2022–2024): slow
+  * convergence, variable gaps S3 Current ASIC flex-load oscillation (Oct 2024–present): ETChash ASICs cycling on/off S4
+  * Hypothetical exploitation surface: boundary / stress scenarios S5 MESS interaction: Olympia re-activation closes the
+  * difficulty-trough gap
+  *
+  * Current oscillation (S3): ETChash ASICs are flex-load / demand-response — they turn off when energy costs exceed a
+  * threshold or grid operator contracts require curtailment. These ASICs cannot mine other coins; they are bricks
+  * without ETC. No alternative revenue stream.
+  *
+  * All on-chain block data is from OscillationFixtures (core-geth verified).
+  */
+class ETChashDifficultyManipulationSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
+
+  // -------------------------------------------------------------------------
+  // Shared infrastructure
+  // -------------------------------------------------------------------------
+
+  private val etcForkNumbers: ForkBlockNumbers = ForkBlockNumbers(
+    frontierBlockNumber = 0,
+    homesteadBlockNumber = 1150000,
+    eip106BlockNumber = Long.MaxValue,
+    eip150BlockNumber = 2500000,
+    eip155BlockNumber = 3000000,
+    eip160BlockNumber = 3000000,
+    eip161BlockNumber = Long.MaxValue,
+    difficultyBombPauseBlockNumber = 3000000,
+    difficultyBombContinueBlockNumber = 5000000,
+    difficultyBombRemovalBlockNumber = 5900000,
+    byzantiumBlockNumber = Long.MaxValue,
+    constantinopleBlockNumber = Long.MaxValue,
+    istanbulBlockNumber = Long.MaxValue,
+    atlantisBlockNumber = 8772000,
+    aghartaBlockNumber = 9573000,
+    phoenixBlockNumber = 10500839,
+    petersburgBlockNumber = Long.MaxValue,
+    ecip1099BlockNumber = 11460000,
+    muirGlacierBlockNumber = Long.MaxValue,
+    magnetoBlockNumber = 13189133,
+    berlinBlockNumber = 13189133,
+    mystiqueBlockNumber = 14525000,
+    spiralBlockNumber = 19250000,
+    olympiaBlockNumber = Long.MaxValue
+  )
+
+  implicit private val blockchainConfig: BlockchainConfig = BlockchainConfig(
+    forkBlockNumbers = etcForkNumbers,
+    maxCodeSize = Some(24576),
+    customGenesisFileOpt = None,
+    customGenesisJsonOpt = None,
+    daoForkConfig = None,
+    accountStartNonce = com.chipprbots.ethereum.domain.UInt256.Zero,
+    chainId = 61,
+    networkId = 1,
+    monetaryPolicyConfig = com.chipprbots.ethereum.utils.MonetaryPolicyConfig(
+      5000000, 0.2, 5000000000000000000L, 3000000000000000000L, 2000000000000000000L
+    ),
+    gasTieBreaker = false,
+    ethCompatibleStorage = true,
+    bootstrapNodes = Set.empty
+  )
+
+  private def header(
+      number: BigInt,
+      difficulty: BigInt,
+      timestamp: Long,
+      hasUncles: Boolean = false
+  ): BlockHeader =
+    BlockHeader(
+      parentHash = ByteString(new Array[Byte](32)),
+      ommersHash = if (hasUncles) ByteString(new Array[Byte](32)) else BlockHeader.EmptyOmmers,
+      beneficiary = ByteString(new Array[Byte](20)),
+      stateRoot = ByteString(new Array[Byte](32)),
+      transactionsRoot = ByteString(new Array[Byte](32)),
+      receiptsRoot = ByteString(new Array[Byte](32)),
+      logsBloom = ByteString(new Array[Byte](256)),
+      difficulty = difficulty,
+      number = number,
+      gasLimit = BigInt(8000000),
+      gasUsed = BigInt(0),
+      unixTimestamp = timestamp,
+      extraData = ByteString.empty,
+      mixHash = ByteString(new Array[Byte](32)),
+      nonce = ByteString(new Array[Byte](8))
+    )
+
+  private def fromSnapshot(s: BlockSnapshot): BlockHeader =
+    header(s.number, s.difficulty, s.timestamp)
+
+  /** For each consecutive (parent, child) pair verify that the DAA produces child.difficulty. */
+  private def verifyDifficultyChain(blocks: Seq[BlockSnapshot]): Unit = {
+    require(blocks.size >= 2, "need at least parent + one child")
+    blocks.sliding(2).foreach {
+      case Seq(parent, child) =>
+        val computed = EthashDifficultyCalculator.calculateDifficulty(
+          child.number,
+          child.timestamp,
+          fromSnapshot(parent)
+        )
+        withClue(s"block ${child.number} (gap=${child.timestamp - parent.timestamp}s)") {
+          computed shouldBe child.difficulty
+        }
+      case _ => // sliding(2) on Seq of 1 — can't happen given the require above
+    }
+  }
+
+  /** Simulate `count` blocks, each `gapSecs` apart, starting from `parentDiff`/`parentTs`. Returns (blockNumber,
+    * difficulty) pairs for the synthetic chain.
+    */
+  private def syntheticChain(
+      startBlock: BigInt,
+      parentDiff: BigInt,
+      parentTs: Long,
+      gapSecs: Long,
+      count: Int
+  ): Seq[(BigInt, BigInt)] = {
+    val results = scala.collection.mutable.ArrayBuffer.empty[(BigInt, BigInt)]
+    var prevDiff = parentDiff
+    var prevTs = parentTs
+    for (i <- 1 to count) {
+      val num = startBlock + i
+      val childTs = prevTs + gapSecs
+      val parentHdr = header(num - 1, prevDiff, prevTs)
+      val newDiff = EthashDifficultyCalculator.calculateDifficulty(num, childTs, parentHdr)
+      results += ((num, newDiff))
+      prevDiff = newDiff
+      prevTs = childTs
+    }
+    results.toSeq
+  }
+
+  // -------------------------------------------------------------------------
+  // Group A — S1: Ethereum Merge spike (Sept 2022)
+  // -------------------------------------------------------------------------
+
+  "ETC DAA during Merge spike" should "reproduce on-chain difficulty for mergeSpike blocks (real data)" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    verifyDifficultyChain(Seq(mergeSpikeParent) ++ mergeSpike)
+  }
+
+  it should "increase difficulty by exactly parentDiff/2048 per fast block" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // All mergeSpike blocks have gap < 9s → c = +1 → newDiff = parentDiff + parentDiff/2048
+    (Seq(mergeSpikeParent) ++ mergeSpike).sliding(2).foreach {
+      case Seq(parent, child) =>
+        val gap = child.timestamp - parent.timestamp
+        if (gap < 9) {
+          val expectedDelta = parent.difficulty / 2048
+          withClue(s"block ${child.number} gap=${gap}s") {
+            child.difficulty shouldBe parent.difficulty + expectedDelta
+          }
+        }
+      case _ =>
+    }
+  }
+
+  it should "demonstrate severe difficulty lag when hashrate triples" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // After 5 consecutive fast blocks, difficulty only rose by ~5/2048 ≈ 0.24%
+    // while hashrate jumped from ~50 TH/s to ~150+ TH/s on arrival day (3x)
+    val firstDiff = mergeSpike.head.difficulty
+    val lastDiff = mergeSpike.last.difficulty
+    val fractionalIncrease = (lastDiff - firstDiff).toDouble / firstDiff.toDouble
+
+    fractionalIncrease should be < 0.005 // less than 0.5% after 5 fast blocks
+    // Meanwhile hashrate tripled — the DAA convergence lag is ~2048 blocks to full equilibrium
+    // during this lag window miners earn far more blocks per hash than at equilibrium
+  }
+
+  it should "converge toward equilibrium at rate of ~parentDiff/2048 per block under sustained 3x hashrate" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // Synthetic: 3x hashrate from premergeBaseline implies ~4.3s block time
+    // c = +1 each block → difficulty rises by D/2048 per block
+    // How many blocks to reach 90% of 3x equilibrium difficulty?
+    val startDiff = premergeBaseline.difficulty
+    val target3xEquil = startDiff * 3
+
+    // After N blocks at c=+1, diff ≈ startDiff * (1 + 1/2048)^N
+    // We find N empirically via the synthetic chain at 4s gaps
+    val chain = syntheticChain(
+      startBlock = premergeBaseline.number,
+      parentDiff = startDiff,
+      parentTs = premergeBaseline.timestamp,
+      gapSecs = 4L,
+      count = 5000
+    )
+    val ninetyPctTarget = target3xEquil * 9 / 10
+    val blocksToConverge = chain.indexWhere { case (_, d) => d >= ninetyPctTarget }
+
+    // With c=+1 each step: ~1502 blocks (D * (2048/2048)^N approximation)
+    blocksToConverge should be > 1000
+    blocksToConverge should be < 3000
+  }
+
+  // -------------------------------------------------------------------------
+  // Group B — S2: Post-Merge miner exodus (2022–2024)
+  // -------------------------------------------------------------------------
+
+  "ETC DAA during miner exodus" should "reproduce on-chain difficulty for declinePhase blocks (real data)" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    verifyDifficultyChain(Seq(declinePhaseParent) ++ declinePhase)
+  }
+
+  it should "show c < 0 for inter-block times above 18 s in decline-phase blocks" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val slowBlocks = (Seq(declinePhaseParent) ++ declinePhase)
+      .sliding(2)
+      .collect {
+        case Seq(parent, child) if child.timestamp - parent.timestamp >= 18 =>
+          val gap = child.timestamp - parent.timestamp
+          (child.number, gap, cCoeff(gap))
+      }
+      .toSeq
+
+    slowBlocks should not be empty
+    slowBlocks.foreach { case (num, gap, c) =>
+      withClue(s"block $num gap=${gap}s") {
+        c should be < 0L
+      }
+    }
+  }
+
+  it should "converge from Merge-peak difficulty toward ASIC-only equilibrium" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // After miner exodus the DAA converges back from the Merge peak toward the ASIC-only baseline.
+    // Expected long-run equilibrium: ~125/185 fraction of peak (asicBaseHrFrac).
+    val actualRatio = cycleEnd.difficulty.toDouble / mergePeak.difficulty.toDouble
+    // Exact ratio depends on elapsed time; just verify we're heading in the right direction
+    actualRatio should be < 1.0 // difficulty fell from Merge peak
+    actualRatio should be > 0.3 // but not to near-zero
+  }
+
+  // -------------------------------------------------------------------------
+  // Group C — S3: ASIC flex-load oscillation (Oct 2024 – Jan 2026)
+  // -------------------------------------------------------------------------
+
+  "ETC DAA during flex-on phase" should "reproduce on-chain difficulty for flexOnPhase blocks (real data)" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    verifyDifficultyChain(Seq(flexOnPhaseParent) ++ flexOnPhase)
+  }
+
+  "ETC DAA during flex-off phase" should "reproduce on-chain difficulty for flexOffPhase blocks (real data)" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    verifyDifficultyChain(Seq(flexOffPhaseParent) ++ flexOffPhase)
+  }
+
+  "Flex-off phase" should "have inter-block gaps consistently above 17 s (≥ 9 of 10 blocks)" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val gaps = (Seq(flexOffPhaseParent) ++ flexOffPhase)
+      .sliding(2)
+      .map {
+        case Seq(p, c) => c.timestamp - p.timestamp
+        case _         => 0L
+      }
+      .toSeq
+    val slowCount = gaps.count(_ >= 18)
+    // Empirical: 9/10 blocks have gap >= 18s; one (block 22,200,018) has gap = 12s
+    slowCount should be >= 9
+  }
+
+  "Flex-off phase" should "trigger c < 0 for the overwhelming majority of observed blocks" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val cValues = (Seq(flexOffPhaseParent) ++ flexOffPhase)
+      .sliding(2)
+      .map {
+        case Seq(p, c) => cCoeff(c.timestamp - p.timestamp)
+        case _         => 0L
+      }
+      .toSeq
+    val negativeCount = cValues.count(_ < 0)
+    negativeCount should be >= 9 // 9/10 — only index 7 (gap=12s) gives c=0
+  }
+
+  "ASIC flex-load cycling" should "create a difficulty trough at the end of the flex-off phase" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // The flex-off phase's last block has lower difficulty than the flex-on phase's first block
+    flexOffPhase.last.difficulty should be < flexOnPhase.head.difficulty
+    // Trough depth: flex-on peak vs flex-off end of window
+    val troughDepth = cycleMid.difficulty - cycleEnd.difficulty
+    troughDepth should be > BigInt(0)
+    // The trough is substantial: over 50% drop from peak to trough
+    val troughRatio = cycleEnd.difficulty.toDouble / cycleMid.difficulty.toDouble
+    troughRatio should be < 0.6
+  }
+
+  "Flex miner re-entry" should "mine fast blocks at depressed difficulty" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // Flex-on phase difficulty is lower than equilibrium after a preceding flex-off trough.
+    // ASICs return when energy becomes available again — no alternative revenue during flex-off;
+    // they simply idle. The depressed difficulty at re-entry is a DAA convergence artifact.
+    val flexOnDiff = flexOnPhase.head.difficulty
+    val peakEqDiff = cycleMid.difficulty
+
+    // This fixture (Mar 2025) captures the approach to peak, not trough entry
+    flexOnDiff should be > BigInt(0)
+    flexOnDiff should be < peakEqDiff * 2 // sanity: not astronomically above peak
+  }
+
+  // -------------------------------------------------------------------------
+  // Group D — S4: Boundary / stress tests
+  // -------------------------------------------------------------------------
+
+  private val flexFractionTable =
+    Table("flexFracOfEquilibrium", 0.10, 0.20, 0.278, 0.324, 0.50)
+
+  "Flex-load exit DAA response" should "produce c = -1 at the observed 0.324 flex fraction exit" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val exitFrac = flexMaxHrFrac // 0.324 ≈ observed
+    val expectedGap = expectedBlockTimeAfterExit(exitFrac) // ≈ 19 s
+    val expectedC = cCoeff(expectedGap)
+    expectedC shouldBe -1L
+  }
+
+  "Flex-load exit threshold" should "be neutral (c = 0) for flex fractions below 0.278" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // Below threshold: block time < 18 s → still c = 0 or c = +1
+    val belowThreshold = 0.20
+    val gap = expectedBlockTimeAfterExit(belowThreshold) // ≈ 16 s
+    cCoeff(gap) shouldBe 0L // 1 - floor(16/9) = 1 - 1 = 0
+  }
+
+  "Flex-load exit threshold" should "trigger c = -1 at and above 0.278 exit fraction" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // At threshold: 13 / (1 - 0.278) = 13 / 0.722 ≈ 18.0 s → floor(18/9) = 2 → c = -1
+    val atThreshold = flexExitThresholdFrac
+    val gap = expectedBlockTimeAfterExit(atThreshold)
+    cCoeff(gap) should be <= 0L
+  }
+
+  "difficulty trough depth" should "scale with flex-load exit fraction over a 500-block off-phase" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val startDiff = cycleStart.difficulty
+    val startTs = cycleStart.timestamp
+
+    forAll(flexFractionTable) { exitFrac =>
+      val gapSecs = expectedBlockTimeAfterExit(exitFrac)
+      val chain = syntheticChain(cycleStart.number, startDiff, startTs, gapSecs, count = 500)
+      val endDiff = chain.last._2
+
+      if (cCoeff(gapSecs) == 0L) {
+        // Below threshold — no trough; difficulty stays approximately flat
+        val drift = (endDiff - startDiff).abs
+        drift should be < startDiff / 20 // < 5% movement
+      } else {
+        // Above threshold — measurable trough
+        endDiff should be < startDiff
+      }
+    }
+  }
+
+  "manipulation advantage" should "exist but be marginal — ASICs idle during flex-off with no offset revenue" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // ETChash ASICs CANNOT switch to other coins or AI workloads during flex-off.
+    // Unlike GPU miners who could offset downtime with alternative revenue, these ASICs idle.
+    // Deliberate manipulation (exit to depress difficulty, re-enter at trough) sacrifices ETC
+    // profit with no compensating income — irrational unless ETC price recovers during the trough.
+    // The test quantifies the trough magnitude from the DAA's perspective:
+
+    val offGap = expectedBlockTimeAfterExit(flexMaxHrFrac) // ≈ 19 s
+    val offChain =
+      syntheticChain(cycleStart.number, cycleStart.difficulty, cycleStart.timestamp, gapSecs = offGap, count = 500)
+    val troughDiff = offChain.last._2
+
+    // Trough advantage: blocks are easier by this fraction at re-entry
+    val advantage = 1.0 - troughDiff.toDouble / cycleStart.difficulty.toDouble
+    advantage should be > 0.0 // some advantage exists from DAA convergence
+    advantage should be < 0.5 // but not a 2x windfall — and all ETC profit was foregone
+  }
+
+  "DAA recovery time" should "return toward full ASIC equilibrium within ~2048 blocks after re-entry" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // After 500 flex-off blocks at 19s, all ASICs return mining at ~4s gaps
+    val offGap = expectedBlockTimeAfterExit(flexMaxHrFrac)
+    val offChain =
+      syntheticChain(cycleStart.number, cycleStart.difficulty, cycleStart.timestamp, gapSecs = offGap, count = 500)
+    val troughDiff = offChain.last._2
+    val troughTs = cycleStart.timestamp + offGap * 500
+
+    // Recovery phase: fast blocks at 4s (all ASICs on)
+    val onChain = syntheticChain(cycleStart.number + 500, troughDiff, troughTs, gapSecs = 4L, count = 2048)
+    val recoveredDiff = onChain.last._2
+
+    // After 2048 fast blocks, should be back near or above the starting difficulty
+    recoveredDiff should be > troughDiff
+    // May overshoot cycleStart.difficulty — that's the oscillation mechanism
+  }
+
+  "Merge-scale hypothetical" should "require thousands of blocks to reach new equilibrium" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // After a 3x hashrate jump (like the Merge) with c=+1 each block:
+    // blocks to reach 90% of new equilibrium ≈ 1400+ blocks (log-convergence)
+    val startDiff = premergeBaseline.difficulty
+    val target3xEquil = startDiff * 3
+    val ninetyPct = target3xEquil * 9 / 10
+
+    val chain =
+      syntheticChain(premergeBaseline.number, startDiff, premergeBaseline.timestamp, gapSecs = 4L, count = 3000)
+    val idx = chain.indexWhere { case (_, d) => d >= ninetyPct }
+
+    idx should be > 1000 // slow convergence — this is the DAA lag
+  }
+
+  // -------------------------------------------------------------------------
+  // Group E — MESS interaction
+  // -------------------------------------------------------------------------
+
+  "MESS polynomial" should "match known values at key time points" taggedAs (UnitTest, ConsensusTest) in {
+    ArtificialFinality.polynomialV(BigInt(0)) shouldBe BigInt(128)
+    // At xcap (25132s ≈ 7 hours), polynomial saturates at 128 + 3840 = 3968
+    ArtificialFinality.polynomialV(BigInt(25132)) shouldBe BigInt(3968)
+    // At half xcap (~3.5h), value is between 128 and 3968
+    val mid = ArtificialFinality.polynomialV(BigInt(12566))
+    mid should be > BigInt(128)
+    mid should be < BigInt(3968)
+    // Short reorgs (< 200s) are nearly unaffected — multiplier ≈ 1x
+    ArtificialFinality.polynomialV(BigInt(200)) should be < BigInt(200)
+  }
+
+  "MESS enabled (Olympia)" should "reject reorg attempt during flex-off difficulty trough" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // Local chain: mined at normal difficulty for 7200s (2 hours)
+    // Attacker builds competing chain at trough difficulty (flex-off depressed)
+    val gpuOffGap = expectedBlockTimeAfterExit(flexMaxHrFrac) // 19s
+    val cycleBlocks = 7200L / gpuOffGap // ~379 blocks
+    val troughDiff = cycleStart.difficulty - (cycleStart.difficulty / 2048) * cycleBlocks
+
+    val localTD = cycleStart.difficulty * cycleBlocks // honest chain: normal difficulty
+    val proposedTD = troughDiff * cycleBlocks // attacker: depressed difficulty
+
+    // At 7200s, polynomialV ≈ 7x → MESS should reject the lower-TD proposed chain
+    ArtificialFinality.shouldRejectReorg(7200L, localTD, proposedTD) shouldBe true
+  }
+
+  "MESS enabled (Olympia)" should "protect against ASIC flex-off + reorg attack" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    // Full flex-off cycle of 500 blocks at 19s each = 9500s timeDelta
+    val timeDelta = 500L * expectedBlockTimeAfterExit(flexMaxHrFrac)
+    val localTD = cycleStart.difficulty * 500
+    val troughDiff = cycleStart.difficulty * 8 / 10 // conservative 20% trough
+    val proposedTD = troughDiff * 500
+
+    // polynomialV caps at xcap=25132 — for timeDelta > xcap we get max multiplier (31x)
+    ArtificialFinality.shouldRejectReorg(timeDelta, localTD, proposedTD) shouldBe true
+  }
+
+  "MESS deactivated (Spiral–Olympia, current mainnet)" should
+    "cover the entire observable oscillation period" taggedAs (UnitTest, ConsensusTest) in {
+      val messConfig = MESSConfig(
+        enabled = true,
+        activationBlock = Some(BigInt(11_380_000)),
+        deactivationBlock = Some(BigInt(19_250_000))
+      )
+      // All oscillation-era blocks are post-Spiral (> 19,250,000)
+      messConfig.isActiveAtBlock(cycleStart.number) shouldBe false
+      messConfig.isActiveAtBlock(cycleMid.number) shouldBe false
+      messConfig.isActiveAtBlock(cycleEnd.number) shouldBe false
+      messConfig.isActiveAtBlock(flexOnPhase.head.number) shouldBe false
+      messConfig.isActiveAtBlock(flexOffPhase.head.number) shouldBe false
+    }
+
+  "MESS deactivated window" should "leave chain exposed to ASIC flex-load reorg attempts" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val messConfig = MESSConfig(
+      enabled = true,
+      activationBlock = Some(BigInt(11_380_000)),
+      deactivationBlock = Some(BigInt(19_250_000))
+    )
+    // With MESS off, shouldRejectReorg is not called; verify WOULD have rejected
+    val timeDelta = 500L * expectedBlockTimeAfterExit(flexMaxHrFrac)
+    val localTD = cycleStart.difficulty * 500
+    val proposedTD = (cycleStart.difficulty * 8 / 10) * 500
+    // MESS would protect — but deactivation means the check is skipped
+    messConfig.isActiveAtBlock(cycleStart.number) shouldBe false
+    ArtificialFinality.shouldRejectReorg(timeDelta, localTD, proposedTD) shouldBe true
+  }
+
+  "MESS Olympia reactivation" should "restore protection at configurable block" taggedAs (
+    UnitTest,
+    ConsensusTest
+  ) in {
+    val olympiaActivation = BigInt(25_000_000)
+    val messConfig = MESSConfig(
+      enabled = true,
+      activationBlock = Some(BigInt(11_380_000)),
+      deactivationBlock = Some(BigInt(19_250_000)),
+      reactivationBlock = Some(olympiaActivation)
+    )
+    // Pre-Olympia oscillation blocks are unprotected
+    messConfig.isActiveAtBlock(cycleStart.number) shouldBe false
+    // Post-Olympia blocks are protected again
+    messConfig.isActiveAtBlock(olympiaActivation) shouldBe true
+    messConfig.isActiveAtBlock(olympiaActivation + 1) shouldBe true
+  }
+}
+// scalastyle:on magic.number

--- a/src/test/scala/com/chipprbots/ethereum/consensus/pow/difficulty/OscillationFixtures.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/pow/difficulty/OscillationFixtures.scala
@@ -1,0 +1,433 @@
+package com.chipprbots.ethereum.consensus.pow.difficulty
+
+/** Real ETC mainnet block data, verified against core-geth RPC (port 8545).
+  *
+  * Miner model (Oct 2024 – present oscillation era):
+  *   - Stable base: ~125 TH/s ETChash ASICs — dedicated hardware, cannot mine other coins, mine whenever energy is
+  *     available. Without ETC this equipment is a brick.
+  *   - Flex load: ~0–60 TH/s ETChash ASICs cycling on/off based on energy cost or grid-operator curtailment contracts
+  *     (demand-response). The sudden large gaps (137 s) and rapid return (137→5 s within 5 blocks) are consistent with
+  *     coordinated batch on/off, not gradual individual profitability decisions.
+  *
+  * Observed oscillation cycle (Oct 2024 – Jan 2026):
+  *   - cycleStart (~21 M, Nov 2024): ~2286 TH difficulty — flex-off equilibrium
+  *   - cycleMid (~21.85 M, Mar 2025): ~4327 TH difficulty — flex-on peak (all ASICs running)
+  *   - cycleEnd (~23.71 M, Jan 2026): ~2086 TH difficulty — flex-off trough (maximum curtailment)
+  *
+  * Flex-load exit threshold for c = −1: exitFrac ≥ 0.278 of equilibrium hashrate. Observed flex fraction: ~0.324 →
+  * above threshold → c < 0 throughout flex-off phases.
+  *
+  * Note: the Merge spike (Sept 2022) and post-Merge decline (2022–2024) DO involve GPU miners migrating from ETH and
+  * then leaving. Only the current oscillation era (Oct 2024+) is the ASIC flex-load phenomenon.
+  */
+object OscillationFixtures {
+
+  /** Single-block snapshot sufficient for difficulty and TD verification. */
+  case class BlockSnapshot(
+      number: BigInt,
+      hash: String,
+      parentHash: String,
+      difficulty: BigInt,
+      totalDifficulty: BigInt,
+      timestamp: Long
+  )
+
+  // ---------------------------------------------------------------------------
+  // Pre-Merge ASIC baseline (Apr 2022, block 15,000,000)
+  // ~50 TH/s native ASIC community; ~13s blocks; no GPU overlay
+  // ---------------------------------------------------------------------------
+
+  val premergeBaseline: BlockSnapshot = BlockSnapshot(
+    number = BigInt(15_000_000),
+    hash = "0x84874b0adc571dd049d02788a013d74c30362de6fdbc0aa178fec370c8dd1114",
+    parentHash = "0xebf1b5d82c42d8fa8dcce8cb2a3a24cc9247a2781bed92e692db93a1061cc8e2",
+    difficulty = BigInt("356469657693355"),
+    totalDifficulty = BigInt("1905451831131517342514"),
+    timestamp = 1650885412L
+  )
+
+  // ---------------------------------------------------------------------------
+  // Ethereum Merge spike (Sept 15, 2022) — blocks 15,948,899–15,948,903
+  // GPU influx: ETC hashrate ~50→~300 TH/s in days; fast blocks (2–6 s each)
+  // mergeSpikeParent is block 15,948,898 — seed for verifyDifficultyChain
+  // ---------------------------------------------------------------------------
+
+  val mergeSpikeParent: BlockSnapshot = BlockSnapshot(
+    number = BigInt(15_948_898),
+    hash = "0x71ba68e765355831815d05159edfff13122badc2bc3433aac8aff0d892bd8109",
+    parentHash = "",
+    difficulty = BigInt("3017524330257252"),
+    totalDifficulty = BigInt("2266739390417665856599"),
+    timestamp = 1663260648L
+  )
+
+  // Inter-block gaps: 2, 3, 5, 6, 3 seconds — all c = +1
+  val mergeSpike: Seq[BlockSnapshot] = Seq(
+    BlockSnapshot(
+      BigInt(15_948_899),
+      "0xeb96a361642107454c631faa44caf2042a6ecebe9314c57cbeeb7480096a5d7e",
+      "0x71ba68e765355831815d05159edfff13122badc2bc3433aac8aff0d892bd8109",
+      BigInt("3018997730809135"),
+      BigInt("2266742409415396665734"),
+      1663260650L
+    ),
+    BlockSnapshot(
+      BigInt(15_948_900),
+      "0x5740b8ff398b9ab03d6c0615132597e8e3b16a7188932ebfe3c955e45fb4ae68",
+      "0xeb96a361642107454c631faa44caf2042a6ecebe9314c57cbeeb7480096a5d7e",
+      BigInt("3020471850794881"),
+      BigInt("2266745429887247460615"),
+      1663260653L
+    ),
+    BlockSnapshot(
+      BigInt(15_948_901),
+      "0xf5cef05b027dd24175d42b313f74f2485da33f4aa6278600dffad511be54d1b4",
+      "0x5740b8ff398b9ab03d6c0615132597e8e3b16a7188932ebfe3c955e45fb4ae68",
+      BigInt("3021946690565776"),
+      BigInt("2266748451833938026391"),
+      1663260658L
+    ),
+    BlockSnapshot(
+      BigInt(15_948_902),
+      "0xc7e5a0b3905c4d632d1f171597a263f2cbe15ccfc22f70be50c6c6cef369584c",
+      "0xf5cef05b027dd24175d42b313f74f2485da33f4aa6278600dffad511be54d1b4",
+      BigInt("3023422250473278"),
+      BigInt("2266751475256188499669"),
+      1663260664L
+    ),
+    BlockSnapshot(
+      BigInt(15_948_903),
+      "0x27d6d6329095e64d434e40132a067e8d6662f89d97df47f75d741aca7160c6de",
+      "0xc7e5a0b3905c4d632d1f171597a263f2cbe15ccfc22f70be50c6c6cef369584c",
+      BigInt("3024898530869016"),
+      BigInt("2266754500154719368685"),
+      1663260667L
+    )
+  )
+
+  /** Peak Merge-era difficulty (Sept 16, 2022) — ~3410 TH, ~300 TH/s equivalent. */
+  val mergePeak: BlockSnapshot = BlockSnapshot(
+    number = BigInt(15_951_400),
+    hash = "0x501eb6291996edaad05f11317dded1a741bf813cdc1e951c90748030ced91b3e",
+    parentHash = "0xc20b97258630d02e92a4569a5efe544701fc47d68790640d12f7a1b9822885f0",
+    difficulty = BigInt("3410908635201688"),
+    totalDifficulty = BigInt("2274898303168627081531"),
+    timestamp = 1663291074L
+  )
+
+  // ---------------------------------------------------------------------------
+  // Post-Merge miner exodus (July 2023) — blocks 18,000,000–18,000,004
+  // GPU refugees (ETH Merge migrants) leaving; highly variable inter-block times (5–268 s)
+  // declinePhaseParent is block 17,999,999 — seed for verifyDifficultyChain
+  // ---------------------------------------------------------------------------
+
+  val declinePhaseParent: BlockSnapshot = BlockSnapshot(
+    number = BigInt(17_999_999),
+    hash = "0xad7aba3851d2c1302a2bfd63a566e8e511c0cef559b95ba13a54f3f45c3df27a",
+    parentHash = "",
+    difficulty = BigInt("1926698365544102"),
+    totalDifficulty = BigInt("5816585972940532730658"),
+    timestamp = 1690407145L
+  )
+
+  // Inter-block gaps: 22, 182, 268, 5, 129 seconds
+  // c values:         -1, -19,  -28, +1,  -13
+  val declinePhase: Seq[BlockSnapshot] = Seq(
+    BlockSnapshot(
+      BigInt(18_000_000),
+      "0x75ee56f65fd654484465c63cd78af5dfdfc583067085f9637650c3ca2c93a683",
+      "0xad7aba3851d2c1302a2bfd63a566e8e511c0cef559b95ba13a54f3f45c3df27a",
+      BigInt("1925757594857802"),
+      BigInt("5816587898698127588460"),
+      1690407167L
+    ),
+    BlockSnapshot(
+      BigInt(18_000_001),
+      "0x2dbc8c3ff39693e6d587e6862d49416887691d0a84404d9cd2518582c84c5fba",
+      "0x75ee56f65fd654484465c63cd78af5dfdfc583067085f9637650c3ca2c93a683",
+      BigInt("1907891679671136"),
+      BigInt("5816589806589807259596"),
+      1690407349L
+    ),
+    BlockSnapshot(
+      BigInt(18_000_002),
+      "0x145191f77c9de7d189834c7354baba1ec654dafa5f8fc878c1318f67195743e9",
+      "0x2dbc8c3ff39693e6d587e6862d49416887691d0a84404d9cd2518582c84c5fba",
+      BigInt("1881807223113144"),
+      BigInt("5816591688397030372740"),
+      1690407617L
+    ),
+    BlockSnapshot(
+      BigInt(18_000_003),
+      "0x976a7f204532eac62acfb8f249e49c1c0bd9d9fc77893557bdc4f4248d93c82f",
+      "0x145191f77c9de7d189834c7354baba1ec654dafa5f8fc878c1318f67195743e9",
+      BigInt("1882726074296304"),
+      BigInt("5816593571123104669044"),
+      1690407622L
+    ),
+    BlockSnapshot(
+      BigInt(18_000_004),
+      "0xda51b6ad912316acf049de0658851ec09ab55a63df7aa4e5f6ef329dd222074c",
+      "0x976a7f204532eac62acfb8f249e49c1c0bd9d9fc77893557bdc4f4248d93c82f",
+      BigInt("1870775176363772"),
+      BigInt("5816595441898281032816"),
+      1690407751L
+    )
+  )
+
+  // ---------------------------------------------------------------------------
+  // ASIC flex-load oscillation — full cycle boundaries (Oct 2024 – Jan 2026)
+  // ---------------------------------------------------------------------------
+
+  /** Oscillation onset (Nov 2024) — flex-off equilibrium, ~2286 TH difficulty. */
+  val cycleStart: BlockSnapshot = BlockSnapshot(
+    number = BigInt(21_000_000),
+    hash = "0x3551672560c1fbc33e20c31c4e91eaa9643c173a7e073872144ea4fdbaac0209",
+    parentHash = "0x1e263ee5eb2fffb3052a59e3cf0d1b0873064b84f6a22b10a6dc6c3570b2a06b",
+    difficulty = BigInt("2285976208884323"),
+    totalDifficulty = BigInt("12223071069702416209526"),
+    timestamp = 1730518580L
+  )
+
+  /** Flex-on peak (Mar 2025) — all ASICs running, difficulty maximum, ~4327 TH. */
+  val cycleMid: BlockSnapshot = BlockSnapshot(
+    number = BigInt(21_852_000),
+    hash = "0x16b21a09f830b63481eff46319d4c9c84ade0cca2b707b2b46d9d72c2e2e6248",
+    parentHash = "0x62148fa093cd098ddef506ef0de54105b291e264bab555f7060b823d6722f808",
+    difficulty = BigInt("4326933474757836"),
+    totalDifficulty = BigInt("15123768209429521428962"),
+    timestamp = 1742028945L
+  )
+
+  /** Flex-off trough (Jan 2026) — maximum curtailment for the cycle, ~2086 TH. */
+  val cycleEnd: BlockSnapshot = BlockSnapshot(
+    number = BigInt(23_706_000),
+    hash = "0x73453ed3739f175416af0768b3835f48d961cad8bb573767d389ec3e1b53ecb5",
+    parentHash = "0xc1a2157823f4e7cb65e0d7ef11d190cbfc672a6c3c6f19b945fb5c32b7229919",
+    difficulty = BigInt("2086436210099032"),
+    totalDifficulty = BigInt("21951580636532252739556"),
+    timestamp = 1767258889L
+  )
+
+  // ---------------------------------------------------------------------------
+  // Flex-on phase: 10 consecutive fast blocks near difficulty peak (Mar 2025)
+  // All ETChash ASICs running; flexOnPhaseParent is block 21,852,179 — seed for verifyDifficultyChain
+  // ---------------------------------------------------------------------------
+
+  val flexOnPhaseParent: BlockSnapshot = BlockSnapshot(
+    number = BigInt(21_852_179),
+    hash = "0x873dbe1c2d83d7b7bc494e5d4a7f7ebaf42941930c56e597fd4a948b64718bea",
+    parentHash = "0x90f5f6677271ce922e6f69e90f45b30be1f4c599957bcfdb24da2e8c4ff9cda3",
+    difficulty = BigInt("4295110242530329"),
+    totalDifficulty = BigInt("15124542577870379169468"),
+    timestamp = 1742031567L
+  )
+
+  // Inter-block gaps: 4, 2, 1, 8, 8, 6, 2, 2, 5, 6 seconds — all c = +1
+  val flexOnPhase: Seq[BlockSnapshot] = Seq(
+    BlockSnapshot(
+      BigInt(21_852_180),
+      "0x9ce8543f386d8d3df818ba72def514f4120e951860fc67015a39a2ba12c96796",
+      "0x873dbe1c2d83d7b7bc494e5d4a7f7ebaf42941930c56e597fd4a948b64718bea",
+      BigInt("4297207464328439"),
+      BigInt("15124546875077843497907"),
+      1742031571L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_181),
+      "0x89dd5def24b55082a83523019478c8045aa4555e11aada3350afdf3b600a3d77",
+      "0x9ce8543f386d8d3df818ba72def514f4120e951860fc67015a39a2ba12c96796",
+      BigInt("4299305710160630"),
+      BigInt("15124551174383553658537"),
+      1742031573L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_182),
+      "0x7cf4b8f5d31583343e3b9fdb02f1d19ab54cf00eca40cce093ca62fc9bb3ae39",
+      "0x89dd5def24b55082a83523019478c8045aa4555e11aada3350afdf3b600a3d77",
+      BigInt("4301404980526919"),
+      BigInt("15124555475788534185456"),
+      1742031574L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_183),
+      "0x9d28e86e1394dabbfa1283ffb58e163a6a1c9a01f384a570c343217118c9490d",
+      "0x7cf4b8f5d31583343e3b9fdb02f1d19ab54cf00eca40cce093ca62fc9bb3ae39",
+      BigInt("4303505275927566"),
+      BigInt("15124559779293810113022"),
+      1742031582L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_184),
+      "0xdf46097d731630cc8282e99f35bc1705578a642c66a47925b7cd9afc4c565d68",
+      "0x9d28e86e1394dabbfa1283ffb58e163a6a1c9a01f384a570c343217118c9490d",
+      BigInt("4305606596863077"),
+      BigInt("15124564084900406976099"),
+      1742031590L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_185),
+      "0x2dbec2bb56f67d5eff6a107dc5e9737d79cde22a99fc13ee6b2c5296b042b126",
+      "0xdf46097d731630cc8282e99f35bc1705578a642c66a47925b7cd9afc4c565d68",
+      BigInt("4307708943834201"),
+      BigInt("15124568392609350810300"),
+      1742031596L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_186),
+      "0x45f2a93a4406128d56f22ad9fc0b01ba7486e94eb1acb63246eadf8e0cb52cc1",
+      "0x2dbec2bb56f67d5eff6a107dc5e9737d79cde22a99fc13ee6b2c5296b042b126",
+      BigInt("4309812317341932"),
+      BigInt("15124572702421668152232"),
+      1742031598L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_187),
+      "0x977129d99acd34656b77b8423d14c51ba9b2822efbbcb1205c676a036152f844",
+      "0x45f2a93a4406128d56f22ad9fc0b01ba7486e94eb1acb63246eadf8e0cb52cc1",
+      BigInt("4311916717887509"),
+      BigInt("15124577014338386039741"),
+      1742031600L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_188),
+      "0xa6a4f0b34892a2ed2c3c50a423e7a611b5cbb5b8e88ab9fe73083d0287c733ee",
+      "0x977129d99acd34656b77b8423d14c51ba9b2822efbbcb1205c676a036152f844",
+      BigInt("4314022145972415"),
+      BigInt("15124581328360532012156"),
+      1742031605L
+    ),
+    BlockSnapshot(
+      BigInt(21_852_189),
+      "0xea4d9a477c8e92f35754d4d1785e0242941f1137c75193b531a52326d0e8ec02",
+      "0xa6a4f0b34892a2ed2c3c50a423e7a611b5cbb5b8e88ab9fe73083d0287c733ee",
+      BigInt("4316128602098378"),
+      BigInt("15124585644489134110534"),
+      1742031611L
+    )
+  )
+
+  // ---------------------------------------------------------------------------
+  // Flex-off phase: 10 consecutive blocks during ASIC curtailment (May 2025)
+  // 9/10 blocks have gap > 17 s → c < 0 → difficulty falling
+  // Block 22,200,018 (index 7) has gap = 12 s → c = 0 (one neutral in ten)
+  // flexOffPhaseParent is block 22,200,010 — seed for verifyDifficultyChain
+  // ---------------------------------------------------------------------------
+
+  val flexOffPhaseParent: BlockSnapshot = BlockSnapshot(
+    number = BigInt(22_200_010),
+    hash = "0xf89a9a2d748a59289c00bca3e36edab92fcb08c41664f8eeac7c9f6f2ac2d8ac",
+    parentHash = "0x29eee1202c2e1eea151ea5d0bef2ed49b3a89b5b51c8c33f4c062c99b5c47309",
+    difficulty = BigInt("3927774101450170"),
+    totalDifficulty = BigInt("16491497699140020264714"),
+    timestamp = 1746771794L
+  )
+
+  // Inter-block gaps: 137, 96, 109, 29, 36, 80, 26, 12, 34, 53 seconds
+  // c values:         -14,  -9,  -11, -2,  -3,  -7, -1,  0,  -2,  -4
+  val flexOffPhase: Seq[BlockSnapshot] = Seq(
+    BlockSnapshot(
+      BigInt(22_200_011),
+      "0x5c2c443873e5630f30680730f82163e09cb2a16a4150f908235654c25ae05e80",
+      "0xf89a9a2d748a59289c00bca3e36edab92fcb08c41664f8eeac7c9f6f2ac2d8ac",
+      BigInt("3900924083178548"),
+      BigInt("16491501600064103443262"),
+      1746771931L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_012),
+      "0x8f5984894284e7912cd2a2083983f5559bbdb216b1ee56457d9a7c3aa1a4c841",
+      "0x5c2c443873e5630f30680730f82163e09cb2a16a4150f908235654c25ae05e80",
+      BigInt("3883781350391147"),
+      BigInt("16491505483845453834409"),
+      1746772027L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_013),
+      "0xd5c4ac052f55540471206850b1326f0e2f7dc182569f49bcee4402c9da100a69",
+      "0x8f5984894284e7912cd2a2083983f5559bbdb216b1ee56457d9a7c3aa1a4c841",
+      BigInt("3862921196653702"),
+      BigInt("16491509346766650488111"),
+      1746772136L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_014),
+      "0x3dd906c2d3adce266b46ec0838dab2ad27e26ad7831559f6650a7b7cd0ce973f",
+      "0xd5c4ac052f55540471206850b1326f0e2f7dc182569f49bcee4402c9da100a69",
+      BigInt("3859148812672596"),
+      BigInt("16491513205915463160707"),
+      1746772165L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_015),
+      "0xd7cc1ba3f2e2a1354e48cfd91cb79b4c5e173ce9bcaee0432181171a75f92ec3",
+      "0x3dd906c2d3adce266b46ec0838dab2ad27e26ad7831559f6650a7b7cd0ce973f",
+      BigInt("3853495762654035"),
+      BigInt("16491517059411225814742"),
+      1746772201L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_016),
+      "0xbb11e2099d4417319fca481d2251bd0523242ac51c872011d281f4e5e389c192",
+      "0xd7cc1ba3f2e2a1354e48cfd91cb79b4c5e173ce9bcaee0432181171a75f92ec3",
+      BigInt("3840324634559029"),
+      BigInt("16491520899735860373771"),
+      1746772281L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_017),
+      "0xbdc8b5280cf68c1d06f53842e682b3e87dfd703a4aea2281ca1b6dc191830272",
+      "0xbb11e2099d4417319fca481d2251bd0523242ac51c872011d281f4e5e389c192",
+      BigInt("3838449476046061"),
+      BigInt("16491524738185336419832"),
+      1746772307L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_018), // gap=12s → c=0, difficulty unchanged from prev block
+      "0xa7319557d0794007b80d476ae39aaff03d28b32f7b31e8db342a06df0533665d",
+      "0xbdc8b5280cf68c1d06f53842e682b3e87dfd703a4aea2281ca1b6dc191830272",
+      BigInt("3838449476046061"),
+      BigInt("16491528576634812465893"),
+      1746772319L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_019),
+      "0x450d1d789830c582ab019309e3be57252b3dc3e6d502175fe8a382caba53efee",
+      "0xa7319557d0794007b80d476ae39aaff03d28b32f7b31e8db342a06df0533665d",
+      BigInt("3834700990229611"),
+      BigInt("16491532411335802695504"),
+      1746772353L
+    ),
+    BlockSnapshot(
+      BigInt(22_200_020),
+      "0x077d7a7c65cc78249e64c179a58753ccc34609fd3656a581057ddb07f48e4d05",
+      "0x450d1d789830c582ab019309e3be57252b3dc3e6d502175fe8a382caba53efee",
+      BigInt("3827211339858071"),
+      BigInt("16491536238547142553575"),
+      1746772406L
+    )
+  )
+
+  // ---------------------------------------------------------------------------
+  // Derived constants from miner composition model
+  //
+  // Equilibrium (all flex ASICs on): ~185 TH/s → 13 s block time
+  // Stable base:  ~125 TH/s ETChash ASICs (always on when energy available)
+  // Flex load:    ~ 60 TH/s ETChash ASICs (curtailed by energy grid demand-response)
+  //
+  // Flex-off expected block time = 13 × (185/125) ≈ 19.2 s → c = −1
+  // ---------------------------------------------------------------------------
+
+  val asicBaseHrFrac: Double = 125.0 / 185.0 // ≈ 0.676
+  val flexMaxHrFrac: Double = 60.0 / 185.0 // ≈ 0.324
+
+  /** Minimum flex-load exit fraction that pushes block time ≥ 18 s → c = −1. */
+  val flexExitThresholdFrac: Double = 1.0 - 13.0 / 18.0 // ≈ 0.278
+
+  /** Expected block time (seconds) when `exitFrac` of equilibrium hashrate exits. */
+  def expectedBlockTimeAfterExit(exitFrac: Double): Long =
+    math.round(13.0 / (1.0 - exitFrac))
+
+  /** DAA c coefficient for a given inter-block gap: max(1 − floor(gap/9), −99). */
+  def cCoeff(gapSecs: Long): Long = math.max(1L - gapSecs / 9L, -99L)
+}

--- a/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
@@ -1,9 +1,12 @@
 package com.chipprbots.ethereum.domain
 
+import org.apache.pekko.util.ByteString
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+import com.chipprbots.ethereum.Fixtures
 import com.chipprbots.ethereum.ObjectGenerators
 import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import com.chipprbots.ethereum.network.p2p.messages.BaseETH6XMessages.NewBlock
@@ -23,6 +26,80 @@ class BlockchainReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckProp
 
       blockchainReader.getBestBlock() shouldBe Some(block)
     }
+  }
+
+  "BlockchainReader.resolveETH69ChainWeight" should "return DB_LOOKUP when peer hash is in ChainWeightStorage (Tier 1)" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    val genesisWeight = ChainWeight.zero.increase(genesis.header)
+    blockchainWriter.save(genesis, Nil, genesisWeight, saveAsBestBlock = true)
+
+    val block1 = genesis.copy(header = genesis.header.copy(parentHash = genesis.header.hash, number = 1))
+    val block1Weight = genesisWeight.increase(block1.header)
+    blockchainWriter.save(block1, Nil, block1Weight, saveAsBestBlock = true)
+
+    val (cw, source) =
+      blockchainReader.resolveETH69ChainWeight(block1.header.hash, block1.header.number, isPoWChain = true)
+    source shouldBe "DB_LOOKUP"
+    cw.totalDifficulty shouldBe block1Weight.totalDifficulty
+  }
+
+  it should "return CANONICAL_NUMBER when peer hash is unknown but peer block number is canonical (Tier 2)" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    val genesisWeight = ChainWeight.zero.increase(genesis.header)
+    blockchainWriter.save(genesis, Nil, genesisWeight, saveAsBestBlock = true)
+
+    val block1 = genesis.copy(header = genesis.header.copy(parentHash = genesis.header.hash, number = 1))
+    val block1Weight = genesisWeight.increase(block1.header)
+    blockchainWriter.save(block1, Nil, block1Weight, saveAsBestBlock = true)
+
+    // Peer advertises a different block hash at height 1 — not in our chain
+    val unknownPeerHash = ByteString(Array.fill(32)(0xab.toByte))
+    unknownPeerHash should not be block1.header.hash
+
+    val (cw, source) =
+      blockchainReader.resolveETH69ChainWeight(unknownPeerHash, block1.header.number, isPoWChain = true)
+    source shouldBe "CANONICAL_NUMBER"
+    cw.totalDifficulty shouldBe block1Weight.totalDifficulty
+  }
+
+  it should "return POW_SCALING fallback when neither hash nor number lookup resolves (Tier 3, startup)" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    val genesisWeight = ChainWeight.zero.increase(genesis.header)
+    blockchainWriter.save(genesis, Nil, genesisWeight, saveAsBestBlock = true)
+
+    // Peer is at a height we've never seen (far ahead of our genesis-only DB)
+    val unknownHash = ByteString(Array.fill(32)(0xcd.toByte))
+    val peerBlockNum = BigInt(5_000_000)
+
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = true)
+    source shouldBe "POW_SCALING"
+    // Startup: ourBestNum == 0 → falls to raw latestBlock
+    cw.totalDifficulty shouldBe peerBlockNum
+  }
+
+  it should "return POS_PROXY block number for post-merge peers (isPoWChain = false)" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    val genesisWeight = ChainWeight.zero.increase(genesis.header)
+    blockchainWriter.save(genesis, Nil, genesisWeight, saveAsBestBlock = true)
+
+    val unknownHash = ByteString(Array.fill(32)(0xef.toByte))
+    val peerBlockNum = BigInt(21_000_000)
+
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = false)
+    source shouldBe "POS_PROXY"
+    cw.totalDifficulty shouldBe peerBlockNum
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
@@ -68,7 +68,22 @@ class BlockchainReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckProp
     cw.totalDifficulty shouldBe block1Weight.totalDifficulty
   }
 
-  it should "return POW_SCALING fallback when neither hash nor number lookup resolves (Tier 3, startup)" taggedAs (
+  it should "return COLD_START (TD=0) when ourBestNum=0 (DB not yet bootstrapped)" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    blockchainWriter.save(genesis, Nil, ChainWeight.zero.increase(genesis.header), saveAsBestBlock = false)
+
+    val unknownHash = ByteString(Array.fill(32)(0xcd.toByte))
+    val peerBlockNum = BigInt(5_000_000)
+
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = true)
+    source shouldBe "COLD_START"
+    cw.totalDifficulty shouldBe BigInt(0)
+  }
+
+  it should "return POW_SCALING proportional estimate when ourBestNum > 0 but peer is ahead" taggedAs (
     UnitTest,
     StateTest
   ) in new EphemBlockchainTestSetup {
@@ -76,14 +91,20 @@ class BlockchainReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckProp
     val genesisWeight = ChainWeight.zero.increase(genesis.header)
     blockchainWriter.save(genesis, Nil, genesisWeight, saveAsBestBlock = true)
 
-    // Peer is at a height we've never seen (far ahead of our genesis-only DB)
+    val block1 = genesis.copy(header = genesis.header.copy(parentHash = genesis.header.hash, number = 1))
+    val block1Weight = genesisWeight.increase(block1.header)
+    blockchainWriter.save(block1, Nil, block1Weight, saveAsBestBlock = true)
+
     val unknownHash = ByteString(Array.fill(32)(0xcd.toByte))
-    val peerBlockNum = BigInt(5_000_000)
+    val peerBlockNum = BigInt(1_000_000)
 
     val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = true)
     source shouldBe "POW_SCALING"
-    // Startup: ourBestNum == 0 → falls to raw latestBlock
-    cw.totalDifficulty shouldBe peerBlockNum
+    cw.totalDifficulty should be > BigInt(0)
+    // POW_SCALING = ourBestTD * peerBlock / ourBestNum; verify proportionality holds
+    val ourBestTD = block1Weight.totalDifficulty
+    val ourBestNum = block1.header.number
+    cw.totalDifficulty shouldBe ourBestTD * peerBlockNum / ourBestNum
   }
 
   it should "return POS_PROXY block number for post-merge peers (isPoWChain = false)" taggedAs (
@@ -100,6 +121,71 @@ class BlockchainReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckProp
     val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = false)
     source shouldBe "POS_PROXY"
     cw.totalDifficulty shouldBe peerBlockNum
+  }
+
+  // ETC mainnet post-Spiral realistic anchor values
+  private val etcBestTD = BigInt("24244691155597214264244")
+  private val etcBestNum = BigInt(24_565_949)
+
+  it should "POW_SCALING estimate be within 0.1% of real TD when peer is within 1000 blocks of our head" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    val gWeight = ChainWeight.zero.increase(genesis.header)
+    blockchainWriter.save(genesis, Nil, gWeight, saveAsBestBlock = true)
+
+    val pivotHeader = Fixtures.Blocks.Genesis.header.copy(parentHash = genesis.header.hash, number = etcBestNum)
+    val pivotBlock = Block(pivotHeader, Fixtures.Blocks.Genesis.body)
+    val pivotWeight = ChainWeight.totalDifficultyOnly(etcBestTD)
+    blockchainWriter.save(pivotBlock, Nil, pivotWeight, saveAsBestBlock = true)
+
+    // Peer is 151 blocks ahead — unknown hash, canonical lookup misses (peer ahead of our head)
+    val peerBlock = etcBestNum + 151
+    val unknownHash = ByteString(Array.fill(32)(0xfe.toByte))
+
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlock, isPoWChain = true)
+    source shouldBe "POW_SCALING"
+
+    val estimate = cw.totalDifficulty
+    val tolerance = etcBestTD / 1000 // 0.1%
+    estimate should be >= (etcBestTD - tolerance)
+    estimate should be <= (etcBestTD + tolerance)
+  }
+
+  it should "return exact real TD (non-inflation) via CANONICAL_NUMBER when peer is at our head height" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    val genesis = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
+    blockchainWriter.save(genesis, Nil, ChainWeight.zero.increase(genesis.header), saveAsBestBlock = true)
+
+    val pivotHeader = Fixtures.Blocks.Genesis.header.copy(parentHash = genesis.header.hash, number = etcBestNum)
+    val pivotBlock = Block(pivotHeader, Fixtures.Blocks.Genesis.body)
+    blockchainWriter.save(pivotBlock, Nil, ChainWeight.totalDifficultyOnly(etcBestTD), saveAsBestBlock = true)
+
+    // Peer at our head height with unknown hash:
+    // Tier 1 (DB_LOOKUP) misses — hash unknown
+    // Tier 2 (CANONICAL_NUMBER) hits — returns exact real TD from our canonical chain
+    val unknownHash = ByteString(Array.fill(32)(0xff.toByte))
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, etcBestNum, isPoWChain = true)
+    source shouldBe "CANONICAL_NUMBER"
+    cw.totalDifficulty shouldBe etcBestTD // exact real TD — no inflation
+  }
+
+  it should "COLD_START TD=0 is always less than any real ETC chain TD" taggedAs (
+    UnitTest,
+    StateTest
+  ) in new EphemBlockchainTestSetup {
+    // No best block saved → ourBestNum=0 → COLD_START
+    val (cw, source) = blockchainReader.resolveETH69ChainWeight(
+      ByteString(Array.fill(32)(0xab.toByte)),
+      BigInt(24_566_000),
+      isPoWChain = true
+    )
+    source shouldBe "COLD_START"
+    cw.totalDifficulty shouldBe BigInt(0)
+    cw.totalDifficulty should be < BigInt("1000000000000000000") // << any real PoW TD
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/domain/BlockchainReaderSpec.scala
@@ -101,10 +101,12 @@ class BlockchainReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckProp
     val (cw, source) = blockchainReader.resolveETH69ChainWeight(unknownHash, peerBlockNum, isPoWChain = true)
     source shouldBe "POW_SCALING"
     cw.totalDifficulty should be > BigInt(0)
-    // POW_SCALING = ourBestTD * peerBlock / ourBestNum; verify proportionality holds
+    // POW_SCALING = ourBestTD + ourCurrentDiff * gap * 9999/10000 (marginal-rate estimate)
     val ourBestTD = block1Weight.totalDifficulty
     val ourBestNum = block1.header.number
-    cw.totalDifficulty shouldBe ourBestTD * peerBlockNum / ourBestNum
+    val ourCurrentDiff = block1.header.difficulty
+    val gap = (peerBlockNum - ourBestNum).max(BigInt(0))
+    cw.totalDifficulty shouldBe ourBestTD + ourCurrentDiff * gap * 9999 / 10000
   }
 
   it should "return POS_PROXY block number for post-merge peers (isPoWChain = false)" taggedAs (

--- a/src/test/scala/com/chipprbots/ethereum/forkid/ForkIdSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/forkid/ForkIdSpec.scala
@@ -20,8 +20,21 @@ class ForkIdSpec extends AnyWordSpec with Matchers {
     }
     "gatherForks for the etc chain correctly" in {
       val res = config.blockchains.map { case (name, conf) => (name, gatherForks(conf)) }
-      res("etc") shouldBe List(1150000, 2500000, 3000000, 5000000, 5900000, 8772000, 9573000, 10500839, 11700000,
-        13189133, 14525000, 19250000)
+      res("etc") shouldBe List(
+        1150000,
+        2500000,
+        3000000,
+        5000000,
+        5900000,
+        8772000,
+        9573000,
+        10500839,
+        11700000,
+        13189133,
+        14525000,
+        19250000,
+        BigInt("1000000000000000000")
+      )
     }
 
     "create correct ForkId for ETC mainnet blocks" in {
@@ -54,7 +67,7 @@ class ForkIdSpec extends AnyWordSpec with Matchers {
       create(14525000 - 1) shouldBe ForkId(0x0f6bf187L, Some(14525000))
       create(14525000) shouldBe ForkId(0x7fd1bb25L, Some(19250000)) // First Mystique block
       create(19250000 - 1) shouldBe ForkId(0x7fd1bb25L, Some(19250000))
-      create(19250000) shouldBe ForkId(0xbe46d57cL, None) // First Spiral block
+      create(19250000) shouldBe ForkId(0xbe46d57cL, Some(BigInt("1000000000000000000"))) // First Spiral block
     }
 
     "create correct ForkId for mordor blocks" in {
@@ -75,13 +88,13 @@ class ForkIdSpec extends AnyWordSpec with Matchers {
       create(5520000 - 1) shouldBe ForkId(0x92b323e0L, Some(5520000))
       create(5520000) shouldBe ForkId(0x8c9b1797L, Some(9957000)) // First Mystique block
       create(9957000 - 1) shouldBe ForkId(0x8c9b1797L, Some(9957000))
-      // Spiral is the latest activated fork on Mordor today. Olympia is not
-      // scheduled on Mordor yet (mordor-chain.conf leaves olympia-block-number
-      // at the sentinel 10^18). Update this assertion when Olympia's Mordor
-      // block is set — the expected shape is then
-      // `ForkId(0x3a6b00d7L, Some(<olympia-block>))` here.
-      create(9957000) shouldBe ForkId(0x3a6b00d7L, None)
-      create(20000000) shouldBe ForkId(0x3a6b00d7L, None)
+      // Spiral is the latest activated fork on Mordor. Olympia is not yet
+      // scheduled (mordor-chain.conf leaves olympia-block-number at sentinel
+      // 10^18), so next=Some(1000000000000000000) is advertised per EIP-2124.
+      // Update this assertion to `ForkId(0x3a6b00d7L, Some(<olympia-block>))`
+      // when Olympia's real Mordor block is set.
+      create(9957000) shouldBe ForkId(0x3a6b00d7L, Some(BigInt("1000000000000000000")))
+      create(20000000) shouldBe ForkId(0x3a6b00d7L, Some(BigInt("1000000000000000000")))
     }
 
     "follow EIP-2124 specification for ForkId at all block heights" in {
@@ -100,9 +113,9 @@ class ForkIdSpec extends AnyWordSpec with Matchers {
       create(1149999) shouldBe ForkId(0xfc64ec04L, Some(1150000))
       create(1150000) shouldBe ForkId(0x97c2c34cL, Some(2500000))
 
-      // Latest fork should have None for next
-      create(19250000) shouldBe ForkId(0xbe46d57cL, None)
-      create(20000000) shouldBe ForkId(0xbe46d57cL, None)
+      // Spiral is the latest activated fork; Olympia sentinel advertised as next
+      create(19250000) shouldBe ForkId(0xbe46d57cL, Some(BigInt("1000000000000000000")))
+      create(20000000) shouldBe ForkId(0xbe46d57cL, Some(BigInt("1000000000000000000")))
     }
 
     // Here's a couple of tests to verify the proper RLP encoding (since FORK_HASH is a 4 byte binary but FORK_NEXT is an 8 byte quantity):

--- a/src/test/scala/com/chipprbots/ethereum/forkid/NetworkForkIdFilteringSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/forkid/NetworkForkIdFilteringSpec.scala
@@ -98,13 +98,13 @@ class NetworkForkIdFilteringSpec extends AnyWordSpec with Matchers {
     "confirm ETC mainnet Spiral forkId is 0xbe46d57c (verified against core-geth)" in {
       val created = ForkId.create(etcGenesisHash, etcConf)(19250000)
       created.hash shouldBe 0xbe46d57cL
-      created.next shouldBe None
+      created.next shouldBe Some(BigInt("1000000000000000000"))
     }
 
     "confirm Mordor Spiral forkId is 0x3a6b00d7 (verified against core-geth)" in {
       val created = ForkId.create(mordorGenesisHash, mordorConf)(9957000)
       created.hash shouldBe 0x3a6b00d7L
-      created.next shouldBe None
+      created.next shouldBe Some(BigInt("1000000000000000000"))
     }
   }
 
@@ -114,11 +114,12 @@ class NetworkForkIdFilteringSpec extends AnyWordSpec with Matchers {
 
   "Olympia fork signal state machine" must {
 
-    // State 1: No Olympia block configured (sentinel 10^18 excluded from fork list).
-    // ForkId = Spiral hash, next=None. This is the current production state.
-    "emit Spiral/None when Olympia block is not configured (current production state)" in {
+    // State 1: Olympia not yet scheduled (olympiaBlockNumber = sentinel 10^18).
+    // ForkId = Spiral hash, next=Some(10^18). This is the current production state —
+    // all three ETC clients advertise Olympia as the next fork per EIP-2124.
+    "emit Spiral/next=Olympia sentinel when Olympia block is not yet scheduled" in {
       val id = ForkId.create(etcGenesisHash, etcConf)(20000000)
-      id shouldBe ForkId(0xbe46d57cL, None)
+      id shouldBe ForkId(0xbe46d57cL, Some(BigInt("1000000000000000000")))
     }
 
     // State 2: Olympia block configured but not yet reached.

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
@@ -104,7 +104,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "handle eth_getRawTransactionByHash request" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(ethTxService = mockEthTxService)
 
     val txResponse: SignedTransaction = Fixtures.Blocks.Block3125369.body.transactionList.head
@@ -300,7 +300,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "eth_getTransactionByHash" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(ethTxService = mockEthTxService)
 
     val txResponse: TransactionResponse = TransactionResponse(Fixtures.Blocks.Block3125369.body.transactionList.head)
@@ -320,7 +320,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "eth_getTransactionCount" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
+    val mockEthUserService = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
 
@@ -380,7 +380,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "eth_getTransactionReceipt post byzantium" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(ethTxService = mockEthTxService)
 
     val arbitraryValue = 42
@@ -470,7 +470,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
   }
 
   it should "eth_getTransactionReceipt pre byzantium" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(ethTxService = mockEthTxService)
 
     val arbitraryValue = 42
@@ -562,7 +562,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     UnitTest,
     RPCTest
   ) in new JsonRpcControllerFixture {
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     (mockEthTxService.ethPendingTransactions _)
       .expects(*)
       .returning(IO.pure(Right(EthPendingTransactionsResponse(List()))))
@@ -604,7 +604,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
       PendingTransaction(fakeTransaction, System.currentTimeMillis)
     }
 
-    val mockEthTxService: EthTxService & scala.reflect.Selectable = mock[EthTxService]
+    val mockEthTxService = mock[EthTxService]
     (mockEthTxService.ethPendingTransactions _)
       .expects(*)
       .returning(IO.pure(Right(EthPendingTransactionsResponse(transactions))))

--- a/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -393,7 +393,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_call" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthInfoService: EthInfoService & scala.reflect.Selectable = mock[EthInfoService]
+    val mockEthInfoService = mock[EthInfoService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethInfoService = mockEthInfoService)
 
@@ -417,7 +417,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_estimateGas" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthInfoService: EthInfoService & scala.reflect.Selectable = mock[EthInfoService]
+    val mockEthInfoService = mock[EthInfoService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethInfoService = mockEthInfoService)
 
@@ -453,7 +453,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getCode" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
+    val mockEthUserService = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
 
@@ -522,7 +522,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getBalance" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
+    val mockEthUserService = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
 
@@ -549,7 +549,7 @@ class JsonRpcControllerEthSpec
     RPCTest,
     DisabledTest
   ) in new JsonRpcControllerFixture {
-    val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
+    val mockEthUserService = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
 
@@ -570,7 +570,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getStorageAt" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthUserService: EthUserService & scala.reflect.Selectable = mock[EthUserService]
+    val mockEthUserService = mock[EthUserService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethUserService = mockEthUserService)
 
@@ -614,7 +614,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_newFilter" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -639,7 +639,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_newBlockFilter" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -659,7 +659,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_newPendingTransactionFilter" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -677,7 +677,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_uninstallFilter" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -695,7 +695,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getFilterChanges" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -798,7 +798,7 @@ class JsonRpcControllerEthSpec
     )
 
     // setup
-    val mockEthProofService: EthProofService & scala.reflect.Selectable = mock[EthProofService]
+    val mockEthProofService = mock[EthProofService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(proofService = mockEthProofService)
     (mockEthProofService.getProof _)
       .expects(expectedDecodedRequest)
@@ -842,7 +842,7 @@ class JsonRpcControllerEthSpec
     RPCTest,
     DisabledTest
   ) in new JsonRpcControllerFixture {
-    val mockEthProofService: EthProofService & scala.reflect.Selectable = mock[EthProofService]
+    val mockEthProofService = mock[EthProofService]
     override val jsonRpcController: JsonRpcController = super.jsonRpcController.copy(proofService = mockEthProofService)
 
     (mockEthProofService.getProof _)
@@ -864,7 +864,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getFilterLogs" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 
@@ -894,7 +894,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_getLogs" taggedAs (UnitTest, RPCTest) in new JsonRpcControllerFixture {
-    val mockEthFilterService: EthFilterService & scala.reflect.Selectable = mock[EthFilterService]
+    val mockEthFilterService = mock[EthFilterService]
     override val jsonRpcController: JsonRpcController =
       super.jsonRpcController.copy(ethFilterService = mockEthFilterService)
 

--- a/src/test/scala/com/chipprbots/ethereum/network/ETH69OscillationChainWeightSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/ETH69OscillationChainWeightSpec.scala
@@ -1,0 +1,311 @@
+package com.chipprbots.ethereum.network
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.consensus.pow.difficulty.OscillationFixtures
+import com.chipprbots.ethereum.consensus.pow.difficulty.OscillationFixtures._
+import com.chipprbots.ethereum.testing.Tags._
+
+// scalastyle:off magic.number
+/** Tests for POW_SCALING chain-weight estimation accuracy across ETH protocol eras.
+  *
+  * ETH/68 carries totalDifficulty on the wire — chain-weight comparison is exact. ETH/69 (EIP-7642) removes TD — fukuii
+  * estimates a peer's TD using (Tier 3 / POW_SCALING):
+  *
+  * estimatedTD = ourBestTD + ourCurrentDiff × gap × 9999/10000 where gap = latestBlock − ourBestBlockNum
+  *
+  * This uses the current block difficulty as the marginal rate rather than the historical average. The 9999/10000
+  * factor guarantees a slight underestimate for constant-difficulty chains (< 0.01% error), ensuring we never
+  * overestimate for stable chains.
+  *
+  * The previous formula (ourBestTD × latestBlock / ourBestNum) used the all-time historical average TD per block (~582
+  * TH for ETC), underestimating each gap block's TD contribution by 70-86% vs the current era (2000-4300 TH per block).
+  * Over an 852K-block gap this translates to a ~16% total-TD underestimate (the cumulative historical TD dominates).
+  *
+  * NOTE: `powScalingEstimate` below is a private copy of the Tier 3 formula in
+  * BlockchainReader.resolveETH69ChainWeight. It must be kept in sync with that method. The full production call path is
+  * tested in ETH69TDSpec and ETChashDifficultyAlignmentSpec.
+  *
+  * Concretely for ETC mainnet (852K-block cycleStart → cycleMid gap):
+  *   - Historical average TD/block ≈ 580 TH (dominated by 2016-2022 low-difficulty era)
+  *   - Current era difficulty ≈ 2000-4300 TH per block (ASIC flex-load oscillation era) → Old formula: ~16% total-TD
+  *     underestimate (gap contribution at 580 TH << actual ~3300 TH avg) → New formula: ~6% underestimate for
+  *     rising-difficulty gap; < 0.01% for constant-difficulty
+  */
+class ETH69OscillationChainWeightSpec extends AnyFlatSpec with Matchers {
+
+  /** Mirrors the Tier 3 POW_SCALING formula in BlockchainReader.resolveETH69ChainWeight. Must stay in sync with:
+    * ourBestTD + ourCurrentDiff * gap * 9999 / 10000
+    */
+  private def powScalingEstimate(
+      ourBestTD: BigInt,
+      ourCurrentDiff: BigInt,
+      latestBlock: BigInt,
+      ourBestNum: BigInt
+  ): BigInt = {
+    val gap = (latestBlock - ourBestNum).max(BigInt(0))
+    ourBestTD + ourCurrentDiff * gap * 9999 / 10000
+  }
+
+  /** Old historical-average formula — kept as a reference baseline for improvement tests. */
+  private def historicalAvgEstimate(ourBestTD: BigInt, latestBlock: BigInt, ourBestNum: BigInt): BigInt =
+    ourBestTD * latestBlock / ourBestNum
+
+  /** TD accumulated by a difficulty that changes linearly by `delta` per block. */
+  private def linearRampTD(baseTD: BigInt, startDiff: BigInt, delta: BigInt, count: BigInt): BigInt =
+    // sum_{i=0}^{count-1} (startDiff + i*delta) = count*startDiff + delta*count*(count-1)/2
+    baseTD + startDiff * count + delta * count * (count - 1) / 2
+
+  // -------------------------------------------------------------------------
+  // ETH/68 era — wire provides totalDifficulty directly
+  // -------------------------------------------------------------------------
+
+  "ETH68 era" should "give 0% estimation error — wire TD is used directly" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // ETH68 peers send exact TD on the wire; POW_SCALING is never called.
+    // The fixture TDs ARE the exact on-chain values.
+    val wireTD = mergeSpike.last.totalDifficulty
+    // Client uses wireTD directly — no estimation error possible
+    wireTD shouldBe mergeSpike.last.totalDifficulty
+  }
+
+  "ETH68 era" should "accurately track TD through Merge spike — hashrate tripling is invisible to wire TD" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Despite the 3x hashrate jump, each ETH68 STATUS message carries the exact current TD.
+    // Chain-weight comparison is unaffected by oscillation — it's bit-exact.
+    val preMerge = mergeSpikeParent.totalDifficulty
+    val postMerge = mergeSpike.last.totalDifficulty
+    val tdGain = postMerge - preMerge
+
+    // 5 fast blocks: each block contributes parentDiff + parentDiff/2048 to TD
+    tdGain should be > BigInt(0)
+    // Sanity: gain is approximately 5 * mergeSpike[0].difficulty
+    val approxGain = mergeSpike.head.difficulty * 5
+    val ratio = tdGain.toDouble / approxGain.toDouble
+    ratio should be > 0.95
+    ratio should be < 1.05
+  }
+
+  "ETH68 era" should "provide bit-exact TD for both ASIC-stable and flex-variable portions" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // ASIC-stable: premergeBaseline; flex-variable: any oscillation-era block
+    // Both have exact on-chain TD values — wire protocol provides both without estimation
+    val asicTD = premergeBaseline.totalDifficulty
+    val flexOnTD = cycleMid.totalDifficulty
+    val flexOffTD = cycleEnd.totalDifficulty
+
+    // Sanity: TD is monotonically increasing
+    asicTD should be < flexOnTD
+    flexOnTD should be < flexOffTD
+    // Bit-exact — no rounding or estimation involved
+    asicTD shouldBe premergeBaseline.totalDifficulty
+    flexOnTD shouldBe cycleMid.totalDifficulty
+    flexOffTD shouldBe cycleEnd.totalDifficulty
+  }
+
+  // -------------------------------------------------------------------------
+  // ETH/68 + ETH/69 mixed era — peers may use either protocol
+  // -------------------------------------------------------------------------
+
+  "ETH68+ETH69 mixed era" should "give 0% error for ETH68 peers — wire TD unaffected by flex-load cycling" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Same as ETH68 era: wire carries exact TD regardless of hashrate oscillation
+    val wireTD = flexOffPhase.last.totalDifficulty
+    wireTD shouldBe flexOffPhase.last.totalDifficulty
+  }
+
+  "ETH68+ETH69 mixed era" should "give non-zero estimation error for ETH69 peers on same chain" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Anchor: cycleStart; ETH69 peer announces latestBlock = cycleMid.number (no TD on wire)
+    val estimated = powScalingEstimate(
+      cycleStart.totalDifficulty,
+      cycleStart.difficulty,
+      cycleMid.number,
+      cycleStart.number
+    )
+    val actual = cycleMid.totalDifficulty
+    // Marginal estimate from cycleStart difficulty — differs from actual (difficulty rose over gap)
+    (estimated should not).equal(actual)
+  }
+
+  "ETH68+ETH69 mixed era" should "underestimate TD for ETH69 peer during flex-on peak" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Anchor: cycleStart (~2286 TH difficulty). Peer at cycleMid: difficulty was ~4327 TH.
+    // Difficulty rose over the 852K-block gap → actual TD/block > anchor difficulty → underestimate.
+    val estimated = powScalingEstimate(
+      cycleStart.totalDifficulty,
+      cycleStart.difficulty,
+      cycleMid.number,
+      cycleStart.number
+    )
+    val actual = cycleMid.totalDifficulty
+    estimated should be < actual
+  }
+
+  "ETH68+ETH69 mixed era" should "reduce POW_SCALING error by > 2x vs historical-average formula" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Old formula: ourBestTD * latestBlock / ourBestNum — extrapolates at ~582 TH historical avg/block
+    // New formula: ourBestTD + ourCurrentDiff * gap * 9999/10000 — uses ~2286 TH anchor difficulty
+    // Both underestimate because actual avg difficulty rose to ~3300 TH over the 852K-block gap.
+    // The improvement is in the gap contribution (old: 580 TH/block vs new: 2286 TH/block vs actual: ~3300 TH).
+    val oldEstimate = historicalAvgEstimate(cycleStart.totalDifficulty, cycleMid.number, cycleStart.number)
+    val newEstimate = powScalingEstimate(
+      cycleStart.totalDifficulty,
+      cycleStart.difficulty,
+      cycleMid.number,
+      cycleStart.number
+    )
+    val actual = cycleMid.totalDifficulty
+
+    val oldError = (actual - oldEstimate).abs.toDouble / actual.toDouble
+    val newError = (actual - newEstimate).abs.toDouble / actual.toDouble
+
+    oldError should be > 0.10 // old formula: ~16% total-TD underestimate (gap extrapolated at 580 TH)
+    newError should be < 0.10 // new formula: ~6% underestimate (uses current diff as marginal rate)
+    oldError / newError should be > 2.0 // at least 2x improvement in total-TD error
+  }
+
+  "ETH68+ETH69 mixed era" should "never overestimate for ETH69 peers at constant difficulty" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Synthetic: constant difficulty = cycleStart.difficulty over 1000 blocks
+    val D = cycleStart.difficulty
+    val anchorTD = cycleStart.totalDifficulty
+    val peerNum = cycleStart.number + BigInt(1000)
+    val actualTD = anchorTD + D * BigInt(1000)
+
+    val estimated = powScalingEstimate(anchorTD, D, peerNum, cycleStart.number)
+    estimated should be <= actualTD // 9999/10000 factor guarantees underestimate for constant diff
+  }
+
+  // -------------------------------------------------------------------------
+  // ETH/69-only era — all peers use POW_SCALING
+  // -------------------------------------------------------------------------
+
+  "ETH69-only era" should "give < 0.1% error for a constant-difficulty (ASIC-only) synthetic chain" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Synthetic ASIC-only chain: constant difficulty = 2000 TH, starting from block 0
+    val constDiff = BigInt("2000000000000000") // 2000 TH
+    val anchorNum = BigInt(1_000_000)
+    val anchorTD = constDiff * anchorNum
+    val peerNum = BigInt(1_100_000)
+    val actualTD = constDiff * peerNum
+
+    val estimated = powScalingEstimate(anchorTD, constDiff, peerNum, anchorNum)
+    val errFrac = (estimated - actualTD).abs.toDouble / actualTD.toDouble
+    errFrac should be < 0.001 // < 0.1% (actual: ~0.01% from 9999/10000 factor)
+  }
+
+  "ETH69-only era" should "overestimate TD when anchor is at flex-on peak and peer is at flex-off trough" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Synthetic: anchor at flex-on difficulty (4000 TH), 10000 blocks later difficulty has FALLEN to 2000 TH
+    // Because difficulty FELL: actual TD per block < anchor difficulty → overestimate
+    val anchorDiff = BigInt("4000000000000000") // 4000 TH
+    val anchorNum = BigInt(1_000_000)
+    val anchorTD = anchorDiff * anchorNum
+    val blockCount = BigInt(10_000)
+    val peerNum = anchorNum + blockCount
+
+    // Linear ramp DOWN: difficulty falls from 4000 TH to 2000 TH over 10000 blocks
+    // delta = -2000 TH / 10000 blocks = -200 GH per block
+    val delta = BigInt("-200000000000")
+    val actualTD = linearRampTD(anchorTD, anchorDiff, delta, blockCount)
+    val estimated = powScalingEstimate(anchorTD, anchorDiff, peerNum, anchorNum)
+
+    estimated should be > actualTD // overestimate when difficulty falls below anchor rate
+  }
+
+  "ETH69-only era" should "underestimate TD when anchor is at flex-off trough and peer is at flex-on peak" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Synthetic: anchor at flex-off difficulty (2000 TH), 10000 blocks later difficulty has RISEN to 4000 TH
+    val anchorDiff = BigInt("2000000000000000") // 2000 TH
+    val anchorNum = BigInt(1_000_000)
+    val anchorTD = anchorDiff * anchorNum
+    val blockCount = BigInt(10_000)
+    val peerNum = anchorNum + blockCount
+
+    // Linear ramp UP: difficulty rises from 2000 TH to 4000 TH over 10000 blocks
+    val delta = BigInt("200000000000")
+    val actualTD = linearRampTD(anchorTD, anchorDiff, delta, blockCount)
+    val estimated = powScalingEstimate(anchorTD, anchorDiff, peerNum, anchorNum)
+
+    estimated should be < actualTD // underestimate when difficulty rises above anchor rate
+  }
+
+  "ETH69-only era" should "have near-zero error for flex-load cycling below the 0.278 exit-fraction threshold" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // Below threshold: block time stays < 18s → c = 0 → difficulty approximately constant
+    // POW_SCALING error is proportional to difficulty variance; below threshold, variance ≈ 0
+    val exitFrac = 0.20 // below flexExitThresholdFrac (0.278)
+    val gap = OscillationFixtures.expectedBlockTimeAfterExit(exitFrac)
+    val c = OscillationFixtures.cCoeff(gap)
+
+    // c = 0 means difficulty does NOT change — constant difficulty → POW_SCALING near-exact
+    c shouldBe 0L
+
+    // Confirm: 10000 constant-difficulty blocks have < 0.01% POW_SCALING error
+    val diff = BigInt("2000000000000000")
+    val anchorNum = BigInt(1_000_000)
+    val anchorTD = diff * anchorNum
+    val peerNum = anchorNum + BigInt(10_000)
+    val actualTD = diff * peerNum
+    val estimated = powScalingEstimate(anchorTD, diff, peerNum, anchorNum)
+    val errFrac = (estimated - actualTD).abs.toDouble / actualTD.toDouble
+    errFrac should be < 0.0001
+  }
+
+  "ETH69-only era" should "have measurable POW_SCALING error for the observed 0.324 flex-load exit fraction" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in {
+    // At 0.324 exit fraction, c = -1 every block → difficulty falls by D/2048 per block
+    val exitFrac = OscillationFixtures.flexMaxHrFrac // 0.324
+    val gap = OscillationFixtures.expectedBlockTimeAfterExit(exitFrac)
+    val c = OscillationFixtures.cCoeff(gap)
+    c shouldBe -1L // flex-off blocks trigger DAA difficulty reduction
+
+    // After 500 flex-off blocks: difficulty falls ~500/2048 ≈ 24% from start
+    val startDiff = BigInt("4000000000000000") // ~4000 TH (at flex-on peak)
+    val anchorNum = BigInt(1_000_000)
+    val blockCount = BigInt(500)
+    val anchorTD = startDiff * anchorNum
+
+    // Simulate falling difficulty with c = -1 each block (approx: linear ramp down by D/2048)
+    val diffDeltaPerBlock = startDiff / 2048 // ≈ D/2048 per block downward
+    val actualTD = linearRampTD(anchorTD, startDiff, -diffDeltaPerBlock, blockCount)
+    val peerNum = anchorNum + blockCount
+    val estimated = powScalingEstimate(anchorTD, startDiff, peerNum, anchorNum)
+
+    // estimated > actual because difficulty fell below the anchor rate
+    estimated should be > actualTD
+
+    val overestimateFrac = (estimated - actualTD).toDouble / actualTD.toDouble
+    overestimateFrac should be > 0.0 // measurable overestimate during falling-diff phase
+    overestimateFrac should be < 0.20 // but not catastrophically wrong for 500 blocks
+  }
+}
+// scalastyle:on magic.number

--- a/src/test/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActorHandshakeSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActorHandshakeSpec.scala
@@ -1,0 +1,219 @@
+package com.chipprbots.ethereum.network
+
+import java.net.InetSocketAddress
+
+import scala.concurrent.duration._
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActorRef
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko.util.ByteString
+
+import org.bouncycastle.util.encoders.Hex
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.db.dataSource.EphemDataSource
+import com.chipprbots.ethereum.db.storage.AppStateStorage
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo
+import com.chipprbots.ethereum.network.NetworkPeerManagerActor.RemoteStatus
+import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
+import com.chipprbots.ethereum.network.PeerEventBusActor.PeerEvent.PeerHandshakeSuccessful
+import com.chipprbots.ethereum.network.PeerEventBusActor.Subscribe
+import com.chipprbots.ethereum.network.PeerEventBusActor.Unsubscribe
+import com.chipprbots.ethereum.network.p2p.messages.Capability
+import com.chipprbots.ethereum.testing.Tags._
+
+// Regression tests for Issues 6 and 8: dual-connection races between inbound and
+// outbound TCP connections to the same peer. All assertions are behavioural: they
+// observe Subscribe / Unsubscribe messages sent to the peerEventBus TestProbe rather
+// than inspecting internal state. This means the tests are robust to internal
+// refactors while still covering the critical paths.
+class NetworkPeerManagerActorHandshakeSpec
+    extends TestKit(ActorSystem("NetworkPeerManagerActorHandshakeSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  private val nodeIdHex = "aa" * 64
+  private val nodeIdBytes = ByteString(Hex.decode(nodeIdHex))
+  private val peerId = PeerId(nodeIdHex)
+
+  private val outboundAddr = new InetSocketAddress("127.0.0.1", 30304)
+  private val inboundAddr = new InetSocketAddress("127.0.0.1", 55555)
+
+  // ETH/69 skips the best-block probe (STATUS carries latestBlock), so the peerManager
+  // TestProbe stays silent and assertions on the bus are unambiguous.
+  private val peerStatus = RemoteStatus(
+    capability = Capability.ETH69,
+    networkId = 61L,
+    chainWeight = ChainWeight.totalDifficultyOnly(10000),
+    bestHash = Fixtures.Blocks.Block3125369.header.hash,
+    genesisHash = Fixtures.Blocks.Genesis.header.hash
+  )
+  private val peerInfo = PeerInfo(peerStatus, forkAccepted = true)
+
+  // ── helpers ──────────────────────────────────────────────────────────────────
+
+  private def newNpma(): (TestActorRef[NetworkPeerManagerActor], TestProbe, TestProbe) = {
+    val pm = TestProbe()
+    val bus = TestProbe()
+    val ref = TestActorRef[NetworkPeerManagerActor](
+      NetworkPeerManagerActor.props(
+        pm.ref,
+        bus.ref,
+        new AppStateStorage(EphemDataSource()),
+        forkResolverOpt = None
+      )
+    )
+    (ref, pm, bus)
+  }
+
+  // NPMA sends two Subscribes to peerEventBusActor at construction:
+  //   1. Subscribe(PeerHandshaked)
+  //   2. Subscribe(MessageClassifier(SNAP request codes, AllPeers))
+  // Drain them before running per-test assertions.
+  private def drainInitialSubscriptions(bus: TestProbe): Unit = {
+    bus.expectMsgType[Subscribe]
+    bus.expectMsgType[Subscribe]
+  }
+
+  private def outboundPeer(): Peer =
+    Peer(peerId, outboundAddr, TestProbe().ref, incomingConnection = false, nodeId = Some(nodeIdBytes))
+
+  private def outboundPeer2(): Peer =
+    Peer(
+      peerId,
+      new InetSocketAddress("127.0.0.1", 30305),
+      TestProbe().ref,
+      incomingConnection = false,
+      nodeId = Some(nodeIdBytes)
+    )
+
+  private def inboundPeer(): Peer =
+    Peer(peerId, inboundAddr, TestProbe().ref, incomingConnection = true, nodeId = Some(nodeIdBytes))
+
+  // ── tests ────────────────────────────────────────────────────────────────────
+
+  // A1 — baseline: first handshake registers the peer.
+  "NetworkPeerManagerActor" should "send Subscribe messages for a new outbound peer on PeerHandshakeSuccessful" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+
+    bus.expectMsgType[Subscribe] // PeerDisconnectedClassifier
+    bus.expectMsgType[Subscribe] // MessageClassifier
+    bus.expectNoMessage(100.millis)
+  }
+
+  // A2 — inbound-wins swap: duplicate handshake must NOT produce a second pair of Subscribes.
+  // Regression for Issue 8 — NPMA previously overwrote peersWithInfo with the duplicate ref,
+  // causing stale outbound dispatches after the connection was swapped.
+  it should "not send additional Subscribe messages when inbound wins over existing outbound (same PeerId)" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]
+    bus.expectMsgType[Subscribe]
+
+    npma ! PeerHandshakeSuccessful(inboundPeer(), peerInfo) // same PeerId, inbound wins
+    bus.expectNoMessage(100.millis)
+  }
+
+  // B1 — suppression: the outbound PeerActor dies after inbound-wins and fires PeerDisconnected.
+  // That disconnect must be suppressed (pendingInboundWinsDisconnects gate) so the inbound
+  // entry is not evicted from peersWithInfo. Regression for Issue 8.
+  it should "suppress PeerDisconnected for the dying outbound after inbound-wins" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]; bus.expectMsgType[Subscribe]
+    npma ! PeerHandshakeSuccessful(inboundPeer(), peerInfo)
+    bus.expectNoMessage(100.millis)
+
+    npma ! PeerDisconnected(peerId) // outbound dying — should be suppressed
+    bus.expectNoMessage(300.millis)
+  }
+
+  // B2 — retention: after the suppressed outbound disconnect, the inbound is still live.
+  // A subsequent genuine disconnect must evict it normally.
+  it should "retain the inbound peer after outbound PeerDisconnected is suppressed" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]; bus.expectMsgType[Subscribe]
+    npma ! PeerHandshakeSuccessful(inboundPeer(), peerInfo)
+    npma ! PeerDisconnected(peerId) // outbound dying — suppressed
+    bus.expectNoMessage(200.millis)
+
+    // Genuine disconnect from the inbound must now evict the peer normally
+    npma ! PeerDisconnected(peerId)
+    bus.expectMsgType[Unsubscribe]
+    bus.expectMsgType[Unsubscribe]
+  }
+
+  // C1 — drop: second outbound for the same PeerId must be silently dropped.
+  it should "drop a second outbound for the same PeerId without adding a duplicate Subscribe" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]; bus.expectMsgType[Subscribe]
+
+    npma ! PeerHandshakeSuccessful(outboundPeer2(), peerInfo) // duplicate outbound — DROPPED
+    bus.expectNoMessage(100.millis)
+
+    // Original peer is still retained
+    npma ! PeerDisconnected(peerId)
+    bus.expectMsgType[Unsubscribe]
+    bus.expectMsgType[Unsubscribe]
+  }
+
+  // C2 — drop: second inbound for the same PeerId must also be silently dropped.
+  it should "drop a second inbound for the same PeerId without adding a duplicate Subscribe" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+    npma ! PeerHandshakeSuccessful(inboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]; bus.expectMsgType[Subscribe]
+
+    npma ! PeerHandshakeSuccessful(
+      Peer(
+        peerId,
+        new InetSocketAddress("127.0.0.1", 55556),
+        TestProbe().ref,
+        incomingConnection = true,
+        nodeId = Some(nodeIdBytes)
+      ),
+      peerInfo
+    )
+    bus.expectNoMessage(100.millis)
+
+    // Original peer is still retained
+    npma ! PeerDisconnected(peerId)
+    bus.expectMsgType[Unsubscribe]
+    bus.expectMsgType[Unsubscribe]
+  }
+
+  // D — eviction: genuine disconnect evicts the peer; a second PeerDisconnected is ignored.
+  it should "evict a peer on genuine PeerDisconnected and ignore a subsequent one for the same PeerId" taggedAs UnitTest in {
+    val (npma, _, bus) = newNpma()
+    drainInitialSubscriptions(bus)
+    npma ! PeerHandshakeSuccessful(outboundPeer(), peerInfo)
+    bus.expectMsgType[Subscribe]; bus.expectMsgType[Subscribe]
+
+    npma ! PeerDisconnected(peerId)
+    bus.expectMsgType[Unsubscribe]
+    bus.expectMsgType[Unsubscribe]
+
+    // Peer is now gone — second disconnect must be ignored (no Unsubscribes)
+    npma ! PeerDisconnected(peerId)
+    bus.expectNoMessage(200.millis)
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/network/PeerManagerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/PeerManagerSpec.scala
@@ -626,6 +626,75 @@ class PeerManagerSpec
     createdPeers.size shouldBe 2
   }
 
+  // Regression for Issue 6: when a maintained peer's outbound actor terminates after
+  // inbound-wins, PMA used to publish Publish(PeerDisconnected(peerId)) unconditionally.
+  // That caused NPMA to evict the still-live inbound entry, creating an infinite
+  // reconnect loop with core-geth. The fix (DUPLICATE_TERMINATED) suppresses the
+  // PeerDisconnected when the winner nodeId is still handshaked in connectedPeers.
+  it should "not publish PeerDisconnected when the terminated outbound's nodeId is still alive via the inbound winner (DUPLICATE_TERMINATED)" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new TestSetup {
+    val hexNodeId = "ff" * 64
+    val nodeIdBytes = ByteString(Hex.decode(hexNodeId))
+    val maintainedUri = new URI(s"enode://$hexNodeId@127.0.0.9:30303")
+
+    start()
+
+    // Step 1: outbound dials out for the maintained peer.
+    // AddMaintainedPeer publishes MaintainedPeersChanged to peerEventBus — drain it so
+    // the final expectNoMessage assertion does not see a stale message.
+    peerManager ! PeerManagerActor.AddMaintainedPeer(maintainedUri)
+    peerEventBus.fishForMessage(3.seconds, "waiting for MaintainedPeersChanged") {
+      case Publish(PeerEvent.MaintainedPeersChanged(_)) => true
+      case _                                            => false
+    }
+    createdPeers(0).probe.expectMsgType[ConnectTo](3.seconds)
+
+    // Step 2: outbound handshakes
+    createdPeers(0).probe.reply(
+      PeerEvent.PeerHandshakeSuccessful(
+        Peer(
+          PeerId(hexNodeId),
+          new InetSocketAddress("127.0.0.9", 30303),
+          createdPeers(0).probe.ref,
+          incomingConnection = false,
+          nodeId = Some(nodeIdBytes)
+        ),
+        initialPeerInfo
+      )
+    )
+
+    // Step 3: inbound from the same maintained peer host
+    val inboundTcp = TestProbe()
+    val inboundAddress = new InetSocketAddress("127.0.0.9", 55555)
+    peerManager ! PeerManagerActor.HandlePeerConnection(inboundTcp.ref, inboundAddress)
+    createdPeers(1).probe.expectMsg(PeerActor.HandleConnection(inboundTcp.ref, inboundAddress))
+
+    // Step 4: inbound handshakes with same nodeId — inbound wins, outbound gets DisconnectPeer
+    createdPeers(1).probe.reply(
+      PeerEvent.PeerHandshakeSuccessful(
+        Peer(
+          PeerId(hexNodeId),
+          inboundAddress,
+          createdPeers(1).probe.ref,
+          incomingConnection = true,
+          nodeId = Some(nodeIdBytes)
+        ),
+        initialPeerInfo
+      )
+    )
+    createdPeers(0).probe.expectMsg(PeerActor.DisconnectPeer(Disconnect.Reasons.AlreadyConnected))
+
+    // Step 5: terminate the outbound — DUPLICATE_TERMINATED must suppress PeerDisconnected
+    createdPeers(0).probe.ref ! PoisonPill
+    peerEventBus.expectNoMessage(500.millis)
+
+    // No reconnect is scheduled (winner still alive) — createdPeers stays at 2
+    testScheduler.timePasses(6000.millis)
+    createdPeers.size shouldBe 2
+  }
+
   behavior.of("outgoingConnectionDemand")
 
   it should "try to connect to at least min-outgoing-peers but no more than max-outgoing-peers" taggedAs (

--- a/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -293,15 +293,12 @@ class NetworkHandshakerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "force supportsSnap=true for ETH69 peers even when snap/1 absent from Hello" taggedAs (
+  it should "set supportsSnap=false for ETH69 peers when snap/1 is absent from Hello" taggedAs (
     UnitTest,
     NetworkTest
   ) in new RemotePeerETH69Setup {
-    // EIP-7642 mandates that ETH/69 peers always support snap as a co-protocol.
-    // Peers negotiating ETH/69 never advertise snap/1 separately in Hello.
-    // EtcHelloExchangeState must force supportsSnap=true whenever ETH69 is negotiated.
-    // See: EtcHelloExchangeState.scala line ~81.
-
+    // ETH/69 and SNAP/1 are independent protocols. A peer can negotiate ETH/69
+    // without advertising snap/1 in Hello. supportsSnap must reflect actual capabilities.
     // remoteHello has only Capability.ETH69, no SNAP1
     val handshakerAfterHelloOpt: Option[Handshaker[PeerInfo]] =
       initHandshakerWithoutResolver.applyMessage(remoteHello)
@@ -313,14 +310,36 @@ class NetworkHandshakerSpec extends AnyFlatSpec with Matchers {
 
     handshakerAfterStatusOpt.get.nextMessage match {
       case Left(HandshakeSuccess(peerInfo)) =>
-        // Core assertion: supportsSnap must be true despite no SNAP1 in Hello
+        peerInfo.remoteStatus.supportsSnap shouldBe false
+        peerInfo.remoteStatus.capability shouldBe Capability.ETH69
+        peerInfo.forkAccepted shouldBe true
+      case Left(HandshakeFailure(reason)) =>
+        fail(s"Expected HandshakeSuccess but got HandshakeFailure($reason)")
+      case Right(nextMsg) =>
+        fail(s"Expected HandshakeSuccess but got next message: ${nextMsg.messageToSend}")
+    }
+  }
+
+  it should "set supportsSnap=true for ETH69 peers when snap/1 is present in Hello" taggedAs (
+    UnitTest,
+    NetworkTest
+  ) in new RemotePeerETH69Setup {
+    val helloWithSnap = remoteHello.copy(capabilities = Seq(Capability.ETH69, Capability.SNAP1))
+    val handshakerAfterHelloOpt: Option[Handshaker[PeerInfo]] =
+      initHandshakerWithoutResolver.applyMessage(helloWithSnap)
+    assert(handshakerAfterHelloOpt.isDefined)
+
+    val handshakerAfterStatusOpt: Option[Handshaker[PeerInfo]] =
+      handshakerAfterHelloOpt.get.applyMessage(remoteStatusMsg)
+    assert(handshakerAfterStatusOpt.isDefined)
+
+    handshakerAfterStatusOpt.get.nextMessage match {
+      case Left(HandshakeSuccess(peerInfo)) =>
         peerInfo.remoteStatus.supportsSnap shouldBe true
         peerInfo.remoteStatus.capability shouldBe Capability.ETH69
         peerInfo.forkAccepted shouldBe true
-
       case Left(HandshakeFailure(reason)) =>
         fail(s"Expected HandshakeSuccess but got HandshakeFailure($reason)")
-
       case Right(nextMsg) =>
         fail(s"Expected HandshakeSuccess but got next message: ${nextMsg.messageToSend}")
     }


### PR DESCRIPTION
## Summary

**ETH/69 + SNAP protocol correctness**

- Fix \`EtcHelloExchangeState\`: ETH/69 and SNAP/1 are independent protocol capabilities. Removes the forced \`supportsSnap=true\` for all ETH/69 peers — ETH/69 specifies a shared message-ID space with snap/1 when *both* are negotiated, but a peer advertising only ETH/69 in Hello has no snap codec channel. The old code dispatched bytecode workers to ETH/69-without-SNAP/1 peers; the workers crashed on the first send, permanently exhausting the 32-actor pool within the first few minutes of the ByteCode+Storage phase. Now derives \`supportsSnap\` from the actual negotiated capabilities (same logic as ETH/64-68 path).
- Fix \`SNAPSyncController.StorageRangeSyncForceCompleted\` handler: add phase guard — only set \`storagePhaseComplete=true\` during \`ByteCodeAndStorageSync\` or later. The consecutive-failures force-complete path could fire during \`AccountRangeSync\`, permanently setting the flag before the storage phase began and silently disabling \`maybeRestartIfStorageStagnant\` recovery for the rest of the run.
- Fix \`StorageRangeCoordinator\`: reset \`consecutiveTaskFailures = 0\` on pivot refresh. Transient SNAP peer exhaustion (peers temporarily unavailable during a pivot storm) was accumulating across pivots and incorrectly triggering \`ForceCompleteStorage\` in the next window.
- Fix \`ByteCodeCoordinator\`: add \`context.watch(worker)\` + \`Terminated\` handler for permanent worker crash recovery. Crashed workers are removed from the pool and their in-flight tasks re-queued. Without this, pool drain to \`idle=0\` was unrecoverable — no new workers were spawned after permanent termination.
- Add \`ByteCodeCoordinator\` stagnation watchdog to \`SNAPSyncController\`: query \`ByteCodeGetProgress\` on the same interval as storage stagnation checks; force-complete bytecode after 10 min of no progress, unblocking \`checkAllDownloadsComplete\`. The storage stagnation path had a recovery mechanism; the bytecode path had none.
- Fix \`AccountRangeCoordinator.tryRedispatchPendingTasks\`: add \`lastDispatchTimeMs\` FIFO tiebreaker in the \`inFlightForPeer\` sort. When multiple peers share the same in-flight count, the previous \`mutable.Set\` hash order was stable and deterministic — permanently starving the same subset of peers. Secondary sort by least-recently-served ensures equal-tier peers rotate.

**SNAP ByteCode phase stability**

- Fix \`ByteCodeCoordinator.ByteCodePeerUnavailable\`: call \`markWorkerIdle(worker)\` after \`ByteCodeWorkerRelease\` for each worker with an in-flight request when a peer disconnects. Previously the worker was signalled to release but not returned to the idle pool — \`workers.size\` still counted it but \`idleWorkers\` did not contain it. Once all 32 workers leaked this way, \`dispatchIfPossible\` found both branches unavailable (\`idleWorkers\` empty, \`workers.size >= maxWorkers\`) and returned without dispatching permanently. All other release sites already called \`markWorkerIdle\`.
- Fix \`ByteCodeCoordinator\`: call \`tryRedispatchPendingTasks()\` after \`ByteCodePivotRefreshed\`, \`ByteCodeTaskComplete\`, and \`ByteCodeTaskFailed\`. Previously cooldowns were cleared and workers returned to idle, but no dispatch attempt followed until the next 1-second \`bytecodeRequestTask\` tick. Matches the pattern already present in AccountRange, Storage, and Healing coordinators.
- Fix \`SNAPSyncController\` AccountRange→ByteCode phase entry: send \`ByteCodePivotRefreshed\` immediately after \`UpdateMaxInFlightPerPeer\` and call \`requestByteCodes()\`. Peers accumulate per-peer exponential backoff during AccountRange; without clearing those cooldowns at the phase boundary, ByteCode dispatch stalls until peers reconnect or the external stagnation watchdog fires. Applied to both the normal transition from AccountRange and the resume-from-checkpoint path.
- Reduce \`ByteCodePeerCooldownConfig.max\` from 2 minutes to 30 seconds, aligning with the ceiling used by AccountRange (30 s) and Healing (30 s) coordinators.
- Raise \`maxFailuresPerHash\` from 10 to 50. In a mixed ETH-mainnet/ETC peer pool, empty responses from ETH-mainnet peers for ETC-specific bytecode hashes can exhaust the threshold before a local ETC-capable peer attempts the hash.
- Raise ByteCode concurrent-request budget from 2 to 8 per peer at phase start.

**SNAP sync peer connectivity**

- Fix SNAP sync peer connectivity: exclude dedicated \`snap-server-peers\` from parallel chain download (GetBlockHeaders) requests; add proactive outbound dial-out to configured snap-server-peers at sync start, not only at state-healing entry; exempt loopback/private addresses from the inbound TCP blacklist check.
- Accept terminal-empty account range (\`accounts=[], proof=[]\`) unconditionally — valid SNAP/1 response for sparse trie regions. Mirrors go-ethereum behaviour; \`verifyStorageRange\` already accepted this form.
- Fix inbound blacklist race in \`ServerActor\`, stale-root storm on pivot refresh, pivot cascade on rapid peer disconnect, disconnect flood log noise.
- Fix \`AccountRangeCoordinator.PeerAvailable\`: preserve \`snaplessPeers\` marking when a known-snapless peer reconnects. The same PeerId always identifies the same physical node; clearing the flag on reconnect allowed ETH-mainnet peers to consume dispatch slots and hash-failure budget before ETC-capable peers were tried.
- Fix \`SNAPSyncController.startStateHealing\`: flush current snap-capable peers to \`TrieNodeHealingCoordinator\` synchronously at phase start. The 0-second initial scheduler delay is async; the explicit flush eliminates the race window between coordinator creation and the first peer-availability notification.

**Network — NPMA/PMA dual-connection races**

- Fix NPMA inbound-wins state desync: when fukuii and a maintained peer simultaneously dial each other, swap \`peersWithInfo\` to the live inbound ref and gate the dying outbound's \`PeerDisconnected\` via \`pendingInboundWinsDisconnects\`. Without this, the outbound's close event evicted the inbound from \`peersWithInfo\`, causing a 15-second reconnect loop.
- Fix PMA DUPLICATE_TERMINATED: suppress \`Publish(PeerDisconnected)\` when the terminated outbound's nodeId is still active via the inbound winner; eliminates the infinite reconnect loop observed against core-geth.
- Add regression test suite (8 tests): \`NetworkPeerManagerActorHandshakeSpec\` (7 behavioural NPMA tests — inbound-wins swap, outbound-disconnect suppression, duplicate-drop, genuine eviction) + \`PeerManagerSpec\` DUPLICATE_TERMINATED.

**ETH/69 chain weight**

- Fix ETH/69 PoW chain weight resolution: 3-tier lookup (DB → canonical block number → POW_SCALING marginal-rate formula \`ourBestTD + currentDifficulty × gap × 9999/10000\`) with oscillation guard. Previous flat-scaling formula introduced ~0.1% error for nearby peers; marginal-rate is exact for recent peers and bounded for distant ones.
- Add spec coverage for all four resolution paths (COLD_START / DB_LOOKUP / CANONICAL_NUMBER / POW_SCALING) with ETC-accurate difficulty values.

**SNAP Phase D — trie healing**

- Fix walk frontier skip (HEALING-1a): DFS no longer descends into subtrees rooted at a proven \`HashNode\`. Eliminates redundant re-fetches of already-healed branches in subsequent healing rounds.
- Fix healing completion guard (HEALING-1b): \`HealingCheckCompletion\` respects \`trieWalkInProgress\` — completion is not signalled while the walk is still running.
- Reduce \`WALK-PULSE\` heartbeat 60 s → 10 s (NOISE-3).
- TCP peer backoff and log noise reduction.

**MESS — Olympia reactivation config**

- \`MESSConfig.reactivationBlock\` now falls back to \`olympia-block-number\` from the parent chain config when \`ecbp1100-reactivate-block-number\` is absent from the \`mess {}\` block. MESS reactivates at the Olympia fork automatically on both ETC mainnet and Mordor with no new config key required. The explicit \`ecbp1100-reactivate-block-number\` still takes priority when present. Add \`MESSConfigParsingSpec\` covering explicit key, olympia fallback, absence, and priority ordering.

**Recovery path hardening (Bug 20 post-sync)**

- Fix \`BytecodeRecoveryActor\` (B4): add \`context.watch(coordinator)\` + \`Terminated\` handler — coordinator crash now commits \`bytecodeRecoveryDone\` and sends \`RecoveryComplete\` instead of hanging \`SyncController\` permanently.
- Fix \`BytecodeRecoveryActor\` (B5): add abandon timeout matching \`storageRecoveryAbandonTimeout\` — if no download progress arrives within the window, recovery completes gracefully. Brings parity with \`StorageRecoveryActor\`'s existing mechanism.
- Fix \`StorageRecoveryActor\` (C4): add \`context.watch(coordinator)\` + \`Terminated\` handler — same pattern as B4.
- Fix \`SyncController\` (D6): \`startRecovery()\` now calls \`context.watch\` on each spawned recovery actor; \`runningRecovery\` handles \`Terminated\` by treating unexpected actor death as \`RecoveryComplete\`, preventing a permanent stuck-in-recovery hang.
- Add \`BytecodeRecoveryActor\` test hooks (\`preloadedMissingForTesting\`, \`coordinatorForTesting\`) mirroring \`StorageRecoveryActor\`'s existing pattern; production code path unchanged.

**Observability + deps**

- Restore Grafana logback event counters after prometheus 1.x migration via Micrometer \`LogbackMetrics\` binder.
- Promote networkId/genesis mismatch rejections from \`log.debug\` to \`log.info\`.
- Elevate \`ByteCode dispatch blocked\` log from \`debug\` to \`warning\` — this path indicates a worker pool invariant violation and should be immediately visible without log-level configuration.
- Elevate \`ByteCodePeerUnavailable\` log to \`info\` with idle-pool state (before/after) so peer-disconnect events and worker recovery are visible in default log output.
- Remove per-request/response \`DEBUG\` log lines from \`PeerRequestHandler\` (\`PEER_REQUEST\`, \`PEER_REQUEST_SUCCESS\`) that produced ~25-30 lines/sec during RegularSync. Timeout and disconnect paths remain at \`WARNING\`. Stale-requestId debug retained.
- Enrich \`BlockImporter\` single-block import log with truncated hash, tx count, and gas used.
- Add \`RegularSync\` 60-second \`PrintStatus\` heartbeat: logs current block, best-known-network block, and lag during the following-head phase.
- Demote per-handshake INFO lines that flood the log at block head to DEBUG: \`ETH69_STATUS: Sending\` (fires every new peer), \`INBOUND_CAP_OFFSETS\` (fires every SNAP peer), \`SNAP/1 capability enabled\` (fires every SNAP peer).
- \`Unable to negotiate protocol\` severity: ERROR → WARN — non-Ethereum crawlers advertising no capabilities are expected at block head, not errors.
- TCP failure warning: drop full 128-char enode URI from the message, keep IP:PORT only.
- \`DECODE_ERROR\`: truncate \`ex.getMessage\` to 80 chars — ETH-mainnet peers sending an 8-field ETH/69 Status (including \`totalDifficulty\`) produced multi-line RLP byte dumps in the WARN.
- \`BlockFetcher\` status: inline \`readyBlocks\`/\`knownTop\`/\`onTop\` fields instead of rendering \`state.status\` as a \`Map[String,Any]\`.
- \`BlockImporter\` multi-block import range: swap \`head\`/\`last\` to produce ascending output (\`importedBlocks\` is newest-first due to prepend recursion).
- Bump cats-effect 3.6.1, fs2 3.12.0, Pekko 1.6.0, scalamock 7.3.2, prometheus-metrics 1.x, ~30 transitive; pin GitHub Actions to commit SHA; add Dependabot for Actions and sbt.

## ETC mainnet validation

Validated on ETC mainnet with Besu (ETH/69+SNAP/1) and core-geth (ETH/68+SNAP/1) as local snap-server-peers plus external Nethermind peers. SNAP sync completed in 337 s from process start (resumed datadir). StateHealing: 2,293,714 trie nodes healed at 6,789 nodes/s, trie walk clean on first pass — zero additional healing rounds. fukuii reached chain head and entered regular sync successfully.

Cold-start SNAP sync (Run 26): 6h55m13s, 0 abandoned bytecodes, ByteCode Fix A (worker leak) verified 135/135, Fix B (phase-boundary cooldown clear) verified.

## Test plan

- [x] \`sbt testOnly *EtcHandshakerSpec\` — ETH/69 snap decision (includes ETH/69-without-SNAP/1 case)
- [x] \`sbt testOnly *ByteCodeCoordinatorSpec\` — worker pool recovery (Terminated handler, PeerUnavailable idle restore, ForceCompleteByteCodes mid-flight) + stagnation watchdog + immediate redispatch on TaskComplete
- [x] \`sbt testOnly *StorageRangeCoordinatorSpec\` — consecutive-failures reset on pivot
- [x] \`sbt testOnly *SNAPSyncControllerSpec\` — phase guard on StorageRangeSyncForceCompleted
- [x] \`sbt testOnly *NetworkPeerManagerActorHandshakeSpec\` — 7 dual-connection race cases
- [x] \`sbt testOnly *BlockchainReaderSpec\` — POW_SCALING marginal-rate assertion
- [x] \`sbt testOnly *AccountRangeCoordinatorSpec\` — snaplessPeers persistence across reconnect
- [x] \`sbt testOnly *MESSConfigParsingSpec\` — reactivationBlock parsing: explicit key, olympia fallback, absence, priority
- [x] \`sbt testOnly *BytecodeRecoveryActorSpec\` — 5 recovery path tests: no-missing, normal download, scan-throws, coordinator crash (B4), abandon timeout (B5)
- [x] \`sbt testOnly *SyncControllerSpec\` — 15 tests: recovery state machine (T6-T9), startup diagnostics SC-1a/SC-1b (T10-T11), HealingImpossible flag clear (T12), RegularSyncStuck SNAP restart (T13)
- [x] \`sbt testOnly com.chipprbots.ethereum.blockchain.sync.*\` — 543 tests pass, 0 failures
- [x] \`sbt scalafmtAll\` clean
- [x] ETC mainnet SNAP sync: complete end-to-end (AccountRange → StorageRange+ByteCode → StateHealing → regular sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)