### PR TITLE
test(blockfetcher): de-flake "always forming chain" via order-independent fishFor

### DIFF
--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -256,22 +256,23 @@ class BlockFetcherSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfter
       val firstGetBlockBodiesResponse: ETH66BlockBodies = ETH66BlockBodies(0, firstBlocksBatch.map(_.body))
       refForAnswerFirstBodiesReq ! PeersClient.Response(fakePeer, firstGetBlockBodiesResponse)
 
-      // Third headers + second bodies requests should now be in flight.
-      peersClient.expectMsgPF() { case PeersClient.Request(_: ETH66GetBlockHeaders, _, _) =>
-        peersClient.lastSender
-      }
-
-      val refForAnswerSecondBodiesReq: org.apache.pekko.actor.ActorRef = peersClient.expectMsgPF() {
-        case PeersClient.Request(_: ETH66GetBlockBodies, _, _) =>
-          peersClient.lastSender
-      }
+      // Third headers + second bodies requests are both in flight; their arrival order is
+      // non-deterministic (two independent ask -> IO -> pipeToSelf hops on the shared IORuntime),
+      // so a bare expectMsgPF expecting the headers request first raced the order and flaked in
+      // release CI — when bodies arrived first the headers PF hit a MatchError. We only need the
+      // bodies sender (to answer it); the prefetch headers request is incidental here (never
+      // answered), so fish for the bodies request specifically and tolerate it in any position.
+      val refForAnswerSecondBodiesReq: org.apache.pekko.actor.ActorRef =
+        peersClient.fishForSpecificMessage(Timeouts.normalTimeout) {
+          case PeersClient.Request(_: ETH66GetBlockBodies, _, _) => peersClient.lastSender
+        }
       peersClient.send(
         refForAnswerSecondBodiesReq,
         PeersClient.Response(fakePeer, ETH66BlockBodies(0, alternativeSecondBlocksBatch.drop(6).map(_.body)))
       )
 
       importer.send(blockFetcher.toClassic, PickBlocks(syncConfig.blocksBatchSize, importer.ref))
-      importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
+      importer.expectMsgPF(Timeouts.normalTimeout) { case BlockFetcher.PickedBlocks(blocks) =>
         val headers = blocks.map(_.header).toList
         assert(HeadersSeq.areChain(headers))
       }


### PR DESCRIPTION
## What

De-flakes `BlockFetcherSpec` "should ensure blocks passed to importer are always forming chain" — the one genuine, release-gating test flake surviving a 4-agent recon of the suite.

## Why it flaked

The test is **untagged**, so it runs in release Tier1/Tier2. It used a bare `expectMsgPF` expecting the **3rd-headers** request before the **2nd-bodies** request — but those arrive in non-deterministic order (two independent `ask -> IO -> pipeToSelf` hops on the shared `IORuntime.global`). When bodies arrived first, the headers partial function hit a `MatchError` → failure. The 3s pekko `single-expect-default` (no override exists in test resources) tightened the race under CI load.

## Fix

The test only needs the **bodies sender** (to answer it); the prefetch headers request is incidental here (never answered). So:
- Fish for the bodies request specifically (`fishForSpecificMessage(Timeouts.normalTimeout)` — a pattern already used elsewhere in this same file), tolerating the headers request in any arrival position.
- Give the final `PickedBlocks` chain assertion a 5s timeout instead of the 3s default.

No coverage lost — the `HeadersSeq.areChain` assertion is unchanged.

## Verification

Forming-chain test passed **8/8 consecutive runs** locally (compile-clean + `testOnly *BlockFetcherSpec -- -z "forming chain"`).

## Scope note

This was the only real code-fixable flake from the recon. Others were already-fixed (`PeerManagerSpec:912` on staging, `PeerEventBusActorSpec`), contradicted (Hive Prague/Osaka are green), or declined (a global ScalaCheck seed-pin trades away property-test coverage). Separately surfaced (not in this PR): the scalafmt "Check formatting" gate is ~46% of recent red CI (autofix land-order), and the Hive `ethereum/sync` interop flake is infra (60s checktimelimit vs JVM cold-start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
