### PR TITLE
fix(snap): unstick proactive pivot-roll on offset=0 + resume cursors instead of re-walk

### DIFF
--- a/ops/barad-dur/fukuii-conf-1/etc.conf
+++ b/ops/barad-dur/fukuii-conf-1/etc.conf
@@ -34,10 +34,13 @@ fukuii {
       # deferred-merkleization run on the same harness.
       use-stack-trie = true
 
-      # Pivot at network tip (offset=0) maximises the SNAP serve window.
-      # Proactive refresh fires at 120-block drift well before the 128-block
-      # cliff where peers stop serving the chosen state.
-      pivot-block-offset = 0
+      # Offset the pivot 64 blocks behind the network tip. Rolling the pivot TO the
+      # live tip (offset=0) is unservable: core-geth peers index their snapshot
+      # ~128 blocks behind head, so a tip-root readiness probe returns "not indexed"
+      # forever and the pivot freezes (observed 2026-06-01: stalled 70+ min at 16.8M
+      # accounts). head-64 lands inside the indexed serve window; the proactive roll
+      # (fires at >100-block drift) keeps the pivot in the [64,100] age band.
+      pivot-block-offset = 64
 
       max-pivot-staleness-blocks = 4096
       request-timeout = 60.seconds

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -101,7 +101,23 @@ class SNAPSyncController(
   // hasn't drifted too far (within MaxPreservedPivotDistance blocks).
   private var preservedRangeProgress: Map[ByteString, ByteString] = Map.empty
   private var preservedAtPivotBlock: Option[BigInt] = None
-  private val MaxPreservedPivotDistance: BigInt = 256
+  // Resume saved account-range cursors across this much pivot drift before falling back to a
+  // full re-walk. Raised from 256 (~55 min ETC) to 50_000 (~1 week ETC) on 2026-06-01: the 256
+  // cap forced a full re-walk of ~16.8M accounts after a 404-block drift, even though FULLY-
+  // COMPLETE ranges are content-addressed and valid across ANY drift and the healing walk from
+  // the new pivot root reconciles the changed-account delta. The cap is now only a perf heuristic
+  // (very large drift => large healing delta where a cold re-walk may be comparable), NOT a
+  // correctness boundary. Correctness comes from: (a) only FULLY-COMPLETE ranges are resumed —
+  // partial ranges re-download from start because the StackTrie cannot resume mid-range (see
+  // AccountRangeCoordinator); and (b) `resumedStaleCursors` forces the healing walk even under
+  // deferred-merkleization.
+  private val MaxPreservedPivotDistance: BigInt = 50_000
+
+  // Set true whenever account-range cursors were resumed from a prior session (resumeProgress
+  // non-empty). Forces StateHealing to run at completion (overriding the deferred-merkleization
+  // skip-healing fast path) so a delta downloaded against a drifted root is never handed off
+  // unwalked. This is the single load-bearing anti-corruption guard for cursor resume.
+  private var resumedStaleCursors: Boolean = false
 
   // Geth-aligned: all 3 coordinators run concurrently from first account response.
   // accountsComplete is set when AccountRangeSyncComplete arrives and NoMore sentinels are sent.
@@ -176,6 +192,15 @@ class SNAPSyncController(
   // Rolling proactively at 100 blocks preserves all downloaded state (unlike go-ethereum).
   private var lastProactivePivotBlock: Option[BigInt] = None
   private val SnapServeWindowBlocks: BigInt = BigInt(100)
+
+  // Roll target margin: a proactive/reactive roll picks networkBest - max(pivotBlockOffset,
+  // SnapServeWindowMargin) so the new root lands INSIDE peers' indexed snapshot window.
+  // Rolling to the live tip (pivot-block-offset=0) probes a root core-geth peers haven't
+  // indexed yet (their snapshot lags head by ~128 blocks) → readiness probe returns
+  // "not indexed" forever → the pivot freezes (observed 2026-06-01: ETC stalled 70+ min
+  // at 16.8M accounts). Margin ≈ half the serve window keeps the new pivot servable with
+  // ~50 blocks of runway before it ages past the 100-block roll trigger.
+  private val SnapServeWindowMargin: BigInt = BigInt(50)
 
   // Pivot readiness probe: before committing a proactive pivot roll, we probe one peer with
   // the candidate root. Only if the peer's snapshot is indexed (returns ≥1 account) do we
@@ -1301,7 +1326,7 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
-      if (SNAPSyncController.shouldSkipHealingAfterDownloads(snapSyncConfig, storagePhaseForceCompleted)) {
+      if (SNAPSyncController.shouldSkipHealingAfterDownloads(snapSyncConfig, storagePhaseForceCompleted, resumedStaleCursors)) {
         // With deferred merkleization, trie nodes were never constructed during download —
         // only flat storage was written. A trie walk would find the entire internal trie "missing",
         // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).
@@ -2673,6 +2698,10 @@ class SNAPSyncController(
         Map.empty
     }
 
+    // Resuming cursors from a prior session ⇒ force the healing walk at completion (see flag decl).
+    // Latch: once set, never cleared for the life of this process.
+    if (resumeProgress.nonEmpty) resumedStaleCursors = true
+
     val storage = getOrCreateMptStorage(currentPivot)
 
     accountRangeCoordinator = Some(
@@ -2902,7 +2931,10 @@ class SNAPSyncController(
         currentNetworkBestFromSnapPeers().foreach { networkBest =>
           val pivotAge = networkBest - pivotBlock.get
           val recentlyRolled = lastProactivePivotBlock.exists(last => (networkBest - last) <= BigInt(50))
-          if (pivotAge > SnapServeWindowBlocks && !recentlyRolled && pivotProbeRequestId.isEmpty) {
+          if (
+            pivotAge > SnapServeWindowBlocks && !recentlyRolled &&
+            pivotProbeRequestId.isEmpty && pendingProbeCommit.isEmpty
+          ) {
             val now = System.currentTimeMillis
             if (now - lastProbeAttemptMs >= ProbeCooldownMs) {
               // Mark that this refresh needs a readiness probe before notifying coordinators.
@@ -2913,7 +2945,13 @@ class SNAPSyncController(
                   s"network=$networkBest age=$pivotAge — readiness probe will fire after header fetch"
               )
               proactiveRollNeedsProbe = true
-              probeAttemptCount = 0 // fresh probe cycle for this roll
+              // Do NOT reset probeAttemptCount here. This branch re-enters every
+              // ProbeCooldownMs to re-probe after a deferral; resetting the counter each
+              // time pinned it at "attempt 1/5" forever, so the force-roll valve in the
+              // probe-response (line ~518) and timeout (line ~786) handlers never fired and
+              // a transient probe failure became a permanent stall (observed 2026-06-01).
+              // The counter is already reset to 0 at the end of every cycle (success or
+              // forced roll), so a genuinely new roll still starts fresh.
               lastProbeAttemptMs = now
               refreshPivotInPlace("proactive pivot roll")
             }
@@ -3422,7 +3460,13 @@ class SNAPSyncController(
                 false
             }
           }
-          .map(networkBest => networkBest - snapSyncConfig.pivotBlockOffset)
+          // Back the roll target off the live tip by at least SnapServeWindowMargin so the
+          // new root is one peers have actually indexed. pivotBlockOffset stays a floor (a
+          // larger configured offset still wins). Rolling to networkBest exactly (offset=0)
+          // froze the ETC pivot on 2026-06-01 — peers return "not indexed" for the tip root.
+          // NOTE: the post-merge (CL-anchored) branch above has the same latent issue at
+          // offset=0; deferred — it fires rarely and has its own freshness-floor handling.
+          .map(networkBest => networkBest - BigInt(snapSyncConfig.pivotBlockOffset).max(SnapServeWindowMargin))
           .filter(_ > 0)
     }
 
@@ -3622,7 +3666,8 @@ class SNAPSyncController(
     // any code path that mutates pivot/root from a different phase.
     validationGeneration += 1
     lastProactivePivotBlock =
-      pivotBlock.map(_ + 64) // approximate networkBest at roll time; pivotBlock = networkBest-64
+      // approximate networkBest at roll time; pivotBlock = networkBest - max(offset, margin)
+      pivotBlock.map(_ + BigInt(snapSyncConfig.pivotBlockOffset).max(SnapServeWindowMargin))
     // Note: mptStorage stays the same — content-addressed nodes don't need re-tagging.
     // The backing storage was already created for the original pivot block number,
     // but since nodes are keyed by hash, they're valid for any root.
@@ -4279,9 +4324,15 @@ object SNAPSyncController {
 
   private[snap] def shouldSkipHealingAfterDownloads(
       snapSyncConfig: SNAPSyncConfig,
-      storagePhaseForceCompleted: Boolean
+      storagePhaseForceCompleted: Boolean,
+      resumedStaleCursors: Boolean
   ): Boolean =
-    snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted
+    // The deferred-merkleization fast path (skip healing, lazy-heal during block execution) is
+    // ONLY safe when the trie was built fresh this session. If any account-range cursor was
+    // resumed from a prior session (against a possibly drifted root), the delta MUST be walked
+    // and re-fetched from the current pivot root before completion — otherwise the state is
+    // handed off with silent holes. So a resume forces the full healing walk.
+    snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted && !resumedStaleCursors
 
   /** Freshness gate for `refreshPivotInPlace`: reject candidate pivots whose source peer is more than `maxStaleness`
     * blocks behind the CL-driven head.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1326,7 +1326,13 @@ class SNAPSyncController(
       accountsComplete && bytecodePhaseComplete && storagePhaseComplete &&
       currentPhase != StateHealing && currentPhase != ChainDownloadCompletion && currentPhase != Completed
     ) {
-      if (SNAPSyncController.shouldSkipHealingAfterDownloads(snapSyncConfig, storagePhaseForceCompleted, resumedStaleCursors)) {
+      if (
+        SNAPSyncController.shouldSkipHealingAfterDownloads(
+          snapSyncConfig,
+          storagePhaseForceCompleted,
+          resumedStaleCursors
+        )
+      ) {
         // With deferred merkleization, trie nodes were never constructed during download —
         // only flat storage was written. A trie walk would find the entire internal trie "missing",
         // taking hours to scan and failing to heal (peers can't serve the full trie via GetTrieNodes).

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -270,13 +270,22 @@ class AccountRangeCoordinator(
           task.next = task.last
           task.done = true
           task
-        case Some(savedNext) if savedNext != task.next =>
-          log.info(
-            s"Resuming range ${task.rangeString} from saved position ${savedNext.take(4).toArray.map("%02x".format(_)).mkString}"
-          )
-          task.next = savedNext
+        case Some(savedNext) =>
+          // Partial range: the mid-range cursor is NOT safe to resume on the StackTrie path.
+          // The per-task SnapHashTrie is in-memory + write-only and was lost on restart; a fresh
+          // StackTrie resuming from `savedNext` would cover only [savedNext, last), orphaning the
+          // already-downloaded prefix (whose root/right-spine were never persisted — only the
+          // 8MiB-flushed left subtrees survived) and seaming an old-root prefix to a new-root
+          // suffix. Re-download the whole range from its pristine start (task.next is left
+          // untouched). Cheap — only the few in-flight ranges, not the completed ones. The
+          // healing walk from the new pivot reconciles any delta across the COMPLETE ranges.
+          if (savedNext != task.next)
+            log.info(
+              s"Re-downloading partial range ${task.rangeString} from start " +
+                "(saved mid-range cursor is not StackTrie-safe to resume)"
+            )
           task
-        case _ => task
+        case None => task
       }
     }
     val (done, todo) = resumed.partition(_.done)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -165,7 +165,8 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
 
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = config,
-      storagePhaseForceCompleted = false
+      storagePhaseForceCompleted = false,
+      resumedStaleCursors = false
     ) shouldBe true
   }
 
@@ -174,7 +175,21 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
 
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = config,
-      storagePhaseForceCompleted = true
+      storagePhaseForceCompleted = true,
+      resumedStaleCursors = false
+    ) shouldBe false
+  }
+
+  it should "force healing when account cursors were resumed, even with clean deferred merkleization" taggedAs UnitTest in {
+    val config = SNAPSyncConfig(deferredMerkleization = true)
+
+    // A resume of saved cursors (possibly against a drifted pivot root) must never take the
+    // skip-healing fast path — otherwise the changed-account delta is handed off unwalked =
+    // silent state corruption. The healing walk from the new root re-fetches the delta.
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = config,
+      storagePhaseForceCompleted = false,
+      resumedStaleCursors = true
     ) shouldBe false
   }
 
@@ -924,27 +939,27 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
   }
 
   // -----------------------------------------------------------------------
-  // Category 2b: 256-Block Safety Valve — AccountRangeProgress preservation
+  // Category 2b: Account-range cursor preservation across pivot drift
   // -----------------------------------------------------------------------
-  // SNAPSyncController stores AccountRangeProgress on coordinator shutdown and
-  // re-passes it when spawning the next coordinator — BUT only if the pivot hasn't
-  // drifted more than MaxPreservedPivotDistance (256) blocks.  Stale progress would
-  // point workers into keyspace that no longer represents the current state root,
-  // so it must be discarded when the chain has moved significantly.
-  // Reference: SNAPSyncController.scala startAccountRangeCoordinator() lines 2041-2086
-  // Cross-reference: Bitcoin headers_sync_chainwork_tests.cpp too_little_work (stale-progress rejection)
+  // SNAPSyncController stores AccountRangeProgress on coordinator shutdown and re-passes it
+  // when spawning the next coordinator IF the pivot drifted ≤ MaxPreservedPivotDistance.
+  // Raised from 256 to 50_000 on 2026-06-01: FULLY-COMPLETE ranges are content-addressed and
+  // valid across ANY drift, and the healing walk from the new root reconciles the changed-account
+  // delta (forced via `resumedStaleCursors`). The cap is now a perf heuristic, NOT a correctness
+  // boundary. Partial ranges are re-downloaded from start (the StackTrie cannot resume mid-range —
+  // see AccountRangeCoordinator). Beyond the cap, the whole saved map is discarded (cold re-walk).
+  // Reference: SNAPSyncController.scala launchAccountRangeWorkers()
 
-  "AccountRangeProgress 256-block safety valve" should "honor saved progress when pivot advances ≤ 256 blocks" taggedAs UnitTest in {
-    // MaxPreservedPivotDistance is a private val = 256 inside SNAPSyncController.
-    // Its value is established here as the preservation semantics test.
-    val MaxPreservedPivotDistance: BigInt = 256
+  "Account-range cursor preservation" should "honor saved progress when pivot drift ≤ MaxPreservedPivotDistance" taggedAs UnitTest in {
+    // MaxPreservedPivotDistance is a private val = 50_000 inside SNAPSyncController.
+    val MaxPreservedPivotDistance: BigInt = 50_000
     val prevPivot: BigInt = BigInt(1_000_000)
     val savedProgress: Map[ByteString, ByteString] = Map(
       ByteString("last1") -> ByteString("next1"),
       ByteString("last2") -> ByteString("next2")
     )
 
-    val currentPivot: BigInt = prevPivot + 100
+    val currentPivot: BigInt = prevPivot + 404 // the 2026-06-01 stall drift — now preserved, not re-walked
     val drift = (currentPivot - prevPivot).abs
     drift should be <= MaxPreservedPivotDistance
 
@@ -955,33 +970,33 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers {
     resumeProgress shouldBe savedProgress
   }
 
-  it should "discard saved progress and restart from task.last when pivot advances > 256 blocks" taggedAs UnitTest in {
-    val MaxPreservedPivotDistance: BigInt = 256
+  it should "discard saved progress (cold re-walk) when pivot drift > MaxPreservedPivotDistance" taggedAs UnitTest in {
+    val MaxPreservedPivotDistance: BigInt = 50_000
     val prevPivot: BigInt = BigInt(1_000_000)
     val savedProgress: Map[ByteString, ByteString] = Map(
       ByteString("last1") -> ByteString("next1"),
       ByteString("last2") -> ByteString("next2")
     )
 
-    val currentPivot: BigInt = prevPivot + 300
+    val currentPivot: BigInt = prevPivot + 60_000
     val drift = (currentPivot - prevPivot).abs
     drift should be > MaxPreservedPivotDistance
 
-    // Controller discards progress — coordinator restarts each range from task.last
+    // Controller discards progress — coordinator restarts each range from its start
     val resumeProgress =
       if (drift <= MaxPreservedPivotDistance) savedProgress
       else Map.empty[ByteString, ByteString]
     resumeProgress shouldBe Map.empty[ByteString, ByteString]
   }
 
-  it should "treat exactly 256 blocks drift as within the window and 257 as outside" taggedAs UnitTest in {
-    val MaxPreservedPivotDistance: BigInt = 256
+  it should "treat exactly MaxPreservedPivotDistance drift as within the window and one beyond as outside" taggedAs UnitTest in {
+    val MaxPreservedPivotDistance: BigInt = 50_000
     val prevPivot: BigInt = BigInt(5_000_000)
 
-    // Boundary: exactly 256 is still preserved
-    ((prevPivot + 256 - prevPivot).abs <= MaxPreservedPivotDistance) shouldBe true
+    // Boundary: exactly 50_000 is still preserved
+    ((prevPivot + 50_000 - prevPivot).abs <= MaxPreservedPivotDistance) shouldBe true
     // One beyond boundary: discarded
-    ((prevPivot + 257 - prevPivot).abs <= MaxPreservedPivotDistance) shouldBe false
+    ((prevPivot + 50_001 - prevPivot).abs <= MaxPreservedPivotDistance) shouldBe false
   }
 
   // -----------------------------------------------------------------------

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -1284,21 +1284,18 @@ class AccountRangeCoordinatorSpec
     system.stop(coord)
   }
 
-  it should "honour resumeProgress on the StackTrie path (Step 6 — restart durability)" taggedAs UnitTest in {
-    // Step 6 of the snap-stacktrie-port plan: verify resume cursors work with
-    // useStackTrie = true. The existing `AccountRangeProgress` →
-    // `putSnapSyncProgress` flow already journals per-task cursors to RocksDB;
-    // on restart, the controller passes `resumeProgress` into the coordinator
-    // and each task's `next` is advanced past where the prior session left off.
-    // For the StackTrie path this is sufficient: SnapHashTrie instances are
-    // re-created from scratch (content-addressed nodes on disk remain valid),
-    // and sort enforcement is satisfied because resumed `next` is monotonically
-    // ascending vs. any prior in-memory state (there is none after restart).
+  it should "re-download a PARTIAL range from start on the StackTrie path (2026-06-01 restart-durability fix)" taggedAs UnitTest in {
+    // A partial range's saved mid-range cursor is NOT safe to resume on the StackTrie path:
+    // the per-task SnapHashTrie is in-memory + write-only and lost on restart, so a fresh trie
+    // resuming from `next` would cover only [next, last), orphaning the already-downloaded prefix
+    // (root/right-spine never persisted) and seaming an old-root prefix to a new-root suffix.
+    // The coordinator therefore re-downloads partial ranges from their pristine start; the healing
+    // walk from the new pivot root reconciles any delta across the COMPLETE ranges.
     val root = kec256(ByteString("stacktrie-resume-root"))
-    // With concurrency = 1 the single AccountTask covers the entire 32-byte
-    // hash space, so its `last` boundary is the maximum 32-byte value.
+    // With concurrency = 1 the single AccountTask covers the entire 32-byte hash space.
     val rangeLast = AccountTask.MaxHash32
-    val resumedNext = ByteString(Array.fill[Byte](32)(0x77.toByte)) // mid-range
+    val resumedNext = ByteString(Array.fill[Byte](32)(0x77.toByte)) // mid-range (partial)
+    val pristineStart = AccountTask.createInitialTasks(root, 1).head.next
 
     val coord = TestActorRef[AccountRangeCoordinator](
       AccountRangeCoordinator.props(
@@ -1315,15 +1312,44 @@ class AccountRangeCoordinatorSpec
     )
     val ua = coord.underlyingActor
 
-    // The single range's task.next must have been advanced to `resumedNext`,
-    // not the canonical zero-start; sort-enforcement on the per-task
-    // SnapHashTrie will work because every future insert is > resumedNext.
+    // The partial range is re-queued from its pristine start (NOT the mid-range cursor),
+    // so a fresh SnapHashTrie covers the full [start, last) range with a real left boundary.
     val pending = ua.pendingTasks.toList
     pending should have size 1
-    pending.head.next shouldEqual resumedNext
+    pending.head.next shouldEqual pristineStart
+    pending.head.next should not equal resumedNext
     pending.head.last shouldEqual rangeLast
 
     // No SnapHashTrie has been instantiated yet (lazy creation on first chunk).
+    ua.taskStackTries shouldBe empty
+
+    system.stop(coord)
+  }
+
+  it should "SKIP a fully-complete range on resume (committed last session, valid across any drift)" taggedAs UnitTest in {
+    // A range whose saved cursor reached its `last` boundary had commit() called last session,
+    // so its full subtrie is on disk as correct content-addressed nodes — valid across any pivot
+    // drift. It is skipped (not re-downloaded), leaving nothing pending for a single-range coord.
+    val root = kec256(ByteString("stacktrie-resume-complete-root"))
+    val rangeLast = AccountTask.MaxHash32
+
+    val coord = TestActorRef[AccountRangeCoordinator](
+      AccountRangeCoordinator.props(
+        stateRoot = root,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        concurrency = 1,
+        snapSyncController = TestProbe().ref,
+        resumeProgress = Map(rangeLast -> rangeLast), // savedNext == last => fully complete
+        accountTrieEcOverride = Some(system.dispatcher),
+        useStackTrie = true
+      )
+    )
+    val ua = coord.underlyingActor
+
+    // The completed range is skipped, so nothing remains to download.
+    ua.pendingTasks.toList shouldBe empty
     ua.taskStackTries shouldBe empty
 
     system.stop(coord)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinatorSpec.scala
@@ -1317,7 +1317,7 @@ class AccountRangeCoordinatorSpec
     val pending = ua.pendingTasks.toList
     pending should have size 1
     pending.head.next shouldEqual pristineStart
-    pending.head.next should not equal resumedNext
+    (pending.head.next should not).equal(resumedNext)
     pending.head.last shouldEqual rangeLast
 
     // No SnapHashTrie has been instantiated yet (lazy creation on first chunk).


### PR DESCRIPTION
## What

Two SNAP-sync stall fixes, validated live on ETC mainnet (2026-06-01). The node had frozen at **16.8M accounts**; both are fixed and it is syncing past it.

### 1. Proactive pivot-roll froze on `pivot-block-offset=0`
With offset 0 the proactive roll targets the **live head**, whose state root core-geth peers index ~128 blocks behind → the readiness probe returns `"not indexed"` forever and the pivot ages out of the serve window (account tasks then return 0-account proof-of-absence). Compounded by `probeAttemptCount = 0` being reset on **every** stagnation tick, which pinned the force-roll backstop at "attempt 1/5" so it never fired. The roll worked for ~14 cycles overnight, then froze for 70+ min when the probed peer stopped serving the tip root.

**Fix:**
- Roll target = `networkBest - max(pivotBlockOffset, SnapServeWindowMargin=50)` (pre-merge branch) so the new root lands inside peers' indexed snapshot window; `pivotBlockOffset` stays a floor.
- Stop resetting `probeAttemptCount` on re-entry so the force-roll valve fires after `MaxProbeAttempts`.
- `ops/barad-dur/fukuii-conf-1/etc.conf`: `pivot-block-offset 0 → 64`.

### 2. Restart re-walked 16.8M accounts instead of resuming
A restart after the stall **discarded all account-range cursors** because the pivot had drifted 404 > `MaxPreservedPivotDistance=256`, forcing a full re-walk — even though the 16.8M accounts were intact on disk (content-addressed).

**Fix** (correctness-reviewed via a 4-agent adversarial investigation):
- Resume **fully-complete** ranges across any drift (they're committed + content-addressed, valid regardless of pivot); raise the cap `256 → 50_000` (~1 week ETC).
- Re-download **partial** ranges from start — the in-memory write-only StackTrie cannot resume mid-range (would orphan the prefix + seam old-root/new-root).
- **Force the healing walk** whenever cursors were resumed (`resumedStaleCursors`), overriding the `deferred-merkleization` skip-healing fast path. The healing walk from the new root re-fetches the changed-account delta.

## Why this is safe
The load-bearing safety was never the 256 cap — it's the **healing walk** (content-addressed ⟹ "on-disk hashes to new root" ≡ "no missing nodes"; the walk is fail-closed and loops until 0 missing). The cap only mattered because `deferred-merkleization=true` *skips* that walk. Forcing the walk after a resume makes relaxing the cap safe; without it, a resumed delta would be handed off unwalked = silent corruption. Storage rides on the same walk (changed storage roots reconciled via `walkStorageTrieDFS`).

## Tests
- `shouldSkipHealingAfterDownloads` now 3-arg; added a "force-heal-on-resume" case.
- `MaxPreservedPivotDistance` boundary tests updated to 50_000.
- StackTrie resume test now asserts partial → re-download-from-start; added a complete-range-skip test.

## Validation
- **Pivot-offset fix**: deployed live; the first proactive roll succeeded (`probe block head-64 → ready → pivot advanced`), account download resumed servable, `WEDGE=0` over hours.
- **Cursor-resume fix**: compile-verified (main + all tests); deploys at the next node restart (can't recover the already-discarded cursors, but prevents future re-walks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
