### PR TITLE
docs(checkpoint): design checkpoint distribution server (CON-008)

### DIFF
--- a/docs/adr/consensus/CON-008-checkpoint-distribution-server.md
+++ b/docs/adr/consensus/CON-008-checkpoint-distribution-server.md
@@ -1,0 +1,290 @@
+# CON-008: Checkpoint Distribution Server
+
+**Status**: Proposed
+
+**Date**: 2026-06-03
+
+## Context
+
+Fukuii can now sync to chain tip, and it ships a complete **checkpoint sync**
+pipeline that lets a fresh node skip SNAP/fast sync entirely by importing a
+pre-built state archive:
+
+| Stage | Component | File |
+|-------|-----------|------|
+| Produce | `fukuii <chain> checkpoint export` | `CheckpointCli.scala`, `CheckpointExporter.scala` |
+| Encode | `.checkpoint` / `.checkpoint.gz` binary format | `CheckpointArchive.scala` |
+| Fetch | HTTP downloader (resumable) | `CheckpointDownloader.scala` |
+| Import | atomic state load + mark SNAP done | `CheckpointImporter.scala` |
+| Wire-up | startup resolution of file/URL | `SyncController.scala` (~L723-774) |
+
+A node operator enables it with one config key (`src/main/resources/conf/base/sync.conf`):
+
+```hocon
+fukuii.sync.checkpoint-sync-url = "https://checkpoints.chipprbots.com/<chain>/latest.checkpoint.gz"
+```
+
+The comment for that key already anticipates this work: *"Operator-supplied
+(chipprbots-hosted or ethpandaops-style infra)."* What does **not** exist yet
+is the server that produces, hosts, and serves those archives. This ADR
+designs that service for the `checkpoints.chipprbots.com` TLD.
+
+### What is actually being served
+
+A `.checkpoint` archive is a full state snapshot at one block:
+
+- the block **header** (RLP) + **chain weight** (total difficulty),
+- **every state-trie node** reachable from `header.stateRoot`,
+- **every storage-trie node** for each non-empty account,
+- **every referenced contract bytecode**,
+- a trailing **CRC32** over the whole stream.
+
+These are large, immutable, write-once blobs. Expect **single-digit to
+low-tens of GiB** per archive for ETC / Mordor / Sepolia, and **substantially
+larger** for ETH mainnet. (Exact sizes must be measured from a real export
+before committing to a storage class — the archive stores raw trie nodes, so
+it is larger than a flat-state snapshot like geth's.) A new archive is cut on
+a schedule (e.g. weekly), so the workload is **large objects, low write rate,
+high read fan-out** — a classic static-object CDN problem, not a database
+problem.
+
+### Constraints imposed by the existing client
+
+The server design is fixed by what `CheckpointDownloader` already does — we
+should host to the client we have, not change the client to fit the host:
+
+1. **Plain HTTPS `GET`.** No auth headers, no signing on the request side.
+2. **Resumable.** It sends `Range: bytes=N-` and expects `206 Partial
+   Content`; if the server answers `200` it restarts from byte 0. The origin
+   **must** honour byte ranges or multi-GiB resumes break.
+3. **Follows redirects** (`HttpClient.Redirect.NORMAL`). So a stable vanity URL
+   can `302` to a versioned object or a CDN/IPFS gateway — the client just
+   follows it.
+4. **Timeouts:** 30 s connect, 30 min per request. The origin must sustain a
+   multi-GiB transfer inside 30 min, i.e. ≳ a few MiB/s to the slowest client;
+   a CDN edge is what makes this comfortable.
+5. **Integrity is CRC32 only.** That catches truncation/bit-rot, **not**
+   tampering — a malicious archive can carry a valid CRC. `CheckpointImporter`
+   additionally checks the embedded `chainId`, but it does **not** verify the
+   imported block hash against any trusted reference. **Whoever controls the
+   URL controls the entire imported state.** Transport authenticity (TLS) and
+   an out-of-band integrity/authenticity channel are therefore part of the
+   design, not optional polish.
+
+## Decision
+
+Host checkpoint archives as **versioned, immutable objects in a Google Cloud
+Storage bucket, fronted by Cloud CDN behind an HTTPS load balancer mapped to
+`checkpoints.chipprbots.com`**. Treat **IPFS as an optional integrity mirror**,
+not the primary serving path.
+
+### 1. Topology
+
+```
+                         checkpoints.chipprbots.com  (managed TLS cert)
+                                      │
+                          ┌───────────▼───────────┐
+                          │  HTTPS Load Balancer   │
+                          │      + Cloud CDN       │   <-- caches multi-GiB blobs at edge
+                          └───────────┬───────────┘
+                                      │ (cache miss)
+                          ┌───────────▼───────────┐
+                          │   GCS bucket (origin)  │   gs://chipprbots-checkpoints
+                          │  versioned, immutable  │
+                          └───────────▲───────────┘
+                                      │ publish
+        ┌─────────────────────────────┴───────────────────────┐
+        │  Checkpoint builder (cron on a synced fukuii node)   │
+        │  export → gzip → sha256 → upload → flip latest →     │
+        │  update manifest → (optional) pin to IPFS            │
+        └──────────────────────────────────────────────────────┘
+```
+
+### 2. URL / object layout
+
+The node config holds a **single** URL per chain, so we need a stable entry
+point plus immutable versioned objects:
+
+```
+gs://chipprbots-checkpoints/
+  etc/
+    21000000-0x1a2b3c.checkpoint.gz          # immutable, content-addressable name
+    21070000-0x9f8e7d.checkpoint.gz
+    latest.checkpoint.gz                     # 302 redirect object -> newest version
+    manifest.json                            # machine-readable index (see §4)
+    manifest.json.sig                        # detached signature over manifest.json
+  mordor/ …
+  sepolia/ …
+  eth/ …
+```
+
+- **Versioned objects** are named `<blockNumber>-<shortBlockHash>.checkpoint.gz`
+  and are **never overwritten** (object versioning + a retention policy
+  enforce this). Long `Cache-Control: public, max-age=31536000, immutable`.
+- **`latest`** is the operator-facing pointer. Implement it as a small object
+  whose only job is to `302` to the current versioned object (or, simpler, as a
+  CDN/LB URL-map rewrite). Short TTL (`max-age=300`) so a new publish is picked
+  up quickly. Because the client follows redirects, `…/latest.checkpoint.gz`
+  resolves transparently.
+- **`manifest.json`** lists every available checkpoint with verification
+  metadata; short TTL.
+
+Recommended operator config:
+
+```hocon
+# Pin to a specific, independently-verified archive (preferred for production):
+fukuii.sync.checkpoint-sync-url = "https://checkpoints.chipprbots.com/etc/21070000-0x9f8e7d.checkpoint.gz"
+
+# Or track latest (convenient for dev / ephemeral nodes):
+fukuii.sync.checkpoint-sync-url = "https://checkpoints.chipprbots.com/etc/latest.checkpoint.gz"
+```
+
+### 3. Why GCS + CDN over IPFS (primary path)
+
+| Criterion | GCS + Cloud CDN | Public IPFS |
+|-----------|-----------------|-------------|
+| Plain HTTPS `GET` from existing client | ✅ native | ✅ via gateway |
+| **HTTP `Range`/206 resume** (required) | ✅ guaranteed | ⚠️ inconsistent across public gateways for multi-GiB |
+| Throughput / latency for multi-GiB | ✅ edge-cached, predictable | ⚠️ gateway-dependent, often slow |
+| Stable URL under our TLD | ✅ | ⚠️ CID changes every export → still need a manifest/redirect anyway |
+| Availability guarantee | ✅ SLA | ⚠️ must run/pay a pinning service → reintroduces a central SPOF |
+| Integrity | CRC32 (in-file) + published SHA-256 + signed manifest | CID is integrity-by-construction |
+| Operational complexity | low (gsutil + lifecycle) | higher (pinning, gateway ops) |
+
+The decisive point: IPFS's headline benefit — **content-addressed integrity**
+— is the one thing our archive format already provides cheaply (CRC32 in-file)
+and that we will additionally publish as a signed SHA-256 manifest. To get
+IPFS's other properties (availability, throughput, Range support) in
+production you end up running a pinning service and a dedicated gateway, which
+is a centralized component anyway — so you pay IPFS's operational cost without
+escaping the centralization you were trying to avoid. GCS + CDN gives the
+required Range semantics, an SLA, and a stable TLD URL with far less moving
+parts.
+
+**Cost note.** Egress dominates the bill (every node pulls multi-GiB). Two
+levers worth evaluating before launch:
+- **Cloud CDN** in front of the bucket collapses repeated edge reads and is
+  strongly recommended regardless.
+- **Cloudflare R2** (S3-compatible, **zero egress fees**, Range-capable) is the
+  strongest pure-cost alternative to a GCS origin and can sit behind the same
+  `checkpoints.chipprbots.com` Cloudflare zone. If projected egress is high,
+  prefer R2 as the origin; the rest of this design (layout, manifest, signing,
+  builder) is storage-agnostic.
+
+### 4. Manifest + integrity / authenticity
+
+Publish a per-chain `manifest.json` alongside the archives. Fukuii does **not**
+consume it today (it just takes a URL), but it is essential for tooling,
+human verification, and a future client enhancement (§7):
+
+```json
+{
+  "network": "etc",
+  "chainId": 61,
+  "checkpoints": [
+    {
+      "blockNumber": 21070000,
+      "blockHash": "0x9f8e7d…",
+      "stateRoot": "0x…",
+      "file": "21070000-0x9f8e7d.checkpoint.gz",
+      "url": "https://checkpoints.chipprbots.com/etc/21070000-0x9f8e7d.checkpoint.gz",
+      "sizeBytes": 9876543210,
+      "sha256": "…",
+      "gzip": true,
+      "createdAt": "2026-06-03T00:00:00Z",
+      "fukuiiVersion": "x.y.z"
+    }
+  ]
+}
+```
+
+Defence in depth, because CRC32 ≠ authenticity:
+
+1. **TLS only** on `checkpoints.chipprbots.com` (HSTS). Prevents on-path
+   tampering of the transport.
+2. **Detached signature** (`cosign` or GPG) over `manifest.json`, published as
+   `manifest.json.sig`, signing key fingerprint documented in the repo. This is
+   the authenticity anchor.
+3. **The archive's block hash is published in the manifest** so operators can
+   cross-check it against a block explorer or their own `bootstrap-checkpoints`
+   entry **before** trusting the imported state.
+4. **Recommended operator practice:** for a given chain, set
+   `checkpoint-sync-url` *and* a matching `bootstrap-checkpoints` /
+   `use-bootstrap-checkpoints` entry for the same block, so the trusted hash is
+   already in config.
+
+### 5. Build & publish pipeline
+
+A scheduled job on a **synced fukuii node** (one of the `barad-dur` /
+`gorgoroth` hosts, ideally a dedicated exporter replica so the export's
+read-only trie walk doesn't contend with a serving node):
+
+1. Pick a **finalized / reorg-safe** block:
+   - post-merge chains (Sepolia, ETH): the finalized block;
+   - PoW chains (ETC, Mordor): tip minus a safety margin (e.g. ≥ 50k blocks),
+     or a known fork-activation block.
+2. `fukuii <chain> checkpoint export --block <N> --output <N>-<hash>.checkpoint --gzip`
+3. Compute `sha256`.
+4. Upload the versioned object to the bucket (immutable, long cache header).
+5. **Atomically** flip `latest` → new object and regenerate + re-sign
+   `manifest.json` **last** (so a half-published state is never the advertised
+   one).
+6. (Optional) `ipfs add` / pin the archive and record the CID in the manifest.
+7. Apply a **retention policy**: keep the last *N* per chain (e.g. 4), lifecycle
+   the rest, to bound storage cost while preserving resume targets.
+
+A template script and runbook live in `ops/checkpoint-server/`.
+
+### 6. Security & operational hardening
+
+- Bucket is **not** publicly writable; only the builder's service account has
+  `objectAdmin`. Reads are public (these are public-network snapshots) via the
+  CDN.
+- **Object Versioning + retention/lock** so a published archive can't be
+  silently mutated.
+- CDN/LB access logs → existing Prometheus/Grafana stack (`ops/.../grafana`,
+  `ops/.../prometheus`) for egress, hit-rate, and 4xx/5xx alerting.
+- Document a **rotation/incident procedure**: if a bad archive ships, remove
+  `latest`, publish a corrected one, rotate the signing key if compromise is
+  suspected.
+
+### 7. Recommended follow-up code change (out of scope for the server, tracked separately)
+
+`CheckpointImporter` currently trusts the archive's block hash implicitly. A
+small, high-value hardening: have `SyncController` (or the importer) **verify
+the imported `blockHash` against a configured trusted reference** — reuse the
+existing `bootstrap-checkpoints` for the same height — and refuse the import on
+mismatch, falling through to SNAP. This turns the distribution server from a
+"trusted" component into a "verifiable" one and removes the single largest risk
+of hosting state centrally. Recommend filing this as its own consensus change.
+
+## Consequences
+
+**Positive**
+- Fast bootstrap for any chain where SNAP-serving peers are scarce
+  (post-merge Sepolia/ETH especially) using infrastructure we already run.
+- Uses the client exactly as built — no protocol or client changes required to
+  ship the server.
+- Stable, branded, TLS-terminated URL under `checkpoints.chipprbots.com`;
+  versioned + immutable objects make resumes and rollbacks safe.
+- Egress controlled by CDN; cost path has a clear R2 escape hatch.
+
+**Negative / risks**
+- Centralized trust anchor: until the §7 client check lands, a node trusting
+  our URL trusts us with its entire state. Mitigated by TLS + signed manifest +
+  documented cross-check, but not eliminated.
+- Egress cost scales with adoption; needs monitoring and possibly R2/Cloudflare.
+- Builder must run against a synced node and pick reorg-safe blocks; a bad
+  block choice ships a uselessly-old or unstable checkpoint.
+
+**Neutral**
+- IPFS remains available as an opt-in mirror; the manifest can carry CIDs so a
+  future, more decentralized distribution mode is additive, not a rewrite.
+
+## References
+
+- `src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/` — full pipeline
+- `src/main/resources/conf/base/sync.conf` — `checkpoint-sync-file` / `checkpoint-sync-url`
+- [CON-002: Bootstrap Checkpoints](CON-002-bootstrap-checkpoints.md)
+- [Checkpoint Service runbook](../../runbooks/checkpoint-service.md)
+- `ops/checkpoint-server/` — build/publish runbook and template script

--- a/docs/adr/consensus/README.md
+++ b/docs/adr/consensus/README.md
@@ -18,6 +18,8 @@ Examples:
 - [CON-004: MESS (Modified Exponential Subjective Scoring) Implementation](CON-004-mess-implementation.md) - Accepted
 - [CON-005: ETH66 Protocol Aware Message Formatting](CON-005-eth66-protocol-aware-message-formatting.md) - Accepted
 - [CON-006: ForkId Compatibility During Initial Sync](CON-006-forkid-compatibility-during-initial-sync.md) - Accepted
+- [CON-007: ETC64 RLP Encoding Fix](CON-007-etc64-rlp-encoding-fix.md) - Accepted
+- [CON-008: Checkpoint Distribution Server](CON-008-checkpoint-distribution-server.md) - Proposed
 
 ## Creating a New Consensus ADR
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,6 +204,8 @@ nav:
         - MESS Implementation: adr/consensus/CON-004-mess-implementation.md
         - ETH66 Formatting: adr/consensus/CON-005-eth66-protocol-aware-message-formatting.md
         - ForkID Compatibility: adr/consensus/CON-006-forkid-compatibility-during-initial-sync.md
+        - ETC64 RLP Encoding Fix: adr/consensus/CON-007-etc64-rlp-encoding-fix.md
+        - Checkpoint Distribution Server: adr/consensus/CON-008-checkpoint-distribution-server.md
       - VM:
         - adr/vm/README.md
         - EIP-3541: adr/vm/VM-001-eip-3541-implementation.md

--- a/ops/checkpoint-server/README.md
+++ b/ops/checkpoint-server/README.md
@@ -77,16 +77,17 @@ cosign verify-blob --key checkpoints.pub --signature \
 #    (block explorer, your own synced node) BEFORE trusting the archive.
 
 # 3. Verify the download against the manifest sha256
-sha256sum etc-21070000.checkpoint.gz   # compare to manifest entry
+sha256sum 21070000-0x9f8e7d.checkpoint.gz   # compare to manifest entry
 ```
 
 For production nodes, set both keys for the same block so the trusted hash is
-in config:
+in config. Bootstrap checkpoints live under `fukuii.sync` (parsed from the
+`sync` section in `Config.scala`), the same namespace as `checkpoint-sync-url`:
 
 ```hocon
 fukuii.sync.checkpoint-sync-url = "https://checkpoints.chipprbots.com/etc/21070000-0x9f8e7d.checkpoint.gz"
-fukuii.blockchain.use-bootstrap-checkpoints = true
-fukuii.blockchain.bootstrap-checkpoints = ["21070000:0x9f8e7d…"]
+fukuii.sync.use-bootstrap-checkpoints = true
+fukuii.sync.bootstrap-checkpoints = ["21070000:0x9f8e7d…"]
 ```
 
 ## Monitoring

--- a/ops/checkpoint-server/README.md
+++ b/ops/checkpoint-server/README.md
@@ -1,0 +1,105 @@
+# Checkpoint Distribution Server
+
+Operational runbook for producing and serving `.checkpoint` archives at
+`checkpoints.chipprbots.com`, so fresh fukuii nodes can bootstrap a full state
+without running SNAP/fast sync.
+
+> Design rationale and the chosen topology (GCS + Cloud CDN, IPFS as an
+> optional mirror) are in
+> [`docs/adr/consensus/CON-008-checkpoint-distribution-server.md`](../../docs/adr/consensus/CON-008-checkpoint-distribution-server.md).
+> Node-operator usage of the checkpoint feature is in
+> [`docs/runbooks/checkpoint-service.md`](../../docs/runbooks/checkpoint-service.md).
+
+## What this serves
+
+Large, immutable, write-once binary archives (full state trie + bytecodes +
+header + chain weight) produced by `fukuii <chain> checkpoint export`. Nodes
+fetch them over plain HTTPS `GET` via the `checkpoint-sync-url` config key. The
+client (`CheckpointDownloader`) **requires HTTP `Range` support** for resumable
+multi-GiB downloads and **follows redirects**, so a stable `latest` URL can
+`302` to a versioned object.
+
+## Bucket / URL layout
+
+```
+gs://chipprbots-checkpoints/<chain>/
+    <blockNumber>-<shortHash>.checkpoint.gz   # immutable, long-cache
+    latest.checkpoint.gz                      # 302 -> newest, short-cache
+    manifest.json                             # index + sha256 + blockHash
+    manifest.json.sig                         # detached signature
+```
+
+`<chain>` is one of `etc`, `mordor`, `sepolia`, `eth` (matching the launcher
+chain selector).
+
+## One-time infrastructure setup
+
+1. **Bucket** (origin): create `gs://chipprbots-checkpoints`, enable Object
+   Versioning, public read, builder service account = `objectAdmin` only.
+2. **HTTPS LB + Cloud CDN**: backend bucket = the GCS bucket, managed TLS cert
+   for `checkpoints.chipprbots.com`, CDN enabled. (Or front with Cloudflare;
+   for high egress prefer a Cloudflare **R2** origin — zero egress fees — with
+   the same layout.)
+3. **DNS**: `checkpoints.chipprbots.com` A/AAAA → LB IP (or Cloudflare proxied).
+4. **Cache policy**: versioned objects `Cache-Control: public, max-age=31536000,
+   immutable`; `latest.*` and `manifest.*` `max-age=300`.
+5. **Signing key**: generate a `cosign`/GPG key for the manifest; publish the
+   public key fingerprint in the repo.
+
+## Publishing a checkpoint
+
+Run on a **synced** fukuii node (preferably a dedicated exporter replica).
+Pick a **reorg-safe** block — finalized on post-merge chains, tip − margin on
+PoW chains.
+
+```bash
+ops/checkpoint-server/publish-checkpoint.sh \
+  --chain etc \
+  --block 21070000 \
+  --bucket gs://chipprbots-checkpoints \
+  --datadir /var/lib/fukuii/etc
+```
+
+The script: exports + gzips, computes sha256, reads the block hash, uploads the
+immutable object, regenerates and re-signs `manifest.json`, flips `latest`
+last, and prunes old versions. See `--help` and inline comments. It is a
+**template** — wire it into your secret/identity story before production use.
+
+## Verification (operators & maintainers)
+
+```bash
+# 1. Fetch and check the signed manifest
+curl -fsSL https://checkpoints.chipprbots.com/etc/manifest.json -o manifest.json
+cosign verify-blob --key checkpoints.pub --signature \
+  <(curl -fsSL https://checkpoints.chipprbots.com/etc/manifest.json.sig) manifest.json
+
+# 2. Cross-check the checkpoint block hash against an independent source
+#    (block explorer, your own synced node) BEFORE trusting the archive.
+
+# 3. Verify the download against the manifest sha256
+sha256sum etc-21070000.checkpoint.gz   # compare to manifest entry
+```
+
+For production nodes, set both keys for the same block so the trusted hash is
+in config:
+
+```hocon
+fukuii.sync.checkpoint-sync-url = "https://checkpoints.chipprbots.com/etc/21070000-0x9f8e7d.checkpoint.gz"
+fukuii.blockchain.use-bootstrap-checkpoints = true
+fukuii.blockchain.bootstrap-checkpoints = ["21070000:0x9f8e7d…"]
+```
+
+## Monitoring
+
+Wire CDN/LB access logs into the existing Prometheus/Grafana stack
+(`ops/barad-dur/prometheus`, `ops/barad-dur/grafana`). Alert on: 5xx rate,
+egress GiB/day, cache hit-rate dropping (origin overload), and publish-job
+failures.
+
+## Incident / rotation
+
+- **Bad archive shipped:** remove/redirect `latest`, publish a corrected
+  versioned object, regenerate + re-sign the manifest. Versioned objects are
+  immutable, so old (good) versions remain valid resume targets.
+- **Signing key compromise:** rotate the key, re-sign all manifests, update the
+  published fingerprint, and announce.

--- a/ops/checkpoint-server/publish-checkpoint.sh
+++ b/ops/checkpoint-server/publish-checkpoint.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 CHAIN=""
-BLOCK=""                       # empty -> exporter uses current best block
+BLOCK=""                       # required: a reorg-safe block, so the name/manifest are deterministic
 BUCKET="gs://chipprbots-checkpoints"
 DATADIR=""
 KEEP=4
@@ -29,10 +29,11 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 usage() {
   cat <<EOF
-Usage: $0 --chain <etc|mordor|sepolia|eth> [--block N] --bucket gs://... [--datadir DIR] [--keep N]
+Usage: $0 --chain <etc|mordor|sepolia|eth> --block N --bucket gs://... [--datadir DIR] [--keep N]
 
   --chain    Chain selector passed to the fukuii launcher (required)
-  --block    Block number to export; reorg-safe (finalized / tip-margin). Omit = best block.
+  --block    Block number to export; reorg-safe (finalized / tip-margin) (required).
+             Required so the published object name and manifest are deterministic.
   --bucket   Destination GCS bucket root (default: $BUCKET)
   --datadir  fukuii datadir for this chain (sets -Dfukuii.datadir)
   --keep     How many versioned archives to retain per chain (default: $KEEP)
@@ -53,7 +54,10 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown arg: $1" >&2; usage 1 ;;
   esac
 done
+# Fail fast on missing required args — before the (potentially multi-GiB) export.
 [[ -n "$CHAIN" ]] || { echo "--chain is required" >&2; usage 1; }
+[[ -n "$BLOCK" ]] || { echo "--block is required (pick a reorg-safe block)" >&2; usage 1; }
+[[ "$BLOCK" =~ ^[0-9]+$ ]] || { echo "--block must be a non-negative integer" >&2; usage 1; }
 
 JVM_OPTS=()
 [[ -n "$DATADIR" ]] && JVM_OPTS+=("-Dfukuii.datadir=$DATADIR")
@@ -72,15 +76,16 @@ GZ_OUT="${RAW_OUT}.gz"   # exporter auto-appends .gz when --gzip is set
 # Block number + hash come from the manifest the exporter logs; in this template
 # we re-read them via the JSON-RPC of the same node. Adjust to your environment.
 : "${RPC_URL:=http://127.0.0.1:8546}"
-hexblock=$(printf '0x%x' "${BLOCK:-0}")
-if [[ -n "$BLOCK" ]]; then
-  BLOCK_HASH=$(curl -fsS -X POST --data \
-    "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"$hexblock\",false],\"id\":1}" \
-    "$RPC_URL" | jq -r '.result.hash')
-else
-  echo "!! --block not given; set BLOCK explicitly so the published name/manifest is deterministic" >&2
+hexblock=$(printf '0x%x' "$BLOCK")
+BLOCK_HASH=$(curl -fsS -X POST --data \
+  "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"$hexblock\",false],\"id\":1}" \
+  "$RPC_URL" | jq -r '.result.hash // empty')
+# A failed RPC / unknown block yields empty here; refuse rather than publishing a
+# `null`-named object or recording an invalid hash in the manifest.
+[[ "$BLOCK_HASH" =~ ^0x[0-9a-fA-F]{64}$ ]] || {
+  echo "!! could not resolve a valid block hash for block $BLOCK from $RPC_URL (got: '${BLOCK_HASH:-<empty>}')" >&2
   exit 1
-fi
+}
 SHORT_HASH="${BLOCK_HASH:0:8}"
 SHA256=$(sha256sum "$GZ_OUT" | cut -d' ' -f1)
 SIZE=$(stat -c%s "$GZ_OUT")
@@ -118,14 +123,22 @@ else
 fi
 
 # --- 5. flip latest LAST --------------------------------------------------
-# Implemented as a redirect object; the LB/CDN can also do this via URL map.
-echo ">> pointing latest -> $OBJ_NAME"
+# Two correct options; this template uses (a) because it is self-contained and
+# works with the existing client (plain GET, no redirect needed):
+#
+#   (a) Server-side copy of the just-published object to `latest.checkpoint.gz`.
+#       `gsutil cp gs://src gs://dst` copies within GCS — it does NOT re-upload
+#       the multi-GiB body from this host. `latest` is then a real, downloadable
+#       archive (short TTL so a new publish is picked up quickly).
+#
+#   (b) PREFERRED AT SCALE: leave `latest` out of the bucket entirely and serve
+#       `…/latest.checkpoint.gz` as an HTTP 302 to the versioned object via a
+#       CDN/LB URL-map rewrite. The client follows redirects, and `latest` never
+#       becomes a mutable large object. Configure this in your LB, not here.
+echo ">> pointing latest -> $OBJ_NAME (server-side copy)"
 gsutil -h "Cache-Control:public, max-age=300" \
-       -h "x-goog-meta-redirect:$PUBLIC_BASE/$OBJ_NAME" \
-       cp "$GZ_OUT" "$BUCKET/$CHAIN/latest.checkpoint.gz"
-# NOTE: a metadata header alone does not redirect. In production prefer a CDN/LB
-# URL rewrite for `latest`, or store latest as a tiny object served with a 302
-# by the edge. Kept simple here; adapt to your LB config.
+       -h "Content-Type:application/octet-stream" \
+       cp "$DEST" "$BUCKET/$CHAIN/latest.checkpoint.gz"
 
 # --- 6. prune -------------------------------------------------------------
 echo ">> pruning to newest $KEEP versions"

--- a/ops/checkpoint-server/publish-checkpoint.sh
+++ b/ops/checkpoint-server/publish-checkpoint.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# publish-checkpoint.sh — produce a .checkpoint archive and publish it to the
+# chipprbots checkpoint distribution bucket (see
+# docs/adr/consensus/CON-008-checkpoint-distribution-server.md).
+#
+# TEMPLATE: review and wire into your identity/secret management before running
+# in production. It assumes `fukuii`, `gsutil`, `sha256sum`, and `jq` are on PATH,
+# and (for signing) `cosign` with a key at $COSIGN_KEY.
+#
+# Workflow:
+#   1. export state at a reorg-safe block  -> <block>-<shorthash>.checkpoint.gz
+#   2. sha256 + read block hash
+#   3. upload immutable versioned object (long cache)
+#   4. regenerate + re-sign manifest.json
+#   5. flip latest.checkpoint.gz LAST (so a half-published state is never advertised)
+#   6. prune old versions, keeping the most recent --keep
+#
+set -euo pipefail
+
+CHAIN=""
+BLOCK=""                       # empty -> exporter uses current best block
+BUCKET="gs://chipprbots-checkpoints"
+DATADIR=""
+KEEP=4
+FUKUII_BIN="${FUKUII_BIN:-fukuii}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+usage() {
+  cat <<EOF
+Usage: $0 --chain <etc|mordor|sepolia|eth> [--block N] --bucket gs://... [--datadir DIR] [--keep N]
+
+  --chain    Chain selector passed to the fukuii launcher (required)
+  --block    Block number to export; reorg-safe (finalized / tip-margin). Omit = best block.
+  --bucket   Destination GCS bucket root (default: $BUCKET)
+  --datadir  fukuii datadir for this chain (sets -Dfukuii.datadir)
+  --keep     How many versioned archives to retain per chain (default: $KEEP)
+
+Env: FUKUII_BIN (default: fukuii), COSIGN_KEY (path to signing key; signing skipped if unset)
+EOF
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --chain)   CHAIN="$2"; shift 2 ;;
+    --block)   BLOCK="$2"; shift 2 ;;
+    --bucket)  BUCKET="$2"; shift 2 ;;
+    --datadir) DATADIR="$2"; shift 2 ;;
+    --keep)    KEEP="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+[[ -n "$CHAIN" ]] || { echo "--chain is required" >&2; usage 1; }
+
+JVM_OPTS=()
+[[ -n "$DATADIR" ]] && JVM_OPTS+=("-Dfukuii.datadir=$DATADIR")
+
+# --- 1. export ------------------------------------------------------------
+RAW_OUT="$WORKDIR/${CHAIN}.checkpoint"
+echo ">> exporting ${CHAIN} state${BLOCK:+ at block $BLOCK} ..."
+EXPORT_ARGS=("$CHAIN" checkpoint export --output "$RAW_OUT" --gzip)
+[[ -n "$BLOCK" ]] && EXPORT_ARGS+=(--block "$BLOCK")
+JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} ${JVM_OPTS[*]:-}" "$FUKUII_BIN" "${EXPORT_ARGS[@]}"
+
+GZ_OUT="${RAW_OUT}.gz"   # exporter auto-appends .gz when --gzip is set
+[[ -f "$GZ_OUT" ]] || { echo "expected $GZ_OUT not found" >&2; exit 1; }
+
+# --- 2. metadata ----------------------------------------------------------
+# Block number + hash come from the manifest the exporter logs; in this template
+# we re-read them via the JSON-RPC of the same node. Adjust to your environment.
+: "${RPC_URL:=http://127.0.0.1:8546}"
+hexblock=$(printf '0x%x' "${BLOCK:-0}")
+if [[ -n "$BLOCK" ]]; then
+  BLOCK_HASH=$(curl -fsS -X POST --data \
+    "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"$hexblock\",false],\"id\":1}" \
+    "$RPC_URL" | jq -r '.result.hash')
+else
+  echo "!! --block not given; set BLOCK explicitly so the published name/manifest is deterministic" >&2
+  exit 1
+fi
+SHORT_HASH="${BLOCK_HASH:0:8}"
+SHA256=$(sha256sum "$GZ_OUT" | cut -d' ' -f1)
+SIZE=$(stat -c%s "$GZ_OUT")
+OBJ_NAME="${BLOCK}-${SHORT_HASH}.checkpoint.gz"
+
+echo ">> block=$BLOCK hash=$BLOCK_HASH size=$SIZE sha256=$SHA256 -> $OBJ_NAME"
+
+# --- 3. upload immutable object ------------------------------------------
+DEST="$BUCKET/$CHAIN/$OBJ_NAME"
+gsutil -h "Cache-Control:public, max-age=31536000, immutable" \
+       -h "Content-Type:application/octet-stream" \
+       cp "$GZ_OUT" "$DEST"
+
+# --- 4. regenerate + sign manifest ---------------------------------------
+MANIFEST="$WORKDIR/manifest.json"
+PUBLIC_BASE="https://checkpoints.chipprbots.com/$CHAIN"
+# Merge the new entry into the existing manifest if present.
+gsutil cp "$BUCKET/$CHAIN/manifest.json" "$MANIFEST" 2>/dev/null || echo '{"network":"'"$CHAIN"'","checkpoints":[]}' > "$MANIFEST"
+jq --argjson n "$BLOCK" --arg h "$BLOCK_HASH" --arg f "$OBJ_NAME" \
+   --arg u "$PUBLIC_BASE/$OBJ_NAME" --argjson s "$SIZE" --arg c "$SHA256" \
+   --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+   .checkpoints = ([{blockNumber:$n, blockHash:$h, file:$f, url:$u, sizeBytes:$s, sha256:$c, gzip:true, createdAt:$t}]
+                   + (.checkpoints // []))
+                  | sort_by(-.blockNumber) | unique_by(.blockNumber)' \
+   "$MANIFEST" > "$MANIFEST.new" && mv "$MANIFEST.new" "$MANIFEST"
+
+gsutil -h "Cache-Control:public, max-age=300" -h "Content-Type:application/json" \
+       cp "$MANIFEST" "$BUCKET/$CHAIN/manifest.json"
+
+if [[ -n "${COSIGN_KEY:-}" ]]; then
+  cosign sign-blob --yes --key "$COSIGN_KEY" --output-signature "$MANIFEST.sig" "$MANIFEST"
+  gsutil -h "Cache-Control:public, max-age=300" cp "$MANIFEST.sig" "$BUCKET/$CHAIN/manifest.json.sig"
+else
+  echo "!! COSIGN_KEY unset — manifest published UNSIGNED (not for production)" >&2
+fi
+
+# --- 5. flip latest LAST --------------------------------------------------
+# Implemented as a redirect object; the LB/CDN can also do this via URL map.
+echo ">> pointing latest -> $OBJ_NAME"
+gsutil -h "Cache-Control:public, max-age=300" \
+       -h "x-goog-meta-redirect:$PUBLIC_BASE/$OBJ_NAME" \
+       cp "$GZ_OUT" "$BUCKET/$CHAIN/latest.checkpoint.gz"
+# NOTE: a metadata header alone does not redirect. In production prefer a CDN/LB
+# URL rewrite for `latest`, or store latest as a tiny object served with a 302
+# by the edge. Kept simple here; adapt to your LB config.
+
+# --- 6. prune -------------------------------------------------------------
+echo ">> pruning to newest $KEEP versions"
+mapfile -t OLD < <(gsutil ls "$BUCKET/$CHAIN/" | grep -E '[0-9]+-0x[0-9a-f]+\.checkpoint\.gz$' | sort -t/ -k5 -V | head -n -"$KEEP")
+for o in "${OLD[@]:-}"; do
+  [[ -n "$o" ]] && { echo "   rm $o"; gsutil rm "$o"; }
+done
+
+echo ">> done: $DEST"


### PR DESCRIPTION
## Summary

Now that the node syncs to tip, this PR designs the **checkpoint distribution server** that will host `.checkpoint` archives at `checkpoints.chipprbots.com`, letting fresh nodes bootstrap a full state via the existing `checkpoint-sync-url` path instead of running SNAP/fast sync.

This is a **design/recommendation** PR (docs + ops template only — no code changes to the node).

## What I reviewed

The complete checkpoint pipeline already in the tree:

| Stage | File |
|-------|------|
| Produce | `CheckpointCli.scala`, `CheckpointExporter.scala` |
| Encode (`.checkpoint`/`.gz`, CRC32 trailer) | `CheckpointArchive.scala` |
| Fetch (HTTPS GET, **Range/resume**, follows redirects) | `CheckpointDownloader.scala` |
| Import (atomic load, marks SNAP done) | `CheckpointImporter.scala` |
| Startup wire-up (`checkpoint-sync-file`/`-url`) | `SyncController.scala` |

Key constraints that drove the design:
- Client speaks **plain HTTPS GET**, **requires `Range`/206** for multi-GiB resume, and **follows redirects** — so a static-object CDN is the natural fit and a stable `latest` URL can `302` to a versioned object.
- Integrity in-file is **CRC32 only** (corruption, not tamper-proofing), and `CheckpointImporter` does **not** cross-check the imported block hash against any trusted reference — so trust currently rests entirely on the URL/TLS. Authenticity is handled via a signed manifest + documented cross-check, and a follow-up client hardening is recommended.

## Recommendation (CON-008)

- **Primary:** GCS bucket (versioned, immutable objects) → **Cloud CDN** → HTTPS LB on `checkpoints.chipprbots.com`.
- **IPFS:** optional integrity *mirror*, not primary — its content-addressing benefit is already covered by in-file CRC32 + a signed SHA-256 manifest, and a production IPFS path needs pinning/gateway infra that reintroduces centralization anyway.
- **Cost escape hatch:** Cloudflare **R2** (zero egress) as an alternative origin if egress is high — the layout/manifest/builder are storage-agnostic.
- Per-chain layout: immutable `<block>-<hash>.checkpoint.gz`, a short-TTL `latest` redirect, and a signed `manifest.json`.
- Build pipeline: scheduled `fukuii <chain> checkpoint export` on a synced node at a **reorg-safe** block → gzip → sha256 → upload → re-sign manifest → flip `latest` last → prune.

## Files

- `docs/adr/consensus/CON-008-checkpoint-distribution-server.md` — the design/decision record
- `ops/checkpoint-server/README.md` — operational runbook
- `ops/checkpoint-server/publish-checkpoint.sh` — template publish pipeline
- ADR index + mkdocs nav updated (also backfilled the missing CON-007 entry)

## Recommended follow-up (separate change)

Harden `CheckpointImporter`/`SyncController` to **verify the imported block hash against a configured trusted reference** (reuse `bootstrap-checkpoints`) and refuse on mismatch. This turns the server from a *trusted* component into a *verifiable* one and removes the main risk of hosting state centrally.

https://claude.ai/code/session_01Kn3ZUcAJR5MPuJDY6LrPQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn3ZUcAJR5MPuJDY6LrPQD)_