### PR TITLE
chore: bump version to 0.6.0 (release)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.5.6"
+(ThisBuild / version) := "0.6.0"


### PR DESCRIPTION
Manual `version.sbt` bump **0.5.6 → 0.6.0** to complete the v0.6.0 release.

#1183 (staging → main) merged the code, but `auto-version.yml` could not push the bump/tag/release to `main` — the `Main_Protection` ruleset rejects direct pushes (`GH013: changes must be made through a pull request`), even from `github-actions[bot]`.

`release.yml` checks out the `v0.6.0` tag and builds with `sbt assembly`/`dist`, so the JAR's internal version comes from `version.sbt` at the tagged commit. This PR ensures the tagged commit reads `0.6.0` — without it the 0.6.0 artifacts would report 0.5.6.

After merge: tag `v0.6.0` at this commit → dispatch `release.yml` (full tier) → GitHub release + jar/zip/tgz + SBOM + signed Docker images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
