### PR TITLE
fix(it): repoint VMTests fixtures + stabilize E2E handshake + gate it/ in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,18 +126,36 @@ jobs:
         env:
           FUKUII_DEV: true
       
-      - name: Run Ethereum/Tests Integration Tests
+      - name: Run Gating Integration Tests (deterministic subset)
         run: |
-          echo "Running ethereum/tests integration test suite..."
-          sbt "IntegrationTest / testOnly *SimpleEthereumTest *BlockchainTestsSpec"
-          
+          echo "Running the deterministic, gate-able slice of the it/ suite..."
+          # IMPORTANT: enumerate specs explicitly. Only fast, fully-deterministic IT specs belong in
+          # the PR gate. The real-socket networking specs (E2EHandshakeSpec, E2ESyncSpec,
+          # RegularSyncItSpec, FastSyncItSpec, …) bind TCP ports and depend on RLPx/handshake timing
+          # that flakes on shared CI runners — they stay in the nightly only (nightly.yml
+          # `IntegrationTest / testOnly`), never in this gate.
+          #
+          #   ethtest:    SimpleEthereumTest, BlockchainTestsSpec, VMTestsSpec  (EVM compliance)
+          #   txExecTest: ForksTest, ContractTest, ECIP1017Test                 (block exec vs fixtures)
+          #
+          # SlowTest is NOT excluded here: ForksTest/VMTestsSpec are tagged SlowTest but each runs in
+          # well under a minute, and excluding it would skip exactly the specs this gate exists to guard.
+          sbt "IntegrationTest / testOnly \
+            com.chipprbots.ethereum.ethtest.SimpleEthereumTest \
+            com.chipprbots.ethereum.ethtest.BlockchainTestsSpec \
+            com.chipprbots.ethereum.ethtest.VMTestsSpec \
+            com.chipprbots.ethereum.txExecTest.ForksTest \
+            com.chipprbots.ethereum.txExecTest.ContractTest \
+            com.chipprbots.ethereum.txExecTest.ECIP1017Test"
+
           echo ""
-          echo "=== Ethereum/Tests Integration Results ==="
-          echo "Tests validate EVM compliance against official ethereum/tests repository"
+          echo "=== Gating Integration Results ==="
+          echo "EVM compliance (ethereum/tests) + block-execution fixtures (txExecTest) validated."
+          echo "Real-socket networking IT specs run in the nightly only — see nightly.yml."
           echo "See test artifacts for detailed results"
         env:
           FUKUII_DEV: true
-        timeout-minutes: 10
+        timeout-minutes: 15
       
       - name: Upload coverage reports to Codecov
         if: always()

--- a/src/it/scala/com/chipprbots/ethereum/ethtest/VMTestsSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/ethtest/VMTestsSpec.scala
@@ -9,7 +9,8 @@ import com.chipprbots.ethereum.testing.Tags._
 
 /** Test suite for ethereum/tests VMTests category
   *
-  * Runs tests from the GeneralStateTests/VMTests directory of the ethereum/tests repository. These tests validate:
+  * Runs tests from the BlockchainTests/GeneralStateTests/VMTests directory of the ethereum/tests repository (the
+  * blockchain-test-formatted variant of the state VMTests). These tests validate:
   *   - EVM opcode execution
   *   - Stack operations
   *   - Memory operations
@@ -28,10 +29,19 @@ import com.chipprbots.ethereum.testing.Tags._
 class VMTestsSpec extends EthereumTestsSpec {
 
   // Base path for VM tests - configurable via system property or environment variable
+  //
+  // IMPORTANT: point at BlockchainTests/GeneralStateTests/VMTests, NOT GeneralStateTests/VMTests.
+  // The GeneralStateTests/* fixtures are in the *state-test* format (env/post/pre/transaction, with
+  // network encoded as keys of the `post` map and NO top-level `network` field). The BlockchainTest
+  // decoder used here (and the rest of this spec, e.g. test.network) requires the *blockchain-test*
+  // format, which lives under BlockchainTests/GeneralStateTests/VMTests (top-level `network`, `blocks`,
+  // `postState`). Same EVM coverage, correct shape. See GeneralStateTestsSpec for the same rationale.
   private val vmTestsBasePath = sys.props
     .get("vmtests.basePath")
     .orElse(sys.env.get("VMTESTS_BASEPATH"))
-    .getOrElse(new File(System.getProperty("user.dir"), "ets/tests/GeneralStateTests/VMTests").getPath)
+    .getOrElse(
+      new File(System.getProperty("user.dir"), "ets/tests/BlockchainTests/GeneralStateTests/VMTests").getPath
+    )
 
   // Supported networks (pre-Spiral fork only)
   val supportedNetworks = Set(

--- a/src/it/scala/com/chipprbots/ethereum/network/E2EHandshakeSpec.scala
+++ b/src/it/scala/com/chipprbots/ethereum/network/E2EHandshakeSpec.scala
@@ -97,9 +97,14 @@ class E2EHandshakeSpec extends FreeSpecBase with Matchers with BeforeAndAfterAll
           _ <- peer1.startRegularSync()
           _ <- peer2.startRegularSync()
 
-          // Both peers try to connect to each other
+          // Both peers try to connect to each other. The first dial must establish an outgoing
+          // handshake (and persist a known node). The reverse dial is best-effort: the PeerManager
+          // de-duplicates simultaneous connections (canConnectTo / hasIncomingPendingFromHost), so
+          // the reverse outgoing dial is legitimately suppressed once the inbound connection from
+          // the first dial already exists. Asserting a known-node registration for the reverse
+          // direction would be asserting behaviour that correct dedup prevents.
           _ <- peer1.connectToPeers(Set(peer2.node))
-          _ <- peer2.connectToPeers(Set(peer1.node))
+          _ <- peer2.connectToPeersBestEffort(Set(peer1.node))
           _ <- IO.sleep(3.seconds)
         } yield
         // Should handle duplicate connection attempts gracefully

--- a/src/it/scala/com/chipprbots/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/util/CommonFakePeer.scala
@@ -331,14 +331,14 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       _ <- IO(storagesInstance.dataSource.destroy())
     } yield ()
 
-  /** Ask the PeerManager to dial the given nodes and block until every requested node has been
-    * persisted as a known node (which only happens after a successful *outgoing* handshake).
+  /** Ask the PeerManager to dial the given nodes and block until every requested node has been persisted as a known
+    * node (which only happens after a successful *outgoing* handshake).
     *
     * @param maxRetries
-    *   number of 1s poll attempts before failing. Defaults to 15 (~15s) rather than the old 5 (~5s):
-    *   under CI the test forks a fresh JVM per test with metrics enabled, and the RLPx + ETH status
-    *   exchange routinely needs more than 5s to complete and flush through the 1s known-node persist
-    *   interval. The old budget made genesis/slow handshakes time out non-deterministically.
+    *   number of 1s poll attempts before failing. Defaults to 15 (~15s) rather than the old 5 (~5s): under CI the test
+    *   forks a fresh JVM per test with metrics enabled, and the RLPx + ETH status exchange routinely needs more than 5s
+    *   to complete and flush through the 1s known-node persist interval. The old budget made genesis/slow handshakes
+    *   time out non-deterministically.
     */
   def connectToPeers(nodes: Set[Node], maxRetries: Int = 15): IO[Unit] =
     for {
@@ -353,12 +353,11 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       }
     } yield ()
 
-  /** Best-effort variant of [[connectToPeers]] for redundant/reverse dials. When both peers dial
-    * each other simultaneously, the PeerManager's connection de-duplication (`canConnectTo` /
-    * `hasIncomingPendingFromHost`) intentionally suppresses one side's *outgoing* dial in favour of
-    * the inbound connection that already exists. The suppressed side therefore never persists a
-    * known-node entry for that peer — that is correct production behaviour, not a failure. This
-    * helper sends the dial and swallows the resulting timeout so a bidirectional attempt can be
+  /** Best-effort variant of [[connectToPeers]] for redundant/reverse dials. When both peers dial each other
+    * simultaneously, the PeerManager's connection de-duplication (`canConnectTo` / `hasIncomingPendingFromHost`)
+    * intentionally suppresses one side's *outgoing* dial in favour of the inbound connection that already exists. The
+    * suppressed side therefore never persists a known-node entry for that peer — that is correct production behaviour,
+    * not a failure. This helper sends the dial and swallows the resulting timeout so a bidirectional attempt can be
     * exercised without asserting an outbound registration that dedup may legitimately prevent.
     */
   def connectToPeersBestEffort(nodes: Set[Node], maxRetries: Int = 15): IO[Unit] =

--- a/src/it/scala/com/chipprbots/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/com/chipprbots/ethereum/sync/util/CommonFakePeer.scala
@@ -331,18 +331,38 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       _ <- IO(storagesInstance.dataSource.destroy())
     } yield ()
 
-  def connectToPeers(nodes: Set[Node]): IO[Unit] =
+  /** Ask the PeerManager to dial the given nodes and block until every requested node has been
+    * persisted as a known node (which only happens after a successful *outgoing* handshake).
+    *
+    * @param maxRetries
+    *   number of 1s poll attempts before failing. Defaults to 15 (~15s) rather than the old 5 (~5s):
+    *   under CI the test forks a fresh JVM per test with metrics enabled, and the RLPx + ETH status
+    *   exchange routinely needs more than 5s to complete and flush through the 1s known-node persist
+    *   interval. The old budget made genesis/slow handshakes time out non-deterministically.
+    */
+  def connectToPeers(nodes: Set[Node], maxRetries: Int = 15): IO[Unit] =
     for {
       _ <- IO {
         peerManager ! DiscoveredNodesInfo(nodes)
       }
-      _ <- retryUntilWithDelay(IO(storagesInstance.storages.knownNodesStorage.getKnownNodes()), 1.second, 5) {
+      _ <- retryUntilWithDelay(IO(storagesInstance.storages.knownNodesStorage.getKnownNodes()), 1.second, maxRetries) {
         knownNodes =>
           val requestedNodes = nodes.map(_.id)
           val currentNodes = knownNodes.map(Node.fromUri).map(_.id)
           requestedNodes.subsetOf(currentNodes)
       }
     } yield ()
+
+  /** Best-effort variant of [[connectToPeers]] for redundant/reverse dials. When both peers dial
+    * each other simultaneously, the PeerManager's connection de-duplication (`canConnectTo` /
+    * `hasIncomingPendingFromHost`) intentionally suppresses one side's *outgoing* dial in favour of
+    * the inbound connection that already exists. The suppressed side therefore never persists a
+    * known-node entry for that peer — that is correct production behaviour, not a failure. This
+    * helper sends the dial and swallows the resulting timeout so a bidirectional attempt can be
+    * exercised without asserting an outbound registration that dedup may legitimately prevent.
+    */
+  def connectToPeersBestEffort(nodes: Set[Node], maxRetries: Int = 15): IO[Unit] =
+    connectToPeers(nodes, maxRetries).attempt.void
 
   private def createChildBlock(parent: Block, parentWeight: ChainWeight, parentWorld: InMemoryWorldStateProxy)(
       updateWorldForBlock: (BigInt, InMemoryWorldStateProxy) => InMemoryWorldStateProxy

--- a/src/it/scala/com/chipprbots/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/com/chipprbots/ethereum/txExecTest/util/FixtureProvider.scala
@@ -23,6 +23,7 @@ import com.chipprbots.ethereum.mpt.BranchNode
 import com.chipprbots.ethereum.mpt.ExtensionNode
 import com.chipprbots.ethereum.mpt.HashNode
 import com.chipprbots.ethereum.mpt.LeafNode
+import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
 import com.chipprbots.ethereum.mpt.MptNode
 import com.chipprbots.ethereum.network.p2p.messages.ETH63._
 import com.chipprbots.ethereum.utils.Config
@@ -204,6 +205,15 @@ object FixtureProvider {
           .toMap
       )
 
+    // Self-consistency guard (ForksTest follow-up, PR #1294): every block header's stateRoot must
+    // resolve to a node present in stateTree.txt. A corrupted/truncated stateTree.txt (the failure
+    // mode that silently broke ForksTest for ~6 months) leaves a header pointing at a stateRoot that
+    // never appears as a node key, so `prepareStorages.traverse(header.stateRoot)` walks into the
+    // `case _ =>` no-op and the chain executes against an empty/partial trie. Fail loudly here, at
+    // load time, with the exact missing root and block number, instead of producing a confusing
+    // downstream MissingNode/validation error.
+    assertStateTreeConsistent(path, headers, stateTree, contractTrees)
+
     // Match headers and bodies by their hash keys to create blocks
     // Note: We keep both the original hash key and the block for later lookup
     val blocksByOriginalHash = headers.flatMap { case (originalHash, header) =>
@@ -227,4 +237,40 @@ object FixtureProvider {
   private def withClose[A, B <: Closeable](closeable: B)(f: B => A): A =
     try f(closeable)
     finally closeable.close()
+
+  /** Fail fast if any block header references a state root that cannot be resolved to a dumped node.
+    *
+    * This mirrors [[prepareStorages]]'s `traverse` lookup exactly: the root node is resolvable iff it
+    * appears as a key in stateTree.txt or contractTrees.txt. The genesis header (number 0) is exempt
+    * because the empty-trie / pre-allocation root is synthesised by the node rather than dumped.
+    *
+    * A header whose stateRoot is unresolvable means stateTree.txt is truncated or out of sync with
+    * headers.txt — the failure mode that silently broke ForksTest for ~6 months (PR #1294). Catching
+    * it here turns a confusing downstream MissingNode/validation error into an explicit fixture-corruption
+    * report naming the offending block number and root.
+    */
+  private def assertStateTreeConsistent(
+      path: String,
+      headers: Map[ByteString, BlockHeader],
+      stateTree: Map[ByteString, MptNode],
+      contractTrees: Map[ByteString, MptNode]
+  ): Unit = {
+    val emptyRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)
+    val missing = headers.values
+      .filter(_.number > 0)
+      .filterNot(_.stateRoot == emptyRoot) // an all-empty state needs no dumped node
+      .filterNot(header => stateTree.contains(header.stateRoot) || contractTrees.contains(header.stateRoot))
+      .map(header => header.number -> Hex.toHexString(header.stateRoot.toArray))
+      .toSeq
+      .sortBy(_._1)
+
+    if (missing.nonEmpty) {
+      val details = missing.map { case (number, root) => s"  block $number -> stateRoot 0x$root" }.mkString("\n")
+      throw new IllegalStateException(
+        s"Corrupt txExecTest fixture at '$path': ${missing.size} block header(s) reference a stateRoot " +
+          s"with no matching node in stateTree.txt. The fixture is truncated or out of sync with " +
+          s"headers.txt and cannot reproduce the chain:\n$details"
+      )
+    }
+  }
 }

--- a/src/it/scala/com/chipprbots/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/com/chipprbots/ethereum/txExecTest/util/FixtureProvider.scala
@@ -240,14 +240,14 @@ object FixtureProvider {
 
   /** Fail fast if any block header references a state root that cannot be resolved to a dumped node.
     *
-    * This mirrors [[prepareStorages]]'s `traverse` lookup exactly: the root node is resolvable iff it
-    * appears as a key in stateTree.txt or contractTrees.txt. The genesis header (number 0) is exempt
-    * because the empty-trie / pre-allocation root is synthesised by the node rather than dumped.
+    * This mirrors [[prepareStorages]]'s `traverse` lookup exactly: the root node is resolvable iff it appears as a key
+    * in stateTree.txt or contractTrees.txt. The genesis header (number 0) is exempt because the empty-trie /
+    * pre-allocation root is synthesised by the node rather than dumped.
     *
-    * A header whose stateRoot is unresolvable means stateTree.txt is truncated or out of sync with
-    * headers.txt — the failure mode that silently broke ForksTest for ~6 months (PR #1294). Catching
-    * it here turns a confusing downstream MissingNode/validation error into an explicit fixture-corruption
-    * report naming the offending block number and root.
+    * A header whose stateRoot is unresolvable means stateTree.txt is truncated or out of sync with headers.txt — the
+    * failure mode that silently broke ForksTest for ~6 months (PR #1294). Catching it here turns a confusing downstream
+    * MissingNode/validation error into an explicit fixture-corruption report naming the offending block number and
+    * root.
     */
   private def assertStateTreeConsistent(
       path: String,


### PR DESCRIPTION
Fixes the remaining nightly failures (VMTestsSpec fixture-path, E2EHandshakeSpec test-design/timing) — both test/fixture issues, fukuii's code is correct — and adds two guardrails: a FixtureProvider state-tree self-consistency assertion + a deterministic it/ subset in the PR gate (so drift like the ForksTest corruption and this VMTests path is caught pre-merge, not in nightly). Real-socket specs stay nightly-only. Companion to #1294 (ForksTest fixture) and #1293 (fast-distro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)