### PR TITLE
fix(engine,hive): unblock hive sync — Engine API binds before ETH RPC + checktimelimit 120s

### DIFF
--- a/.github/workflows/_hive-sim.yml
+++ b/.github/workflows/_hive-sim.yml
@@ -258,7 +258,12 @@ jobs:
             --client "$CLIENTS"
             --sim.parallelism "$PARALLELISM"
             --sim.timelimit "$SIM_TIMELIMIT"
-            --client.checktimelimit=60s
+            # 120s (was 60s): fukuii is a JVM client whose cold class-load + JIT
+            # warmup can consume most of a 60s budget before the sink reaches the
+            # sync target, tipping slow fukuii-sink sync tests over the deadline.
+            # Benign for native clients (geth/nethermind respond well within 60s);
+            # the timeout only matters when a client is genuinely slow to get ready.
+            --client.checktimelimit=120s
             --loglevel 3
           )
           [ -n "$SIM_LIMIT" ]   && args+=(--sim.limit   "$SIM_LIMIT")

--- a/hive/fukuii/fukuii.sh
+++ b/hive/fukuii/fukuii.sh
@@ -157,11 +157,16 @@ if [ -n "$HIVE_MINER" ]; then
     FLAGS="$FLAGS -Dfukuii.mining.coinbase=$HIVE_MINER"
 fi
 
+# Hive clients are ephemeral: one short sync run, then discarded. Cap JIT at C1
+# (-XX:TieredStopAtLevel=1) so the JVM reaches readiness fast — full C2 optimization
+# never pays off in a single 3000-block sync and only lengthens cold-start, which is
+# what tips slow fukuii-sink sync tests over hive's --client.checktimelimit.
 exec java \
     -Xmx512m \
     -Xms128m \
     -Xss2M \
     -XX:+UseG1GC \
+    -XX:TieredStopAtLevel=1 \
     -XX:MaxMetaspaceSize=256m \
     -XX:+ExitOnOutOfMemoryError \
     $FLAGS \

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -56,11 +56,19 @@ abstract class BaseNode extends Node {
     startPeerManager()
     startDiscoveryManager()
 
-    // Phase 3: API servers (user-facing, ready as early as possible)
+    // Phase 3: API servers (user-facing, ready as early as possible).
+    // Bind the Engine API (8551) BEFORE the ETH JSON-RPC (8545). Hive's client-readiness
+    // check (and a real CL) probes the ETH RPC, then immediately drives sync via the Engine
+    // API. The Engine API runs on an isolated ActorSystem and `startEngineApiServer()` Await-
+    // blocks until 8551 is actually bound — so binding it first guarantees 8551 is listening
+    // by the time 8545 (the readiness signal) comes up. With the old order, hive declared the
+    // node ready on 8545 and the sim's engine_newPayloadV3 hit 8551 before it had bound →
+    // "connection refused" → instant sync failure (hive ethereum/sync "sync fukuii from
+    // go-ethereum", 2026-06-01). No-op when the Engine API is disabled (e.g. ETC mainnet).
+    startEngineApiServer()
     startJsonRpcHttpServer()
     startJsonRpcWsServer()
     startJsonRpcIpcServer()
-    startEngineApiServer()
 
     // Phase 5: Background work
     startSyncController()


### PR DESCRIPTION
## What

Hardens the Hive `ethereum/sync` interop tests — the only fukuii-gating hive surface that still flakes the build (it gates every `staging→main` release, and has since the #1183 wave).

## Root cause (infra, not protocol)

fukuii is a **JVM** hive client. Its cold class-load + JIT warmup can consume most of hive's `--client.checktimelimit=60s` before the sink reaches the sync target, tipping the slow fukuii-**sink** tests (`sync fukuii from go-ethereum`, `sync fukuii from fukuii`, `sync nethermind from fukuii`) over the deadline. `parallelism=1` already removed CPU contention; this finishes the job. (Distinct from the 2 *protocol-broken* tests that stay `gate_excluded`.)

## Changes

1. **`_hive-sim.yml`: `--client.checktimelimit` `60s → 120s`** — 2× budget for JVM cold-start + the 3000-block sync. Benign for native clients (geth/nethermind respond well within 60s); the timeout only bites a genuinely-slow client.
2. **`hive/fukuii/fukuii.sh`: add `-XX:TieredStopAtLevel=1`** — hive clients are ephemeral (one short sync, then discarded), so cap JIT at C1 to reach readiness fast; full C2 optimization never pays off in a single 3000-block sync and only lengthens cold-start.

## Validation

PRs to `staging` don't run hive (it triggers on PRs to `main`), so validated by **dispatching the `hive-sync` workflow on this branch** — confirming the slow fukuii-sink tests no longer trip the deadline. Result linked in a comment.

If any test still flakes after this, the fallback is the existing `gate_exclude` mechanism. The fast (~4-6s) handshake-race failure mode, if it recurs, is a separate follow-up (hive adapter handshake-await).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: root-caused the remaining gated failure (`sync fukuii from go-ethereum`)

The first hive-sync dispatch **validated the timeout fix** (`sync nethermind from fukuii` took 65 s and PASSED — would have failed at the old 60 s). The one remaining gated failure, `sync fukuii from go-ethereum`, turned out **not** to be a timeout or a protocol bug:

```
sync failed: Post "http://172.17.0.5:8551": dial tcp 172.17.0.5:8551: connect: connection refused
```

fukuii's **Engine API (8551) wasn't bound** when the sim sent the first `engine_newPayloadV3`. `StdNode.start()` bound the ETH RPC (8545) *before* the Engine API (8551, last), and hive's readiness check is on 8545 — so hive declared the node ready and the sim hit 8551 before its (isolated-ActorSystem) HTTP server had bound. fukuii syncs fine from nethermind/fukuii sources because the timing happened to win there.

**Second commit (`fix(engine):`)** reorders `startEngineApiServer()` before `startJsonRpcHttpServer()`. Since `startEngineApiServer()` Await-blocks until 8551 is bound, 8545 (the readiness signal) now only comes up after 8551 is listening. This benefits any CL, not just hive, and is a no-op when the Engine API is disabled (ETC mainnet). Re-dispatched hive-sync to confirm.