### PR TITLE
ci(auto-version): trigger patch bump on staging pushes

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
       - develop
+      - staging
     paths-ignore:
       - 'docs/**'
       - '*.md'
@@ -67,8 +68,8 @@ jobs:
           MANUAL_INCREMENT: ${{ github.event.inputs.increment_type }}
         run: |
           # Increment policy:
-          #   develop          → patch (0.0.+1)
-          #   main / master    → minor (0.+1.0)
+          #   staging / develop → patch (0.0.+1)
+          #   main / master     → minor (0.+1.0)
           #   workflow_dispatch → caller picks (major / minor / patch)
           # Major bumps are intentionally manual-only — there is no automatic
           # path to a major version on a push, since major changes always


### PR DESCRIPTION
## Summary
- Add `staging` to the push trigger branches in `.github/workflows/auto-version.yml` so merges into `staging` bump the patch version. The policy step's `else` branch already maps non-main/master pushes to `patch`, so no logic change is needed — just the trigger.
- Update the policy comment to reflect that both `staging` and `develop` get patch bumps.

## Why
Version was stuck at `0.5.0` because development is happening on `staging`, but the auto-version workflow only listened to `main` / `master` / `develop`. After this lands, the next merge into `staging` will bump to `0.5.1` and dispatch `release.yml` with `release_tier=patch`.

## Test plan
- [ ] Merge this PR into `staging`.
- [ ] Confirm the `Auto Version Increment` workflow runs on the merge commit.
- [ ] Confirm `version.sbt` is bumped to `0.5.1` and tag `v0.5.1` is pushed.
- [ ] Confirm `release.yml` is dispatched with `release_tier=patch`.