### PR TITLE
fix(snap): unwedge pivot refresh on serve-window expiry + preserve range cursors

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3548,7 +3548,9 @@ class SNAPSyncController(
       // → they re-escalated forever and the node wedged. Re-arm them against the current root so
       // stateless tracking clears and dispatch resumes. PivotRefreshed is idempotent on an
       // unchanged root (the handler's `stateRoot = root` is a no-op), so no state is destroyed.
-      log.info(s"Pivot refresh produced same root ($newRoot): $reason. Re-arming coordinators to clear stateless peers.")
+      log.info(
+        s"Pivot refresh produced same root ($newRoot): $reason. Re-arming coordinators to clear stateless peers."
+      )
       accountRangeCoordinator.foreach(_ ! actors.Messages.PivotRefreshed(newStateRoot))
       storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePivotRefreshed(newStateRoot))
       return

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -671,10 +671,20 @@ class SNAPSyncController(
       // are ~99.9% valid across pivot changes) and avoids the download-stall-restart loop.
       val now = System.currentTimeMillis()
       if (now - lastPivotRestartMs < MinPivotRestartInterval.toMillis) {
-        log.warning(
-          s"Ignoring PivotStateUnservable due to restart guard " +
-            s"(phase=$currentPhase, emptyResponses=$emptyResponses, reason=$reason)"
+        // Within the debounce window a pivot refresh is already in flight (or just produced a
+        // same-root no-op). Do NOT swallow the escalation — that left the coordinators' stateless
+        // set full so they re-escalated forever and the node wedged on a dead pivot. Re-arm them
+        // against the current root so stateless tracking clears and dispatch resumes.
+        // INVARIANT: do not increment consecutivePivotRefreshes and do not call any destructive
+        // path here — only the consecutivePivotRefreshes>=Max branch may reach restart/dormant.
+        log.info(
+          s"Debouncing PivotStateUnservable (refresh in flight, phase=$currentPhase, " +
+            s"emptyResponses=$emptyResponses, reason=$reason) — re-arming coordinators"
         )
+        stateRoot.foreach { root =>
+          accountRangeCoordinator.foreach(_ ! actors.Messages.PivotRefreshed(root))
+          storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePivotRefreshed(root))
+        }
       } else if (currentPhase == AccountRangeSync || currentPhase == ByteCodeAndStorageSync) {
         lastPivotRestartMs = now
         consecutivePivotRefreshes += 1
@@ -3532,7 +3542,15 @@ class SNAPSyncController(
       // A same-root "refresh" is information-free for the coordinator (their data for this
       // root is unchanged) but does not warrant destroying state. Strikes and snapless have
       // already been cleared at coordinator level via PR #1255; nothing further to do.
-      log.info(s"Pivot refresh produced same root ($newRoot): $reason. No-op — preserving accumulated state.")
+      // BUG fix: when the serve window expired and peers can no longer serve THIS root but the
+      // refresh resolved to the same root (e.g. a scarce snap-peer pool with no newer servable
+      // pivot), returning without notifying the coordinators left their statelessPeers set full
+      // → they re-escalated forever and the node wedged. Re-arm them against the current root so
+      // stateless tracking clears and dispatch resumes. PivotRefreshed is idempotent on an
+      // unchanged root (the handler's `stateRoot = root` is a no-op), so no state is destroyed.
+      log.info(s"Pivot refresh produced same root ($newRoot): $reason. Re-arming coordinators to clear stateless peers.")
+      accountRangeCoordinator.foreach(_ ! actors.Messages.PivotRefreshed(newStateRoot))
+      storageRangeCoordinator.foreach(_ ! actors.Messages.StoragePivotRefreshed(newStateRoot))
       return
     }
 
@@ -3580,6 +3598,21 @@ class SNAPSyncController(
 
     // Update internal state
     pivotBlock = Some(newPivotBlock)
+    // BUG fix: advance the preserved-progress anchor with the live pivot so on-disk range
+    // cursors stay within MaxPreservedPivotDistance of the pivot we restart at. The anchor was
+    // latched once to the ORIGINAL pivot and never advanced, so after many in-place refreshes a
+    // restart found the saved pivot thousands of blocks stale, failed the drift check, and wiped
+    // ~10M accounts of cursors (full keyspace re-scan). Account-trie nodes are content-addressed
+    // (keccak256-keyed), so a traversal cursor is valid across any pivot jump; healing reconciles
+    // the per-leaf delta against the new root.
+    if (preservedAtPivotBlock.isDefined) {
+      preservedAtPivotBlock = Some(newPivotBlock)
+      if (preservedRangeProgress.nonEmpty) {
+        appStateStorage
+          .putSnapSyncProgress(serializeSnapProgress(preservedRangeProgress, newPivotBlock))
+          .commit()
+      }
+    }
     stateRoot = Some(newStateRoot)
     // Bump validationGeneration so any in-flight validation Future's result
     // is dropped on arrival rather than applied against the stale root. The

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -1220,11 +1220,19 @@ class AccountRangeCoordinator(
       // Reset the counter so the next pivot has a fresh budget; preserve task position.
       task.requeueCount = 0
       pendingTasks.enqueue(task)
-      snapSyncController ! PivotStateUnservable(
-        rootHash = stateRoot,
-        reason = s"task ${task.rangeString} hit MaxRequeuesPerTask: $reason",
-        consecutiveEmptyResponses = AccountRangeCoordinator.MaxRequeuesPerTask
-      )
+      // Gate the escalation on pivotRefreshRequested so only the FIRST task to exhaust its
+      // budget escalates per pivot cycle. Without this, all ~16 ranges escalate at once when a
+      // serve window expires, producing a PivotStateUnservable burst (observed ~50 in one log).
+      // pivotRefreshRequested is cleared in the PivotRefreshed handler, so each fresh pivot
+      // gets a fresh escalation.
+      if (!pivotRefreshRequested) {
+        pivotRefreshRequested = true
+        snapSyncController ! PivotStateUnservable(
+          rootHash = stateRoot,
+          reason = s"task ${task.rangeString} hit MaxRequeuesPerTask: $reason",
+          consecutiveEmptyResponses = AccountRangeCoordinator.MaxRequeuesPerTask
+        )
+      }
     } else {
       pendingTasks.enqueue(task)
     }


### PR DESCRIPTION
## Problem
The ETC SNAP node **stalls at ~10M accounts and cannot reach tip.** Two compounding `SNAPSyncController` bugs (root-caused via git archaeology, fix scoped surgically with an adversarial regression check).

## BUG 1 — the stall
The `PivotStateUnservable` handler's 30s "restart guard" was originally a rate-limiter for a **destructive `restartSnapSync`**. When the handler was rewritten to call the **non-destructive `refreshPivotInPlace`** (PR #1032), the throttle was left at the top — so it now silently **swallows legitimate pivot refreshes** on serve-window expiry. Worse, on a scarce snap-peer pool the refresh resolves to the *same root* and hits the same-root no-op `return`, which **returned without notifying coordinators** → their `statelessPeers` set stayed full → they re-escalated forever → the node wedged on a dead pivot (`Ignoring PivotStateUnservable due to restart guard` ×50 in one log).

**Fix:** (a) same-root branch re-arms coordinators (`PivotRefreshed`, idempotent on unchanged root) before returning; (b) the guard branch **debounces** instead of swallowing (re-arms coordinators, no counter touch, no destructive path); (c) `AccountRangeCoordinator.requeueOrEscalate` gates the escalation on `pivotRefreshRequested` so only the first exhausted task escalates per cycle (kills the ~16× burst).

## BUG 2 — re-scan on restart
`preservedAtPivotBlock` was latched once to the **original** pivot and never advanced when the pivot is refreshed. After many in-place refreshes a restart found the saved pivot thousands of blocks stale → failed the `MaxPreservedPivotDistance(256)` drift check → **wiped ~10M account cursors** (full keyspace re-scan, the "16 ranges, 0 complete" + counter reset). **Fix:** advance the anchor with the live pivot and re-persist (account-trie nodes are content-addressed → cursors stay valid across the jump; healing reconciles the per-leaf delta).

## Safety (no regression)
The destructive paths (`restartSnapSync` / `enterDormantMode`) are reachable **only** via the `consecutivePivotRefreshes >= MaxConsecutivePivotRefreshes(10)` branch — **untouched**. The debounce never increments that counter or calls a destructive method, so the dormant-mode backstop still fires under sustained all-stateless conditions. `fallbackToFastSync` is not reachable from this handler.

## Validation
Builds clean; deployed to barad-dûr ETC, resumes SNAP. Live acceptance criterion: cross a serve-window expiry → **one** `PivotStateUnservable` → `Re-arming coordinators` / `Pivot refreshed` → dispatch resumes with **no `Ignoring…` spam and no counter reset**, advancing past ~10M. (Watching now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
