### PR TITLE
fix(db): bound RocksDB native memory; drop unbounded SNAP proof-verifier cache

### DIFF
--- a/src/main/resources/conf/base/db.conf
+++ b/src/main/resources/conf/base/db.conf
@@ -34,6 +34,17 @@
       # Block cache: 512MB (up from 256MB). During SNAP sync, cache hit rate directly impacts
       # read performance for proof verification and trie lookups. Aligned with erigon/besu.
       block-cache-size = 536870912
+
+      # Global cap on total memtable (write-buffer) memory summed across ALL column
+      # families. RocksDB's default is per-CF buffers with no shared ceiling; with 16
+      # column families that is ~1.9GiB of unbounded off-heap during SNAP's write-heavy
+      # phase — the dominant off-heap growth vector that starved a memory-tight host on
+      # ETC mainnet. 512MiB bounds the sum regardless of CF count or write intensity.
+      db-write-buffer-size = 536870912
+
+      # Cap on total live WAL across column families. Also forces a flush of the laggard
+      # CF so the memtable pinning the oldest WAL is released rather than accumulating.
+      max-total-wal-size = 536870912
     }
 
     # Define which database to use [rocksdb]

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -618,8 +618,13 @@ class StorageRangeCoordinator(
     super.postStop()
   }
 
-  // Storage management
-  private val proofVerifiers = mutable.Map[ByteString, MerkleProofVerifier]()
+  // Storage management.
+  // MerkleProofVerifier is constructed inline per response (see verifyStorageRange call).
+  // It was previously cached per storage root in a mutable.Map cleared only on pivot
+  // refresh — but the verifier holds just a 32-byte root + Logger, so the cache saved
+  // nothing and leaked one entry per distinct contract storage root (~0.3–0.5GiB of dead
+  // heap at ETC's 13M+ contracts). Inline construction makes the heap O(in-flight), not
+  // O(contracts-seen-since-last-pivot).
 
   override def preStart(): Unit = {
     log.info(s"StorageRangeCoordinator starting (concurrency=$maxInFlightRequests, batchSize=$maxAccountsPerBatch)")
@@ -835,7 +840,6 @@ class StorageRangeCoordinator(
       peerBatchSuccessStreak.clear()
       peerResponseBytesTarget.clear()
       emptyResponsesByTask.clear()
-      proofVerifiers.clear()
 
       // Discard streaming per-account tries — already-flushed content-addressed nodes
       // remain on disk and will be referenced by the new root's healing pass if still valid,
@@ -1172,7 +1176,7 @@ class StorageRangeCoordinator(
       task.slots = accountSlots
       task.proof = proofForThisTask
 
-      val verifier = getOrCreateVerifier(task.storageRoot)
+      val verifier = MerkleProofVerifier(task.storageRoot)
       verifier.verifyStorageRange(accountSlots, proofForThisTask, task.next, task.last) match {
         case Left(error) =>
           log.warning(s"Storage proof verification failed for account ${task.accountString}: $error")
@@ -1264,9 +1268,6 @@ class StorageRangeCoordinator(
     // Immediately pipeline more work to this peer — don't wait for StoragePeerAvailable
     dispatchIfPossible(peer)
   }
-
-  private def getOrCreateVerifier(storageRoot: ByteString): MerkleProofVerifier =
-    proofVerifiers.getOrElseUpdate(storageRoot, MerkleProofVerifier(storageRoot))
 
   private def handleTimeout(requestId: BigInt): Unit = {
     activeTasks.remove(requestId).foreach { case (peer, batchTasks, _) =>

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -276,6 +276,12 @@ trait RocksDbConfig {
   val levelCompaction: Boolean
   val blockSize: Long
   val blockCacheSize: Long
+  // Global ceiling (bytes) on the sum of all column-family memtables. Concrete with a
+  // default so existing implementors (tests, alternate configs) need no change; the
+  // production config overrides it via InstanceConfig.
+  val dbWriteBufferSize: Long = 512L * 1024 * 1024
+  // Ceiling (bytes) on total live WAL across column families.
+  val maxTotalWalSize: Long = 512L * 1024 * 1024
 }
 
 object RocksDbDataSource extends Logger {
@@ -363,6 +369,16 @@ object RocksDbDataSource extends Logger {
         .setMaxOpenFiles(maxOpenFiles)
         .setIncreaseParallelism(maxThreads)
         .setCreateMissingColumnFamilies(true)
+        // Global ceiling on the SUM of all column-family memtables. Without it, each
+        // of the 16 column families independently holds up to write_buffer_size ×
+        // max_write_buffer_number (~64MiB×2) with no shared cap — ~1.9GiB of off-heap
+        // that grows with SNAP's write-heavy phase and (on a memory-tight host) starved
+        // the box on ETC mainnet. db_write_buffer_size bounds the total regardless of
+        // CF count or write intensity; this is the dominant off-heap growth vector.
+        .setDbWriteBufferSize(dbWriteBufferSize)
+        // Cap total live WAL across CFs; also forces a flush of the laggard CF so the
+        // memtable pinning the oldest WAL is released rather than accumulating.
+        .setMaxTotalWalSize(maxTotalWalSize)
 
       val cfOpts =
         new ColumnFamilyOptions()

--- a/src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala
+++ b/src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala
@@ -129,6 +129,12 @@ class InstanceConfig(val config: TypesafeConfig, val instanceId: String = "defau
       override val levelCompaction: Boolean = rocksDbConfig.getBoolean("level-compaction-dynamic-level-bytes")
       override val blockSize: Long = rocksDbConfig.getLong("block-size")
       override val blockCacheSize: Long = rocksDbConfig.getLong("block-cache-size")
+      override val dbWriteBufferSize: Long =
+        if (rocksDbConfig.hasPath("db-write-buffer-size")) rocksDbConfig.getLong("db-write-buffer-size")
+        else 512L * 1024 * 1024
+      override val maxTotalWalSize: Long =
+        if (rocksDbConfig.hasPath("max-total-wal-size")) rocksDbConfig.getLong("max-total-wal-size")
+        else 512L * 1024 * 1024
     }
   }
 


### PR DESCRIPTION
## Problem

RocksDB native (off-heap) memory was effectively unbounded. `createDB` opens **16 column families** (default + 15 namespaces) but set **no global memtable ceiling** (`db_write_buffer_size=0`) and **no WAL cap** (`max_total_wal_size=0`). Total memtable memory therefore scaled as `CF_count × write_buffer_size × max_write_buffer_number` (~16 × 64 MiB × 2 ≈ **1.9 GiB**) and grew hardest during SNAP's write-heavy phase — the dominant off-heap growth vector. On a memory-tight host this starved the box during ETC mainnet sync (~86M accounts).

A second, smaller leak: `StorageRangeCoordinator` cached a `MerkleProofVerifier` **per distinct contract storage root**, cleared only on pivot refresh — ~0.3–0.5 GiB of dead heap at ETC's 13M+ contracts, for an object that holds only a 32-byte root.

## Fix

- **`RocksDbDataSource`** — add `setDbWriteBufferSize` + `setMaxTotalWalSize` to the shared `DBOptions` (configurable, default 512 MiB). Caps total memtable + WAL memory regardless of CF count or write intensity.
- **`RocksDbConfig` trait** — add `dbWriteBufferSize` / `maxTotalWalSize` with defaults so existing implementors (tests, alternate configs) compile unchanged.
- **`db.conf` / `InstanceConfig`** — expose `db-write-buffer-size` / `max-total-wal-size` (with `hasPath` fallback so older configs keep working).
- **`StorageRangeCoordinator`** — remove the unbounded `proofVerifiers` cache; construct `MerkleProofVerifier` inline per response.

## Validation

Built and deployed to barad-dûr ETC mainnet:
- RocksDB `LOG` confirms `Options.db_write_buffer_size: 536870912` and `Options.max_total_wal_size: 536870912` (were `0`).
- Off-heap anon working set dropped from **~8.3 GiB → ~6 GiB** and is now **state-size-independent** (held flat across the account phase, contract count climbing monotonically — no OOM-kill, no restart).
- Block cache pinned at 512 MiB.

## Coordination notes

- Base is **`staging`** (0.5.1).
- File-wise overlap with **#1285** (`may-sprint`, also → `staging`) which touches `RocksDbDataSource.scala` + `StorageRangeCoordinator.scala` for unrelated reasons — same integration branch, so coordinate merge order (no logical/duplicated work; neither implements memtable/WAL bounds).
- The barad-dûr `docker-compose.yml` host-safety change (`mem_limit` 12g→8g + `MALLOC_ARENA_MAX=2`) is deployment-specific and intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
