### PR TITLE
fix(snap): rotate snap peers on missing-node fetch instead of hammering one

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcher.scala
@@ -21,6 +21,7 @@ import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchCommand
 import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchedStateNode
 import com.chipprbots.ethereum.crypto.kec256
 import com.chipprbots.ethereum.network.Peer
+import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.p2p.Message
 import com.chipprbots.ethereum.network.p2p.messages.ETH63.GetNodeData
 import com.chipprbots.ethereum.network.p2p.messages.ETH63.NodeData
@@ -79,7 +80,7 @@ class StateNodeFetcher(
             requester = Some(
               StateNodeRequester(hash, sender, stateRoot, paths, attempts = 0, isByteCode, fallbackRoot)
             )
-            requestStateNode(hash, stateRoot, paths, isByteCode)
+            requestStateNode(hash, stateRoot, paths, isByteCode, Set.empty)
         }
         Behaviors.same
 
@@ -106,9 +107,12 @@ class StateNodeFetcher(
 
       case StateNodeFetcher.RetryStateNodeRequest =>
         // The peer request resolved to NoSuitablePeer / RequestFailed and FetchRequest piped this
-        // fallback to us. Count it as a failed attempt and either schedule another fire or signal
-        // exhaustion to BlockImporter (which has a 5-minute backoff handler for empty responses).
-        requester.foreach(retryOrExhaust)
+        // fallback to us. This also fires when every snap peer is already in triedPeers (no
+        // un-tried server left this round), so reset the rotation set to re-cycle through the whole
+        // snap pool — peers that were busy or briefly blacklisted earlier may now serve this root.
+        // Then count a failed attempt and either schedule another fire or signal exhaustion to
+        // BlockImporter (which has a 5-minute backoff handler for empty responses).
+        requester.foreach(req => retryOrExhaust(req.copy(triedPeers = Set.empty)))
         Behaviors.same
 
       case StateNodeFetcher.FireRequest =>
@@ -120,7 +124,7 @@ class StateNodeFetcher(
             ByteStringUtils.hash2string(req.hash),
             req.attempts
           )
-          requestStateNode(req.hash, req.stateRoot, req.paths, req.isByteCode)
+          requestStateNode(req.hash, req.stateRoot, req.paths, req.isByteCode, req.triedPeers)
         }
         Behaviors.same
 
@@ -186,12 +190,16 @@ class StateNodeFetcher(
                 updated.stateRoot.map(r => ByteStringUtils.hash2string(r.take(4))).getOrElse("<none>")
               )
               requester = Some(updated)
-              requestStateNode(updated.hash, updated.stateRoot, updated.paths, updated.isByteCode)
+              requestStateNode(updated.hash, updated.stateRoot, updated.paths, updated.isByteCode, updated.triedPeers)
               Behaviors.same[StateNodeFetcherCommand]
             case None =>
-              log.warn("SNAP TrieNodes response was empty, retrying")
+              // This peer doesn't serve the node at this root. Record it so the next retry rotates
+              // to a DIFFERENT snap peer (peers index different block windows), then retry. Empty
+              // here is a correct "I don't have this root" answer, not misbehaviour — a short
+              // rotation exclusion is enough without a long blacklist.
+              log.warn("SNAP TrieNodes response was empty, rotating to a different snap peer")
               peersClient ! BlacklistPeer(peer.id, BlacklistReason.EmptyStateNodeResponse)
-              retryOrExhaust(stateNodeRequester)
+              retryOrExhaust(stateNodeRequester.copy(triedPeers = stateNodeRequester.triedPeers + peer.id))
               Behaviors.same[StateNodeFetcherCommand]
           }
         } else {
@@ -217,12 +225,18 @@ class StateNodeFetcher(
                     updated.stateRoot.map(r => ByteStringUtils.hash2string(r.take(4))).getOrElse("<none>")
                   )
                   requester = Some(updated)
-                  requestStateNode(updated.hash, updated.stateRoot, updated.paths, updated.isByteCode)
+                  requestStateNode(
+                    updated.hash,
+                    updated.stateRoot,
+                    updated.paths,
+                    updated.isByteCode,
+                    updated.triedPeers
+                  )
                   Behaviors.same[StateNodeFetcherCommand]
                 case None =>
-                  log.warn("SNAP TrieNodes: got {} nodes but none matched target hash, retrying", nodes.size)
+                  log.warn("SNAP TrieNodes: got {} nodes but none matched target hash, rotating peer", nodes.size)
                   peersClient ! BlacklistPeer(peer.id, BlacklistReason.WrongStateNodeResponse)
-                  retryOrExhaust(stateNodeRequester)
+                  retryOrExhaust(stateNodeRequester.copy(triedPeers = stateNodeRequester.triedPeers + peer.id))
                   Behaviors.same[StateNodeFetcherCommand]
               }
           }
@@ -238,7 +252,9 @@ class StateNodeFetcher(
     req.fallbackStateRoot
       .filter(fallback => !req.stateRoot.contains(fallback))
       .map { fallback =>
-        req.copy(stateRoot = Some(fallback), fallbackStateRoot = None)
+        // New root ⇒ a different set of peers may be able to serve it, so reset the rotation
+        // exclusion and re-evaluate the whole snap pool against the fallback root.
+        req.copy(stateRoot = Some(fallback), fallbackStateRoot = None, triedPeers = Set.empty)
       }
 
   private def handleByteCodesValues(peer: Peer, codes: Seq[ByteString]): Behavior[StateNodeFetcherCommand] =
@@ -247,9 +263,9 @@ class StateNodeFetcher(
         if (codes.isEmpty) {
           // Per SNAP/1, an empty ByteCodes response means the server doesn't have any of the
           // requested codes — equivalent to a stateless response. Retry against another peer.
-          log.warn("SNAP ByteCodes response was empty, retrying")
+          log.warn("SNAP ByteCodes response was empty, rotating to a different snap peer")
           peersClient ! BlacklistPeer(peer.id, BlacklistReason.EmptyStateNodeResponse)
-          retryOrExhaust(stateNodeRequester)
+          retryOrExhaust(stateNodeRequester.copy(triedPeers = stateNodeRequester.triedPeers + peer.id))
           Behaviors.same[StateNodeFetcherCommand]
         } else {
           // Codes are returned in the same order as requested hashes; we only request one hash
@@ -265,9 +281,9 @@ class StateNodeFetcher(
               requester = None
               Behaviors.same[StateNodeFetcherCommand]
             case None =>
-              log.warn("SNAP ByteCodes: got {} codes but none matched target codeHash, retrying", codes.size)
+              log.warn("SNAP ByteCodes: got {} codes but none matched target codeHash, rotating peer", codes.size)
               peersClient ! BlacklistPeer(peer.id, BlacklistReason.WrongStateNodeResponse)
-              retryOrExhaust(stateNodeRequester)
+              retryOrExhaust(stateNodeRequester.copy(triedPeers = stateNodeRequester.triedPeers + peer.id))
               Behaviors.same[StateNodeFetcherCommand]
           }
         }
@@ -283,17 +299,18 @@ class StateNodeFetcher(
       hash: ByteString,
       stateRoot: Option[ByteString],
       paths: Option[Seq[Seq[ByteString]]],
-      isByteCode: Boolean
+      isByteCode: Boolean,
+      excludePeers: Set[PeerId]
   ): Unit =
     if (isByteCode) {
-      sendGetByteCodes(hash)
+      sendGetByteCodes(hash, excludePeers)
     } else {
       (stateRoot, paths) match {
         case (Some(root), Some(pathGroups)) if pathGroups.nonEmpty =>
           // Use SNAP GetTrieNodes with the SAME root the paths were computed from.
           // The paths are HP-encoded nibble prefixes from a trie walk against this root.
           // Using a different root would make paths invalid — the trie structure differs.
-          sendGetTrieNodes(root, pathGroups)
+          sendGetTrieNodes(root, pathGroups, excludePeers)
 
         case _ =>
           // Fallback to GetNodeData (pre-ETH68 peers only)
@@ -309,11 +326,16 @@ class StateNodeFetcher(
       }
     }
 
-  private def sendGetTrieNodes(root: ByteString, pathGroups: Seq[Seq[ByteString]]): Unit = {
+  private def sendGetTrieNodes(
+      root: ByteString,
+      pathGroups: Seq[Seq[ByteString]],
+      excludePeers: Set[PeerId]
+  ): Unit = {
     log.info(
-      "Requesting missing state node via SNAP GetTrieNodes ({} path groups, root={})",
+      "Requesting missing state node via SNAP GetTrieNodes ({} path groups, root={}, excluding {} tried peer(s))",
       pathGroups.size,
-      root.take(4).toArray.map("%02x".format(_)).mkString
+      root.take(4).toArray.map("%02x".format(_)).mkString,
+      excludePeers.size
     )
     val request = GetTrieNodes(
       requestId = ETH66.nextRequestId,
@@ -322,7 +344,7 @@ class StateNodeFetcher(
       responseBytes = BigInt(512 * 1024)
     )
     val resp = makeRequest(
-      Request(request, BestSnapPeer, (msg: GetTrieNodes) => new GetTrieNodesEnc(msg)),
+      Request(request, BestSnapPeerExcluding(excludePeers), (msg: GetTrieNodes) => new GetTrieNodesEnc(msg)),
       StateNodeFetcher.RetryStateNodeRequest
     )
     context.pipeToSelf(resp.unsafeToFuture()) {
@@ -336,10 +358,11 @@ class StateNodeFetcher(
     * is served by every snap-capable peer regardless of their ETH version, so this works even when the entire peer set
     * is ETH68+ (no GetNodeData).
     */
-  private def sendGetByteCodes(codeHash: ByteString): Unit = {
+  private def sendGetByteCodes(codeHash: ByteString, excludePeers: Set[PeerId]): Unit = {
     log.info(
-      "Requesting missing bytecode via SNAP GetByteCodes (codeHash={})",
-      ByteStringUtils.hash2string(codeHash)
+      "Requesting missing bytecode via SNAP GetByteCodes (codeHash={}, excluding {} tried peer(s))",
+      ByteStringUtils.hash2string(codeHash),
+      excludePeers.size
     )
     val request = GetByteCodes(
       requestId = ETH66.nextRequestId,
@@ -347,7 +370,7 @@ class StateNodeFetcher(
       responseBytes = BigInt(512 * 1024)
     )
     val resp = makeRequest(
-      Request(request, BestSnapPeer, (msg: GetByteCodes) => new GetByteCodesEnc(msg)),
+      Request(request, BestSnapPeerExcluding(excludePeers), (msg: GetByteCodes) => new GetByteCodesEnc(msg)),
       StateNodeFetcher.RetryStateNodeRequest
     )
     context.pipeToSelf(resp.unsafeToFuture()) {
@@ -366,11 +389,14 @@ object StateNodeFetcher {
   ): Behavior[StateNodeFetcherCommand] =
     Behaviors.setup(context => new StateNodeFetcher(peersClient, syncConfig, supervisor, context))
 
-  // Bounded retry budget: 10 attempts × 5s backoff ≈ 50s per missing node before signaling
-  // exhaustion to BlockImporter. Without a bound, the resolvingMissingNode loop could spin forever
-  // when peers keep returning empty TrieNodes (Bug 30 — peers outside the SNAP serve window
-  // disconnect on every GetTrieNodes request).
-  val MaxStateNodeFetchRetries: Int = 10
+  // Bounded retry budget: 30 attempts × 5s backoff ≈ 150s per missing node before signaling
+  // exhaustion to BlockImporter. Each retry rotates to a different snap peer (BestSnapPeerExcluding
+  // over StateNodeRequester.triedPeers), so 30 attempts cycle the whole ~10-peer ETC snap pool ~3×
+  // — enough to reach a peer whose block window covers the parent root. (Was 10 / ≈50s, which on
+  // ETC mainnet exhausted before a serving peer was sampled and stalled regular sync ~14 min on a
+  // single post-pivot storage node, observed 2026-06-02.) Kept well under BlockImporter's ~15 min
+  // StuckEscapeThreshold so a slow fetch can't trip an unwanted SNAP re-sync.
+  val MaxStateNodeFetchRetries: Int = 30
   val BackoffInterval: FiniteDuration = 5.seconds
 
   sealed trait StateNodeFetcherCommand
@@ -398,6 +424,10 @@ object StateNodeFetcher {
       isByteCode: Boolean = false,
       // One-shot fallback root: cleared the moment we switch to it, so we only attempt the
       // root-swap once per recovery (no flip-flop between primary and fallback).
-      fallbackStateRoot: Option[ByteString] = None
+      fallbackStateRoot: Option[ByteString] = None,
+      // Snap peers already tried for the CURRENT root that returned empty/wrong responses.
+      // Excluded from the next GetTrieNodes/GetByteCodes peer selection so each retry samples a
+      // different server. Reset when we switch roots or cycle through the whole pool.
+      triedPeers: Set[PeerId] = Set.empty
   )
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcherSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/StateNodeFetcherSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import com.chipprbots.ethereum.blockchain.sync.PeersClient
-import com.chipprbots.ethereum.blockchain.sync.PeersClient.BestSnapPeer
+import com.chipprbots.ethereum.blockchain.sync.PeersClient.BestSnapPeerExcluding
 import com.chipprbots.ethereum.blockchain.sync.TestSyncConfig
 import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchCommand
 import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.FetchedStateNode
@@ -30,8 +30,10 @@ import com.chipprbots.ethereum.testing.Tags._
   *     supervisor instead of looping forever.
   *   - In-flight de-dup: a second FetchStateNode for the same hash updates replyTo only — no parallel SNAP request gets
   *     fired.
-  *   - Bytecode path: FetchStateNode with isByteCode=true routes to SNAP GetByteCodes (BestSnapPeer), not GetNodeData.
-  *     This unblocks contract bytecode recovery on ETH68-only peer sets where GetNodeData is unavailable.
+  *   - Bytecode path: FetchStateNode with isByteCode=true routes to SNAP GetByteCodes (BestSnapPeerExcluding), not
+  *     GetNodeData. This unblocks contract bytecode recovery on ETH68-only peer sets where GetNodeData is unavailable.
+  *   - Peer rotation: every SNAP request selects via BestSnapPeerExcluding(triedPeers); the first attempt excludes the
+  *     empty set, and empty/wrong responses add the responding peer so each retry samples a different snap server.
   */
 class StateNodeFetcherSpec
     extends TestKit(ActorSystem("StateNodeFetcherSpec"))
@@ -74,7 +76,7 @@ class StateNodeFetcherSpec
 
   "StateNodeFetcher" - {
 
-    "with isByteCode=true, routes the request to SNAP GetByteCodes via BestSnapPeer" taggedAs UnitTest in new TestSetup {
+    "with isByteCode=true, routes the request to SNAP GetByteCodes via BestSnapPeerExcluding" taggedAs UnitTest in new TestSetup {
       fetcher ! StateNodeFetcher.FetchStateNode(
         hash = targetHash,
         originalSender = replyToProbe.ref,
@@ -92,7 +94,9 @@ class StateNodeFetcherSpec
       val req = peersClientProbe.expectMsgClass(3.seconds, classOf[PeersClient.Request[_]])
       req.message shouldBe a[GetByteCodes]
       req.message.asInstanceOf[GetByteCodes].hashes shouldBe Seq(targetHash)
-      req.peerSelector shouldBe BestSnapPeer
+      // First attempt excludes nothing; on empty/wrong responses the responding peer is added to
+      // triedPeers so the next retry rotates to a different snap server (no more single-peer hammer).
+      req.peerSelector shouldBe BestSnapPeerExcluding(Set.empty)
     }
 
     "with stateRoot + paths, routes the request to SNAP GetTrieNodes (not GetByteCodes)" taggedAs UnitTest in new TestSetup {
@@ -110,7 +114,7 @@ class StateNodeFetcherSpec
       val req = peersClientProbe.expectMsgClass(3.seconds, classOf[PeersClient.Request[_]])
       req.message shouldBe a[GetTrieNodes]
       req.message.asInstanceOf[GetTrieNodes].rootHash shouldBe stateRoot
-      req.peerSelector shouldBe BestSnapPeer
+      req.peerSelector shouldBe BestSnapPeerExcluding(Set.empty)
     }
 
     "de-duplicates a second FetchStateNode for the in-flight hash (no parallel request)" taggedAs UnitTest in new TestSetup {
@@ -165,9 +169,10 @@ class StateNodeFetcherSpec
       )
       peersClientProbe.expectMsgClass(3.seconds, classOf[PeersClient.Request[_]])
 
-      // Drive the retry counter directly — each RetryStateNodeRequest increments attempts via
-      // retryOrExhaust. The 10th call (MaxStateNodeFetchRetries) hits the exhaust branch and
-      // sends an empty FetchedStateNode to BlockImporter, triggering its 5-min backoff handler.
+      // Drive the retry counter directly — each RetryStateNodeRequest resets the rotation set and
+      // increments attempts via retryOrExhaust. The MaxStateNodeFetchRetries-th call hits the
+      // exhaust branch and sends an empty FetchedStateNode to BlockImporter, triggering its 5-min
+      // backoff handler.
       (1 to StateNodeFetcher.MaxStateNodeFetchRetries).foreach { _ =>
         fetcher ! StateNodeFetcher.RetryStateNodeRequest
       }


### PR DESCRIPTION
## Problem

After SNAP sync completes, regular-sync block execution can hit a storage/state node the local trie lacks (a post-pivot node, or a deferred-merkleization gap). `StateNodeFetcher` recovers it on demand via SNAP `GetTrieNodes` against the **parent block's exact state root** — the one root guaranteed to contain it.

The fetch was sent via `BestSnapPeer` (non-excluding) on **every** retry, so all attempts hammered the same best peer. If that peer's block window didn't cover the parent root, it returned empty forever, and the `10 × 5s` (~50s) budget exhausted before a serving peer was ever sampled.

**Observed live on ETC mainnet (2026-06-02):** regular sync stalled **~14 min** on a single storage node (`e5018ccd…` for account `888157b2…`, block 24682594) before blacklist-driven rotation incidentally reached a serving peer. That's close enough to `BlockImporter`'s ~15 min `StuckEscapeThreshold` to risk an **unwanted SNAP re-sync**.

## Fix

- **Peer rotation:** select via `BestSnapPeerExcluding(triedPeers)`. Empty/wrong responses add the responding peer to `triedPeers` so each retry rotates to a *different* snap server; when the whole pool is excluded (`NoSuitablePeer` → `RetryStateNodeRequest`) the set resets and re-cycles. Switching to the fallback root also resets it (a new root re-opens the whole pool). Applied to both `GetTrieNodes` and `GetByteCodes`.
- **Deeper budget:** `MaxStateNodeFetchRetries` 10 → 30 (~150s) — cycles the ~10-peer ETC snap pool ~3×, still well under the ~15 min escape valve.

## Tests

`StateNodeFetcherSpec`: assert the selector is `BestSnapPeerExcluding(Set.empty)` on the first attempt; refresh the exhaustion-budget docs. Rotation across real peers is validated live on the ETC mainnet node (the 14-min stall is exactly what this eliminates — turning it into seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)