### PR TITLE
test(olympia): EIP-7702 SetCode, EIP-2935 block hash history, BLS12-381, P-256 precompile coverage

### DIFF
--- a/src/test/scala/com/chipprbots/ethereum/ledger/BlockHashHistorySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/BlockHashHistorySpec.scala
@@ -1,0 +1,139 @@
+package com.chipprbots.ethereum.ledger
+
+import org.apache.pekko.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.Mocks
+import com.chipprbots.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import com.chipprbots.ethereum.domain._
+import com.chipprbots.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
+import com.chipprbots.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostOlympia
+import com.chipprbots.ethereum.ledger.BlockExecution.HistoryServeWindow
+import com.chipprbots.ethereum.ledger.BlockExecution.HistoryStorageAddress
+import com.chipprbots.ethereum.ledger.BlockExecution.HistoryStorageCode
+import com.chipprbots.ethereum.mpt.MerklePatriciaTrie
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.BlockchainConfig
+import com.chipprbots.ethereum.utils.Config
+import com.chipprbots.ethereum.utils.Config.SyncConfig
+
+/** EIP-2935: Block hash history storage behavioral integration tests.
+  *
+  * Exercises [[BlockExecution.executeBlockTransactions]] at and around the Olympia activation block to verify that
+  * parent hashes are stored in the history contract at the correct slot `(blockNumber − 1) % 8191`, the contract is
+  * deployed at the activation block, storage is absent before activation, and the 8191-slot wrap-around works
+  * correctly.
+  */
+class BlockHashHistorySpec extends AnyFlatSpec with Matchers {
+
+  private val Window: BigInt = HistoryServeWindow
+
+  trait TestSetup extends EphemBlockchainTestSetup {
+    override lazy val vm: VMImpl = new Mocks.MockVM()
+
+    val olympiaBlock: BigInt = 10
+
+    implicit override lazy val blockchainConfig: BlockchainConfig = blockchainConfig0
+      .withUpdatedForkBlocks(_.copy(olympiaBlockNumber = olympiaBlock))
+
+    private lazy val blockchainConfig0: BlockchainConfig = Config.blockchains.blockchainConfig
+
+    override lazy val blockQueue = BlockQueue(blockchainReader, SyncConfig(Config.config))
+
+    override lazy val blockValidation = new BlockValidation(
+      mining.withValidators(Mocks.MockValidatorsAlwaysSucceed),
+      blockchainReader,
+      blockQueue
+    )
+
+    lazy val exec: BlockExecution = new BlockExecution(
+      blockchain,
+      blockchainReader,
+      blockchainWriter,
+      storagesInstance.storages.evmCodeStorage,
+      mining.blockPreparator,
+      blockValidation
+    )
+
+    val emptyWorld: InMemoryWorldStateProxy = InMemoryWorldStateProxy(
+      storagesInstance.storages.evmCodeStorage,
+      blockchain.getBackingMptStorage(-1),
+      (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
+      UInt256.Zero,
+      ByteString(MerklePatriciaTrie.EmptyRootHash),
+      noEmptyAccounts = false,
+      ethCompatibleStorage = true
+    )
+
+    def makeBlock(number: BigInt, parentHash: ByteString, isOlympia: Boolean = true): Block = Block(
+      header = Fixtures.Blocks.ValidBlock.header.copy(
+        number = number,
+        parentHash = parentHash,
+        gasLimit = 8_000_000,
+        gasUsed = 0,
+        extraFields = if (isOlympia) HefPostOlympia(BigInt(0)) else HefEmpty
+      ),
+      body = BlockBody(Nil, Nil)
+    )
+
+    def runBlock(block: Block, world: InMemoryWorldStateProxy = emptyWorld): InMemoryWorldStateProxy =
+      exec.executeBlockTransactions(block, world).toOption.get.worldState
+  }
+
+  "EIP-2935 block hash history" should "store parent hash at the correct slot for the Olympia activation block" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in new TestSetup {
+    val parentHash: ByteString = ByteString(Array.fill(32)(0xab.toByte))
+    val world = runBlock(makeBlock(olympiaBlock, parentHash))
+
+    val slot = (olympiaBlock - 1) % Window
+    world.getStorage(HistoryStorageAddress).load(slot) shouldBe UInt256(parentHash).toBigInt
+  }
+
+  it should "deploy the history storage contract code at the Olympia activation block" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in new TestSetup {
+    val world = runBlock(makeBlock(olympiaBlock, ByteString(Array.fill(32)(0x01.toByte))))
+    world.getCode(HistoryStorageAddress) shouldBe HistoryStorageCode
+  }
+
+  it should "wrap around the 8191-slot window: block N and block N+8191 share the same slot" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in new TestSetup {
+    val hashA = ByteString(Array.fill(32)(0xaa.toByte))
+    val hashB = ByteString(Array.fill(32)(0xbb.toByte))
+
+    val world1 = runBlock(makeBlock(olympiaBlock, hashA))
+    val world2 = runBlock(makeBlock(olympiaBlock + Window, hashB), world1)
+
+    val slot = (olympiaBlock - 1) % Window
+    world2.getStorage(HistoryStorageAddress).load(slot) shouldBe UInt256(hashB).toBigInt
+  }
+
+  it should "NOT write history storage for blocks before Olympia activation" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in new TestSetup {
+    val world = runBlock(
+      makeBlock(olympiaBlock - 1, ByteString(Array.fill(32)(0xdd.toByte)), isOlympia = false)
+    )
+
+    val slot = (olympiaBlock - 2) % Window
+    world.getStorage(HistoryStorageAddress).load(slot) shouldBe BigInt(0)
+    world.getCode(HistoryStorageAddress) shouldBe ByteString.empty
+  }
+
+  "HistoryStorageCode" should "start with the CALLER opcode (0x33) per EIP-2935 spec" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in {
+    HistoryStorageCode should not be empty
+    HistoryStorageCode.head shouldBe 0x33.toByte
+  }
+}

--- a/src/test/scala/com/chipprbots/ethereum/ledger/SetCodeAuthorizationSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/ledger/SetCodeAuthorizationSpec.scala
@@ -1,0 +1,208 @@
+package com.chipprbots.ethereum.ledger
+
+import java.security.SecureRandom
+
+import org.apache.pekko.util.ByteString
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.Fixtures
+import com.chipprbots.ethereum.crypto.ECDSASignature
+import com.chipprbots.ethereum.crypto.generateKeyPair
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.domain._
+import com.chipprbots.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostOlympia
+import com.chipprbots.ethereum.domain.SetCodeTransaction.addressToDelegation
+import com.chipprbots.ethereum.rlp.PrefixedRLPEncodable
+import com.chipprbots.ethereum.rlp.RLPImplicitConversions.toEncodeable
+import com.chipprbots.ethereum.rlp.RLPImplicits.given
+import com.chipprbots.ethereum.rlp.RLPList
+import com.chipprbots.ethereum.rlp.encode
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.utils.BlockchainConfig
+
+/** EIP-7702: SetCode authorization execution behavioral tests.
+  *
+  * Tests drive [[BlockPreparator.executeTransaction]] with Type-4 [[SetCodeTransaction]]s and verify the state changes
+  * produced by the authorization pipeline: delegation code, nonce increment, EOA-only guard, wildcard chain ID,
+  * undelegate (zero target), nonce mismatch skip, and gas refund for pre-existing authority accounts.
+  */
+// scalastyle:off magic.number
+class SetCodeAuthorizationSpec extends AnyFlatSpec with Matchers {
+
+  private val setup = new TestSetup {}
+  private val secureRandom = new SecureRandom()
+
+  private val olympiaConfig: BlockchainConfig = setup.blockchainConfig.withUpdatedForkBlocks(
+    _.copy(olympiaBlockNumber = BigInt(1), homesteadBlockNumber = BigInt(0), eip155BlockNumber = BigInt(0))
+  )
+
+  private val olympiaHeader: BlockHeader = Fixtures.Blocks.ValidBlock.header.copy(
+    number = 2,
+    gasLimit = 30_000_000,
+    gasUsed = 0,
+    extraFields = HefPostOlympia(BigInt(1_000_000_000))
+  )
+
+  private val targetAddress: Address = Address(0x42)
+  private val senderKeyPair: AsymmetricCipherKeyPair = generateKeyPair(secureRandom)
+  private val senderAddress: Address = Address(senderKeyPair)
+  private val senderBalance: UInt256 = UInt256(BigInt("1000000000000000000000"))
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private def signAuth(
+      keyPair: AsymmetricCipherKeyPair,
+      chainId: BigInt,
+      target: Address,
+      nonce: BigInt
+  ): SetCodeAuthorization = {
+    val sigHash = kec256(
+      encode(
+        PrefixedRLPEncodable(
+          0x05,
+          RLPList(toEncodeable(chainId), toEncodeable(target.toArray), toEncodeable(nonce))
+        )
+      )
+    )
+    val sig = ECDSASignature.sign(sigHash, keyPair)
+    val yParity = if (sig.v == ECDSASignature.negativePointSign) BigInt(0) else BigInt(1)
+    SetCodeAuthorization(chainId, target, nonce, yParity, sig.r, sig.s)
+  }
+
+  private def buildWorld(
+      extra: Map[Address, Account] = Map.empty,
+      extraCode: Map[Address, ByteString] = Map.empty
+  ): InMemoryWorldStateProxy = {
+    val base = setup.emptyWorld.saveAccount(senderAddress, Account(nonce = UInt256(0), balance = senderBalance))
+    val withAccts = extra.foldLeft(base) { case (w, (addr, acc)) => w.saveAccount(addr, acc) }
+    extraCode.foldLeft(withAccts) { case (w, (addr, code)) => w.saveCode(addr, code) }
+  }
+
+  private def makeSetCodeTx(
+      authList: List[SetCodeAuthorization],
+      senderNonce: BigInt = 0
+  ): SignedTransaction = {
+    val tx = SetCodeTransaction(
+      chainId = olympiaConfig.chainId,
+      nonce = senderNonce,
+      maxPriorityFeePerGas = BigInt(0),
+      maxFeePerGas = BigInt(2_000_000_000),
+      gasLimit = BigInt(500_000),
+      receivingAddress = Some(Address(1)),
+      value = BigInt(0),
+      payload = ByteString.empty,
+      accessList = Nil,
+      authorizationList = authList
+    )
+    SignedTransaction.sign(tx, senderKeyPair, Some(olympiaConfig.chainId))
+  }
+
+  private def execTx(stx: SignedTransaction, world: InMemoryWorldStateProxy): InMemoryWorldStateProxy =
+    setup.prep.executeTransaction(stx, senderAddress, olympiaHeader, world)(olympiaConfig).worldState
+
+  // ── Tests ────────────────────────────────────────────────────────────────
+
+  "SetCodeAuthorization" should "set delegation code on authority account after valid authorization" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, olympiaConfig.chainId, targetAddress, nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), buildWorld())
+    result.getCode(authority) shouldBe addressToDelegation(targetAddress)
+  }
+
+  it should "increment authority nonce after applying authorization" taggedAs (OlympiaTest, ConsensusTest) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, olympiaConfig.chainId, targetAddress, nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), buildWorld())
+    result.getAccount(authority).map(_.nonce.toBigInt) shouldBe Some(BigInt(1))
+  }
+
+  it should "skip authorization with wrong chain ID (not 0 and not current chain)" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, BigInt(999), targetAddress, nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), buildWorld())
+    result.getCode(authority) shouldBe ByteString.empty
+  }
+
+  it should "accept chain ID = 0 as wildcard (any chain)" taggedAs (OlympiaTest, ConsensusTest) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, BigInt(0), targetAddress, nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), buildWorld())
+    result.getCode(authority) shouldBe addressToDelegation(targetAddress)
+  }
+
+  it should "clear delegation when target address is zero (EIP-7702 undelegate)" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val existingCode = addressToDelegation(targetAddress)
+    val world = buildWorld(
+      extra = Map(authority -> Account(nonce = UInt256(0), balance = UInt256(0))),
+      extraCode = Map(authority -> existingCode)
+    )
+    val auth = signAuth(authKeys, olympiaConfig.chainId, Address(0L), nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), world)
+    result.getCode(authority) shouldBe ByteString.empty
+  }
+
+  it should "skip authorization if authority nonce does not match" taggedAs (OlympiaTest, ConsensusTest) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, olympiaConfig.chainId, targetAddress, nonce = 5)
+    val result = execTx(makeSetCodeTx(List(auth)), buildWorld())
+    result.getCode(authority) shouldBe ByteString.empty
+  }
+
+  it should "issue a gas refund for pre-existing authority accounts" taggedAs (OlympiaTest, ConsensusTest) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val auth = signAuth(authKeys, olympiaConfig.chainId, targetAddress, nonce = 0)
+    val stx = makeSetCodeTx(List(auth))
+
+    val gasWithExisting = setup.prep
+      .executeTransaction(
+        stx,
+        senderAddress,
+        olympiaHeader,
+        buildWorld(extra = Map(authority -> Account(nonce = UInt256(0), balance = UInt256(100))))
+      )(olympiaConfig)
+      .gasUsed
+    val gasWithoutExisting = setup.prep
+      .executeTransaction(stx, senderAddress, olympiaHeader, buildWorld())(olympiaConfig)
+      .gasUsed
+
+    gasWithExisting should be < gasWithoutExisting
+    (gasWithoutExisting - gasWithExisting) should be <= BigInt(12_500)
+  }
+
+  it should "not set code on a non-EOA authority (contract code blocks delegation)" taggedAs (
+    OlympiaTest,
+    ConsensusTest
+  ) in {
+    val authKeys = generateKeyPair(secureRandom)
+    val authority = Address(authKeys)
+    val contractCode = ByteString(0x60.toByte, 0x60.toByte, 0x60.toByte, 0x40.toByte)
+    val world = buildWorld(
+      extra = Map(authority -> Account(nonce = UInt256(0), balance = UInt256(0))),
+      extraCode = Map(authority -> contractCode)
+    )
+    val auth = signAuth(authKeys, olympiaConfig.chainId, targetAddress, nonce = 0)
+    val result = execTx(makeSetCodeTx(List(auth)), world)
+    result.getCode(authority) shouldBe contractCode
+  }
+}
+// scalastyle:on magic.number

--- a/src/test/scala/com/chipprbots/ethereum/vm/BLS12381PrecompileSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/BLS12381PrecompileSpec.scala
@@ -1,0 +1,147 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.bouncycastle.util.encoders.Hex
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.vm.BlockchainConfigForEvm.EtcForks
+import com.chipprbots.ethereum.vm.BlockchainConfigForEvm.EthForks
+import com.chipprbots.ethereum.vm.PrecompiledContracts._
+
+/** EIP-2537: BLS12-381 precompile execution behavioral tests.
+  *
+  * Tests drive [[BlsG1Add]], [[BlsG2Add]], [[BlsG1MultiExp]], [[BlsG2MultiExp]], [[BlsPairing]], [[BlsMapG1]], and
+  * [[BlsMapG2]] via their `exec` methods using canonical EIP-2537 test vectors. Gas constant tests verify the four
+  * constant-gas precompiles.
+  *
+  * All execution tests call `assume(LibEthPairings.ENABLED)` and are cancelled (not failed) when the native
+  * `libeth_pairings` shared library is absent from the JVM.
+  */
+// scalastyle:off line.size.limit
+class BLS12381PrecompileSpec extends AnyFlatSpec with Matchers {
+
+  import org.hyperledger.besu.nativelib.bls12_381.LibEthPairings
+
+  private def h(s: String): ByteString = ByteString(Hex.decode(s))
+
+  // ── EIP-2537 point constants ─────────────────────────────────────────────
+
+  private val g1Gen: String =
+    "0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb" +
+      "0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"
+
+  private val g1P1: String =
+    "00000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca9426" +
+      "00000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a21"
+
+  private val g1Zero: String = "00" * 128
+
+  private val g2Gen: String =
+    "00000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8" +
+      "0000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e" +
+      "000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801" +
+      "000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"
+
+  private val g2Double: String =
+    "000000000000000000000000000000001638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053" +
+      "000000000000000000000000000000000a4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c33577" +
+      "000000000000000000000000000000000468fb440d82b0630aeb8dca2b5256789a66da69bf91009cbfe6bd221e47aa8ae88dece9764bf3bd999d95d71e4c9899" +
+      "000000000000000000000000000000000f6d4552fa65dd2638b361543f887136a43253d9c66c411697003f7a13c308f5422e1aa0a59c8967acdefd8b6e36ccf3"
+
+  // ── Tests ────────────────────────────────────────────────────────────────
+
+  "BlsG1Add" should "add two valid G1 points and return the correct sum" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val input = h(g1Gen + g1P1)
+    val expected = h(
+      "000000000000000000000000000000000a40300ce2dec9888b60690e9a41d3004fda4886854573974fab73b046d3147ba5b7a5bde85279ffede1b45b3918d82d" +
+        "0000000000000000000000000000000006d3d887e9f53b9ec4eb6cedf5607226754b07c01ace7834f57f3e7315faefb739e59018e22c492006190fba4a870025"
+    )
+    BlsG1Add.exec(input) shouldBe Some(expected)
+  }
+
+  it should "return the point unchanged when adding the identity (G1 + 0 = G1)" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    BlsG1Add.exec(h(g1Gen + g1Zero)) shouldBe Some(h(g1Gen))
+  }
+
+  it should "return None for empty input" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    BlsG1Add.exec(ByteString.empty) shouldBe None
+  }
+
+  "BlsG2Add" should "add G2Gen to itself and return 2·G2Gen" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    BlsG2Add.exec(h(g2Gen + g2Gen)) shouldBe Some(h(g2Double))
+  }
+
+  it should "return None for empty input" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    BlsG2Add.exec(ByteString.empty) shouldBe None
+  }
+
+  "BlsG1MultiExp" should "compute scalar multiplication 1*G1 = G1" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val scalar1 = "0000000000000000000000000000000000000000000000000000000000000001"
+    BlsG1MultiExp.exec(h(g1Gen + scalar1)) shouldBe Some(h(g1Gen))
+  }
+
+  "BlsG2MultiExp" should "compute scalar multiplication 1*G2 = G2" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val scalar1 = "0000000000000000000000000000000000000000000000000000000000000001"
+    BlsG2MultiExp.exec(h(g2Gen + scalar1)) shouldBe Some(h(g2Gen))
+  }
+
+  "BlsPairing" should "return 0x01 for a pair of identity points (vacuous truth)" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val expected = h("0000000000000000000000000000000000000000000000000000000000000001")
+    BlsPairing.exec(ByteString(new Array[Byte](384))) shouldBe Some(expected)
+  }
+
+  it should "return 0x00 for (G1, G2) — pairing ≠ 1 in GT" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val expected = h("0000000000000000000000000000000000000000000000000000000000000000")
+    BlsPairing.exec(h(g1Gen + g2Gen)) shouldBe Some(expected)
+  }
+
+  "BlsMapG1" should "map a valid Fp field element to a G1 point" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val input = h(
+      "00000000000000000000000000000000156c8a6a2c184569d69a76be144b5cdc5141d2d2ca4fe341f011e25e3969c55ad9e9b9ce2eb833c81a908e5fa4ac5f03"
+    )
+    val expected = h(
+      "00000000000000000000000000000000184bb665c37ff561a89ec2122dd343f20e0f4cbcaec84e3c3052ea81d1834e192c426074b02ed3dca4e7676ce4ce48ba" +
+        "0000000000000000000000000000000004407b8d35af4dacc809927071fc0405218f1401a6d15af775810e4e460064bcc9468beeba82fdc751be70476c888bf3"
+    )
+    BlsMapG1.exec(input) shouldBe Some(expected)
+  }
+
+  "BlsMapG2" should "map a valid Fp2 field element to a G2 point" taggedAs (OlympiaTest, VMTest) in {
+    assume(LibEthPairings.ENABLED, "BLS12-381 native library not loaded")
+    val input = h(
+      "0000000000000000000000000000000007355d25caf6e7f2f0cb2812ca0e513bd026ed09dda65b177500fa31714e09ea0ded3a078b526bed3307f804d4b93b04" +
+        "0000000000000000000000000000000002829ce3c021339ccb5caf3e187f6370e1e2a311dec9b75363117063ab2015603ff52c3d3b98f19c2f65575e99e8b78c"
+    )
+    val expected = h(
+      "0000000000000000000000000000000000e7f4568a82b4b7dc1f14c6aaa055edf51502319c723c4dc2688c7fe5944c213f510328082396515734b6612c4e7bb7" +
+        "00000000000000000000000000000000126b855e9e69b1f691f816e48ac6977664d24d99f8724868a184186469ddfd4617367e94527d4b74fc86413483afb35b" +
+        "000000000000000000000000000000000caead0fd7b6176c01436833c79d305c78be307da5f6af6c133c47311def6ff1e0babf57a0fb5539fce7ee12407b0a42" +
+        "000000000000000000000000000000001498aadcf7ae2b345243e281ae076df6de84455d766ab6fcdaad71fab60abb2e8b980a440043cd305db09d283c895e3d"
+    )
+    BlsMapG2.exec(input) shouldBe Some(expected)
+  }
+
+  "BLS12-381 gas constants" should "match EIP-2537 specification" taggedAs (OlympiaTest, VMTest) in {
+    val etc = EtcForks.Olympia
+    val eth = EthForks.Berlin
+    val in = ByteString.empty
+    BlsG1Add.gas(in, etc, eth) shouldBe BigInt(375)
+    BlsG2Add.gas(in, etc, eth) shouldBe BigInt(600)
+    BlsMapG1.gas(in, etc, eth) shouldBe BigInt(5500)
+    BlsMapG2.gas(in, etc, eth) shouldBe BigInt(23800)
+  }
+}
+// scalastyle:on line.size.limit

--- a/src/test/scala/com/chipprbots/ethereum/vm/P256VerifySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/vm/P256VerifySpec.scala
@@ -1,0 +1,78 @@
+package com.chipprbots.ethereum.vm
+
+import org.apache.pekko.util.ByteString
+
+import org.bouncycastle.util.encoders.Hex
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.vm.PrecompiledContracts.P256Verify
+
+/** EIP-7951: secp256r1 (P-256) precompile execution behavioral tests.
+  *
+  * Tests drive [[PrecompiledContracts.P256Verify]] via its `exec` method using Wycheproof ECDSA P-256 SHA-256 test
+  * vectors. Covers valid signature, invalid signature, short input, degenerate r/s values, and an off-curve public key.
+  */
+// scalastyle:off line.size.limit
+class P256VerifySpec extends AnyFlatSpec with Matchers {
+
+  private def h(s: String): ByteString = ByteString(Hex.decode(s))
+
+  private val success32 = h("0000000000000000000000000000000000000000000000000000000000000001")
+  private val failure32 = h("0000000000000000000000000000000000000000000000000000000000000000")
+
+  "P256Verify" should "return 0x01 for a valid secp256r1 signature (Wycheproof SHA-256 #1)" taggedAs (
+    OlympiaTest,
+    VMTest
+  ) in {
+    // Input layout: hash(32) + r(32) + s(32) + Qx(32) + Qy(32) = 160 bytes
+    val input = h(
+      "bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023" + // hash
+        "2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18" + // r
+        "4cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76" + // s
+        "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838" + // Qx
+        "c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e" // Qy
+    )
+    P256Verify.exec(input) shouldBe Some(success32)
+  }
+
+  it should "return 0x00 for a modified-r/s signature (Wycheproof SHA-256 #3)" taggedAs (OlympiaTest, VMTest) in {
+    val input = h(
+      "bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023" + // hash
+        "d45c5740946b2a147f59262ee6f5bc90bd01ed280528b62b3aed5fc93f06f739" + // r (modified)
+        "b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db" + // s (modified)
+        "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838" + // Qx
+        "c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e" // Qy
+    )
+    P256Verify.exec(input) shouldBe Some(failure32)
+  }
+
+  it should "return Some(empty) for input shorter than 160 bytes" taggedAs (OlympiaTest, VMTest) in {
+    P256Verify.exec(ByteString(new Array[Byte](159))) shouldBe Some(ByteString.empty)
+    P256Verify.exec(ByteString.empty) shouldBe Some(ByteString.empty)
+  }
+
+  it should "return 0x00 for all-zero r and s" taggedAs (OlympiaTest, VMTest) in {
+    val input = h(
+      "bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023" + // hash
+        "0000000000000000000000000000000000000000000000000000000000000000" + // r = 0
+        "0000000000000000000000000000000000000000000000000000000000000000" + // s = 0
+        "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838" + // Qx
+        "c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e" // Qy
+    )
+    P256Verify.exec(input) shouldBe Some(failure32)
+  }
+
+  it should "return 0x00 when the public key is not on the P-256 curve" taggedAs (OlympiaTest, VMTest) in {
+    val input = h(
+      "bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023" + // hash
+        "2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18" + // r (valid)
+        "4cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76" + // s (valid)
+        "0000000000000000000000000000000000000000000000000000000000000000" + // Qx = 0
+        "0000000000000000000000000000000000000000000000000000000000000001" // Qy = 1 (not on curve)
+    )
+    P256Verify.exec(input) shouldBe Some(failure32)
+  }
+}
+// scalastyle:on line.size.limit


### PR DESCRIPTION
## What

Adds 30 behavioral tests across four Olympia / ECIP-1121 features already implemented in staging but missing dedicated test coverage.

**Four new files, 572 insertions, 0 production changes.**

---

### P256VerifySpec — 5 tests (EIP-7951 secp256r1)

Drives `PrecompiledContracts.P256Verify.exec()` with Wycheproof ECDSA P-256 SHA-256 test vectors:
- Valid signature → `0x01` (32-byte padded)
- Modified r/s → `0x00`
- Input < 160 bytes → `Some(empty)` (rejection before crypto)
- All-zero r/s → `0x00`
- Off-curve public key (Qx=0, Qy=1) → `0x00`

### BLS12381PrecompileSpec — 12 tests + 1 gas test (EIP-2537)

Drives `BlsG1Add`, `BlsG2Add`, `BlsG1MultiExp`, `BlsG2MultiExp`, `BlsPairing`, `BlsMapG1`, `BlsMapG2` with canonical EIP-2537 test vectors. All execution tests are guarded by `assume(LibEthPairings.ENABLED)` — cancelled (not failed) when the native library is absent. Gas constant tests always run.

### BlockHashHistorySpec — 5 tests (EIP-2935)

Drives `BlockExecution.executeBlockTransactions` at and around the Olympia activation block:
- Parent hash stored at slot `(blockNumber − 1) % 8191`
- History contract code deployed at activation block (starts with CALLER opcode `0x33`)
- 8191-slot wrap-around: block N and N+8191 share the same slot
- No storage written before activation
- `HistoryStorageCode` starts with `0x33` per spec

### SetCodeAuthorizationSpec — 8 tests (EIP-7702)

Drives `BlockPreparator.executeTransaction` with Type-4 `SetCodeTransaction`:
- Delegation code written to authority account
- Authority nonce incremented after authorization
- Wrong chain ID (≠ 0 and ≠ current) skips authorization
- Chain ID = 0 accepted as wildcard
- Zero target address clears existing delegation (undelegate)
- Nonce mismatch skips authorization
- Pre-existing authority account receives ≤12,500 gas refund
- Non-EOA authority (existing non-delegation code) blocks delegation

## Why

These features landed in staging without targeted behavioral tests. The existing `OlympiaEipEnablementSpec` (50 tests) and `PreOlympiaForkComplianceSpec` (47 tests) cover opcode enumeration and pre-fork compliance but not execution correctness, ledger integration, or precompile input/output contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)