### PR TITLE
fix(sync): ETH68 bootstrap TD inflation — forward-walk chain weight repair

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightRepair.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightRepair.scala
@@ -1,0 +1,104 @@
+package com.chipprbots.ethereum.blockchain.sync
+
+import com.chipprbots.ethereum.domain.ChainWeight
+import com.chipprbots.ethereum.domain.BlockchainReader
+import com.chipprbots.ethereum.domain.BlockchainWriter
+import com.chipprbots.ethereum.utils.Logger
+
+/** Repairs inflated chain weights caused by the ETH68 bootstrap TD seeding.
+  *
+  * During SNAP sync, `updateBestBlockForPivot` seeds the pivot block's chain weight from the peer's advertised
+  * best-block TD (STATUS message). On a PoW chain the peer's TD at their head exceeds the pivot's canonical TD by
+  * roughly `(peerHead - pivot) × avgDifficulty`. This inflated value is stored for the pivot and inherited by every
+  * subsequent block import.
+  *
+  * This class corrects the inflation with a forward walk: starting from the last pre-pivot block whose chain weight was
+  * computed correctly (by block processing), it recomputes each block's TD as `TD[n-1] + difficulty[n]` and overwrites
+  * the stored value. The walk stops at `endBlock`.
+  *
+  * The repair is O(n) in the number of blocks from pivot to head. On ETC mainnet (~50K blocks per day, pivot typically
+  * 50–200 blocks behind head) this completes in well under a second.
+  *
+  * If the pre-pivot header or its chain weight is not yet available (e.g. backfill hasn't reached that point), the
+  * repair is deferred. It will be attempted again on the next restart.
+  */
+class ChainWeightRepair(
+    blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter
+) extends Logger {
+
+  /** Attempt to repair chain weights from `pivotBlock` to `endBlock`.
+    *
+    * @return
+    *   Right(count) — number of blocks corrected; Left(msg) — deferred with reason.
+    */
+  def repairFrom(pivotBlock: BigInt, endBlock: BigInt): Either[String, Int] = {
+    if (pivotBlock <= 0) {
+      log.debug("Chain weight repair: pivot is genesis, no ETH68 inflation possible")
+      return Right(0)
+    }
+
+    val prePivotNum = pivotBlock - 1
+    val prePivotHeader =
+      blockchainReader.getBlockHeaderByNumber(prePivotNum)
+    val prePivotWeight =
+      prePivotHeader.flatMap(h => blockchainReader.getChainWeightByHash(h.hash))
+
+    (prePivotHeader, prePivotWeight) match {
+      case (Some(_), Some(weight)) =>
+        log.info(
+          "Chain weight repair: walking forward from block {} (anchorTD={}) to {}",
+          prePivotNum,
+          weight.totalDifficulty,
+          endBlock
+        )
+        walkForward(pivotBlock, weight.totalDifficulty, endBlock)
+
+      case (None, _) =>
+        Left(
+          s"Chain weight repair deferred: block $prePivotNum header not available " +
+            s"(backfill may not have reached pivot yet)"
+        )
+
+      case (Some(_), None) =>
+        Left(
+          s"Chain weight repair deferred: block $prePivotNum chain weight not stored " +
+            s"(block may not have been fully imported yet)"
+        )
+    }
+  }
+
+  private def walkForward(fromBlock: BigInt, anchorTD: BigInt, toBlock: BigInt): Either[String, Int] = {
+    var prevTD = anchorTD
+    var block = fromBlock
+    var corrected = 0
+    var missingHeader = false
+
+    while (block <= toBlock && !missingHeader) {
+      blockchainReader.getBlockHeaderByNumber(block) match {
+        case None =>
+          log.warn(
+            "Chain weight repair: block {} header missing; stopping at {} blocks corrected",
+            block,
+            corrected
+          )
+          missingHeader = true
+
+        case Some(header) =>
+          val correctTD = prevTD + header.difficulty
+          blockchainWriter.storeChainWeight(header.hash, ChainWeight.totalDifficultyOnly(correctTD)).commit()
+          prevTD = correctTD
+          corrected += 1
+      }
+      block += 1
+    }
+
+    if (missingHeader)
+      Left(
+        s"Chain weight repair partial: corrected $corrected blocks up to ${block - 1}, " +
+          s"stopped at first missing header"
+      )
+    else
+      Right(corrected)
+  }
+}

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -909,6 +909,50 @@ class SyncController(
     }
   }
 
+  /** Attempt to correct ETH68-inflated chain weights before starting regular sync.
+    *
+    * The ETH68 STATUS handshake seeds the SNAP pivot block's TD from the peer's advertised best-block TD, which
+    * includes blocks the pivot has not yet reached. This inflated TD propagates to every subsequent block import. The
+    * repair walks forward from the pre-pivot block (whose TD was computed correctly by block processing) and rewrites
+    * TDs through `bestBlockNumber`. If pre-pivot headers are not yet available (backfill in progress) the repair is
+    * deferred to the next restart.
+    *
+    * Operator escape hatch: set system property `fukuii.reset-chain-weight-repair=true` to clear the done flag and
+    * re-run the repair.
+    */
+  private def runChainWeightRepairIfNeeded(): Unit = {
+    if (sys.props.get("fukuii.reset-chain-weight-repair").contains("true")) {
+      appStateStorage.clearEth68ChainWeightRepairDone().commit()
+      log.info("[CHAIN-WEIGHT-REPAIR] Done flag cleared by operator — will re-run repair")
+    }
+    if (appStateStorage.isEth68ChainWeightRepairDone()) return
+
+    appStateStorage.getSnapSyncPivotBlock() match {
+      case None =>
+        // No SNAP pivot — fast sync path, no ETH68 inflation possible
+        appStateStorage.setEth68ChainWeightRepairDone().commit()
+
+      case Some(pivotBlock) =>
+        val bestBlock = blockchainReader.getBestBlockNumber()
+        val repair = new ChainWeightRepair(blockchainReader, blockchainWriter)
+        repair.repairFrom(pivotBlock, bestBlock) match {
+          case Right(0) =>
+            log.info("[CHAIN-WEIGHT-REPAIR] No blocks needed correction (pivot=genesis or no inflation)")
+            appStateStorage.setEth68ChainWeightRepairDone().commit()
+          case Right(count) =>
+            log.info(
+              "[CHAIN-WEIGHT-REPAIR] Corrected {} block TDs from pivot {} to best {}",
+              count,
+              pivotBlock,
+              bestBlock
+            )
+            appStateStorage.setEth68ChainWeightRepairDone().commit()
+          case Left(reason) =>
+            log.warning("[CHAIN-WEIGHT-REPAIR] Deferred: {} — will retry on next restart", reason)
+        }
+    }
+  }
+
   def startFastSync(): Unit = {
     syncGeneration += 1
     val fastSync = context.actorOf(
@@ -988,6 +1032,7 @@ class SyncController(
   }
 
   def startRegularSync(resumeBackfill: Boolean = true): ActorRef = {
+    runChainWeightRepairIfNeeded()
     syncGeneration += 1
     val peersClient =
       context.actorOf(

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/AppStateStorage.scala
@@ -381,6 +381,22 @@ class AppStateStorage(val dataSource: DataSource) extends TransactionalKeyValueS
       toUpsert = Nil
     )
 
+  // ====================================================
+  // ETH68 bootstrap TD inflation repair gate (Group B)
+  // ====================================================
+
+  /** True once ChainWeightRepair has successfully corrected inflated TDs from a SNAP pivot. One-shot: cleared only by
+    * explicit operator action (system property `fukuii.reset-chain-weight-repair=true`).
+    */
+  def isEth68ChainWeightRepairDone(): Boolean =
+    get(Keys.Eth68ChainWeightRepairDone).contains("true")
+
+  def setEth68ChainWeightRepairDone(): DataSourceBatchUpdate =
+    put(Keys.Eth68ChainWeightRepairDone, "true")
+
+  def clearEth68ChainWeightRepairDone(): DataSourceBatchUpdate =
+    remove(Keys.Eth68ChainWeightRepairDone)
+
   /** True iff SNAP is done AND a backfill target was previously persisted AND any of the three cursors is below the
     * target. `SyncController.start()` uses this to spawn a standalone `ChainDownloader` alongside regular sync.
     */
@@ -425,6 +441,8 @@ object AppStateStorage {
     val BackfillBestHeader = "BackfillBestHeader"
     val BackfillBestBody = "BackfillBestBody"
     val BackfillBestReceipt = "BackfillBestReceipt"
+    // ETH68 bootstrap TD inflation repair
+    val Eth68ChainWeightRepairDone = "Eth68ChainWeightRepairDone"
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightRepairSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightRepairSpec.scala
@@ -1,0 +1,104 @@
+package com.chipprbots.ethereum.blockchain.sync
+
+import org.apache.pekko.util.ByteString
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.db.dataSource.DataSourceBatchUpdate
+import com.chipprbots.ethereum.domain.{BlockHeader, BlockchainReader, BlockchainWriter, ChainWeight => CW}
+import com.chipprbots.ethereum.testing.Tags._
+
+class ChainWeightRepairSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  private def fakeHash(n: Int): ByteString =
+    ByteString(Array.fill(31)(0.toByte) :+ n.toByte)
+
+  private def hdr(number: BigInt, difficulty: BigInt): BlockHeader =
+    BlockHeader(
+      parentHash = fakeHash((number - 1).toInt.max(0)),
+      ommersHash = ByteString(Array.fill(32)(0.toByte)),
+      beneficiary = ByteString(Array.fill(20)(0.toByte)),
+      stateRoot = ByteString(Array.fill(32)(0.toByte)),
+      transactionsRoot = ByteString(Array.fill(32)(0.toByte)),
+      receiptsRoot = ByteString(Array.fill(32)(0.toByte)),
+      logsBloom = ByteString(Array.fill(256)(0.toByte)),
+      difficulty = difficulty,
+      number = number,
+      gasLimit = 8000000L,
+      gasUsed = 0L,
+      unixTimestamp = number.toLong * 13L,
+      extraData = ByteString.empty,
+      mixHash = ByteString(Array.fill(32)(0.toByte)),
+      nonce = ByteString(Array.fill(8)(0.toByte))
+    )
+
+  // Stub batch that silently accepts commit() calls
+  private def batch(): DataSourceBatchUpdate = stub[DataSourceBatchUpdate]
+
+  // ── tests ──────────────────────────────────────────────────────────────────
+
+  "ChainWeightRepair" should "correct inflated pivot and subsequent block TDs via forward walk" taggedAs UnitTest in {
+    val diff = BigInt(100)
+    val hdrs = (0 to 4).map(i => hdr(i, diff))
+
+    val reader = mock[BlockchainReader]
+    val writer = mock[BlockchainWriter]
+
+    // Pre-pivot (block 1) correctly stored with TD = 200
+    (reader.getBlockHeaderByNumber _).expects(BigInt(1)).returning(Some(hdrs(1)))
+    (reader.getChainWeightByHash _).expects(hdrs(1).hash).returning(Some(CW.totalDifficultyOnly(diff * 2)))
+
+    // Walk blocks 2, 3, 4
+    (reader.getBlockHeaderByNumber _).expects(BigInt(2)).returning(Some(hdrs(2)))
+    (reader.getBlockHeaderByNumber _).expects(BigInt(3)).returning(Some(hdrs(3)))
+    (reader.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(hdrs(4)))
+
+    // Corrected TDs: 300, 400, 500
+    (writer.storeChainWeight _).expects(hdrs(2).hash, CW.totalDifficultyOnly(diff * 3)).returning(batch())
+    (writer.storeChainWeight _).expects(hdrs(3).hash, CW.totalDifficultyOnly(diff * 4)).returning(batch())
+    (writer.storeChainWeight _).expects(hdrs(4).hash, CW.totalDifficultyOnly(diff * 5)).returning(batch())
+
+    new ChainWeightRepair(reader, writer).repairFrom(pivotBlock = 2, endBlock = 4) shouldBe Right(3)
+  }
+
+  it should "return Right(0) when pivot is genesis (block 0)" taggedAs UnitTest in {
+    new ChainWeightRepair(mock[BlockchainReader], mock[BlockchainWriter])
+      .repairFrom(pivotBlock = 0, endBlock = 0) shouldBe Right(0)
+  }
+
+  it should "return Left when pre-pivot header is absent (backfill not yet reached pivot)" taggedAs UnitTest in {
+    val reader = mock[BlockchainReader]
+    (reader.getBlockHeaderByNumber _).expects(BigInt(4)).returning(None)
+
+    new ChainWeightRepair(reader, mock[BlockchainWriter])
+      .repairFrom(pivotBlock = 5, endBlock = 10) shouldBe a[Left[_, _]]
+  }
+
+  it should "return Left when pre-pivot chain weight is not stored" taggedAs UnitTest in {
+    val reader = mock[BlockchainReader]
+    val prePivot = hdr(4, BigInt(100))
+    (reader.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(prePivot))
+    (reader.getChainWeightByHash _).expects(prePivot.hash).returning(None)
+
+    new ChainWeightRepair(reader, mock[BlockchainWriter])
+      .repairFrom(pivotBlock = 5, endBlock = 10) shouldBe a[Left[_, _]]
+  }
+
+  it should "handle a single-block correction (pivot == endBlock)" taggedAs UnitTest in {
+    val diff = BigInt(200)
+    val hdrs = (0 to 1).map(i => hdr(i, diff))
+    val reader = mock[BlockchainReader]
+    val writer = mock[BlockchainWriter]
+
+    (reader.getBlockHeaderByNumber _).expects(BigInt(0)).returning(Some(hdrs(0)))
+    (reader.getChainWeightByHash _).expects(hdrs(0).hash).returning(Some(CW.totalDifficultyOnly(diff)))
+    (reader.getBlockHeaderByNumber _).expects(BigInt(1)).returning(Some(hdrs(1)))
+    (writer.storeChainWeight _).expects(hdrs(1).hash, CW.totalDifficultyOnly(diff * 2)).returning(batch())
+
+    new ChainWeightRepair(reader, writer).repairFrom(pivotBlock = 1, endBlock = 1) shouldBe Right(1)
+  }
+}


### PR DESCRIPTION
## What

After SNAP sync completes, the pivot block's stored chain weight is seeded from the peer's STATUS-advertised best-block TD. On a PoW chain this exceeds the pivot's canonical TD by approximately `(peerHead - pivot) × avgDifficulty`. Every subsequent block import inherits this inflation — all stored TDs are wrong.

**Four files:** `ChainWeightRepair.scala` (new, 104L), `SyncController.scala` (+45L), `AppStateStorage.scala` (+18L), `ChainWeightRepairSpec.scala` (new, 5 tests).

---

## Root cause

`SNAPSyncController.updateBestBlockForPivot()` seeds pivot TD from `bestSnapPeerTD` (the peer's STATUS-advertised best-block TD):

```scala
.orElse(peerTD.filter(_ > BigInt(0)).map(td => (td, "ETH68_BOOTSTRAP")))
```

The peer's TD at their head includes difficulty from blocks the pivot hasn't reached yet. Example: pivot at block 20,000,000, peer head at block 21,000,000 with avg difficulty 2,000 → TD inflated by 2,000,000,000.

---

## Fix

`ChainWeightRepair` runs once at `SyncController.startRegularSync`, before the regular sync actors start:

1. Find the last pre-pivot block whose TD was computed correctly by block processing
2. Walk forward: `TD[n] = TD[n-1] + header.difficulty` for every block from pivot to current best
3. Overwrite each stored chain weight with the corrected value
4. Set `Eth68ChainWeightRepairDone` in AppStateStorage (one-shot gate)

If the pre-pivot header is not yet available (backfill still in progress), repair is deferred with a warning log. It will succeed on the next restart once backfill has progressed.

**Operator escape hatch:** `-Dfukuii.reset-chain-weight-repair=true` clears the done flag and re-runs the repair.

---

## Tests

`ChainWeightRepairSpec` (5 tests):
- Corrects inflated pivot + subsequent TDs via forward walk
- Right(0) at genesis pivot (no inflation possible)
- Left when pre-pivot header absent (deferred)
- Left when pre-pivot chain weight not stored (deferred)
- Single-block correction (pivot == endBlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)