### PR TITLE
fix(metrics): wire Micrometer PrometheusMeterRegistry into prometheus-1.x default registry

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/metrics/MeterRegistryBuilder.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/MeterRegistryBuilder.scala
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.config.MeterFilter
 import io.micrometer.jmx.JmxMeterRegistry
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.prometheus.metrics.model.registry.PrometheusRegistry
 
 import com.chipprbots.ethereum.utils.Logger
 import com.chipprbots.ethereum.utils.LoggingUtils.getClassName
@@ -26,8 +27,13 @@ object MeterRegistryBuilder extends Logger {
 
     log.info(s"Build JMX Meter Registry: ${jmxMeterRegistry}")
 
+    // Wire Micrometer's PrometheusMeterRegistry to share the prometheus-1.x default
+    // registry that `Metrics.start()`'s `PrometheusHTTPServer` serves. Without this, the
+    // default-arg constructor creates an isolated registry, and every Counter/Gauge/Timer
+    // written via Micrometer is stranded — only JVM metrics from `JvmMetrics.builder().register()`
+    // (which writes directly to the default registry) ever reach /metrics.
     val prometheusMeterRegistry =
-      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, PrometheusRegistry.defaultRegistry, StdMetricsClock)
 
     log.info(s"Build Prometheus Meter Registry: ${prometheusMeterRegistry}")
 


### PR DESCRIPTION
## Summary

After the prometheus-1.x migration in #1278, the HTTP server in \`Metrics.start()\` (\`io.prometheus.metrics.exporter.httpserver.HTTPServer\`) serves the new client's \`PrometheusRegistry.defaultRegistry()\` singleton. \`JvmMetrics.builder().register()\` and \`LogbackMetrics\` both write to that registry, so /metrics still showed JVM + logback samples. But Micrometer's \`PrometheusMeterRegistry(PrometheusConfig.DEFAULT)\` constructor creates an *isolated internal registry* — every Counter/Gauge/Timer authored through the app's \`MetricsContainer\` (the entire \`app_snapsync_*\`, \`app_network_*\`, \`app_blockchain_*\` surface) was stranded there.

Result: /metrics dropped from ~250+ lines of app data to 172 lines of JVM-only data, and every Grafana panel went blank.

## Fix

Use the three-arg \`PrometheusMeterRegistry(config, registry, clock)\` constructor to point Micrometer at \`PrometheusRegistry.defaultRegistry\`, so the HTTP server sees a unified registry.

## Validation

Live on \`fukuii-primary\` (ETC mainnet SNAP):
- \`/metrics\` now exposes 68 app metric families (was 0)
- Prometheus scrape target healthy
- \`fukuii-snap-sync\` Grafana dashboard panels read back populated (\`app_snapsync_phase_current_gauge\`, \`app_snapsync_accounts_synced_gauge\`, etc.)
- Direct Prometheus query: \`accounts_synced=153412 phase=1 rss=2.89GiB\` after ~2 min of sync

## Test plan

- [x] Sync compiles
- [x] Live verification on barad-dûr primary: \`curl http://localhost:9095/metrics | grep -c '^app_'\` returns 68
- [x] Prometheus scrape target \`fukuii-primary\` is up
- [x] Grafana dashboard \`fukuii-snap-sync\` panels render

🤖 Generated with [Claude Code](https://claude.com/claude-code)