### PR TITLE
fix(snap): replace traversePath range proof with trie reconstruction

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
@@ -16,10 +16,9 @@ import scala.annotation.unused
 /** Merkle proof verifier for SNAP sync.
   *
   * Verifies SNAP range proofs using trie reconstruction (go-ethereum VerifyRangeProof algorithm):
-  *   1. Build a partial trie by resolving both boundary key paths from proof nodes.
-  *   2. Prune internal nodes between the boundaries (unsetInternal equivalent).
-  *   3. Re-insert all response leaves and hash the result.
-  *   4. Compare the reconstructed root hash with the expected root.
+  *   1. Build a partial trie by resolving both boundary key paths from proof nodes. 2. Prune internal nodes between the
+  *      boundaries (unsetInternal equivalent). 3. Re-insert all response leaves and hash the result. 4. Compare the
+  *      reconstructed root hash with the expected root.
   *
   * @param rootHash
   *   Expected root hash (state root for accounts, storage root for slots).
@@ -87,20 +86,19 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       proofMap: Map[ByteString, MptNode]
   ): Either[String, Unit] = {
     // Validate: monotonically strictly increasing keys, no empty values
-    for (i <- 0 until leaves.length - 1) {
+    for (i <- 0 until leaves.length - 1)
       if (cmpBytes(leaves(i)._1, leaves(i + 1)._1) >= 0)
         return Left("range is not monotonically increasing")
-    }
     if (leaves.exists(_._2.isEmpty))
       return Left("range contains deletion (empty value)")
 
     // Edge case B: proof present, zero leaves — proof of absence
     if (leaves.isEmpty) {
       val rootNode = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
-      val trie     = new PartialProofTrie(rootNode, proofMap)
+      val trie = new PartialProofTrie(rootNode, proofMap)
       trie.resolveEdge(hashToNibbles(firstKey), allowNonExistent = true) match {
         case Left(err) => return Left(err)
-        case Right(())  => ()
+        case Right(()) => ()
       }
       return if (hasRightElement(trie.root, hashToNibbles(firstKey)))
         Left("more entries available")
@@ -114,39 +112,39 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     // Special case: single element where firstKey == lastKey (existent proof)
     if (leaves.length == 1 && firstKey == lastKey) {
       val rootNode = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
-      val trie     = new PartialProofTrie(rootNode, proofMap)
+      val trie = new PartialProofTrie(rootNode, proofMap)
       trie.resolveEdge(hashToNibbles(firstKey), allowNonExistent = false) match {
         case Left(err) => return Left(err)
-        case Right(())  => ()
+        case Right(()) => ()
       }
       trie.insertLeaf(hashToNibbles(leaves.head._1), leaves.head._2)
       val computed = trie.computeHash()
       return if (computed == rootHash) Right(())
-             else Left(s"single-element range proof hash mismatch")
+      else Left(s"single-element range proof hash mismatch")
     }
 
     if (cmpBytes(firstKey, lastKey) >= 0) return Left("invalid edge keys")
     if (firstKey.length != lastKey.length) return Left("inconsistent edge key lengths")
 
     val firstNibbles = hashToNibbles(firstKey)
-    val lastNibbles  = hashToNibbles(lastKey)
-    val rootNode     = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
-    val trie         = new PartialProofTrie(rootNode, proofMap)
+    val lastNibbles = hashToNibbles(lastKey)
+    val rootNode = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
+    val trie = new PartialProofTrie(rootNode, proofMap)
 
     // Phase 1: resolve both edge paths into the partial trie
     trie.resolveEdge(firstNibbles, allowNonExistent = true) match {
       case Left(err) => return Left(err)
-      case Right(())  => ()
+      case Right(()) => ()
     }
     trie.resolveEdge(lastNibbles, allowNonExistent = true) match {
       case Left(err) => return Left(err)
-      case Right(())  => ()
+      case Right(()) => ()
     }
 
     // Phase 2: prune internal nodes between boundaries
     trie.pruneInternals(firstNibbles, lastNibbles) match {
       case Left(err) => return Left(err)
-      case Right(())  => ()
+      case Right(()) => ()
     }
 
     // Phase 3: insert all leaves
@@ -163,9 +161,9 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
   /** Mutable-state wrapper around an immutable MptNode tree.
     *
     * Implements the three phases of geth VerifyRangeProof:
-    *   - resolveEdge  → proofToPath
+    *   - resolveEdge → proofToPath
     *   - pruneInternals → unsetInternal + unset
-    *   - insertLeaf  → MPT put (without storage)
+    *   - insertLeaf → MPT put (without storage)
     */
   private class PartialProofTrie(initialRoot: MptNode, proofMap: Map[ByteString, MptNode]) {
     var root: MptNode = initialRoot
@@ -189,7 +187,11 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
     // ── Phase 1: resolveEdgePath ─────────────────────────────────────────────
 
-    private def resolveEdgePath(node: MptNode, remaining: Seq[Int], allowNonExistent: Boolean): Either[String, MptNode] = {
+    private def resolveEdgePath(
+        node: MptNode,
+        remaining: Seq[Int],
+        allowNonExistent: Boolean
+    ): Either[String, MptNode] = {
       val resolved = node match {
         case HashNode(bytes) =>
           proofMap.get(ByteString(bytes)) match {
@@ -209,7 +211,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
         case branch: BranchNode =>
           val nibble = remaining.head
-          val child  = branch.children(nibble)
+          val child = branch.children(nibble)
           child match {
             case NullNode if allowNonExistent => Right(branch)
             case NullNode                     => Left("node not in trie (null child at boundary path)")
@@ -241,8 +243,8 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       node match {
         case ext: ExtensionNode =>
           val sharedNibbles = toNibbleSeq(ext.sharedKey)
-          val forkLeft      = comparePrefix(left, pos, sharedNibbles)
-          val forkRight     = comparePrefix(right, pos, sharedNibbles)
+          val forkLeft = comparePrefix(left, pos, sharedNibbles)
+          val forkRight = comparePrefix(right, pos, sharedNibbles)
           if (forkLeft == 0 && forkRight == 0) {
             findForkAndPrune(ext.next, left, right, pos + sharedNibbles.length).map { newNext =>
               ExtensionNode(ext.sharedKey, newNext)
@@ -264,16 +266,21 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
         case other => Right(other)
       }
 
-    private def handleBranchFork(branch: BranchNode, left: Seq[Int], right: Seq[Int], pos: Int): Either[String, MptNode] = {
-      val leftNibble  = left(pos)
+    private def handleBranchFork(
+        branch: BranchNode,
+        left: Seq[Int],
+        right: Seq[Int],
+        pos: Int
+    ): Either[String, MptNode] = {
+      val leftNibble = left(pos)
       val rightNibble = right(pos)
       // Null out all children strictly between the two boundary nibbles
       var b = branch
       for (i <- leftNibble + 1 until rightNibble)
         b = b.updateChild(i, NullNode)
       for {
-        newLeftChild  <- pruneOneSide(b.children(leftNibble),  left,  pos + 1, removeLeft = false)
-        b2             = b.updateChild(leftNibble, newLeftChild)
+        newLeftChild <- pruneOneSide(b.children(leftNibble), left, pos + 1, removeLeft = false)
+        b2 = b.updateChild(leftNibble, newLeftChild)
         newRightChild <- pruneOneSide(b2.children(rightNibble), right, pos + 1, removeLeft = true)
       } yield b2.updateChild(rightNibble, newRightChild)
     }
@@ -339,7 +346,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
         case ext: ExtensionNode =>
           val sharedNibbles = toNibbleSeq(ext.sharedKey)
-          val keySlice      = key.drop(pos).take(sharedNibbles.length)
+          val keySlice = key.drop(pos).take(sharedNibbles.length)
           if (keySlice != sharedNibbles) {
             // Extension's path diverges from boundary key: sibling check
             val cmp = compareNibbleSeqs(sharedNibbles, keySlice)
@@ -353,7 +360,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
         case leaf: LeafNode =>
           // Either the boundary leaf itself (remove → will be re-inserted) or a sibling
           val leafNibbles = toNibbleSeq(leaf.key)
-          val remaining   = key.drop(pos)
+          val remaining = key.drop(pos)
           if (leafNibbles == remaining) {
             Right(NullNode) // boundary leaf: remove and re-insert in phase 3
           } else {
@@ -379,7 +386,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
           if (keyNibbles.isEmpty) {
             BranchNode(branch.children.clone(), Some(value))
           } else {
-            val nibble   = keyNibbles.head
+            val nibble = keyNibbles.head
             val newChild = doInsertLeaf(branch.children(nibble), keyNibbles.tail, value)
             branch.updateChild(nibble, newChild)
           }
@@ -396,7 +403,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     // Port of MerklePatriciaTrie.putInLeafNode (stripped of NodeInsertResult / storage)
     private def insertIntoLeaf(leaf: LeafNode, keyNibbles: Seq[Int], value: ByteString): MptNode = {
       val existingNibbles = toNibbleSeq(leaf.key)
-      val ml              = matchingLength(existingNibbles, keyNibbles)
+      val ml = matchingLength(existingNibbles, keyNibbles)
 
       if (ml == existingNibbles.length && ml == keyNibbles.length) {
         // Exact key match: replace value
@@ -414,9 +421,9 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
       } else {
         // Common prefix of length ml: wrap in extension → branch
-        val prefix         = keyNibbles.take(ml)
+        val prefix = keyNibbles.take(ml)
         val existingSuffix = existingNibbles.drop(ml)
-        val newKeySuffix   = keyNibbles.drop(ml)
+        val newKeySuffix = keyNibbles.drop(ml)
         val b0 =
           if (existingSuffix.isEmpty) BranchNode.withValueOnly(leaf.value.toArray)
           else {
@@ -431,7 +438,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     // Port of MerklePatriciaTrie.putInExtensionNode (stripped of NodeInsertResult / storage)
     private def insertIntoExtension(ext: ExtensionNode, keyNibbles: Seq[Int], value: ByteString): MptNode = {
       val sharedNibbles = toNibbleSeq(ext.sharedKey)
-      val ml            = matchingLength(sharedNibbles, keyNibbles)
+      val ml = matchingLength(sharedNibbles, keyNibbles)
 
       if (ml == 0) {
         // No common prefix: convert extension to branch
@@ -449,7 +456,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       } else {
         // Partial match at ml: split extension into prefix + branch
         val commonPrefix = sharedNibbles.take(ml)
-        val extSuffix    = sharedNibbles.drop(ml)
+        val extSuffix = sharedNibbles.drop(ml)
         val newKeySuffix = keyNibbles.drop(ml)
         val extTailChild =
           if (extSuffix.length == 1) ext.next
@@ -466,10 +473,10 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
   // Port of go-ethereum hasRightElement: true if any trie element exists lexicographically
   // after keyNibbles in the resolved partial trie.
   private def hasRightElement(node: MptNode, keyNibbles: Seq[Int]): Boolean = {
-    var current   = node
+    var current = node
     var remaining = keyNibbles
-    var found     = false
-    while (current != null && !found) {
+    var found = false
+    while (current != null && !found)
       current match {
         case branch: BranchNode =>
           if (remaining.nonEmpty) {
@@ -477,7 +484,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
             if ((n + 1 until 16).exists(!branch.children(_).isNull)) {
               found = true
             } else {
-              current   = branch.children(n)
+              current = branch.children(n)
               remaining = remaining.tail
             }
           } else {
@@ -490,7 +497,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
             found = compareNibbleSeqs(sharedNibbles, remaining.take(sharedNibbles.length)) > 0
             current = null
           } else {
-            current   = ext.next
+            current = ext.next
             remaining = remaining.drop(sharedNibbles.length)
           }
 
@@ -498,7 +505,6 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
         case _ => current = null
       }
-    }
     found
   }
 
@@ -508,7 +514,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     bs.toArray.toSeq.map(_ & 0xff)
 
   private def hashToNibbles(hash: ByteString): Seq[Int] =
-    hash.flatMap { byte => Seq((byte >> 4) & 0x0f, byte & 0x0f) }.map(_.toInt)
+    hash.flatMap(byte => Seq((byte >> 4) & 0x0f, byte & 0x0f)).map(_.toInt)
 
   // comparePrefix: compare key.drop(pos).take(len) vs ref nibbles.
   // Returns 0 if equal, negative if key-slice < ref or too short, positive if key-slice > ref.
@@ -525,7 +531,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
   private def compareNibbleSeqs(a: Seq[Int], b: Seq[Int]): Int = {
     val len = math.min(a.length, b.length)
-    var i   = 0
+    var i = 0
     while (i < len) {
       val d = a(i) - b(i)
       if (d != 0) return d
@@ -543,7 +549,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
   private def cmpBytes(a: ByteString, b: ByteString): Int = {
     val aa = a.toArray
     val bb = b.toArray
-    var i  = 0
+    var i = 0
     while (i < math.min(aa.length, bb.length)) {
       val d = (aa(i) & 0xff) - (bb(i) & 0xff)
       if (d != 0) return d
@@ -562,7 +568,7 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     }
 
   private def buildProofMap(nodes: Seq[MptNode]): Map[ByteString, MptNode] =
-    nodes.map { node => ByteString(node.hash) -> node }.toMap
+    nodes.map(node => ByteString(node.hash) -> node).toMap
 
   // ─── Legacy traversal methods (dead code — kept for reference, not called) ──
 
@@ -580,8 +586,8 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       expectedAccount: Account
   ): Either[String, Unit] =
     proofMap.get(currentHash) match {
-      case None                         => Right(())
-      case Some(leafNode: LeafNode)     => verifyLeafAccount(leafNode, expectedAccount)
+      case None                     => Right(())
+      case Some(leafNode: LeafNode) => verifyLeafAccount(leafNode, expectedAccount)
       case Some(branchNode: BranchNode) =>
         if (path.isEmpty) {
           branchNode.terminator match {
@@ -630,7 +636,9 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     if (proofNodes.isEmpty) return Left("Empty proof")
     val firstNodeHash = ByteString(proofNodes.head.hash)
     if (firstNodeHash != rootHash)
-      Left(s"Proof root mismatch: got ${firstNodeHash.take(4).toArray.map("%02x".format(_)).mkString}... expected ${rootHash.take(4).toArray.map("%02x".format(_)).mkString}...")
+      Left(
+        s"Proof root mismatch: got ${firstNodeHash.take(4).toArray.map("%02x".format(_)).mkString}... expected ${rootHash.take(4).toArray.map("%02x".format(_)).mkString}..."
+      )
     else Right(())
   }
 
@@ -656,8 +664,9 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       case Some(branchNode: BranchNode) =>
         if (path.isEmpty) {
           branchNode.terminator match {
-            case Some(value) => if (value == expectedValue) Right(()) else Left("Storage value mismatch at branch terminator")
-            case None        => Left("Path ended at branch without terminator")
+            case Some(value) =>
+              if (value == expectedValue) Right(()) else Left("Storage value mismatch at branch terminator")
+            case None => Left("Path ended at branch without terminator")
           }
         } else {
           val nextIndex = path.head

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
@@ -9,85 +9,40 @@ import com.chipprbots.ethereum.mpt.LeafNode
 import com.chipprbots.ethereum.mpt.ExtensionNode
 import com.chipprbots.ethereum.mpt.BranchNode
 import com.chipprbots.ethereum.mpt.HashNode
+import com.chipprbots.ethereum.mpt.NullNode
 import com.chipprbots.ethereum.utils.Logger
 import scala.annotation.unused
 
-/** Merkle proof verifier for SNAP sync
+/** Merkle proof verifier for SNAP sync.
   *
-  * Verifies Merkle Patricia Trie proofs for account ranges and storage ranges received during SNAP sync. Follows
-  * core-geth implementation patterns from eth/protocols/snap/sync.go
-  *
-  * The verification process:
-  *   1. Decode proof nodes from their RLP-encoded form 2. Build a partial trie from the proof nodes 3. Verify that
-  *      accounts/storage slots exist in the trie at expected paths 4. Verify the trie root matches the expected root
-  *      (state root or storage root)
+  * Verifies SNAP range proofs using trie reconstruction (go-ethereum VerifyRangeProof algorithm):
+  *   1. Build a partial trie by resolving both boundary key paths from proof nodes.
+  *   2. Prune internal nodes between the boundaries (unsetInternal equivalent).
+  *   3. Re-insert all response leaves and hash the result.
+  *   4. Compare the reconstructed root hash with the expected root.
   *
   * @param rootHash
-  *   Expected root hash to verify against (state root or storage root)
+  *   Expected root hash (state root for accounts, storage root for slots).
   */
 class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
-  /** Verify an account range response with Merkle proof
-    *
-    * This method verifies that:
-    *   1. The proof is valid and forms a proper Merkle Patricia Trie path 2. All accounts in the range are present in
-    *      the proof 3. The proof root matches the expected state root
-    *
-    * @param accounts
-    *   Accounts to verify (hash -> account)
-    * @param proof
-    *   Merkle proof nodes (RLP-encoded)
-    * @param startHash
-    *   Starting hash of the range
-    * @param endHash
-    *   Ending hash of the range
-    * @return
-    *   Either error message or Unit on success
-    */
+  // ─── Public API ────────────────────────────────────────────────────────────
+
   def verifyAccountRange(
       accounts: Seq[(ByteString, Account)],
       proof: Seq[ByteString],
-      @unused startHash: ByteString,
-      @unused endHash: ByteString
+      startHash: ByteString,
+      endHash: ByteString
   ): Either[String, Unit] = {
-
-    if (proof.isEmpty && accounts.isEmpty) {
-      return Right(())
-    }
-
-    // If we have accounts, we need a proof
-    if (proof.isEmpty && accounts.nonEmpty) {
-      return Left(s"Missing proof for ${accounts.size} accounts")
-    }
-
+    if (proof.isEmpty && accounts.isEmpty) return Right(())
     try {
-      // Decode proof nodes
-      val proofNodes = decodeProofNodes(proof)
-
-      // Build proof map: hash -> node
-      val proofMap = buildProofMap(proofNodes)
-
-      // Verify each account is in the proof
-      val verificationResults = accounts.map { case (accountHash, account) =>
-        verifyAccountInProof(accountHash, account, proofMap) match {
-          case Left(error) =>
-            Left(s"Account ${accountHash.take(4).toArray.map("%02x".format(_)).mkString} verification failed: $error")
-          case Right(_) => Right(())
-        }
+      val leaves = accounts.map { case (h, a) => h -> ByteString(Account.accountSerializer.toBytes(a)) }
+      if (proof.isEmpty) {
+        // Nil proof: full trie response, verify by streaming hash (geth: StackTrie path)
+        return verifyCompleteRange(leaves)
       }
-
-      // Check if any verification failed
-      verificationResults.collectFirst { case Left(error) => error } match {
-        case Some(error) => return Left(error)
-        case None        => // Continue
-      }
-
-      // Verify the proof forms a valid path to the state root
-      verifyProofRoot(proofNodes) match {
-        case Left(error) => Left(s"Proof root verification failed: $error")
-        case Right(_)    => Right(())
-      }
-
+      val proofMap = buildProofMap(decodeProofNodes(proof))
+      verifyRangeProofByReconstruction(startHash, endHash, leaves, proofMap)
     } catch {
       case e: Exception =>
         log.warn(s"Merkle proof verification error: ${e.getMessage}")
@@ -95,121 +50,555 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     }
   }
 
-  /** Decode RLP-encoded proof nodes
+  def verifyStorageRange(
+      slots: Seq[(ByteString, ByteString)],
+      proof: Seq[ByteString],
+      startHash: ByteString,
+      endHash: ByteString
+  ): Either[String, Unit] = {
+    if (proof.isEmpty && slots.isEmpty) return Right(())
+    try {
+      if (proof.isEmpty) {
+        return verifyCompleteRange(slots)
+      }
+      val proofMap = buildProofMap(decodeProofNodes(proof))
+      verifyRangeProofByReconstruction(startHash, endHash, slots, proofMap)
+    } catch {
+      case e: Exception =>
+        log.warn(s"Storage Merkle proof verification error: ${e.getMessage}")
+        Left(s"Storage verification error: ${e.getMessage}")
+    }
+  }
+
+  // ─── Reconstruction algorithm ───────────────────────────────────────────────
+
+  private def verifyCompleteRange(leaves: Seq[(ByteString, ByteString)]): Either[String, Unit] = {
+    val snapTrie = new SnapHashTrie(_ => ())
+    leaves.foreach { case (k, v) => snapTrie.update(k.toArray, v.toArray) }
+    val computed = snapTrie.commit()
+    if (computed == rootHash) Right(())
+    else Left(s"complete-range hash mismatch")
+  }
+
+  private def verifyRangeProofByReconstruction(
+      firstKey: ByteString,
+      lastKey: ByteString,
+      leaves: Seq[(ByteString, ByteString)],
+      proofMap: Map[ByteString, MptNode]
+  ): Either[String, Unit] = {
+    // Validate: monotonically strictly increasing keys, no empty values
+    for (i <- 0 until leaves.length - 1) {
+      if (cmpBytes(leaves(i)._1, leaves(i + 1)._1) >= 0)
+        return Left("range is not monotonically increasing")
+    }
+    if (leaves.exists(_._2.isEmpty))
+      return Left("range contains deletion (empty value)")
+
+    // Edge case B: proof present, zero leaves — proof of absence
+    if (leaves.isEmpty) {
+      val rootNode = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
+      val trie     = new PartialProofTrie(rootNode, proofMap)
+      trie.resolveEdge(hashToNibbles(firstKey), allowNonExistent = true) match {
+        case Left(err) => return Left(err)
+        case Right(())  => ()
+      }
+      return if (hasRightElement(trie.root, hashToNibbles(firstKey)))
+        Left("more entries available")
+      else Right(())
+    }
+
+    // Validate: firstKey <= leaves.head
+    if (cmpBytes(firstKey, leaves.head._1) > 0)
+      return Left("unexpected key-value pairs preceding the requested range")
+
+    // Special case: single element where firstKey == lastKey (existent proof)
+    if (leaves.length == 1 && firstKey == lastKey) {
+      val rootNode = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
+      val trie     = new PartialProofTrie(rootNode, proofMap)
+      trie.resolveEdge(hashToNibbles(firstKey), allowNonExistent = false) match {
+        case Left(err) => return Left(err)
+        case Right(())  => ()
+      }
+      trie.insertLeaf(hashToNibbles(leaves.head._1), leaves.head._2)
+      val computed = trie.computeHash()
+      return if (computed == rootHash) Right(())
+             else Left(s"single-element range proof hash mismatch")
+    }
+
+    if (cmpBytes(firstKey, lastKey) >= 0) return Left("invalid edge keys")
+    if (firstKey.length != lastKey.length) return Left("inconsistent edge key lengths")
+
+    val firstNibbles = hashToNibbles(firstKey)
+    val lastNibbles  = hashToNibbles(lastKey)
+    val rootNode     = proofMap.getOrElse(rootHash, return Left("root node missing from proof"))
+    val trie         = new PartialProofTrie(rootNode, proofMap)
+
+    // Phase 1: resolve both edge paths into the partial trie
+    trie.resolveEdge(firstNibbles, allowNonExistent = true) match {
+      case Left(err) => return Left(err)
+      case Right(())  => ()
+    }
+    trie.resolveEdge(lastNibbles, allowNonExistent = true) match {
+      case Left(err) => return Left(err)
+      case Right(())  => ()
+    }
+
+    // Phase 2: prune internal nodes between boundaries
+    trie.pruneInternals(firstNibbles, lastNibbles) match {
+      case Left(err) => return Left(err)
+      case Right(())  => ()
+    }
+
+    // Phase 3: insert all leaves
+    leaves.foreach { case (k, v) => trie.insertLeaf(hashToNibbles(k), v) }
+
+    // Phase 4: verify root hash
+    val computed = trie.computeHash()
+    if (computed == rootHash) Right(())
+    else Left(s"range proof hash mismatch")
+  }
+
+  // ─── PartialProofTrie ───────────────────────────────────────────────────────
+
+  /** Mutable-state wrapper around an immutable MptNode tree.
     *
-    * @param proof
-    *   Sequence of RLP-encoded nodes
-    * @return
-    *   Decoded MPT nodes
+    * Implements the three phases of geth VerifyRangeProof:
+    *   - resolveEdge  → proofToPath
+    *   - pruneInternals → unsetInternal + unset
+    *   - insertLeaf  → MPT put (without storage)
     */
+  private class PartialProofTrie(initialRoot: MptNode, proofMap: Map[ByteString, MptNode]) {
+    var root: MptNode = initialRoot
+
+    def resolveEdge(keyNibbles: Seq[Int], allowNonExistent: Boolean): Either[String, Unit] =
+      resolveEdgePath(root, keyNibbles, allowNonExistent) match {
+        case Right(newRoot) => root = newRoot; Right(())
+        case Left(err)      => Left(err)
+      }
+
+    def pruneInternals(leftNibbles: Seq[Int], rightNibbles: Seq[Int]): Either[String, Unit] =
+      findForkAndPrune(root, leftNibbles, rightNibbles, 0) match {
+        case Right(newRoot) => root = newRoot; Right(())
+        case Left(err)      => Left(err)
+      }
+
+    def insertLeaf(keyNibbles: Seq[Int], value: ByteString): Unit =
+      root = doInsertLeaf(root, keyNibbles, value)
+
+    def computeHash(): ByteString = ByteString(root.hash)
+
+    // ── Phase 1: resolveEdgePath ─────────────────────────────────────────────
+
+    private def resolveEdgePath(node: MptNode, remaining: Seq[Int], allowNonExistent: Boolean): Either[String, MptNode] = {
+      val resolved = node match {
+        case HashNode(bytes) =>
+          proofMap.get(ByteString(bytes)) match {
+            case Some(n) => n
+            case None    => return Left(s"proof node missing: ${bytes.take(4).map("%02x".format(_)).mkString}...")
+          }
+        case other => other
+      }
+      resolved match {
+        case NullNode =>
+          if (allowNonExistent) Right(NullNode)
+          else Left("node not in trie (null at boundary)")
+
+        case leaf: LeafNode => Right(leaf)
+
+        case branch: BranchNode if remaining.isEmpty => Right(branch)
+
+        case branch: BranchNode =>
+          val nibble = remaining.head
+          val child  = branch.children(nibble)
+          child match {
+            case NullNode if allowNonExistent => Right(branch)
+            case NullNode                     => Left("node not in trie (null child at boundary path)")
+            case _ =>
+              resolveEdgePath(child, remaining.tail, allowNonExistent).map { newChild =>
+                branch.updateChild(nibble, newChild)
+              }
+          }
+
+        case ext: ExtensionNode =>
+          val sharedNibbles = toNibbleSeq(ext.sharedKey)
+          if (remaining.startsWith(sharedNibbles)) {
+            resolveEdgePath(ext.next, remaining.drop(sharedNibbles.length), allowNonExistent).map { newNext =>
+              ExtensionNode(ext.sharedKey, newNext)
+            }
+          } else if (allowNonExistent) {
+            Right(ext)
+          } else {
+            Left("extension key mismatch in proof")
+          }
+
+        case other => Right(other)
+      }
+    }
+
+    // ── Phase 2: pruneInternals ──────────────────────────────────────────────
+
+    private def findForkAndPrune(node: MptNode, left: Seq[Int], right: Seq[Int], pos: Int): Either[String, MptNode] =
+      node match {
+        case ext: ExtensionNode =>
+          val sharedNibbles = toNibbleSeq(ext.sharedKey)
+          val forkLeft      = comparePrefix(left, pos, sharedNibbles)
+          val forkRight     = comparePrefix(right, pos, sharedNibbles)
+          if (forkLeft == 0 && forkRight == 0) {
+            findForkAndPrune(ext.next, left, right, pos + sharedNibbles.length).map { newNext =>
+              ExtensionNode(ext.sharedKey, newNext)
+            }
+          } else {
+            handleExtensionFork(ext, sharedNibbles, left, right, pos, forkLeft, forkRight)
+          }
+
+        case branch: BranchNode =>
+          if (left(pos) == right(pos)) {
+            val nibble = left(pos)
+            findForkAndPrune(branch.children(nibble), left, right, pos + 1).map { newChild =>
+              branch.updateChild(nibble, newChild)
+            }
+          } else {
+            handleBranchFork(branch, left, right, pos)
+          }
+
+        case other => Right(other)
+      }
+
+    private def handleBranchFork(branch: BranchNode, left: Seq[Int], right: Seq[Int], pos: Int): Either[String, MptNode] = {
+      val leftNibble  = left(pos)
+      val rightNibble = right(pos)
+      // Null out all children strictly between the two boundary nibbles
+      var b = branch
+      for (i <- leftNibble + 1 until rightNibble)
+        b = b.updateChild(i, NullNode)
+      for {
+        newLeftChild  <- pruneOneSide(b.children(leftNibble),  left,  pos + 1, removeLeft = false)
+        b2             = b.updateChild(leftNibble, newLeftChild)
+        newRightChild <- pruneOneSide(b2.children(rightNibble), right, pos + 1, removeLeft = true)
+      } yield b2.updateChild(rightNibble, newRightChild)
+    }
+
+    private def handleExtensionFork(
+        ext: ExtensionNode,
+        sharedNibbles: Seq[Int],
+        left: Seq[Int],
+        right: Seq[Int],
+        pos: Int,
+        forkLeft: Int,
+        forkRight: Int
+    ): Either[String, MptNode] = {
+      val sl = math.signum(forkLeft)
+      val sr = math.signum(forkRight)
+      (sl, sr) match {
+        case (-1, -1) => Left("empty range: both boundaries below extension key")
+        case (1, 1)   => Left("empty range: both boundaries above extension key")
+
+        case (fl, fr) if fl != 0 && fr != 0 =>
+          Right(NullNode) // extension entirely in range (one side < ext, other side > ext)
+
+        case (0, fr) if fr != 0 =>
+          // Left matches extension, right is larger → prune right side of extension's subtree
+          ext.next match {
+            case _: LeafNode => Right(NullNode)
+            case _ =>
+              pruneOneSide(ext.next, left, pos + sharedNibbles.length, removeLeft = false).map { newNext =>
+                if (newNext.isNull) NullNode else ExtensionNode(ext.sharedKey, newNext)
+              }
+          }
+
+        case (fl, 0) if fl != 0 =>
+          // Right matches extension, left is smaller → prune left side
+          ext.next match {
+            case _: LeafNode => Right(NullNode)
+            case _ =>
+              pruneOneSide(ext.next, right, pos + sharedNibbles.length, removeLeft = true).map { newNext =>
+                if (newNext.isNull) NullNode else ExtensionNode(ext.sharedKey, newNext)
+              }
+          }
+
+        case _ => Right(ext)
+      }
+    }
+
+    // Prune one side of a boundary path. Returns the updated subtree, or NullNode to remove it.
+    // removeLeft=false: remove subtrees to the RIGHT of the key (used for left boundary).
+    // removeLeft=true:  remove subtrees to the LEFT  of the key (used for right boundary).
+    private def pruneOneSide(child: MptNode, key: Seq[Int], pos: Int, removeLeft: Boolean): Either[String, MptNode] =
+      child match {
+        case branch: BranchNode =>
+          // Null children on the side being removed
+          var b = branch
+          if (removeLeft) {
+            for (i <- 0 until key(pos)) b = b.updateChild(i, NullNode)
+          } else {
+            for (i <- key(pos) + 1 until 16) b = b.updateChild(i, NullNode)
+          }
+          pruneOneSide(b.children(key(pos)), key, pos + 1, removeLeft).map { newKeyChild =>
+            b.updateChild(key(pos), newKeyChild)
+          }
+
+        case ext: ExtensionNode =>
+          val sharedNibbles = toNibbleSeq(ext.sharedKey)
+          val keySlice      = key.drop(pos).take(sharedNibbles.length)
+          if (keySlice != sharedNibbles) {
+            // Extension's path diverges from boundary key: sibling check
+            val cmp = compareNibbleSeqs(sharedNibbles, keySlice)
+            Right(if ((removeLeft && cmp < 0) || (!removeLeft && cmp > 0)) NullNode else child)
+          } else {
+            pruneOneSide(ext.next, key, pos + sharedNibbles.length, removeLeft).map { newNext =>
+              if (newNext.isNull) NullNode else ExtensionNode(ext.sharedKey, newNext)
+            }
+          }
+
+        case leaf: LeafNode =>
+          // Either the boundary leaf itself (remove → will be re-inserted) or a sibling
+          val leafNibbles = toNibbleSeq(leaf.key)
+          val remaining   = key.drop(pos)
+          if (leafNibbles == remaining) {
+            Right(NullNode) // boundary leaf: remove and re-insert in phase 3
+          } else {
+            val cmp = compareNibbleSeqs(leafNibbles, remaining)
+            Right(if ((removeLeft && cmp < 0) || (!removeLeft && cmp > 0)) NullNode else child)
+          }
+
+        case NullNode => Right(NullNode)
+        case _        => Right(child)
+      }
+
+    // ── Phase 3: insertLeaf ─────────────────────────────────────────────────
+
+    private def doInsertLeaf(node: MptNode, keyNibbles: Seq[Int], value: ByteString): MptNode =
+      node match {
+        case NullNode =>
+          LeafNode(ByteString(keyNibbles.map(_.toByte).toArray), value)
+
+        case leaf: LeafNode =>
+          insertIntoLeaf(leaf, keyNibbles, value)
+
+        case branch: BranchNode =>
+          if (keyNibbles.isEmpty) {
+            BranchNode(branch.children.clone(), Some(value))
+          } else {
+            val nibble   = keyNibbles.head
+            val newChild = doInsertLeaf(branch.children(nibble), keyNibbles.tail, value)
+            branch.updateChild(nibble, newChild)
+          }
+
+        case ext: ExtensionNode =>
+          insertIntoExtension(ext, keyNibbles, value)
+
+        case HashNode(_) =>
+          throw new IllegalStateException("HashNode in range during leaf insertion — pruneInternals incomplete")
+
+        case _ => node
+      }
+
+    // Port of MerklePatriciaTrie.putInLeafNode (stripped of NodeInsertResult / storage)
+    private def insertIntoLeaf(leaf: LeafNode, keyNibbles: Seq[Int], value: ByteString): MptNode = {
+      val existingNibbles = toNibbleSeq(leaf.key)
+      val ml              = matchingLength(existingNibbles, keyNibbles)
+
+      if (ml == existingNibbles.length && ml == keyNibbles.length) {
+        // Exact key match: replace value
+        LeafNode(leaf.key, value)
+
+      } else if (ml == 0) {
+        // No common prefix: create branch with both leaves under their first nibbles
+        val b0 =
+          if (existingNibbles.isEmpty) BranchNode.withValueOnly(leaf.value.toArray)
+          else {
+            val existingLeaf = LeafNode(ByteString(existingNibbles.tail.map(_.toByte).toArray), leaf.value)
+            BranchNode.withSingleChild(existingNibbles.head.toByte, existingLeaf, None)
+          }
+        doInsertLeaf(b0, keyNibbles, value)
+
+      } else {
+        // Common prefix of length ml: wrap in extension → branch
+        val prefix         = keyNibbles.take(ml)
+        val existingSuffix = existingNibbles.drop(ml)
+        val newKeySuffix   = keyNibbles.drop(ml)
+        val b0 =
+          if (existingSuffix.isEmpty) BranchNode.withValueOnly(leaf.value.toArray)
+          else {
+            val existingLeaf = LeafNode(ByteString(existingSuffix.tail.map(_.toByte).toArray), leaf.value)
+            BranchNode.withSingleChild(existingSuffix.head.toByte, existingLeaf, None)
+          }
+        val b1 = doInsertLeaf(b0, newKeySuffix, value)
+        ExtensionNode(ByteString(prefix.map(_.toByte).toArray), b1)
+      }
+    }
+
+    // Port of MerklePatriciaTrie.putInExtensionNode (stripped of NodeInsertResult / storage)
+    private def insertIntoExtension(ext: ExtensionNode, keyNibbles: Seq[Int], value: ByteString): MptNode = {
+      val sharedNibbles = toNibbleSeq(ext.sharedKey)
+      val ml            = matchingLength(sharedNibbles, keyNibbles)
+
+      if (ml == 0) {
+        // No common prefix: convert extension to branch
+        val sharedHead = sharedNibbles.head
+        val extChild =
+          if (sharedNibbles.length == 1) ext.next
+          else ExtensionNode(ByteString(sharedNibbles.tail.map(_.toByte).toArray), ext.next)
+        val b0 = BranchNode.withSingleChild(sharedHead.toByte, extChild, None)
+        doInsertLeaf(b0, keyNibbles, value)
+
+      } else if (ml == sharedNibbles.length) {
+        // Extension key fully matches: recurse into next
+        ExtensionNode(ext.sharedKey, doInsertLeaf(ext.next, keyNibbles.drop(ml), value))
+
+      } else {
+        // Partial match at ml: split extension into prefix + branch
+        val commonPrefix = sharedNibbles.take(ml)
+        val extSuffix    = sharedNibbles.drop(ml)
+        val newKeySuffix = keyNibbles.drop(ml)
+        val extTailChild =
+          if (extSuffix.length == 1) ext.next
+          else ExtensionNode(ByteString(extSuffix.tail.map(_.toByte).toArray), ext.next)
+        val b0 = BranchNode.withSingleChild(extSuffix.head.toByte, extTailChild, None)
+        val b1 = doInsertLeaf(b0, newKeySuffix, value)
+        ExtensionNode(ByteString(commonPrefix.map(_.toByte).toArray), b1)
+      }
+    }
+  }
+
+  // ─── hasRightElement ────────────────────────────────────────────────────────
+
+  // Port of go-ethereum hasRightElement: true if any trie element exists lexicographically
+  // after keyNibbles in the resolved partial trie.
+  private def hasRightElement(node: MptNode, keyNibbles: Seq[Int]): Boolean = {
+    var current   = node
+    var remaining = keyNibbles
+    var found     = false
+    while (current != null && !found) {
+      current match {
+        case branch: BranchNode =>
+          if (remaining.nonEmpty) {
+            val n = remaining.head
+            if ((n + 1 until 16).exists(!branch.children(_).isNull)) {
+              found = true
+            } else {
+              current   = branch.children(n)
+              remaining = remaining.tail
+            }
+          } else {
+            current = null
+          }
+
+        case ext: ExtensionNode =>
+          val sharedNibbles = toNibbleSeq(ext.sharedKey)
+          if (!remaining.startsWith(sharedNibbles)) {
+            found = compareNibbleSeqs(sharedNibbles, remaining.take(sharedNibbles.length)) > 0
+            current = null
+          } else {
+            current   = ext.next
+            remaining = remaining.drop(sharedNibbles.length)
+          }
+
+        case _: LeafNode => current = null
+
+        case _ => current = null
+      }
+    }
+    found
+  }
+
+  // ─── Shared utilities ────────────────────────────────────────────────────────
+
+  private def toNibbleSeq(bs: ByteString): Seq[Int] =
+    bs.toArray.toSeq.map(_ & 0xff)
+
+  private def hashToNibbles(hash: ByteString): Seq[Int] =
+    hash.flatMap { byte => Seq((byte >> 4) & 0x0f, byte & 0x0f) }.map(_.toInt)
+
+  // comparePrefix: compare key.drop(pos).take(len) vs ref nibbles.
+  // Returns 0 if equal, negative if key-slice < ref or too short, positive if key-slice > ref.
+  private def comparePrefix(key: Seq[Int], pos: Int, ref: Seq[Int]): Int = {
+    val slice = key.drop(pos).take(ref.length)
+    if (slice.length < ref.length) {
+      // Truncated slice — compare what we have then treat as smaller
+      val partial = compareNibbleSeqs(slice, ref.take(slice.length))
+      if (partial != 0) partial else -1
+    } else {
+      compareNibbleSeqs(slice, ref)
+    }
+  }
+
+  private def compareNibbleSeqs(a: Seq[Int], b: Seq[Int]): Int = {
+    val len = math.min(a.length, b.length)
+    var i   = 0
+    while (i < len) {
+      val d = a(i) - b(i)
+      if (d != 0) return d
+      i += 1
+    }
+    a.length - b.length
+  }
+
+  private def matchingLength(a: Seq[Int], b: Seq[Int]): Int = {
+    var i = 0
+    while (i < math.min(a.length, b.length) && a(i) == b(i)) i += 1
+    i
+  }
+
+  private def cmpBytes(a: ByteString, b: ByteString): Int = {
+    val aa = a.toArray
+    val bb = b.toArray
+    var i  = 0
+    while (i < math.min(aa.length, bb.length)) {
+      val d = (aa(i) & 0xff) - (bb(i) & 0xff)
+      if (d != 0) return d
+      i += 1
+    }
+    aa.length - bb.length
+  }
+
   private def decodeProofNodes(proof: Seq[ByteString]): Seq[MptNode] =
     proof.map { nodeBytes =>
-      try
-        MptTraversals.decodeNode(nodeBytes.toArray)
+      try MptTraversals.decodeNode(nodeBytes.toArray)
       catch {
         case e: Exception =>
           throw new IllegalArgumentException(s"Failed to decode proof node: ${e.getMessage}", e)
       }
     }
 
-  /** Build a map of node hash -> node for quick lookup
-    *
-    * @param nodes
-    *   Proof nodes
-    * @return
-    *   Map of hash to node
-    */
   private def buildProofMap(nodes: Seq[MptNode]): Map[ByteString, MptNode] =
-    nodes.map { node =>
-      ByteString(node.hash) -> node
-    }.toMap
+    nodes.map { node => ByteString(node.hash) -> node }.toMap
 
-  /** Verify an account exists in the proof
-    *
-    * @param accountHash
-    *   Hash of the account
-    * @param account
-    *   Account data
-    * @param proofMap
-    *   Map of node hashes to nodes
-    * @return
-    *   Either error or success
-    */
-  private def verifyAccountInProof(
+  // ─── Legacy traversal methods (dead code — kept for reference, not called) ──
+
+  @unused private def verifyAccountInProof(
       accountHash: ByteString,
       account: Account,
       proofMap: Map[ByteString, MptNode]
-  ): Either[String, Unit] = {
+  ): Either[String, Unit] =
+    traversePath(rootHash, hashToNibbles(accountHash), proofMap, account)
 
-    // For now, we do a simplified verification:
-    // Just check that we can find a path in the proof nodes
-    // A full implementation would traverse the trie path
-
-    // Convert account hash to nibbles (path in the trie)
-    val path = hashToNibbles(accountHash)
-
-    // Start from the root (use stateRoot for account verification)
-    val root = rootHash
-
-    // Traverse the proof following the path
-    traversePath(root, path, proofMap, account)
-  }
-
-  /** Traverse the trie path to find the account
-    *
-    * @param currentHash
-    *   Hash of current node to look up
-    * @param path
-    *   Remaining path (nibbles) to traverse
-    * @param proofMap
-    *   Map of node hashes to nodes
-    * @param expectedAccount
-    *   Expected account at the end of path
-    * @return
-    *   Either error or success
-    */
-  private def traversePath(
+  @unused private def traversePath(
       currentHash: ByteString,
       path: Seq[Int],
       proofMap: Map[ByteString, MptNode],
       expectedAccount: Account
   ): Either[String, Unit] =
-    // Look up the node in the proof
     proofMap.get(currentHash) match {
-      case None =>
-        // Node not in proof - this is acceptable for partial proofs
-        // The proof only needs to cover the range being verified
-        Right(())
-
-      case Some(leafNode: LeafNode) =>
-        // Found a leaf - verify it matches the expected account
-        verifyLeafAccount(leafNode, expectedAccount)
-
+      case None                         => Right(())
+      case Some(leafNode: LeafNode)     => verifyLeafAccount(leafNode, expectedAccount)
       case Some(branchNode: BranchNode) =>
-        // Branch node - follow the path
         if (path.isEmpty) {
-          // We're at the end of the path
           branchNode.terminator match {
             case Some(value) => verifyAccountValue(value, expectedAccount)
             case None        => Left("Path ended at branch without terminator")
           }
         } else {
-          // Continue traversal
           val nextIndex = path.head
           branchNode.children.lift(nextIndex) match {
             case Some(nextNode: HashNode) =>
               traversePath(ByteString(nextNode.hash), path.tail, proofMap, expectedAccount)
             case Some(nextNode) =>
               traversePath(ByteString(nextNode.hash), path.tail, proofMap, expectedAccount)
-            case None =>
-              Left(s"No child at index $nextIndex")
+            case None => Left(s"No child at index $nextIndex")
           }
         }
-
       case Some(extensionNode: ExtensionNode) =>
-        // Extension node - match the shared key
-        // NOTE: MptTraversals.decodeNode already HexPrefix-decodes the compact path encoding,
-        // so `sharedKey` here is already a sequence of nibbles (0-15), one nibble per byte.
         val sharedNibbles = extensionNode.sharedKey.map(_.toInt)
         if (path.startsWith(sharedNibbles)) {
           extensionNode.next match {
@@ -218,322 +607,69 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
             case nextNode =>
               traversePath(ByteString(nextNode.hash), path.drop(sharedNibbles.length), proofMap, expectedAccount)
           }
-        } else {
-          Left("Path doesn't match extension node")
-        }
-
-      case Some(_) =>
-        Left("Unexpected node type")
+        } else Left("Path doesn't match extension node")
+      case Some(_) => Left("Unexpected node type")
     }
 
-  /** Verify leaf node contains expected account
-    *
-    * @param leaf
-    *   Leaf node from proof
-    * @param expectedAccount
-    *   Expected account
-    * @return
-    *   Either error or success
-    */
-  private def verifyLeafAccount(leaf: LeafNode, expectedAccount: Account): Either[String, Unit] =
+  @unused private def verifyLeafAccount(leaf: LeafNode, expectedAccount: Account): Either[String, Unit] =
     verifyAccountValue(leaf.value, expectedAccount)
 
-  /** Verify account value matches expected account
-    *
-    * Decodes the RLP-encoded account and compares key fields to expected values. This ensures the account data in the
-    * proof matches what we expect.
-    *
-    * @param value
-    *   RLP-encoded account value
-    * @param expectedAccount
-    *   The account we expect to find
-    * @return
-    *   Either error or success
-    */
-  private def verifyAccountValue(value: ByteString, expectedAccount: Account): Either[String, Unit] =
+  @unused private def verifyAccountValue(value: ByteString, expectedAccount: Account): Either[String, Unit] =
     try {
-      // Decode the account from RLP using the standard Account serializer
       val decoded = Account.accountSerializer.fromBytes(value.toArray)
-
-      // Compare key fields to ensure account data matches
-      if (decoded.nonce != expectedAccount.nonce) {
-        Left(s"Account nonce mismatch: expected ${expectedAccount.nonce}, got ${decoded.nonce}")
-      } else if (decoded.balance != expectedAccount.balance) {
-        Left(s"Account balance mismatch: expected ${expectedAccount.balance}, got ${decoded.balance}")
-      } else if (decoded.storageRoot != expectedAccount.storageRoot) {
-        Left(s"Account storageRoot mismatch: expected ${expectedAccount.storageRoot}, got ${decoded.storageRoot}")
-      } else if (decoded.codeHash != expectedAccount.codeHash) {
-        Left(s"Account codeHash mismatch: expected ${expectedAccount.codeHash}, got ${decoded.codeHash}")
-      } else {
-        Right(())
-      }
+      if (decoded.nonce != expectedAccount.nonce) Left(s"Account nonce mismatch")
+      else if (decoded.balance != expectedAccount.balance) Left(s"Account balance mismatch")
+      else if (decoded.storageRoot != expectedAccount.storageRoot) Left(s"Account storageRoot mismatch")
+      else if (decoded.codeHash != expectedAccount.codeHash) Left(s"Account codeHash mismatch")
+      else Right(())
     } catch {
-      case e: Exception =>
-        Left(s"Failed to decode account value: ${e.getMessage}")
+      case e: Exception => Left(s"Failed to decode account value: ${e.getMessage}")
     }
 
-  /** Verify the proof root matches the expected state root
-    *
-    * @param proofNodes
-    *   Decoded proof nodes
-    * @return
-    *   Either error or success
-    */
-  private def verifyProofRoot(proofNodes: Seq[MptNode]): Either[String, Unit] = {
-    if (proofNodes.isEmpty) {
-      return Left("Empty proof")
-    }
-
-    // The first node should be the root or a node that hashes to the root
-    val firstNode = proofNodes.head
-    val firstNodeHash = ByteString(firstNode.hash)
-
-    // For AccountRange proofs we expect the first node to be the root (core-geth behavior).
-    if (firstNodeHash != rootHash) {
-      Left(
-        s"Proof root mismatch: got ${firstNodeHash.take(4).toArray.map("%02x".format(_)).mkString}..., " +
-          s"expected ${rootHash.take(4).toArray.map("%02x".format(_)).mkString}..."
-      )
-    } else Right(())
+  @unused private def verifyProofRoot(proofNodes: Seq[MptNode]): Either[String, Unit] = {
+    if (proofNodes.isEmpty) return Left("Empty proof")
+    val firstNodeHash = ByteString(proofNodes.head.hash)
+    if (firstNodeHash != rootHash)
+      Left(s"Proof root mismatch: got ${firstNodeHash.take(4).toArray.map("%02x".format(_)).mkString}... expected ${rootHash.take(4).toArray.map("%02x".format(_)).mkString}...")
+    else Right(())
   }
 
-  /** Convert hash to nibbles (hex digits) for trie path
-    *
-    * @param hash
-    *   Hash bytes
-    * @return
-    *   Sequence of nibbles (0-15)
-    */
-  private def hashToNibbles(hash: ByteString): Seq[Int] =
-    hash
-      .flatMap { byte =>
-        Seq((byte >> 4) & 0x0f, byte & 0x0f)
-      }
-      .map(_.toInt)
-
-  /** Verify a storage range response with Merkle proof
-    *
-    * This method verifies storage slots against an account's storage root. Similar to account verification but operates
-    * on storage tries.
-    *
-    * The verification process:
-    *   1. Decode proof nodes from their RLP-encoded form 2. Build a partial storage trie from the proof nodes 3. Verify
-    *      that storage slots exist in the trie at expected paths 4. Verify the proof root matches the expected storage
-    *      root
-    *
-    * Note: The rootHash of this verifier should be the account's storageRoot when verifying storage ranges.
-    *
-    * @param slots
-    *   Storage slots to verify (slotHash -> slotValue)
-    * @param proof
-    *   Merkle proof nodes (RLP-encoded)
-    * @param startHash
-    *   Starting hash of the range
-    * @param endHash
-    *   Ending hash of the range
-    * @return
-    *   Either error message or Unit on success
-    */
-  def verifyStorageRange(
-      slots: Seq[(ByteString, ByteString)],
-      proof: Seq[ByteString],
-      startHash: ByteString,
-      endHash: ByteString
-  ): Either[String, Unit] = {
-
-    if (slots.isEmpty && proof.isEmpty) {
-      return Right(())
-    }
-
-    // Without proofs, we can still validate basic invariants (ordering + bounds) and accept.
-    if (proof.isEmpty && slots.nonEmpty) {
-      return validateStorageSlotsBasic(slots, startHash, endHash)
-    }
-
-    // If we have proofs but no slots, this can be a valid proof-of-absence for sparse tries.
-    if (slots.isEmpty && proof.nonEmpty) {
-      try {
-        val proofNodes = decodeProofNodes(proof)
-        return verifyProofRoot(proofNodes).left.map(err => s"Storage proof root verification failed: $err")
-      } catch {
-        case e: Exception =>
-          log.warn(s"Storage Merkle proof verification error: ${e.getMessage}")
-          return Left(s"Storage verification error: ${e.getMessage}")
-      }
-    }
-
-    try {
-      // Decode proof nodes
-      val proofNodes = decodeProofNodes(proof)
-
-      // Build proof map: hash -> node
-      val proofMap = buildProofMap(proofNodes)
-
-      // Verify each storage slot is in the proof
-      val verificationResults = slots.map { case (slotHash, slotValue) =>
-        verifyStorageSlotInProof(slotHash, slotValue, proofMap) match {
-          case Left(error) =>
-            Left(s"Storage slot ${slotHash.take(4).toArray.map("%02x".format(_)).mkString} verification failed: $error")
-          case Right(_) => Right(())
-        }
-      }
-
-      // Check if any verification failed
-      verificationResults.collectFirst { case Left(error) => error } match {
-        case Some(error) => return Left(error)
-        case None        => // Continue
-      }
-
-      // Verify the proof forms a valid path to the storage root
-      verifyProofRoot(proofNodes) match {
-        case Left(error) => Left(s"Storage proof root verification failed: $error")
-        case Right(_)    => Right(())
-      }
-
-    } catch {
-      case e: Exception =>
-        log.warn(s"Storage Merkle proof verification error: ${e.getMessage}")
-        Left(s"Storage verification error: ${e.getMessage}")
-    }
-  }
-
-  private def validateStorageSlotsBasic(
-      slots: Seq[(ByteString, ByteString)],
-      startHash: ByteString,
-      endHash: ByteString
-  ): Either[String, Unit] = {
-    def cmp(a: ByteString, b: ByteString): Int = {
-      val aa = a.toArray
-      val bb = b.toArray
-      var i = 0
-      while (i < math.min(aa.length, bb.length)) {
-        val ai = aa(i) & 0xff
-        val bi = bb(i) & 0xff
-        if (ai != bi) return ai - bi
-        i += 1
-      }
-      aa.length - bb.length
-    }
-
-    // Monotonic strictly increasing
-    var i = 1
-    while (i < slots.size) {
-      val prev = slots(i - 1)._1
-      val cur = slots(i)._1
-      if (cmp(prev, cur) >= 0) {
-        return Left("Storage slots not monotonically increasing")
-      }
-      i += 1
-    }
-
-    // Bounds (best-effort; endHash is treated as an exclusive upper bound when provided)
-    if (slots.nonEmpty) {
-      val first = slots.head._1
-      if (startHash.nonEmpty && cmp(first, startHash) < 0) {
-        return Left("First storage slot is before requested start")
-      }
-      val last = slots.last._1
-      if (endHash.nonEmpty && cmp(last, endHash) >= 0) {
-        return Left("Last storage slot is at/after requested limit")
-      }
-    }
-
-    Right(())
-  }
-
-  /** Verify a storage slot exists in the proof
-    *
-    * Similar to verifyAccountInProof but for storage slots.
-    *
-    * @param slotHash
-    *   Hash of the storage slot
-    * @param slotValue
-    *   Value of the storage slot
-    * @param proofMap
-    *   Map of node hashes to nodes
-    * @return
-    *   Either error or success
-    */
-  private def verifyStorageSlotInProof(
+  @unused private def verifyStorageSlotInProof(
       slotHash: ByteString,
       slotValue: ByteString,
       proofMap: Map[ByteString, MptNode]
-  ): Either[String, Unit] = {
+  ): Either[String, Unit] =
+    traverseStoragePath(rootHash, hashToNibbles(slotHash), proofMap, slotValue)
 
-    // Convert slot hash to nibbles (path in the trie)
-    val path = hashToNibbles(slotHash)
-
-    // Start from the storage root
-    val root = rootHash
-
-    // Traverse the proof following the path
-    traverseStoragePath(root, path, proofMap, slotValue)
-  }
-
-  /** Traverse the storage trie path to find the slot
-    *
-    * Similar to traversePath but for storage slots.
-    *
-    * @param currentHash
-    *   Hash of current node to look up
-    * @param path
-    *   Remaining path (nibbles) to traverse
-    * @param proofMap
-    *   Map of node hashes to nodes
-    * @param expectedValue
-    *   Expected slot value at the end of path
-    * @return
-    *   Either error or success
-    */
-  private def traverseStoragePath(
+  @unused private def traverseStoragePath(
       currentHash: ByteString,
       path: Seq[Int],
       proofMap: Map[ByteString, MptNode],
       expectedValue: ByteString
   ): Either[String, Unit] =
-    // Look up the node in the proof
     proofMap.get(currentHash) match {
       case None =>
-        // Node not in proof - this is acceptable for partial proofs
         Right(())
-
       case Some(leafNode: LeafNode) =>
-        // Found a leaf - verify it matches the expected value
-        if (leafNode.value == expectedValue) {
-          Right(())
-        } else {
-          Left(
-            s"Storage value mismatch: expected ${expectedValue.take(4).toArray.map("%02x".format(_)).mkString}, got ${leafNode.value.take(4).toArray.map("%02x".format(_)).mkString}"
-          )
-        }
-
+        if (leafNode.value == expectedValue) Right(())
+        else Left(s"Storage value mismatch")
       case Some(branchNode: BranchNode) =>
-        // Branch node - follow the path
         if (path.isEmpty) {
-          // We're at the end of the path
           branchNode.terminator match {
-            case Some(value) =>
-              if (value == expectedValue) Right(())
-              else Left(s"Storage value mismatch at branch terminator")
-            case None => Left("Path ended at branch without terminator")
+            case Some(value) => if (value == expectedValue) Right(()) else Left("Storage value mismatch at branch terminator")
+            case None        => Left("Path ended at branch without terminator")
           }
         } else {
-          // Continue traversal
           val nextIndex = path.head
           branchNode.children.lift(nextIndex) match {
             case Some(nextNode: HashNode) =>
               traverseStoragePath(ByteString(nextNode.hash), path.tail, proofMap, expectedValue)
             case Some(nextNode) =>
               traverseStoragePath(ByteString(nextNode.hash), path.tail, proofMap, expectedValue)
-            case None =>
-              Left(s"No child at index $nextIndex")
+            case None => Left(s"No child at index $nextIndex")
           }
         }
-
       case Some(extensionNode: ExtensionNode) =>
-        // Extension node - match the shared key
-        // NOTE: MptTraversals.decodeNode already HexPrefix-decodes the compact path encoding,
-        // so `sharedKey` here is already a sequence of nibbles (0-15), one nibble per byte.
         val sharedNibbles = extensionNode.sharedKey.map(_.toInt)
         if (path.startsWith(sharedNibbles)) {
           extensionNode.next match {
@@ -542,24 +678,24 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
             case nextNode =>
               traverseStoragePath(ByteString(nextNode.hash), path.drop(sharedNibbles.length), proofMap, expectedValue)
           }
-        } else {
-          Left("Path doesn't match extension node")
-        }
-
-      case Some(_) =>
-        Left("Unexpected node type")
+        } else Left("Path doesn't match extension node")
+      case Some(_) => Left("Unexpected node type")
     }
+
+  @unused private def validateStorageSlotsBasic(
+      slots: Seq[(ByteString, ByteString)],
+      @unused startHash: ByteString,
+      @unused endHash: ByteString
+  ): Either[String, Unit] = {
+    var i = 1
+    while (i < slots.size) {
+      if (cmpBytes(slots(i - 1)._1, slots(i)._1) >= 0) return Left("Storage slots not monotonically increasing")
+      i += 1
+    }
+    Right(())
+  }
 }
 
 object MerkleProofVerifier {
-
-  /** Create a new verifier for a given root hash
-    *
-    * @param rootHash
-    *   Root hash (state root or storage root)
-    * @return
-    *   New verifier instance
-    */
-  def apply(rootHash: ByteString): MerkleProofVerifier =
-    new MerkleProofVerifier(rootHash)
+  def apply(rootHash: ByteString): MerkleProofVerifier = new MerkleProofVerifier(rootHash)
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
@@ -16,7 +16,7 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
   private val ZeroKey = ByteString(Array.fill(32)(0x00.toByte))
-  private val MaxKey  = ByteString(Array.fill(32)(0xff.toByte))
+  private val MaxKey = ByteString(Array.fill(32)(0xff.toByte))
 
   /** Generate proper SNAP boundary proofs from an MPT by walking both edge paths. */
   private def generateBoundaryProof[K, V](
@@ -25,7 +25,7 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
       lastKey: K
   ): Seq[ByteString] = {
     val firstProof = trie.getProof(firstKey).getOrElse(Vector.empty)
-    val lastProof  = trie.getProof(lastKey).getOrElse(Vector.empty)
+    val lastProof = trie.getProof(lastKey).getOrElse(Vector.empty)
     (firstProof ++ lastProof)
       .distinctBy(node => ByteString(node.hash))
       .map(node => ByteString(MptTraversals.encodeNode(node)))
@@ -43,16 +43,20 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
   "MerkleProofVerifier" should "accept terminal empty account range for non-empty state root" taggedAs UnitTest in {
     val verifier = MerkleProofVerifier(kec256(ByteString("test-root")))
     verifier.verifyAccountRange(
-      accounts = Seq.empty, proof = Seq.empty,
-      startHash = ZeroKey, endHash = MaxKey
+      accounts = Seq.empty,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
   it should "accept empty proof for empty account list when trie is empty" taggedAs UnitTest in {
     val verifier = MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash))
     verifier.verifyAccountRange(
-      accounts = Seq.empty, proof = Seq.empty,
-      startHash = ZeroKey, endHash = MaxKey
+      accounts = Seq.empty,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
@@ -77,7 +81,8 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val result = verifier.verifyAccountRange(
       accounts = Seq(ByteString.fromArray(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
       proof = Seq.empty,
-      startHash = ZeroKey, endHash = MaxKey
+      startHash = ZeroKey,
+      endHash = MaxKey
     )
     result shouldBe a[Left[_, _]]
   }
@@ -89,7 +94,10 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val storageRoot = computeStorageRoot(slots)
 
     MerkleProofVerifier(storageRoot).verifyStorageRange(
-      slots = slots, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      slots = slots,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
@@ -100,7 +108,10 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val wrongRoot = kec256(ByteString("wrong"))
 
     MerkleProofVerifier(wrongRoot).verifyStorageRange(
-      slots = slots, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      slots = slots,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
@@ -111,7 +122,8 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     verifier.verifyAccountRange(
       accounts = Seq(ByteString.fromArray(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
       proof = Seq(ByteString("not-a-valid-rlp-node")),
-      startHash = ZeroKey, endHash = MaxKey
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
@@ -120,7 +132,8 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     verifier.verifyStorageRange(
       slots = Seq(ByteString(Array.fill(32)(0x10.toByte)) -> ByteString("value")),
       proof = Seq(ByteString("not-valid-rlp-xxxxxxxxxx")),
-      startHash = ZeroKey, endHash = MaxKey
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
@@ -129,7 +142,8 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     verifier.verifyAccountRange(
       accounts = Seq(ByteString(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
       proof = Seq(ByteString(Array.fill(32)(0xde.toByte)), ByteString(Array[Byte](0x01, 0x02, 0x03))),
-      startHash = ZeroKey, endHash = MaxKey
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
@@ -137,7 +151,10 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
   it should "accept empty storage proof for empty slots" taggedAs UnitTest in {
     MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash)).verifyStorageRange(
-      slots = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      slots = Seq.empty,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
@@ -145,7 +162,10 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val storage = new TestMptStorage()
     val storageTrie = MerklePatriciaTrie[ByteString, ByteString](storage)
     MerkleProofVerifier(ByteString(storageTrie.getRootHash)).verifyStorageRange(
-      slots = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      slots = Seq.empty,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
@@ -156,7 +176,9 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte) // slot2 < slot1
     MerkleProofVerifier(kec256(ByteString("storage-root"))).verifyStorageRange(
       slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2")),
-      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
@@ -164,39 +186,46 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val sameSlot = ByteString(Array.fill(32)(0x55.toByte))
     MerkleProofVerifier(kec256(ByteString("storage-root"))).verifyStorageRange(
       slots = Seq(sameSlot -> ByteString("v1"), sameSlot -> ByteString("v2")),
-      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
   // ── Valid proof with reconstruction ─────────────────────────────────────────
 
   it should "verify account range with valid boundary proof" taggedAs UnitTest in {
-    val storage  = new TestMptStorage()
-    val acct1    = Account(nonce = 1, balance = 100)
-    val acct2    = Account(nonce = 2, balance = 200)
-    val key1     = ByteString(Array.fill(32)(0x10.toByte))
-    val key2     = ByteString(Array.fill(32)(0x20.toByte))
-    val trie     = MerklePatriciaTrie[ByteString, Account](storage).put(key1, acct1).put(key2, acct2)
-    val proof    = generateBoundaryProof(trie, key1, key2)
+    val storage = new TestMptStorage()
+    val acct1 = Account(nonce = 1, balance = 100)
+    val acct2 = Account(nonce = 2, balance = 200)
+    val key1 = ByteString(Array.fill(32)(0x10.toByte))
+    val key2 = ByteString(Array.fill(32)(0x20.toByte))
+    val trie = MerklePatriciaTrie[ByteString, Account](storage).put(key1, acct1).put(key2, acct2)
+    val proof = generateBoundaryProof(trie, key1, key2)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     verifier.verifyAccountRange(
       accounts = Seq(key1 -> acct1, key2 -> acct2),
-      proof = proof, startHash = key1, endHash = key2
+      proof = proof,
+      startHash = key1,
+      endHash = key2
     ) shouldBe Right(())
   }
 
   it should "verify storage range with valid boundary proof" taggedAs UnitTest in {
-    val storage  = new TestMptStorage()
-    val key1     = ByteString(Array.fill(32)(0x10.toByte))
-    val key2     = ByteString(Array.fill(32)(0x20.toByte))
-    val trie     = MerklePatriciaTrie[ByteString, ByteString](storage).put(key1, ByteString("v1")).put(key2, ByteString("v2"))
-    val proof    = generateBoundaryProof(trie, key1, key2)
+    val storage = new TestMptStorage()
+    val key1 = ByteString(Array.fill(32)(0x10.toByte))
+    val key2 = ByteString(Array.fill(32)(0x20.toByte))
+    val trie =
+      MerklePatriciaTrie[ByteString, ByteString](storage).put(key1, ByteString("v1")).put(key2, ByteString("v2"))
+    val proof = generateBoundaryProof(trie, key1, key2)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     verifier.verifyStorageRange(
       slots = Seq(key1 -> ByteString("v1"), key2 -> ByteString("v2")),
-      proof = proof, startHash = key1, endHash = key2
+      proof = proof,
+      startHash = key1,
+      endHash = key2
     ) shouldBe Right(())
   }
 
@@ -209,14 +238,18 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val key2 = ByteString(Array.fill(32)(0x30.toByte))
     val acct = Account(nonce = 1)
     val trie = MerklePatriciaTrie[ByteString, Account](storage)
-      .put(key0, acct).put(key1, acct).put(key2, acct)
-    val proof    = generateBoundaryProof(trie, key0, key2)
+      .put(key0, acct)
+      .put(key1, acct)
+      .put(key2, acct)
+    val proof = generateBoundaryProof(trie, key0, key2)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     // Omit key1 — creates a gap that must be detected via hash mismatch
     verifier.verifyAccountRange(
       accounts = Seq(key0 -> acct, key2 -> acct),
-      proof = proof, startHash = key0, endHash = key2
+      proof = proof,
+      startHash = key0,
+      endHash = key2
     ) shouldBe a[Left[_, _]]
   }
 
@@ -224,46 +257,53 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val storage = new TestMptStorage()
     val key0 = ByteString(Array.fill(32)(0x10.toByte))
     val key1 = ByteString(Array.fill(32)(0x20.toByte))
-    val realAcct  = Account(nonce = 1, balance = 100)
+    val realAcct = Account(nonce = 1, balance = 100)
     val wrongAcct = Account(nonce = 999, balance = 0)
-    val trie  = MerklePatriciaTrie[ByteString, Account](storage).put(key0, realAcct).put(key1, realAcct)
+    val trie = MerklePatriciaTrie[ByteString, Account](storage).put(key0, realAcct).put(key1, realAcct)
     val proof = generateBoundaryProof(trie, key0, key1)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     // Peer returns wrong value for key1
     verifier.verifyAccountRange(
       accounts = Seq(key0 -> realAcct, key1 -> wrongAcct),
-      proof = proof, startHash = key0, endHash = key1
+      proof = proof,
+      startHash = key0,
+      endHash = key1
     ) shouldBe a[Left[_, _]]
   }
 
   // ── Single-element and edge-proof variants ───────────────────────────────────
 
   it should "handle proof with single account correctly" taggedAs UnitTest in {
-    val storage  = new TestMptStorage()
-    val acct     = Account(nonce = 1, balance = 100)
-    val key      = ByteString(Array.fill(32)(0x42.toByte))
-    val trie     = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
-    val proof    = generateBoundaryProof(trie, key, key)
+    val storage = new TestMptStorage()
+    val acct = Account(nonce = 1, balance = 100)
+    val key = ByteString(Array.fill(32)(0x42.toByte))
+    val trie = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
+    val proof = generateBoundaryProof(trie, key, key)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     // Single-element with exact boundary proof (firstKey == lastKey)
     verifier.verifyAccountRange(
       accounts = Seq(key -> acct),
-      proof = proof, startHash = key, endHash = key
+      proof = proof,
+      startHash = key,
+      endHash = key
     ) shouldBe Right(())
   }
 
   it should "handle proof with multiple storage slots correctly" taggedAs UnitTest in {
-    val storage  = new TestMptStorage()
-    val keys     = (1 to 5).map(i => ByteString(Array.fill(31)(0x00.toByte) :+ i.toByte))
-    val slots    = keys.map(_ -> ByteString("v"))
-    val trie     = slots.foldLeft(MerklePatriciaTrie[ByteString, ByteString](storage)) { case (t, (k, v)) => t.put(k, v) }
-    val proof    = generateBoundaryProof(trie, keys.head, keys.last)
+    val storage = new TestMptStorage()
+    val keys = (1 to 5).map(i => ByteString(Array.fill(31)(0x00.toByte) :+ i.toByte))
+    val slots = keys.map(_ -> ByteString("v"))
+    val trie = slots.foldLeft(MerklePatriciaTrie[ByteString, ByteString](storage)) { case (t, (k, v)) => t.put(k, v) }
+    val proof = generateBoundaryProof(trie, keys.head, keys.last)
     val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     verifier.verifyStorageRange(
-      slots = slots, proof = proof, startHash = keys.head, endHash = keys.last
+      slots = slots,
+      proof = proof,
+      startHash = keys.head,
+      endHash = keys.last
     ) shouldBe Right(())
   }
 
@@ -271,30 +311,34 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
   it should "reject account proof where proof root hash does not match state root" taggedAs UnitTest in {
     val realStateRoot = kec256(ByteString("real-state-root"))
-    val verifier      = MerkleProofVerifier(realStateRoot)
-    val wrongNode     = LeafNode(ByteString(0x42.toByte), ByteString("some-value"))
-    val wrongProof    = Seq(ByteString(MptTraversals.encodeNode(wrongNode)))
-    val key           = ByteString(Array.fill(32)(0x42.toByte))
+    val verifier = MerkleProofVerifier(realStateRoot)
+    val wrongNode = LeafNode(ByteString(0x42.toByte), ByteString("some-value"))
+    val wrongProof = Seq(ByteString(MptTraversals.encodeNode(wrongNode)))
+    val key = ByteString(Array.fill(32)(0x42.toByte))
 
     // Wrong proof → root node hash ≠ realStateRoot → Left
     verifier.verifyAccountRange(
       accounts = Seq(key -> Account(nonce = 1)),
-      proof = wrongProof, startHash = ZeroKey, endHash = MaxKey
+      proof = wrongProof,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe a[Left[_, _]]
   }
 
   // ── Adversarial / crash-safety ───────────────────────────────────────────────
 
   it should "accept proof for non-existent key without crashing" taggedAs UnitTest in {
-    val storage     = new TestMptStorage()
+    val storage = new TestMptStorage()
     val realAccount = Account(nonce = 1, balance = 100)
-    val trie        = MerklePatriciaTrie[ByteString, Account](storage).put(ByteString("real-key"), realAccount)
-    val verifier    = MerkleProofVerifier(ByteString(trie.getRootHash))
-    val proof       = Seq(ByteString(trie.getRootHash)) // raw hash bytes, not valid RLP
+    val trie = MerklePatriciaTrie[ByteString, Account](storage).put(ByteString("real-key"), realAccount)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
+    val proof = Seq(ByteString(trie.getRootHash)) // raw hash bytes, not valid RLP
 
     val result = verifier.verifyAccountRange(
       accounts = Seq(ByteString(Array.fill(32)(0x99.toByte)) -> realAccount),
-      proof = proof, startHash = ZeroKey, endHash = MaxKey
+      proof = proof,
+      startHash = ZeroKey,
+      endHash = MaxKey
     )
     // Must not throw; either outcome acceptable
     result match {
@@ -304,17 +348,19 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "accept bloated proof with extra irrelevant nodes without crashing" taggedAs UnitTest in {
-    val storage    = new TestMptStorage()
-    val acct       = Account(nonce = 5, balance = 500)
-    val key        = ByteString(Array.fill(32)(0x55.toByte))
-    val trie       = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
+    val storage = new TestMptStorage()
+    val acct = Account(nonce = 5, balance = 500)
+    val key = ByteString(Array.fill(32)(0x55.toByte))
+    val trie = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
     val validProof = generateBoundaryProof(trie, key, key)
-    val bloated    = validProof ++ Seq(ByteString("irrelevant-node-aaa"), ByteString("irrelevant-node-bbb"))
-    val verifier   = MerkleProofVerifier(ByteString(trie.getRootHash))
+    val bloated = validProof ++ Seq(ByteString("irrelevant-node-aaa"), ByteString("irrelevant-node-bbb"))
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
     val result = verifier.verifyAccountRange(
       accounts = Seq(key -> acct),
-      proof = bloated, startHash = key, endHash = key
+      proof = bloated,
+      startHash = key,
+      endHash = key
     )
     result match {
       case Right(_)    => succeed
@@ -326,7 +372,10 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
   it should "accept account with zero-value fields (default/deleted account)" taggedAs UnitTest in {
     MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash)).verifyAccountRange(
-      accounts = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      accounts = Seq.empty,
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     ) shouldBe Right(())
   }
 
@@ -337,7 +386,9 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val storageRoot = kec256(ByteString("storage-root"))
     val result = MerkleProofVerifier(storageRoot).verifyStorageRange(
       slots = Seq(slotHash -> ByteString.empty),
-      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+      proof = Seq.empty,
+      startHash = ZeroKey,
+      endHash = MaxKey
     )
     // Should fail — either due to hash mismatch or SnapHashTrie rejecting empty value
     result shouldBe a[Left[_, _]]

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifierSpec.scala
@@ -13,35 +13,47 @@ import com.chipprbots.ethereum.testing.TestMptStorage
 
 class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
 
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private val ZeroKey = ByteString(Array.fill(32)(0x00.toByte))
+  private val MaxKey  = ByteString(Array.fill(32)(0xff.toByte))
+
+  /** Generate proper SNAP boundary proofs from an MPT by walking both edge paths. */
+  private def generateBoundaryProof[K, V](
+      trie: MerklePatriciaTrie[K, V],
+      firstKey: K,
+      lastKey: K
+  ): Seq[ByteString] = {
+    val firstProof = trie.getProof(firstKey).getOrElse(Vector.empty)
+    val lastProof  = trie.getProof(lastKey).getOrElse(Vector.empty)
+    (firstProof ++ lastProof)
+      .distinctBy(node => ByteString(node.hash))
+      .map(node => ByteString(MptTraversals.encodeNode(node)))
+  }
+
+  /** Compute the storage root from a set of ordered (k, v) pairs using SnapHashTrie. */
+  private def computeStorageRoot(slots: Seq[(ByteString, ByteString)]): ByteString = {
+    val t = new SnapHashTrie(_ => ())
+    slots.foreach { case (k, v) => t.update(k.toArray, v.toArray) }
+    t.commit()
+  }
+
+  // ── Zero-leaf / empty-proof edge cases ──────────────────────────────────────
+
   "MerkleProofVerifier" should "accept terminal empty account range for non-empty state root" taggedAs UnitTest in {
-    // go-ethereum accepts accounts=0 + proof=0 unconditionally as a valid terminal-empty range
-    // (no accounts exist between startHash and endHash). This is correct for sparse tries.
-    // See: verifyStorageRange which already accepts empty slots + empty proof unconditionally.
-    val stateRoot = kec256(ByteString("test-root"))
-    val verifier = MerkleProofVerifier(stateRoot)
-
-    val result = verifier.verifyAccountRange(
-      accounts = Seq.empty,
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
+    val verifier = MerkleProofVerifier(kec256(ByteString("test-root")))
+    verifier.verifyAccountRange(
+      accounts = Seq.empty, proof = Seq.empty,
+      startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
   }
 
   it should "accept empty proof for empty account list when trie is empty" taggedAs UnitTest in {
-    val stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)
-    val verifier = MerkleProofVerifier(stateRoot)
-
-    val result = verifier.verifyAccountRange(
-      accounts = Seq.empty,
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
+    val verifier = MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash))
+    verifier.verifyAccountRange(
+      accounts = Seq.empty, proof = Seq.empty,
+      startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
   }
 
   it should "accept proof-only account range as valid proof of absence" taggedAs UnitTest in {
@@ -49,520 +61,285 @@ class MerkleProofVerifierSpec extends AnyFlatSpec with Matchers {
     val proof = Seq(ByteString(MptTraversals.encodeNode(proofNode)))
     val verifier = MerkleProofVerifier(ByteString(proofNode.hash))
 
-    val result = verifier.verifyAccountRange(
+    verifier.verifyAccountRange(
       accounts = Seq.empty,
       proof = proof,
       startHash = ByteString.fromArray(Array.fill(32)(0x7f.toByte)),
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
+      endHash = MaxKey
+    ) shouldBe Right(())
   }
 
-  it should "reject missing proof when accounts are present" taggedAs UnitTest in {
-    val stateRoot = kec256(ByteString("test-root"))
-    val verifier = MerkleProofVerifier(stateRoot)
+  // ── Nil-proof (full-range hash) path ────────────────────────────────────────
 
-    val account = (ByteString("account1"), Account(nonce = 1, balance = 100))
-
+  it should "reject accounts with empty proof when hash does not match" taggedAs UnitTest in {
+    // Empty proof = claim to provide the complete account range; hash must match.
+    val verifier = MerkleProofVerifier(kec256(ByteString("test-root")))
     val result = verifier.verifyAccountRange(
-      accounts = Seq(account),
+      accounts = Seq(ByteString.fromArray(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
       proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
+      startHash = ZeroKey, endHash = MaxKey
     )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("Missing proof")
-  }
-
-  it should "verify account range with valid proof" taggedAs UnitTest in {
-    // Create a simple in-memory storage and trie
-    val storage = new TestMptStorage()
-
-    // Create accounts
-    val account1 = Account(nonce = 1, balance = 100)
-    val account2 = Account(nonce = 2, balance = 200)
-
-    // Build trie
-    val trie = MerklePatriciaTrie[ByteString, Account](storage)
-      .put(ByteString("account1"), account1)
-      .put(ByteString("account2"), account2)
-
-    val stateRoot = ByteString(trie.getRootHash)
-
-    // Create proof by getting the trie nodes
-    val proof = collectTrieNodes(trie)
-
-    // Verify the range
-    val verifier = MerkleProofVerifier(stateRoot)
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(
-        (ByteString("account1"), account1),
-        (ByteString("account2"), account2)
-      ),
-      proof = proof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // Since we have a simplified implementation, we accept the proof structure
-    result match {
-      case Right(_)    => succeed
-      case Left(error) =>
-        // Acceptable errors for simplified implementation
-        if (error.contains("verification") || error.contains("Verification error")) succeed
-        else fail(s"Unexpected error: $error")
-    }
-  }
-
-  it should "verify storage range with valid proof" taggedAs UnitTest in {
-    // Create a simple in-memory storage and trie for storage slots
-    val storage = new TestMptStorage()
-
-    // Build storage trie
-    val storageTrie = MerklePatriciaTrie[ByteString, ByteString](storage)
-      .put(ByteString("slot1"), ByteString("value1"))
-      .put(ByteString("slot2"), ByteString("value2"))
-
-    val storageRoot = ByteString(storageTrie.getRootHash)
-
-    // Create proof
-    val proof = collectTrieNodes(storageTrie)
-
-    // Verify the range
-    val verifier = MerkleProofVerifier(storageRoot)
-    val result = verifier.verifyStorageRange(
-      slots = Seq(
-        (ByteString("slot1"), ByteString("value1")),
-        (ByteString("slot2"), ByteString("value2"))
-      ),
-      proof = proof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // Since we have a simplified implementation, we accept the proof structure
-    result match {
-      case Right(_)    => succeed
-      case Left(error) =>
-        // Acceptable errors for simplified implementation
-        if (error.contains("verification") || error.contains("Verification error")) succeed
-        else fail(s"Unexpected error: $error")
-    }
-  }
-
-  it should "handle malformed proof gracefully" taggedAs UnitTest in {
-    val stateRoot = kec256(ByteString("test-root"))
-    val verifier = MerkleProofVerifier(stateRoot)
-
-    val account = (ByteString("account1"), Account(nonce = 1, balance = 100))
-    val malformedProof = Seq(ByteString("not-a-valid-rlp-node"))
-
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(account),
-      proof = malformedProof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
     result shouldBe a[Left[_, _]]
   }
 
-  it should "accept empty storage proof for empty slots" taggedAs UnitTest in {
-    val storageRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq.empty,
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
-  }
-
-  it should "handle proof with single account correctly" taggedAs UnitTest in {
-    val storage = new TestMptStorage()
-    val account = Account(nonce = 1, balance = 100)
-
-    val trie = MerklePatriciaTrie[ByteString, Account](storage)
-      .put(ByteString("account1"), account)
-
-    val stateRoot = ByteString(trie.getRootHash)
-    val proof = collectTrieNodes(trie)
-
-    val verifier = MerkleProofVerifier(stateRoot)
-    val result = verifier.verifyAccountRange(
-      accounts = Seq((ByteString("account1"), account)),
-      proof = proof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // Accept as long as it doesn't crash
-    result match {
-      case Right(_) => succeed
-      case Left(error) =>
-        if (error.contains("verification") || error.contains("Verification error")) succeed
-        else fail(s"Unexpected error: $error")
-    }
-  }
-
-  it should "handle proof with multiple storage slots correctly" taggedAs UnitTest in {
-    val storage = new TestMptStorage()
-
-    val slots = (1 to 5).map { i =>
-      (ByteString(s"slot$i"), ByteString(s"value$i"))
-    }
-
-    val storageTrie = slots.foldLeft(MerklePatriciaTrie[ByteString, ByteString](storage)) { case (trie, (key, value)) =>
-      trie.put(key, value)
-    }
-
-    val storageRoot = ByteString(storageTrie.getRootHash)
-    val proof = collectTrieNodes(storageTrie)
-
-    val verifier = MerkleProofVerifier(storageRoot)
-    val result = verifier.verifyStorageRange(
-      slots = slots,
-      proof = proof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // Accept as long as it doesn't crash
-    result match {
-      case Right(_) => succeed
-      case Left(error) =>
-        if (error.contains("verification") || error.contains("Verification error")) succeed
-        else fail(s"Unexpected error: $error")
-    }
-  }
-
-  /** Helper method to collect all trie nodes as RLP-encoded proof */
-  private def collectTrieNodes[K, V](trie: MerklePatriciaTrie[K, V]): Seq[ByteString] = {
-    // For testing purposes, collect nodes from the trie
-    // In a real implementation, the proof would be generated by the peer
-    import scala.collection.mutable
-    val nodes = mutable.ArrayBuffer[ByteString]()
-
-    try {
-      // Get the root node
-      val rootHash = trie.getRootHash
-      if (rootHash.nonEmpty && rootHash != MerklePatriciaTrie.EmptyRootHash) {
-        // Add the root hash as a proof node (simplified)
-        nodes += ByteString(rootHash)
-      }
-    } catch {
-      case _: Exception => // Ignore errors in test helper
-    }
-
-    nodes.toSeq
-  }
-
-  // ---- J6: Missing coverage -----------------------------------------------
-
-  it should "reject accounts with missing proof when proof is empty" taggedAs UnitTest in {
-    val stateRoot = kec256(ByteString("some-root"))
-    val verifier = MerkleProofVerifier(stateRoot)
-
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(ByteString("addr1") -> Account(nonce = 1, balance = 10)),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("Missing proof")
-  }
-
-  it should "reject storage slots that are not monotonically increasing" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    // slot2 < slot1 — out of order
-    val slot1 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x42.toByte)
-    val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte)
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2")),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("monotonic")
-  }
-
-  it should "reject storage slots where first slot is before requested start" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    // startHash = 0x10..., first slot = 0x05... → before start
-    val startHash = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte)
-    val slot = ByteString(Array.fill(31)(0x00.toByte) :+ 0x05.toByte)
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot -> ByteString("v")),
-      proof = Seq.empty,
-      startHash = startHash,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("before requested start")
-  }
-
-  it should "reject storage slots where last slot is at or after endHash" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    // endHash = 0x80..., last slot = 0x80... → at limit (exclusive upper bound)
-    val endHash = ByteString(Array.fill(31)(0x00.toByte) :+ 0x80.toByte)
-    val slot = ByteString(Array.fill(31)(0x00.toByte) :+ 0x80.toByte)
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot -> ByteString("v")),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = endHash
-    )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("at/after requested limit")
-  }
-
-  it should "accept storage slots that are monotonically increasing within bounds" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-
+  it should "accept nil proof for complete storage range when hash matches" taggedAs UnitTest in {
     val slot1 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte)
     val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x20.toByte)
-    val slot3 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x30.toByte)
+    val slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2"))
+    val storageRoot = computeStorageRoot(slots)
 
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2"), slot3 -> ByteString("v3")),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
+    MerkleProofVerifier(storageRoot).verifyStorageRange(
+      slots = slots, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
+  }
 
-    result shouldBe Right(())
+  it should "reject nil-proof storage range when hash does not match" taggedAs UnitTest in {
+    val slot1 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte)
+    val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x20.toByte)
+    val slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2"))
+    val wrongRoot = kec256(ByteString("wrong"))
+
+    MerkleProofVerifier(wrongRoot).verifyStorageRange(
+      slots = slots, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
+
+  // ── Malformed proofs ─────────────────────────────────────────────────────────
+
+  it should "handle malformed proof gracefully" taggedAs UnitTest in {
+    val verifier = MerkleProofVerifier(kec256(ByteString("test-root")))
+    verifier.verifyAccountRange(
+      accounts = Seq(ByteString.fromArray(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
+      proof = Seq(ByteString("not-a-valid-rlp-node")),
+      startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
+
+  it should "reject a malformed proof node for storage range" taggedAs UnitTest in {
+    val verifier = MerkleProofVerifier(kec256(ByteString("storage-root")))
+    verifier.verifyStorageRange(
+      slots = Seq(ByteString(Array.fill(32)(0x10.toByte)) -> ByteString("value")),
+      proof = Seq(ByteString("not-valid-rlp-xxxxxxxxxx")),
+      startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
+
+  it should "return Left with error for deliberately corrupted proof bytes" taggedAs UnitTest in {
+    val verifier = MerkleProofVerifier(kec256(ByteString("some-state-root")))
+    verifier.verifyAccountRange(
+      accounts = Seq(ByteString(Array.fill(32)(0x01.toByte)) -> Account(nonce = 1)),
+      proof = Seq(ByteString(Array.fill(32)(0xde.toByte)), ByteString(Array[Byte](0x01, 0x02, 0x03))),
+      startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
+
+  // ── Empty-proof storage edge cases ──────────────────────────────────────────
+
+  it should "accept empty storage proof for empty slots" taggedAs UnitTest in {
+    MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash)).verifyStorageRange(
+      slots = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
   }
 
   it should "accept proof-of-absence for storage range with empty slots and valid proof" taggedAs UnitTest in {
     val storage = new TestMptStorage()
     val storageTrie = MerklePatriciaTrie[ByteString, ByteString](storage)
-    val storageRoot = ByteString(storageTrie.getRootHash)
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    // Empty trie root → empty proof is valid proof-of-absence
-    val result = verifier.verifyStorageRange(
-      slots = Seq.empty,
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
+    MerkleProofVerifier(ByteString(storageTrie.getRootHash)).verifyStorageRange(
+      slots = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
   }
 
-  it should "reject a malformed proof node for storage range" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
+  // ── Monotonicity validation ──────────────────────────────────────────────────
 
-    val malformedProof = Seq(ByteString("not-valid-rlp-xxxxxxxxxx"))
-    val slot = ByteString(Array.fill(32)(0x10.toByte))
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot -> ByteString("value")),
-      proof = malformedProof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe a[Left[_, _]]
+  it should "reject storage slots that are not monotonically increasing" taggedAs UnitTest in {
+    val slot1 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x42.toByte)
+    val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte) // slot2 < slot1
+    MerkleProofVerifier(kec256(ByteString("storage-root"))).verifyStorageRange(
+      slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2")),
+      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
   }
 
-  // ── Adversarial cases (go-ethereum trie/proof_test.go parity) ─────────────
+  it should "reject storage range where first and last slot have identical hashes" taggedAs UnitTest in {
+    val sameSlot = ByteString(Array.fill(32)(0x55.toByte))
+    MerkleProofVerifier(kec256(ByteString("storage-root"))).verifyStorageRange(
+      slots = Seq(sameSlot -> ByteString("v1"), sameSlot -> ByteString("v2")),
+      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
 
-  // TestMissingKeyProof analogue: a proof node exists but covers a key that is NOT
-  // in the accounts list. Fukuii's partial-proof model accepts this — the traversal
-  // reaches None (node not in proof map) which is treated as "partial proof, ok".
-  it should "accept proof for non-existent key without crashing" taggedAs UnitTest in {
+  // ── Valid proof with reconstruction ─────────────────────────────────────────
+
+  it should "verify account range with valid boundary proof" taggedAs UnitTest in {
+    val storage  = new TestMptStorage()
+    val acct1    = Account(nonce = 1, balance = 100)
+    val acct2    = Account(nonce = 2, balance = 200)
+    val key1     = ByteString(Array.fill(32)(0x10.toByte))
+    val key2     = ByteString(Array.fill(32)(0x20.toByte))
+    val trie     = MerklePatriciaTrie[ByteString, Account](storage).put(key1, acct1).put(key2, acct2)
+    val proof    = generateBoundaryProof(trie, key1, key2)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
+
+    verifier.verifyAccountRange(
+      accounts = Seq(key1 -> acct1, key2 -> acct2),
+      proof = proof, startHash = key1, endHash = key2
+    ) shouldBe Right(())
+  }
+
+  it should "verify storage range with valid boundary proof" taggedAs UnitTest in {
+    val storage  = new TestMptStorage()
+    val key1     = ByteString(Array.fill(32)(0x10.toByte))
+    val key2     = ByteString(Array.fill(32)(0x20.toByte))
+    val trie     = MerklePatriciaTrie[ByteString, ByteString](storage).put(key1, ByteString("v1")).put(key2, ByteString("v2"))
+    val proof    = generateBoundaryProof(trie, key1, key2)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
+
+    verifier.verifyStorageRange(
+      slots = Seq(key1 -> ByteString("v1"), key2 -> ByteString("v2")),
+      proof = proof, startHash = key1, endHash = key2
+    ) shouldBe Right(())
+  }
+
+  // ── Gap detection (the core bug being fixed) ─────────────────────────────────
+
+  it should "detect missing account in the middle of a range" taggedAs UnitTest in {
     val storage = new TestMptStorage()
-    val realAccount = Account(nonce = 1, balance = 100)
+    val key0 = ByteString(Array.fill(32)(0x10.toByte))
+    val key1 = ByteString(Array.fill(32)(0x20.toByte))
+    val key2 = ByteString(Array.fill(32)(0x30.toByte))
+    val acct = Account(nonce = 1)
     val trie = MerklePatriciaTrie[ByteString, Account](storage)
-      .put(ByteString("real-key"), realAccount)
-    val stateRoot = ByteString(trie.getRootHash)
-    val proof = collectTrieNodes(trie)
-    val verifier = MerkleProofVerifier(stateRoot)
+      .put(key0, acct).put(key1, acct).put(key2, acct)
+    val proof    = generateBoundaryProof(trie, key0, key2)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
-    // Ask verifier to check a key that is NOT in the trie — should not throw
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(ByteString("missing-key") -> realAccount),
-      proof = proof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // collectTrieNodes returns raw 32-byte hash bytes (not RLP-encoded trie node data).
-    // decodeProofNodes fails to parse them and returns Left gracefully — no crash.
-    // Either outcome is acceptable: the key point is the verifier doesn't throw.
-    result match {
-      case Right(_)    => succeed
-      case Left(error) => error should not be empty
-    }
+    // Omit key1 — creates a gap that must be detected via hash mismatch
+    verifier.verifyAccountRange(
+      accounts = Seq(key0 -> acct, key2 -> acct),
+      proof = proof, startHash = key0, endHash = key2
+    ) shouldBe a[Left[_, _]]
   }
 
-  // TestBloatedProof analogue: extra irrelevant proof nodes injected alongside a
-  // valid root node. The verifier should not crash and should process normally.
-  it should "accept bloated proof with extra irrelevant nodes without crashing" taggedAs UnitTest in {
+  it should "detect fabricated account value with valid proof structure" taggedAs UnitTest in {
     val storage = new TestMptStorage()
-    val account = Account(nonce = 5, balance = 500)
-    val trie = MerklePatriciaTrie[ByteString, Account](storage)
-      .put(ByteString("account-key"), account)
-    val stateRoot = ByteString(trie.getRootHash)
-    val validProof = collectTrieNodes(trie)
-    val bloatedProof = validProof ++ Seq(
-      ByteString("irrelevant-node-aaaaaaaaa"),
-      ByteString("irrelevant-node-bbbbbbbbb")
-    )
-    val verifier = MerkleProofVerifier(stateRoot)
+    val key0 = ByteString(Array.fill(32)(0x10.toByte))
+    val key1 = ByteString(Array.fill(32)(0x20.toByte))
+    val realAcct  = Account(nonce = 1, balance = 100)
+    val wrongAcct = Account(nonce = 999, balance = 0)
+    val trie  = MerklePatriciaTrie[ByteString, Account](storage).put(key0, realAcct).put(key1, realAcct)
+    val proof = generateBoundaryProof(trie, key0, key1)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
-    // Bloated proof may fail proof decoding on the extra garbage nodes, but must not throw
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(ByteString("account-key") -> account),
-      proof = bloatedProof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    // Either accepts (valid root node first) or rejects with a structured error — never throws
-    result match {
-      case Right(_)    => succeed
-      case Left(error) => error should not be empty
-    }
+    // Peer returns wrong value for key1
+    verifier.verifyAccountRange(
+      accounts = Seq(key0 -> realAcct, key1 -> wrongAcct),
+      proof = proof, startHash = key0, endHash = key1
+    ) shouldBe a[Left[_, _]]
   }
 
-  // TestBadRangeProof analogue: proof bytes are deliberately corrupted. The verifier
-  // must return Left with a meaningful error rather than throwing an exception.
-  it should "return Left with error for deliberately corrupted proof bytes" taggedAs UnitTest in {
-    val stateRoot = kec256(ByteString("some-state-root"))
-    val verifier = MerkleProofVerifier(stateRoot)
-    val corruptedProof = Seq(
-      ByteString(Array.fill(32)(0xde.toByte)), // garbage bytes, not valid RLP
-      ByteString(Array[Byte](0x01, 0x02, 0x03))
-    )
+  // ── Single-element and edge-proof variants ───────────────────────────────────
 
-    val result = verifier.verifyAccountRange(
-      accounts = Seq(ByteString("key") -> Account(nonce = 1, balance = 1)),
-      proof = corruptedProof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
+  it should "handle proof with single account correctly" taggedAs UnitTest in {
+    val storage  = new TestMptStorage()
+    val acct     = Account(nonce = 1, balance = 100)
+    val key      = ByteString(Array.fill(32)(0x42.toByte))
+    val trie     = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
+    val proof    = generateBoundaryProof(trie, key, key)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
-    result shouldBe a[Left[_, _]]
-    result.left.get should not be empty
+    // Single-element with exact boundary proof (firstKey == lastKey)
+    verifier.verifyAccountRange(
+      accounts = Seq(key -> acct),
+      proof = proof, startHash = key, endHash = key
+    ) shouldBe Right(())
   }
 
-  // TestEmptyValueRangeProof analogue: account with zero nonce and zero balance
-  // (a "default" account, effectively deleted). Should be accepted without error.
-  it should "accept account with zero-value fields (default/deleted account)" taggedAs UnitTest in {
-    val stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)
-    val verifier = MerkleProofVerifier(stateRoot)
+  it should "handle proof with multiple storage slots correctly" taggedAs UnitTest in {
+    val storage  = new TestMptStorage()
+    val keys     = (1 to 5).map(i => ByteString(Array.fill(31)(0x00.toByte) :+ i.toByte))
+    val slots    = keys.map(_ -> ByteString("v"))
+    val trie     = slots.foldLeft(MerklePatriciaTrie[ByteString, ByteString](storage)) { case (t, (k, v)) => t.put(k, v) }
+    val proof    = generateBoundaryProof(trie, keys.head, keys.last)
+    val verifier = MerkleProofVerifier(ByteString(trie.getRootHash))
 
-    val result = verifier.verifyAccountRange(
-      accounts = Seq.empty,
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
+    verifier.verifyStorageRange(
+      slots = slots, proof = proof, startHash = keys.head, endHash = keys.last
+    ) shouldBe Right(())
   }
 
-  // TestRangeProofWithNonExistentProof analogue: a proof where the root node's hash
-  // does NOT match the expected state root. The verifier must reject it.
+  // ── Root-hash mismatch ───────────────────────────────────────────────────────
+
   it should "reject account proof where proof root hash does not match state root" taggedAs UnitTest in {
     val realStateRoot = kec256(ByteString("real-state-root"))
-    val verifier = MerkleProofVerifier(realStateRoot)
+    val verifier      = MerkleProofVerifier(realStateRoot)
+    val wrongNode     = LeafNode(ByteString(0x42.toByte), ByteString("some-value"))
+    val wrongProof    = Seq(ByteString(MptTraversals.encodeNode(wrongNode)))
+    val key           = ByteString(Array.fill(32)(0x42.toByte))
 
-    // Build a proof node whose hash is different from realStateRoot
-    val wrongNode = LeafNode(ByteString(0x42.toByte), ByteString("some-value"))
-    val wrongProof = Seq(ByteString(MptTraversals.encodeNode(wrongNode)))
+    // Wrong proof → root node hash ≠ realStateRoot → Left
+    verifier.verifyAccountRange(
+      accounts = Seq(key -> Account(nonce = 1)),
+      proof = wrongProof, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe a[Left[_, _]]
+  }
+
+  // ── Adversarial / crash-safety ───────────────────────────────────────────────
+
+  it should "accept proof for non-existent key without crashing" taggedAs UnitTest in {
+    val storage     = new TestMptStorage()
+    val realAccount = Account(nonce = 1, balance = 100)
+    val trie        = MerklePatriciaTrie[ByteString, Account](storage).put(ByteString("real-key"), realAccount)
+    val verifier    = MerkleProofVerifier(ByteString(trie.getRootHash))
+    val proof       = Seq(ByteString(trie.getRootHash)) // raw hash bytes, not valid RLP
 
     val result = verifier.verifyAccountRange(
-      accounts = Seq(ByteString("key") -> Account(nonce = 1, balance = 1)),
-      proof = wrongProof,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
+      accounts = Seq(ByteString(Array.fill(32)(0x99.toByte)) -> realAccount),
+      proof = proof, startHash = ZeroKey, endHash = MaxKey
     )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("mismatch")
+    // Must not throw; either outcome acceptable
+    result match {
+      case Right(_)    => succeed
+      case Left(error) => error should not be empty
+    }
   }
 
-  // TestSameSideProofs analogue for storage: a storage range proof where the first
-  // slot is lexicographically equal to the last (zero-width range). The basic
-  // validator accepts single-element ranges; an equal-element pair fails monotonicity.
-  it should "reject storage range where first and last slot have identical hashes" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-    val sameSlot = ByteString(Array.fill(32)(0x55.toByte))
+  it should "accept bloated proof with extra irrelevant nodes without crashing" taggedAs UnitTest in {
+    val storage    = new TestMptStorage()
+    val acct       = Account(nonce = 5, balance = 500)
+    val key        = ByteString(Array.fill(32)(0x55.toByte))
+    val trie       = MerklePatriciaTrie[ByteString, Account](storage).put(key, acct)
+    val validProof = generateBoundaryProof(trie, key, key)
+    val bloated    = validProof ++ Seq(ByteString("irrelevant-node-aaa"), ByteString("irrelevant-node-bbb"))
+    val verifier   = MerkleProofVerifier(ByteString(trie.getRootHash))
 
-    val result = verifier.verifyStorageRange(
-      slots = Seq(sameSlot -> ByteString("v1"), sameSlot -> ByteString("v2")),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
+    val result = verifier.verifyAccountRange(
+      accounts = Seq(key -> acct),
+      proof = bloated, startHash = key, endHash = key
     )
-
-    result shouldBe a[Left[_, _]]
-    result.left.get should include("monotonic")
+    result match {
+      case Right(_)    => succeed
+      case Left(error) => error should not be empty
+    }
   }
 
-  // TestEmptyValueRangeProof analogue for storage: a storage slot whose value is
-  // empty (deleted/zeroed). Should be accepted as a valid slot without error.
-  it should "accept storage slot with empty (zeroed) value" taggedAs UnitTest in {
-    val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
+  // ── Empty-value / zero-account edge cases ────────────────────────────────────
+
+  it should "accept account with zero-value fields (default/deleted account)" taggedAs UnitTest in {
+    MerkleProofVerifier(ByteString(MerklePatriciaTrie.EmptyRootHash)).verifyAccountRange(
+      accounts = Seq.empty, proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
+    ) shouldBe Right(())
+  }
+
+  it should "reject nil-proof storage range with empty (zeroed) slot value" taggedAs UnitTest in {
+    // Storage slots with empty values are deletions — the nil-proof hash check will fail
+    // because the SnapHashTrie either panics or computes a different hash
     val slotHash = ByteString(Array.fill(32)(0x33.toByte))
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slotHash -> ByteString.empty),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
-    )
-
-    result shouldBe Right(())
-  }
-
-  // TestGappedRangeProof analogue: a proof covering two keys with a gap between them.
-  // The current implementation validates ordering but not trie-level completeness
-  // (it's a simplified verifier). Two disjoint slots in ascending order should pass
-  // the monotonicity check.
-  it should "accept storage range with a gap between two monotonically increasing keys" taggedAs UnitTest in {
     val storageRoot = kec256(ByteString("storage-root"))
-    val verifier = MerkleProofVerifier(storageRoot)
-
-    val slot1 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x10.toByte)
-    // gap: 0x10 → 0x30 (0x20 is absent)
-    val slot2 = ByteString(Array.fill(31)(0x00.toByte) :+ 0x30.toByte)
-
-    val result = verifier.verifyStorageRange(
-      slots = Seq(slot1 -> ByteString("v1"), slot2 -> ByteString("v2")),
-      proof = Seq.empty,
-      startHash = ByteString.empty,
-      endHash = ByteString.fromArray(Array.fill(32)(0xff.toByte))
+    val result = MerkleProofVerifier(storageRoot).verifyStorageRange(
+      slots = Seq(slotHash -> ByteString.empty),
+      proof = Seq.empty, startHash = ZeroKey, endHash = MaxKey
     )
-
-    // Simplified verifier: monotonicity passes, trie-level gap detection not implemented
-    result shouldBe Right(())
+    // Should fail — either due to hash mismatch or SnapHashTrie rejecting empty value
+    result shouldBe a[Left[_, _]]
   }
 }


### PR DESCRIPTION
## What

Replaces the per-leaf `traversePath` / `traverseStoragePath` proof verification model with the correct trie reconstruction algorithm (go-ethereum `VerifyRangeProof`, Besu `isValidRangeProof`).

**Two files changed:** `MerkleProofVerifier.scala`, `MerkleProofVerifierSpec.scala` (801 insertions, 888 deletions).

---

## Why

### The bug (silent mid-range bypass)

The previous implementation called `traversePath` for every account or slot individually, using proof nodes as a lookup table. When a node hash wasn't found, it returned `Right(())`:

```scala
case None =>
  // Node not in proof - this is acceptable for partial proofs
  Right(())
```

SNAP range proofs only include path nodes for the **left and right boundary keys**. Mid-range accounts diverge from both boundary paths, so their paths legitimately hit nodes not in the proof map. The old code passed this silently — cryptographically verifying **nothing** for mid-range accounts.

A malicious peer could serve correct boundary proofs with arbitrary fabricated accounts in between and Fukuii would accept them with `Right(())`.

### The fix: trie reconstruction

Algorithm used by both go-ethereum (`trie/proof.go VerifyRangeProof`) and Besu (`WorldStateProofProvider.isValidRangeProof`):

1. **Phase 1 — resolveEdgePath** (→ `proofToPath`): Walk from root → `firstKey` path, resolving every `HashNode` from proof nodes. Repeat for `lastKey`, merging into same partial tree.

2. **Phase 2 — pruneInternals** (→ `unsetInternal`): Walk from the fork point where boundaries diverge. Replace all internal structure between boundaries with `NullNode`. Boundary leaves themselves are also removed (re-inserted in Phase 3).

3. **Phase 3 — insertLeaf + hash**: Insert every response leaf into the pruned tree. Call `root.hash` — which recursively encodes, inlining nodes < 32 bytes and hashing nodes ≥ 32 bytes. Compare against the expected state/storage root.

**Invariant**: if the peer returned exactly the leaves in the trie between `firstKey` and `lastKey` (no more, no fewer, no wrong values), the reconstructed root hash equals the expected root. Any gap, fabrication, or wrong value causes a mismatch.

### Key Scala implementation notes

- `PartialProofTrie` — private class with `var root: MptNode`. All nodes are immutable case class instances; "mutation" is `root = newRoot` only.
- `insertLeaf` — port of `MerklePatriciaTrie.putInLeafNode/Extension/Branch` stripped of storage tracking and `HashNode` resolution (which would indicate a bug in `pruneInternals`).
- `LeafNode.key` and `ExtensionNode.sharedKey` store raw nibble bytes (0–15), NOT HexPrefix-encoded — HexPrefix only applied during RLP encoding in `MptTraversals`.
- `traversePath` / `traverseStoragePath` kept as `@unused` dead code for reference.

---

## Tests

- `generateBoundaryProof` helper replaces the broken `collectTrieNodes` (which returned only the root hash, not actual RLP-encoded proof nodes).
- **Gap detection**: builds 3-element trie, returns only 2 elements → `Left` (hash mismatch). This was the primary silent bug — previously returned `Right(())`.
- **Fabricated value**: correct keys, wrong value for one account → `Left`.
- **Nil-proof complete range**: hash via SnapHashTrie matches.
- **Proof of absence**: resolves boundary path, checks `hasRightElement`.
- All 24 tests pass.

---

## Validation

- Full test suite: 3,264 tests, 0 failures on `june-jams` after rebase onto v0.6.3.
- The gap detection test (`should detect missing account in the middle of a range`) verifies the primary regression: it passes after the fix and would have returned `Right(())` before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)