### PR TITLE
fix(storage/snap): fsync-backed commitSync for crash-safe SNAP finalization

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -4056,7 +4056,18 @@ class SNAPSyncController(
           // Pivot data is written first so a crash between writes leaves the node in a
           // recoverable state (D3 startup gate detects SnapSyncDone=true with unreachable
           // root and restarts SNAP). Mirrors Besu SnapSyncStatePersistenceManager ordering.
-          appStateStorage.snapSyncDone().commit()
+          //
+          // All three completion flags (snapSyncDone + bytecodeRecoveryDone + storageRecoveryDone)
+          // are written atomically in a single fsync-backed commit. A crash before this call
+          // leaves all flags absent → startup retries SNAP. A crash after → all flags present
+          // → startup proceeds directly to regular sync. There is no inconsistent half-written
+          // state. commitSync() flushes the OS write buffer to disk before returning, eliminating
+          // the ~5-30s dirty-writeback window that previously caused spurious SNAP-RECOVERY.
+          appStateStorage
+            .snapSyncDone()
+            .and(appStateStorage.bytecodeRecoveryDone())
+            .and(appStateStorage.storageRecoveryDone())
+            .commitSync()
 
           log.info(s"SNAP sync completed successfully at block $pivot (hash=${pivotHash.take(8).toHex})")
 

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
@@ -48,6 +48,13 @@ trait DataSource {
     */
   def update(dataSourceUpdates: Seq[DataUpdate]): Unit
 
+  /** Fsync-backed variant of [[update]]: flushes the OS write buffer to disk before returning. Used for critical
+    * one-time writes (e.g. SNAP finalization) where losing the write on power-loss would force an expensive recovery.
+    * Default implementation falls back to [[update]] for non-RocksDB backends (e.g. ephemeral in-memory stores used in
+    * tests).
+    */
+  def updateSync(dataSourceUpdates: Seq[DataUpdate]): Unit = update(dataSourceUpdates)
+
   /** This function updates the DataSource by deleting all the (key-value) pairs in it.
     */
   def clear(): Unit

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSourceBatchUpdate.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSourceBatchUpdate.scala
@@ -15,4 +15,10 @@ case class DataSourceBatchUpdate(dataSource: DataSource, updates: Array[DataUpda
   def commit(): Unit =
     dataSource.update(ArraySeq.unsafeWrapArray(updates))
 
+  /** Fsync-backed commit: calls [[DataSource.updateSync]] to flush the OS write buffer to disk. Use only for critical
+    * one-time writes where durability matters more than throughput.
+    */
+  def commitSync(): Unit =
+    dataSource.updateSync(ArraySeq.unsafeWrapArray(updates))
+
 }

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -78,11 +78,21 @@ class RocksDbDataSource(
     } finally dbLock.readLock().unlock()
   }
 
-  override def update(dataSourceUpdates: Seq[DataUpdate]): Unit = {
+  override def update(dataSourceUpdates: Seq[DataUpdate]): Unit =
+    doWrite(dataSourceUpdates, sync = false)
+
+  /** Fsync-backed write: flushes the OS write buffer to disk before returning. Used for critical one-time commits (SNAP
+    * finalization) to prevent spurious SNAP-RECOVERY on crash. Slightly slower than [[update]] due to the fsync system
+    * call; only use where durability is required and frequency is low.
+    */
+  override def updateSync(dataSourceUpdates: Seq[DataUpdate]): Unit =
+    doWrite(dataSourceUpdates, sync = true)
+
+  private def doWrite(dataSourceUpdates: Seq[DataUpdate], sync: Boolean): Unit = {
     dbLock.writeLock().lock()
     try {
       assureNotClosed()
-      withResources(new WriteOptions()) { writeOptions =>
+      withResources(new WriteOptions().setSync(sync)) { writeOptions =>
         withResources(new WriteBatch()) { batch =>
           dataSourceUpdates.foreach {
             case DataSourceUpdate(namespace, toRemove, toUpsert) =>


### PR DESCRIPTION
## What

Adds `commitSync()` to the storage layer and uses it in `finalizeSnapSync()` to eliminate a crash-recovery bug.

**Four files, 37 insertions, 3 deletions. No production behaviour change under normal operation.**

---

## The bug

`finalizeSnapSync()` wrote `snapSyncDone` with a plain OS-buffered `commit()`. RocksDB's default `WriteOptions::sync = false` means the write sits in the OS page cache for up to ~5-30 seconds before being flushed to disk. A power-loss or OOM-kill within that window leaves `snapSyncDone` absent on restart.

The startup gate sees no `SnapSyncDone` flag → triggers full SNAP-RECOVERY: an ~1h20m flat scan of all 83M account keys to verify trie consistency.

---

## The fix

### `DataSource.updateSync()` (default: falls back to `update()`)
Non-RocksDB backends (ephemeral in-memory stores used in tests) get the default implementation — no test changes required.

### `RocksDbDataSource.updateSync()` (overrides with `sync=true`)
```scala
override def updateSync(dataSourceUpdates: Seq[DataUpdate]): Unit =
  doWrite(dataSourceUpdates, sync = true)
```
`WriteOptions().setSync(true)` forces an fsync system call before returning. The shared `doWrite(sync: Boolean)` helper avoids duplicating the write-batch logic.

### `DataSourceBatchUpdate.commitSync()`
```scala
def commitSync(): Unit = dataSource.updateSync(ArraySeq.unsafeWrapArray(updates))
```

### `finalizeSnapSync()` — atomic flag chain
```scala
appStateStorage
  .snapSyncDone()
  .and(appStateStorage.bytecodeRecoveryDone())
  .and(appStateStorage.storageRecoveryDone())
  .commitSync()
```
All three completion flags are written atomically in a single fsync-backed commit. Either all three are durable or none are — no half-written state on crash.

---

## Design notes

- **go-ethereum and Besu do not use explicit fsync** at SNAP finalization; they rely on RocksDB WAL durability. This is a targeted strengthening, not a deviation from the reference client model.
- `commitSync()` is used **only at the finalization juncture** — not on per-block writes. Performance impact is negligible (one fsync at SNAP completion, which happens once per lifetime).
- The `DataSource.updateSync()` default falls back to `update()`, so all non-RocksDB implementations (ephemeral DB, mock stores) continue to work without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)