### PR TITLE
Add Fukuii operations skills for maintenance & node management

### DIFF
--- a/.claude/skills/CONVENTIONS.md
+++ b/.claude/skills/CONVENTIONS.md
@@ -1,0 +1,118 @@
+# Shared conventions for Fukuii operations skills
+
+Every skill in this directory assumes the contract below. Skills reference this
+file instead of repeating it.
+
+## 1. Locating the node
+
+- **Binary / entry point**: `./bin/fukuii <network>` (e.g. `etc`, `mordor`,
+  `sepolia`), or the wrapper `./fukuii.sh` → `ops/tools/fukuii-cli.sh`.
+- **Data directory**: `~/.fukuii/<network>/` by default (overridable via
+  `-Dfukuii.datadir=...` or config). Contains `node.key`, `keystore/`, `logs/`,
+  `rocksdb/`, `knownNodes.json`, `app-state.json`.
+- **Config file**: `conf/fukuii.conf` (HOCON). Network sub-configs live under
+  `src/main/resources/conf/`.
+- **JSON-RPC endpoint**: HTTP on the configured RPC port. The **default is
+  `8546`** (`network.rpc.http.port`; WebSocket default `8552`, Engine API
+  authrpc `8551`). Some older runbook examples say `8545` — **confirm the actual
+  port** from config before calling. Never assume.
+
+## 2. Calling the node
+
+Standard JSON-RPC 2.0 over HTTP. Canonical shape:
+
+```bash
+curl -s -X POST http://localhost:<RPC_PORT> \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"<method>","params":[<args>]}'
+```
+
+The relevant namespace must be enabled in config. The shipped default is
+`network.rpc.apis = "eth,web3,net,personal,fukuii,debug,qa,admin"` — note that
+**`mcp` is NOT enabled by default**, so the in-process MCP tools require adding
+`mcp` to that list. If a method returns "method not found", the namespace is
+likely disabled — surface that, don't silently retry.
+
+Useful read-only methods for diagnostics (safe, no state change):
+`web3_clientVersion`, `net_version`, `net_listening`, `net_peerCount`,
+`eth_syncing`, `eth_blockNumber`, `eth_mining`, `eth_hashrate`, `eth_coinbase`,
+`admin_nodeInfo`, `admin_peers`, `admin_datadir`, `admin_listBlockedIPs`,
+`miner_getStatus`. The in-process **MCP read tools** (`mcp_node_status`,
+`mcp_sync_status`, `mcp_peer_list`, `mcp_blockchain_info`, `mcp_node_info`,
+`mcp_mining_rpc_summary`, …) return the same data in agent-friendly form.
+
+## 3. Guarded-write protocol (read this)
+
+Skills are allowed to perform **write / control** operations, but must gate them.
+Classify every action before running it:
+
+- 🟢 **Read-only** — run freely (the methods in §2, log reading, `df`, status
+  checks). No confirmation needed.
+- 🟡 **Reversible write** — e.g. `admin_addPeer` / `admin_removePeer`,
+  `admin_changeLogLevel`, `admin_maxPeers`, `admin_blockIP` / `admin_unblockIP`,
+  `admin_addTrustedPeer` / `admin_removeTrustedPeer`, `miner_start` /
+  `miner_stop` / `miner_setEtherbase`. **State the exact call and expected
+  effect, then confirm with the operator before executing.**
+- 🔴 **Irreversible / disruptive** — e.g. `admin_importChain`, restoring a
+  datadir over an existing one, deleting/pruning `rocksdb/`, rotating
+  `node.key`, editing config that requires a restart, anything that stops the
+  node or can lose data. **Require explicit confirmation, take a backup first
+  (see `fukuii-backup-restore`), and never run unprompted.**
+
+Rules:
+1. Show the operator the precise command(s) before a 🟡/🔴 action; proceed only
+   on a clear go-ahead.
+2. For 🔴 actions, confirm a current backup exists first.
+3. Prefer the least-destructive path that achieves the goal.
+4. After a write, re-run the matching read check to confirm the effect.
+5. Report faithfully — if a step failed or was skipped, say so with the output.
+
+## 4. Output contract
+
+End each skill run with a short, structured result:
+- **Verdict / outcome** (e.g. `HEALTHY` / `DEGRADED` / `ACTION REQUIRED`).
+- **Evidence** — the specific values observed (block height, peer count, error
+  lines), not vibes.
+- **Actions taken** — every 🟡/🔴 call actually executed.
+- **Recommended next steps** — exact commands, ready to run.
+
+## 5. ETC reality check
+
+Fukuii's primary network is **Ethereum Classic** (PoW/Ethash, chain id 61,
+ECIP-1017 emission). It is **not** ETH mainnet: no Proof-of-Stake/merge, no
+EIP-1559, no blobs. Mining is real and relevant here. See `CLAUDE.md`. Don't
+recommend ETH-mainnet-only procedures for ETC networks.
+
+## Skill authoring template
+
+```markdown
+---
+name: fukuii-<verb-noun>
+description: >-
+  <What the skill does in one sentence>. Use when <concrete triggers / phrases
+  the operator might say>. <Any important scope limit or safety note>.
+---
+
+# <Title>
+
+## When to use
+<Bullet triggers.>
+
+## Inputs to gather first
+<Network, RPC port, datadir — per CONVENTIONS §1.>
+
+## Procedure
+<Numbered steps. Mark each write 🟡/🔴 per CONVENTIONS §3. Cite exact methods/commands.>
+
+## Decision guide
+<Symptom → action table where useful.>
+
+## Deep reference
+<Link the backing docs/runbooks/*.md (Level-3 progressive disclosure).>
+
+## Output
+<Per CONVENTIONS §4.>
+```
+
+Frontmatter rules: `name` lowercase letters/numbers/hyphens, ≤64 chars, no
+reserved words; `description` ≤1024 chars, says **what** and **when**.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,66 @@
+# Fukuii operations skills
+
+Project-scoped [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+that turn Fukuii's **maintenance and node-management runbooks** into repeatable,
+guard-railed procedures. Each skill encodes *one* operational workflow, calls the
+node's real interfaces (JSON-RPC `admin_*` / `eth_*` / `miner_*`, the in-process
+MCP tools, the `fukuii cli` subcommands), and links back to the authoritative
+runbook under `docs/runbooks/` for deep reference.
+
+The goal is **consistent prompting and control**: every operator and every agent
+runs the same validated steps against the same endpoints, with the same safety
+gates, instead of improvising one-off commands.
+
+## Why skills (not just docs or tools)
+
+| Form | Fukuii has | Good for |
+| :--- | :--- | :--- |
+| **Tools** (atomic calls) | JSON-RPC `admin_*`/`eth_*`/`miner_*`, 15 read-only MCP tools, `fukuii cli` | One deterministic operation |
+| **Runbooks** (prose) | `docs/runbooks/`, `docs/operations/` | Human reading, reference depth |
+| **Skills** (this dir) | — | Multi-step *workflows* that orchestrate tools + judgement + safety gates, loaded on demand |
+
+Skills sit on top of the existing tools. They do **not** replace the runbooks —
+they reference them (Level-3 progressive disclosure), so the runbook stays the
+single source of truth.
+
+## Skill index
+
+| Skill | Workflow | Backing runbook(s) |
+| :--- | :--- | :--- |
+| `fukuii-node-health-check`   | Full health verdict: status, sync, peers, height, log scan | operations/metrics-and-monitoring, MCP health prompt |
+| `fukuii-sync-troubleshooting`| Diagnose stalled/slow SNAP or full sync; tuning levers | runbooks/snap-sync-*, operations/monitoring-snap-sync |
+| `fukuii-peer-management`     | Inspect/add/remove/trust peers, maxPeers, static nodes | runbooks/peering, network-management; for-operators/static-nodes |
+| `fukuii-backup-restore`      | Back up & restore datadir/keys; export/import chain | runbooks/backup-restore |
+| `fukuii-disk-management`     | Disk-pressure triage, pruning, datadir sizing | runbooks/disk-management |
+| `fukuii-log-triage`          | Set log level at runtime; pattern-triage logs | runbooks/log-triage, operations/LOGGING |
+| `fukuii-mining-operations`   | Validate & control ETC mining via `miner_*`/`eth_*` | runbooks/mining-operations |
+| `fukuii-key-management`      | Generate/encrypt keys & genesis allocs via `fukuii cli` | cli/CliCommands, runbooks/first-start |
+| `fukuii-tls-operations`      | TLS for JSON-RPC; cert rotation | runbooks/tls-operations, security |
+| `fukuii-checkpoint-service`  | Operate the checkpointing service | runbooks/checkpoint-service |
+| `fukuii-node-configuration`  | Edit `fukuii.conf`, pick operating mode safely | runbooks/node-configuration, operating-modes |
+| `fukuii-first-start`         | Bootstrap a brand-new node end to end | runbooks/first-start |
+| `fukuii-security-hardening`  | IP block/unblock, trusted peers, RPC exposure review | runbooks/security; admin block/trusted methods |
+| `fukuii-custom-networks`     | Stand up a private/consortium/custom-genesis chain | runbooks/custom-networks, enterprise-deployment |
+
+## Validation
+
+Every interface these skills name (RPC method, MCP tool/prompt, `fukuii cli`
+subcommand, config key) is cross-checked against the node source on this branch —
+see [`VALIDATION.md`](./VALIDATION.md) for the method, the last result, and the
+runbook-vs-code drift the check caught. **Re-run it whenever the RPC surface,
+CLI, or config schema changes.**
+
+## Shared conventions
+
+Every skill assumes the contract in [`CONVENTIONS.md`](./CONVENTIONS.md):
+how to locate the node, call its RPC, and — most importantly — the
+**guarded-write protocol** (confirm before any state-changing or irreversible
+action). Read it once; skills reference it rather than repeating it.
+
+## Authoring / extending
+
+New operational workflow? Add `.claude/skills/<verb-noun>/SKILL.md` following the
+template in [`CONVENTIONS.md`](./CONVENTIONS.md#skill-authoring-template), point it
+at the relevant runbook, and add a row above. Keep `SKILL.md` bodies lean (the
+heavy reference lives in `docs/`); the frontmatter `description` must say **what**
+the skill does **and when** to use it.

--- a/.claude/skills/VALIDATION.md
+++ b/.claude/skills/VALIDATION.md
@@ -1,0 +1,74 @@
+# Skills ↔ node validation
+
+These skills drive the node **as implemented today**, so every interface they
+name is cross-checked against the source on the branch. This file records the
+method and how to re-run it when the node changes.
+
+> Re-run this whenever the JSON-RPC surface, CLI, or config schema changes
+> (e.g. after touching `JsonRpcController.scala`, `cli/CliCommands.scala`, or
+> `src/main/resources/conf/`). A skill that references a removed/renamed
+> interface is a bug.
+
+## How to re-validate
+
+```bash
+# 1) Every RPC method named in a skill must be registered in the controller
+grep -rhoE '\b(eth|admin|miner|net|fukuii|qa|web3|rpc|personal|debug)_[a-zA-Z]+' .claude/skills/ | sort -u
+grep -rhoE '"(eth|admin|miner|net|fukuii|qa|web3|rpc|personal|debug)_[a-zA-Z]+"' \
+  src/main/scala/com/chipprbots/ethereum/jsonrpc/JsonRpcController.scala | tr -d '"' | sort -u
+# (diff the two; every referenced method must appear in the controller list)
+
+# 2) Every MCP tool name must exist in McpTools.scala (prompts in McpPrompts.scala)
+grep -rhoE 'mcp_[a-z_]+' .claude/skills/ | sort -u
+grep -E 'val name = ' src/main/scala/com/chipprbots/ethereum/jsonrpc/mcp/McpTools.scala
+
+# 3) Every `fukuii cli <cmd>` must be wired in CliCommands.scala
+grep -nE 'Command\b' src/main/scala/com/chipprbots/ethereum/cli/CliCommands.scala
+
+# 4) Every config key must exist under src/main/resources/conf/
+#    (grep the key path in base/*.conf and the network templates)
+```
+
+## Result of the last run (branch base: `staging`)
+
+| Surface | Referenced | Status |
+| :-- | :-- | :-- |
+| JSON-RPC methods (`admin_*`, `eth_*`, `miner_*`, `net_*`, `fukuii_*`, `web3_*`, `rpc_*`) | 41 distinct | **All present** in `JsonRpcController.scala` |
+| MCP read tools (`mcp_node_status`, `mcp_sync_status`, `mcp_peer_list`, `mcp_blockchain_info`, `mcp_node_info`, `mcp_mining_rpc_summary`) | 6 | **All present** in `McpTools.scala` |
+| MCP prompt (`mcp_node_health_check`) | 1 | **Present** in `McpPrompts.scala` (a prompt, not a tool) |
+| CLI (`generate-private-key`, `generate-key-pairs`, `derive-address`, `encrypt-key`, `generate-allocs`) | 5 | **All wired** in `CliCommands.scala` |
+| Config keys (`network.rpc.*`, `sync.*`, `mining.*`, `network.server-address/discovery.port`) | 12 | **All present** under `conf/base/*.conf` |
+| Doc/source links | 27 | **All resolve** (`conf/fukuii.conf` is the operator-supplied override, by design not a repo file) |
+
+## Mismatches found between the legacy runbooks and the node — corrected in the skills
+
+The validation surfaced several places where the existing prose runbooks have
+drifted from the code. The skills use the **code's** truth and flag the drift:
+
+1. **RPC port** — default is **`8546`** (`network.rpc.http.port`), not `8545` as
+   some runbooks/MCP examples show. CONVENTIONS and skills use 8546.
+2. **P2P port** — both server and discovery default to **`30303`**; the peering
+   runbook's `9076` is stale. Corrected in `fukuii-peer-management`.
+3. **MCP namespace** — `mcp` is **not** in the default
+   `network.rpc.apis = "eth,web3,net,personal,fukuii,debug,qa,admin"`; it must be
+   added to use the in-process MCP tools. Documented in CONVENTIONS.
+4. **RPC TLS keys** — the node uses a **nested** `network.rpc.http.certificate {
+   keystore-path, keystore-type, password-file }` block (default
+   `certificate = null`), **not** the flat `certificate-keystore-path` form
+   (that's the separate *faucet* config). Corrected in `fukuii-tls-operations`
+   and `fukuii-node-configuration`.
+5. **`compact-database` CLI** — does **not** exist (only a commented example in
+   `known-issues.md`). `fukuii-disk-management` explicitly says so instead of
+   recommending it.
+6. **Checkpoint service** — config-driven (`sync.checkpoint-sync-file` /
+   `-url`), there is **no `checkpoint_*` RPC**. `fukuii-checkpoint-service`
+   reflects this.
+
+## Caveat
+
+This validates that every interface a skill names **exists and is spelled
+correctly** in the current source. It does not execute the skills against a live
+node (no node is running in this environment). End-to-end behavioral validation
+(start a node, run each skill's read path, dry-run the guarded writes) should be
+done in a staging deployment before relying on the guarded-write steps in
+production.

--- a/.claude/skills/fukuii-backup-restore/SKILL.md
+++ b/.claude/skills/fukuii-backup-restore/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fukuii-backup-restore
+description: >-
+  Back up and restore a Fukuii node — node key, keystore, config, known peers,
+  and the RocksDB blockchain/state database — plus chain export/import for
+  portable backups. Use when asked to back up before an upgrade or risky change,
+  set up a backup strategy, restore after data loss/corruption, or run disaster
+  recovery. Backups are read-only; restore and chain import are irreversible
+  writes that must follow the guarded-write protocol.
+---
+
+# Fukuii backup & restore
+
+Read `../CONVENTIONS.md` first. Backups are 🟢; **restore over an existing datadir
+and `admin_importChain` are 🔴** — explicit confirmation, and verify a backup
+exists before overwriting anything.
+
+## When to use
+- Before an upgrade, config change, prune, or any 🔴 maintenance elsewhere.
+- Recovering from disk failure, RocksDB corruption, or operator error.
+- Standing up a standby/replica from a known-good snapshot.
+
+## Inputs to gather first
+Network, datadir (`admin_datadir`), backup destination, available space.
+
+## What to back up (priority order)
+| Tier | Paths under `~/.fukuii/<network>/` | Notes |
+| :-- | :-- | :-- |
+| **Critical, tiny** | `node.key`, `keystore/`, config (`conf/fukuii.conf`) | Irreplaceable — keys cannot be regenerated. Back up frequently, off-box. |
+| **Operational** | `knownNodes.json`, `app-state.json` | Speeds recovery; small. |
+| **Bulk, regenerable** | `rocksdb/` (blockchain + state) | Large; can be re-synced but slow. Snapshot daily/before changes. |
+| Skip | `logs/` | Not needed for recovery. |
+
+## Procedure
+1. **Backup critical files** (🟢) — copy keys/config to secure, off-box storage.
+   Treat `node.key` and `keystore/` as secrets; restrict permissions.
+2. **Backup the database** (🟢, but quiesce first) — for a consistent RocksDB
+   copy, **stop the node** (🔴 — it's a disruption) or use a filesystem/VM
+   snapshot (preferred: minimal downtime). A hot file copy of `rocksdb/` while
+   running can be inconsistent — avoid unless using a snapshot.
+3. **Portable chain export** (🟡) — `admin_exportChain` writes a portable chain
+   file (good for moving between hosts / sharing a known-good chain).
+4. **Restore** (🔴) — confirm the target datadir's current contents are
+   expendable / already backed up, stop the node, replace `rocksdb/` + restore
+   keys/config, fix permissions, restart, then run `fukuii-node-health-check`.
+5. **Import chain** (🔴) — `admin_importChain(<file>)` to load an exported chain.
+   Confirm intent; this mutates local chain state.
+6. **Validate** (🟢) — after any restore, confirm version/network, `eth_syncing`
+   resumes, peers connect, and the tip is sane.
+
+## Strategy quick-pick
+Hybrid (recommended): hourly key/config backups + daily DB snapshot + on-demand
+snapshot before changes. RTO/RPO trade-offs are tabulated in the runbook.
+
+## Deep reference
+- `docs/runbooks/backup-restore.md` (strategy matrix, DR planning, validation)
+
+## Output
+CONVENTIONS §4 block. Evidence = what was backed up/restored, sizes, and the
+post-restore health result. Record every 🔴 step and its confirmation.

--- a/.claude/skills/fukuii-checkpoint-service/SKILL.md
+++ b/.claude/skills/fukuii-checkpoint-service/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fukuii-checkpoint-service
+description: >-
+  Operate Fukuii's checkpoint-based rapid sync — point a fresh node at a trusted
+  checkpoint archive (local file or HTTP URL) so it imports a known pivot and
+  starts SNAP sync immediately instead of waiting on peer consensus, and produce
+  checkpoint archives for others. Use when bootstrapping a node fast, running a
+  checkpoint source for a fleet, or debugging why checkpoint import didn't engage.
+  Config changes require a restart — an irreversible/disruptive action under the
+  guarded-write protocol.
+---
+
+# Fukuii checkpoint service (rapid sync)
+
+Read `../CONVENTIONS.md` first. This is **config-driven**, not an RPC API — there
+are no `checkpoint_*` JSON-RPC methods. Config edits need a restart → 🔴.
+
+## What it is
+On a **fresh** database (best-block == 0, SNAP not already done), Fukuii can
+import a trusted `.checkpoint` archive and use its block as the pivot, skipping
+the "wait for 3+ peers" phase before SNAP sync. Backed by
+`blockchain/checkpoint/CheckpointArchive.scala` (+ `CheckpointDownloader`,
+`CheckpointExporter`).
+
+## When to use
+- Bootstrapping a node and you want sync to start in seconds, not minutes.
+- Running a checkpoint archive endpoint for your own fleet.
+- Investigating why a configured checkpoint was ignored.
+
+## Config keys (under `sync`, see `base/sync.conf`)
+| Key | Meaning |
+| :-- | :-- |
+| `sync.checkpoint-sync-file` | Path to a local `.checkpoint` archive to import (empty = off) |
+| `sync.checkpoint-sync-url` | HTTP URL to fetch the archive to `${datadir}/checkpoint.bin` (resumable), then import |
+| `sync.do-snap-sync` | Must be enabled for the rapid-sync path |
+
+## Procedure
+1. **Obtain a trusted archive** — only import checkpoints from a source you
+   trust; a malicious checkpoint is a trust-root attack. Verify provenance.
+2. **Configure** (🔴) — set `checkpoint-sync-file` *or* `checkpoint-sync-url` (a
+   local file takes priority). Ensure the DB is fresh — checkpoint import only
+   engages when best-block == 0 and SNAP isn't already marked done.
+3. **Start & confirm** (🟢 after restart) — watch logs for checkpoint import,
+   then `eth_syncing`/`mcp_sync_status` should show SNAP starting from the
+   checkpoint pivot rather than block 0.
+4. **Produce an archive** — use `CheckpointExporter` to generate a `.checkpoint`
+   from a synced node for distribution (see runbook for the exact invocation).
+
+## Gotchas (verify before blaming the feature)
+- Won't engage on a **non-fresh** DB — that's by design.
+- Requires SNAP enabled; with `do-snap-sync=false` the pivot path differs.
+
+## Deep reference
+- `docs/runbooks/checkpoint-service.md`
+- `src/main/resources/conf/base/sync.conf` (lines defining `checkpoint-sync-*`)
+- `src/main/scala/com/chipprbots/ethereum/blockchain/checkpoint/`
+
+## Output
+CONVENTIONS §4 block. Evidence = the log line showing checkpoint import and the
+pivot block the node started from.

--- a/.claude/skills/fukuii-custom-networks/SKILL.md
+++ b/.claude/skills/fukuii-custom-networks/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: fukuii-custom-networks
+description: >-
+  Stand up a private, consortium, or otherwise custom EVM network on Fukuii —
+  author a custom genesis (chain id, allocs, fork schedule), wire bootstrap/static
+  nodes, and configure consensus, without modifying source. Use when creating a
+  private chain, a consortium/enterprise network, an L2-style custom-genesis
+  chain, or a local multi-node test network. Genesis/config authoring plus the
+  node start are setup actions; key/alloc generation is security-sensitive under
+  the guarded-write protocol.
+---
+
+# Fukuii custom networks
+
+Read `../CONVENTIONS.md` first. Building genesis/allocs involves keys → 🔴 for
+that part (`fukuii-key-management`); the rest is config + 🟢 verification.
+
+## When to use
+- Private or consortium chain with its own chain id and genesis.
+- Custom fork schedule / gas params, or an L2-style custom-genesis chain.
+- Local multi-node test network across clients.
+
+## Procedure
+1. **Define the chain** — choose a unique chain id (avoid collisions with public
+   nets — ETC is 61), the fork schedule, and gas/consensus parameters. Start from
+   `src/universal/custom-config-example.conf` and `conf/enterprise-template.conf`.
+2. **Build genesis allocs** (🔴) — generate funding keys and addresses with
+   `fukuii cli generate-key-pairs` / `derive-address`, then
+   `fukuii cli generate-allocs --balance <wei> --address <addr> …` to emit the
+   `alloc` JSON. Safeguard the funding keys.
+3. **Author the network config** — point the node at your genesis and set chain
+   id, consensus (PoW/PoA per deployment), and any custom params in your override
+   config. Don't edit shipped `base/*.conf`; layer your own file.
+4. **Wire peers** — for a closed network, configure bootstrap/static nodes so the
+   members find each other (`fukuii-peer-management`,
+   `docs/for-operators/static-nodes-configuration.md`; `fukuii-cli` has multi-node
+   helpers like `start 3nodes` / `sync-static-nodes`).
+5. **Start & verify** (🟢) — launch each node (`./bin/fukuii -Dconfig.file=<your.conf>`),
+   confirm `eth_chainId` matches, peers connect, and blocks advance
+   (`fukuii-node-health-check`).
+
+## Validation checklist
+- `eth_chainId` returns the intended id on every node.
+- Genesis hash identical across all members (mismatched genesis = no peering).
+- Funding accounts hold the expected balances.
+
+## Deep reference
+- `docs/runbooks/custom-networks.md`, `docs/runbooks/enterprise-deployment.md`
+- `src/universal/custom-config-example.conf`, `conf/enterprise-template.conf`
+- `docs/for-operators/static-nodes-configuration.md`
+
+## Output
+CONVENTIONS §4 block. Evidence = chain id, matching genesis hash across nodes,
+and first-block progression. Never include funding private keys.

--- a/.claude/skills/fukuii-disk-management/SKILL.md
+++ b/.claude/skills/fukuii-disk-management/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fukuii-disk-management
+description: >-
+  Triage and manage Fukuii's disk usage — understand the datadir layout, measure
+  RocksDB growth, free space safely, and size storage for ETC's large chain. Use
+  when disk is filling up, the node warns about space, you're planning capacity,
+  or sync is slow due to I/O. Measurement is read-only; any deletion/relocation
+  of the database is an irreversible action under the guarded-write protocol.
+---
+
+# Fukuii disk management
+
+Read `../CONVENTIONS.md` first. Inspection is 🟢; deleting/moving `rocksdb/` or
+relocating the datadir is 🔴 — back up (`fukuii-backup-restore`) and confirm
+first.
+
+## When to use
+- Low free space / "no space left on device" in logs.
+- Planning storage for a new ETC node (the DB is large — hundreds of GB).
+- I/O-bound sync (often a disk-type/space problem, not a sync bug).
+
+## Datadir layout (`~/.fukuii/<network>/`)
+| Path | Typical size (ETC) | Prunable? |
+| :-- | :-- | :-- |
+| `node.key`, `keystore/` | tiny | never delete |
+| `rocksdb/` | hundreds of GB (bulk) | regenerable by re-sync only |
+| `logs/` | up to ~500 MB (rotated) | yes, safe |
+| `knownNodes.json`, `app-state.json` | tiny | operational |
+
+## Procedure
+1. **Locate & measure** (🟢) — `admin_datadir`, then `df -h <datadir>` and
+   `du -sh <datadir>/rocksdb`. Identify the biggest consumer.
+2. **Reclaim the easy wins first** (🟢/🟡) — rotated logs under `logs/` are safe
+   to remove; temp/JFR files under the configured temp dir can be cleared. This
+   alone often relieves pressure without touching the DB.
+3. **Database growth is mostly unavoidable** — block bodies and headers cannot be
+   pruned (they're the chain). Do **not** expect a "prune blockchain" command:
+   there is **no `fukuii cli compact-database` subcommand** today (it appears only
+   as a commented example in `known-issues.md`). RocksDB compaction is internal
+   and tuned via `base/db.conf`, not an operator action.
+4. **If space is genuinely exhausted** (🔴) — the real levers are: add storage /
+   grow the volume, **relocate the datadir** to a larger/faster disk (stop node,
+   move `rocksdb/`, point `fukuii.datadir` at the new path, restart), or as a last
+   resort re-sync onto fresh storage. Each requires a backup and confirmation.
+5. **Verify** (🟢) — re-check `df -h` and run `fukuii-node-health-check`.
+
+## Sizing guidance
+ETC mainnet is large and grows steadily (~30 GB/yr bodies). Provision SSD/NVMe
+with generous headroom; HDDs starve SNAP sync. See the runbook's breakdown table.
+
+## Deep reference
+- `docs/runbooks/disk-management.md` (storage breakdown, optimization)
+- `docs/runbooks/known-issues.md` (note the `compact-database` caveat above)
+- `src/main/resources/conf/base/db.conf` (RocksDB tuning — internal compaction)
+
+## Output
+CONVENTIONS §4 block. Evidence = actual `df`/`du` figures before and after.

--- a/.claude/skills/fukuii-first-start/SKILL.md
+++ b/.claude/skills/fukuii-first-start/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: fukuii-first-start
+description: >-
+  Bring up a brand-new Fukuii node end to end — pick the network, generate the
+  node key, set the datadir and config, start the node, and confirm it discovers
+  peers and begins syncing. Use when bootstrapping a fresh node, onboarding a new
+  host, or setting up ETC/Mordor/Sepolia for the first time. Generating keys and
+  starting the node are security-sensitive/irreversible actions under the
+  guarded-write protocol.
+---
+
+# Fukuii first start
+
+Read `../CONVENTIONS.md` first. Key generation is 🔴 (secrets — see
+`fukuii-key-management`); the rest is mostly setup + 🟢 verification.
+
+## When to use
+First boot of a node on a new host, or standing up an additional node for a role.
+
+## Procedure
+1. **Choose network & datadir** — `etc` (ETC mainnet, chain id 61), `mordor`
+   (ETC testnet), `sepolia`/`holesky` (ETH testnets), or a custom genesis
+   (`fukuii-custom-networks`). Default datadir `~/.fukuii/<network>/`.
+2. **Generate the node key** (🔴) — bootstrap `node.key`:
+   `fukuii cli generate-key-pairs > ~/.fukuii/<network>/node.key`
+   (line 1 = private key used by the node; line 2 = public node ID for enodes).
+   Restrict permissions; back it up (`fukuii-backup-restore`).
+3. **Minimal config** — for a standard node the shipped network config suffices.
+   Override only what the role needs (RPC apis/port, datadir) in `conf/fukuii.conf`
+   — see `fukuii-node-configuration`. For fast bootstrap, consider a checkpoint
+   (`fukuii-checkpoint-service`).
+4. **Start** — `./bin/fukuii <network>` (or `./fukuii.sh <network>` →
+   `ops/tools/fukuii-cli.sh`). Watch the logs come up cleanly.
+5. **Verify bring-up** (🟢) — within a few minutes:
+   - `web3_clientVersion` / `net_version` → node up, correct network.
+   - `net_peerCount` climbing toward 5+ (else `fukuii-peer-management`).
+   - `eth_syncing` showing progress (else `fukuii-sync-troubleshooting`).
+   - Then a full `fukuii-node-health-check`.
+
+## Common first-start issues
+| Symptom | Hand off to |
+| :-- | :-- |
+| No peers after several minutes | `fukuii-peer-management` |
+| Sync not advancing | `fukuii-sync-troubleshooting` |
+| Errors in startup log | `fukuii-log-triage` |
+| Out of disk during initial sync | `fukuii-disk-management` |
+
+## Deep reference
+- `docs/runbooks/first-start.md`, `docs/runbooks/node-configuration.md`
+
+## Output
+CONVENTIONS §4 block. Evidence = version/network, peer count, and sync progress
+observed after start. Confirm the node key was generated and backed up (no key
+material in the output).

--- a/.claude/skills/fukuii-key-management/SKILL.md
+++ b/.claude/skills/fukuii-key-management/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fukuii-key-management
+description: >-
+  Generate and handle Fukuii cryptographic material via the `fukuii cli`
+  subcommands — node private keys, key pairs, address derivation, key encryption,
+  and genesis allocation snippets. Use when bootstrapping a node identity,
+  creating accounts/keys, deriving an address from a private key, encrypting a
+  key for the keystore, or building genesis allocs for a custom network. Keys are
+  secrets — handling them is an irreversible, security-sensitive action under the
+  guarded-write protocol.
+---
+
+# Fukuii key management
+
+Read `../CONVENTIONS.md` first. **Everything here touches secrets.** Treat key
+output as 🔴: never echo a private key into shared logs/PRs, restrict file
+permissions, and confirm intent before generating or overwriting `node.key`.
+
+## When to use
+- First-time node bootstrap (create `node.key`) — see also `fukuii-first-start`.
+- Create account key pairs, derive an address, or encrypt a key for the keystore.
+- Build `alloc` entries for a custom-genesis chain (`fukuii-custom-networks`).
+
+## Available subcommands (exactly these — verified in `cli/CliCommands.scala`)
+| Command | Purpose |
+| :-- | :-- |
+| `fukuii cli generate-private-key` | Emit a new random secp256k1 private key |
+| `fukuii cli generate-key-pairs [n]` | Emit `n` key pairs (priv on line 1, pub/node-id on line 2) |
+| `fukuii cli derive-address <private-key>` | Derive the account/address from a private key |
+| `fukuii cli encrypt-key --passphrase <p> <private-key>` | Produce an encrypted keystore entry |
+| `fukuii cli generate-allocs --balance <b> [--key …] [--address …]` | Genesis `alloc` JSON |
+
+> There is **no** `import-key`, `compact-database`, or other subcommand beyond
+> the five above. Don't invent flags — check `fukuii cli <cmd> --help`.
+
+## Procedure
+1. **Confirm scope & isolation** — run on a trusted host; ensure output goes to a
+   secure location, not a terminal others can see.
+2. **Generate** (🔴) — pick the subcommand above. For a node identity, the public
+   line of `generate-key-pairs` is the node ID used in enodes.
+3. **Encrypt before storing** — for account keys, `encrypt-key` then place the
+   resulting file under `~/.fukuii/<network>/keystore/` with tight permissions.
+4. **Back up immediately** (🔴) — keys are unrecoverable; copy to secure off-box
+   storage per `fukuii-backup-restore` before relying on them.
+5. **Never** reuse, commit, or paste private keys; rotate if exposure is suspected.
+
+## Deep reference
+- `src/main/scala/com/chipprbots/ethereum/cli/CliCommands.scala` (source of truth)
+- `docs/runbooks/first-start.md` (node.key bootstrap), `docs/runbooks/security.md`
+
+## Output
+CONVENTIONS §4 block — **without** secret material. Report *what* was generated
+and *where* it was stored (path/permissions), never the key value.

--- a/.claude/skills/fukuii-log-triage/SKILL.md
+++ b/.claude/skills/fukuii-log-triage/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fukuii-log-triage
+description: >-
+  Configure Fukuii logging and triage problems through logs — set the log level
+  at runtime without a restart, switch JSON output, find the log files, and map
+  common error patterns (peer drops, RocksDB, OOM, sync stalls) to causes. Use
+  when investigating any node issue via logs, when asked to raise/lower
+  verbosity, or to enable structured logging. Reading logs is read-only; changing
+  the live log level is a reversible write under the guarded-write protocol.
+---
+
+# Fukuii log triage
+
+Read `../CONVENTIONS.md` first. Reading logs is 🟢; `admin_changeLogLevel` is 🟡
+(state the level and confirm — DEBUG/TRACE are verbose and can fill disk).
+
+## When to use
+- Diagnosing almost any node problem (logs are the primary signal).
+- Temporarily raising verbosity to capture a transient issue, then lowering it.
+- Turning on JSON logs for aggregation (Loki/ELK).
+
+## Log locations & config
+- Files: `~/.fukuii/<network>/logs/fukuii.log` (rotated; `*.log.zip`, 10 MB ×
+  up to 50). Configured by `src/main/resources/logback.xml`.
+- Levels: `TRACE < DEBUG < INFO (default) < WARN < ERROR`.
+- Static config (`logging { logs-level, json-output, logs-dir, logs-file }`) or
+  env `FUKUII_LOG_LEVEL` / `FUKUII_LOGGING_JSON_OUTPUT=true` — both need a restart.
+
+## Procedure
+1. **Set level at runtime** (🟡, no restart) — `admin_changeLogLevel("<LEVEL>")`.
+   Use this to bump to DEBUG just long enough to capture the symptom, then return
+   to INFO. Confirm before going to DEBUG/TRACE (volume + disk).
+2. **Read & scan** (🟢) — tail the live file; grep for `ERROR`/`WARN`, stack
+   traces, and the patterns below around the incident window.
+3. **Classify** (🟢) — map to the table, then hand off.
+
+## Pattern → cause → hand-off
+| Log pattern | Likely cause | Hand off to |
+| :-- | :-- | :-- |
+| Repeated peer disconnect / handshake fail | P2P/connectivity | `fukuii-peer-management` |
+| `AccountRange`/pivot stall, snap errors | sync stall | `fukuii-sync-troubleshooting` |
+| RocksDB corruption / IO error | disk/DB | `fukuii-disk-management`, then restore |
+| `OutOfMemoryError`, GC thrash | heap/resources | tune JVM heap (`.jvmopts`); restart |
+| `No space left on device` | disk full | `fukuii-disk-management` |
+| TLS/cert errors on RPC | RPC TLS | `fukuii-tls-operations` |
+
+## Deep reference
+- `docs/runbooks/log-triage.md` (pattern catalogue, analysis tooling)
+- `docs/operations/LOGGING.md`, `docs/operations/metrics-and-monitoring.md`
+
+## Output
+CONVENTIONS §4 block. Quote the **specific** log lines as evidence; record any
+level change made and that it was reverted.

--- a/.claude/skills/fukuii-mining-operations/SKILL.md
+++ b/.claude/skills/fukuii-mining-operations/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fukuii-mining-operations
+description: >-
+  Validate and control Ethereum Classic (ETC) PoW/Ethash mining on a Fukuii node
+  — check mining state, start/stop the internal miner, set the coinbase, inspect
+  hashrate and work, and wire up external miners. Use when asked to start/stop
+  mining, verify a miner is producing blocks, change the reward address, or debug
+  why mining isn't working. ETC-only (PoW); status checks are read-only,
+  start/stop/set-etherbase are reversible writes under the guarded-write protocol.
+---
+
+# Fukuii mining operations
+
+Read `../CONVENTIONS.md` first. ETC is PoW/Ethash — mining is real here (never on
+ETH-mainnet PoS networks). Status reads are 🟢; `miner_start`/`miner_stop`/
+`miner_setEtherbase` are 🟡 (confirm — they change block production and rewards).
+
+## When to use
+- Start or stop block production without restarting the node.
+- Confirm the node is actually mining and earning to the right address.
+- Connect/validate an external miner (stratum/getWork) against the node.
+
+## Prerequisites
+- ETC (or other PoW) network, node **fully synced**, Ethash consensus.
+- `mining { mining-enabled, coinbase }` configured (`base/mining.conf`). A miner
+  with no/zero coinbase earns nothing — check first.
+
+## Procedure
+1. **Status** (🟢) — `eth_mining` (bool), `miner_getStatus`, `eth_hashrate`,
+   `eth_coinbase`. MCP `mcp_mining_rpc_summary` gives a one-shot summary.
+2. **Confirm readiness** (🟢) — node synced (`eth_syncing == false`) and coinbase
+   set to the intended address. Mining while unsynced wastes work.
+3. **Start** (🟡) — `miner_start` (params `[]`). Then re-check `eth_mining == true`
+   and watch `eth_hashrate` climb.
+4. **Stop** (🟡) — `miner_stop`.
+5. **Change reward address** (🟡) — `miner_setEtherbase("0x…")` (or
+   `eth_setEtherbase`). Double-check the address before confirming — misdirected
+   rewards are unrecoverable.
+6. **External miners** (🟢/config) — expose `eth_getWork` / `eth_submitWork` /
+   `eth_submitHashrate`; point the external miner at the RPC endpoint.
+7. **Persisting across restarts** (🔴 — config edit + restart) — set
+   `mining.mining-enabled = true` and `mining.coinbase` in `fukuii.conf`.
+
+## Troubleshooting
+| Symptom | Check |
+| :-- | :-- |
+| `eth_mining` false after `miner_start` | consensus is Ethash? node synced? errors in log |
+| Mining but no rewards | coinbase correct? blocks actually sealed (check tip author) |
+| Zero/low hashrate | CPU/external miner; `mine-rounds`; resource starvation |
+
+## Deep reference
+- `docs/runbooks/mining-operations.md` (config, external-miner integration)
+- `src/main/resources/conf/base/mining.conf`, `base/pow.conf`
+
+## Output
+CONVENTIONS §4 block. Evidence = before/after `eth_mining`/hashrate/coinbase;
+list every 🟡 call and its confirmation.

--- a/.claude/skills/fukuii-node-configuration/SKILL.md
+++ b/.claude/skills/fukuii-node-configuration/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: fukuii-node-configuration
+description: >-
+  Safely edit a Fukuii node's HOCON configuration and choose an operating mode —
+  network selection, datadir, RPC apis/ports, sync mode (SNAP vs fast), mining,
+  and resource settings — with a back-up-then-restart discipline. Use when asked
+  to change config, enable an RPC namespace, switch sync strategy, set the
+  datadir, or pick an operating profile. Editing config and restarting is an
+  irreversible/disruptive action under the guarded-write protocol.
+---
+
+# Fukuii node configuration
+
+Read `../CONVENTIONS.md` first. Almost every config change needs a restart → 🔴
+(back up config first; the node is unavailable during restart).
+
+## When to use
+- Enable/disable an RPC namespace (e.g. add `mcp` or `admin`).
+- Switch sync mode, set the datadir, change ports, tune resources.
+- Pick an operating profile for a role (RPC provider, miner, bootnode, …).
+
+## Config model
+- HOCON, layered: base fragments in `src/main/resources/conf/base/*.conf`
+  (`network.conf`, `sync.conf`, `mining.conf`, `db.conf`, …) composed per network
+  (`etc.conf`, `mordor.conf`, `sepolia.conf`, …). Operators override via their own
+  `conf/fukuii.conf` and `-Dconfig.file=`.
+- Templates worth reading: `conf/enterprise-template.conf`,
+  `src/universal/custom-config-example.conf`.
+
+## High-value keys (verified)
+| Concern | Key(s) |
+| :-- | :-- |
+| RPC namespaces | `network.rpc.apis` (default `eth,web3,net,personal,fukuii,debug,qa,admin`; add `mcp` for MCP tools) |
+| RPC bind/port | `network.rpc.http.{interface,port,mode}` (default `localhost:8546`, `http`) |
+| Sync strategy | `sync.do-snap-sync`, `sync.do-fast-sync` |
+| Rapid sync | `sync.checkpoint-sync-file` / `-url` (→ `fukuii-checkpoint-service`) |
+| Mining | `mining.mining-enabled`, `mining.coinbase` (→ `fukuii-mining-operations`) |
+| TLS | `network.rpc.http.mode` + nested `network.rpc.http.certificate { keystore-path, keystore-type, password-file }` (→ `fukuii-tls-operations`) |
+| P2P | `network.server-address.port`, `network.discovery.port` (default `30303`) |
+
+## Procedure
+1. **Back up current config** (🟢) — copy `fukuii.conf` aside (`fukuii-backup-restore`).
+2. **Make the smallest change** (🔴) — edit one concern at a time; keep overrides
+   in the operator config, don't hand-edit shipped `base/*.conf`.
+3. **Validate before restart** — sanity-check HOCON syntax; cross-check key paths
+   against the `base/*.conf` source (typos silently fall back to defaults).
+4. **Restart & verify** (🔴) — restart, then confirm the change took effect
+   (e.g. `rpc_modules` for enabled apis, `eth_syncing` for sync mode) and run
+   `fukuii-node-health-check`.
+5. **Roll back** — if the node misbehaves, restore the backed-up config and restart.
+
+## Deep reference
+- `docs/runbooks/node-configuration.md`, `docs/runbooks/operating-modes.md`
+- `src/main/resources/conf/base/` (authoritative key names/defaults)
+
+## Output
+CONVENTIONS §4 block. Evidence = the key(s) changed, old→new values, and the
+post-restart verification result.

--- a/.claude/skills/fukuii-node-health-check/SKILL.md
+++ b/.claude/skills/fukuii-node-health-check/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: fukuii-node-health-check
+description: >-
+  Produce a comprehensive health verdict for a running Fukuii node — client
+  version, sync state, peer count, latest block height, mining state, and a
+  recent-log scan — rolled into HEALTHY / DEGRADED / ACTION REQUIRED. Use when
+  asked to "check the node", "is my node OK", do a routine/scheduled health
+  check, or verify a node before or after maintenance. Read-only; safe to run
+  anytime.
+---
+
+# Fukuii node health check
+
+Read `../CONVENTIONS.md` first (locating the node, calling RPC, output contract).
+This skill is **read-only** — no guarded writes.
+
+## When to use
+- Routine "is everything OK?" checks, dashboards-by-hand, on-call triage.
+- Before starting any maintenance, and again after, to confirm a clean state.
+- As the first step when a vaguer problem is reported, to localize it.
+
+## Inputs to gather first
+Network (`etc`/`mordor`/`sepolia`/…), RPC host/port, datadir. See CONVENTIONS §1.
+
+## Procedure (all 🟢 read-only)
+1. **Liveness / identity** — `web3_clientVersion`, `net_version`,
+   `net_listening`. Node up? Right network?
+2. **Sync** — `eth_syncing`. `false` = synced; otherwise inspect
+   `currentBlock` vs `highestBlock` (and SNAP pivot if present). Cross-check
+   with MCP `mcp_sync_status`.
+3. **Chain tip** — `eth_blockNumber`; compare against a known-good external tip
+   for the network if available. A tip far behind wall-clock = stale.
+4. **Peers** — `net_peerCount` and `admin_peers` (or `mcp_peer_list`). Healthy
+   ETC node: ~20–40 peers. **< 5 peers = degraded**, 0 = isolated.
+5. **Mining** (only if this node mines) — `eth_mining`, `miner_getStatus`,
+   `eth_hashrate`, `eth_coinbase`. See `fukuii-mining-operations` for depth.
+6. **Resources** — `admin_datadir` → then `df -h <datadir>` for free space; flag
+   < 10% free. (Hand off to `fukuii-disk-management` if tight.)
+7. **Log scan** — tail `~/.fukuii/<network>/logs/fukuii.log` for `ERROR`/`WARN`
+   bursts, stack traces, `OutOfMemory`, repeated peer drops, RocksDB errors.
+
+## Decision guide
+| Symptom | Verdict | Hand off to |
+| :-- | :-- | :-- |
+| Synced, peers ≥ 10, no error burst | HEALTHY | — |
+| Syncing but progressing, peers OK | DEGRADED (expected) | `fukuii-sync-troubleshooting` if stalled |
+| Peers < 5 / 0 | ACTION REQUIRED | `fukuii-peer-management` |
+| Disk < 10% free | ACTION REQUIRED | `fukuii-disk-management` |
+| Repeated ERROR / OOM / RocksDB corruption | ACTION REQUIRED | `fukuii-log-triage` |
+
+## Deep reference
+- `docs/operations/metrics-and-monitoring.md` (Prometheus/JMX/Grafana/Kamon)
+- `docs/operations/LOGGING.md`
+- The in-process MCP prompt `mcp_node_health_check` covers the same intent.
+
+## Output
+Emit the CONVENTIONS §4 block: **Verdict**, **Evidence** (actual numbers/lines),
+**Actions taken** (none — read-only), **Recommended next steps** (with the exact
+hand-off skill and commands).

--- a/.claude/skills/fukuii-peer-management/SKILL.md
+++ b/.claude/skills/fukuii-peer-management/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: fukuii-peer-management
+description: >-
+  Inspect and manage a Fukuii node's peer connections — list peers, add/remove
+  peers, mark trusted peers, tune max-peers, and configure static/bootstrap
+  nodes. Use when peer count is low, the node is isolated, you need to pin a
+  specific peer, connect to a private/consortium set, or troubleshoot P2P
+  connectivity. Listing is read-only; add/remove/trust/maxPeers are reversible
+  writes under the guarded-write protocol.
+---
+
+# Fukuii peer management
+
+Read `../CONVENTIONS.md` first. `admin_peers`/`admin_nodeInfo` are 🟢; the
+add/remove/trust/maxPeers calls are 🟡 (confirm before executing).
+
+## When to use
+- Low/zero peer count, node "isolated", sync starved for peers.
+- Pin a known-good peer, or build a private/consortium peer set.
+- Diagnose discovery/connectivity (ports, NAT, firewall).
+
+## Inputs to gather first
+Network, RPC port, datadir. Target peer enode URI(s) for any write. CONVENTIONS §1.
+
+## Background (ETC defaults)
+- Both discovery (UDP, devp2p v4) and the Ethereum wire protocol (TCP/RLPx)
+  default to port **30303** (`network.server-address.port` /
+  `network.discovery.port` in `base/network.conf`) — confirm from config; some
+  older runbooks quote `9076`, which is stale. Healthy node: ~20–40 peers.
+- Known peers persist in `~/.fukuii/<network>/knownNodes.json`.
+- `admin_*` peer methods have `net_*` equivalents that also exist
+  (`net_listPeers`, `net_connectToPeer`, `net_disconnectPeer`) — use whichever
+  the deployment enables.
+
+## Procedure
+1. **Inspect** (🟢) — `admin_peers` (or `mcp_peer_list`) for current peers;
+   `net_peerCount` for the total; `admin_nodeInfo` for your own enode/ports.
+2. **Diagnose low count** (🟢) — check listening (`net_listening`), that
+   discovery/TCP ports are open/forwarded, and that bootstrap nodes are reachable.
+   If sync (not peering) is the real issue, hand to `fukuii-sync-troubleshooting`.
+3. **Add a peer** (🟡) — `admin_addPeer("enode://<id>@<host>:<port>")`. State the
+   enode and confirm, then call; re-run `admin_peers` to verify it connected.
+4. **Remove a peer** (🟡) — `admin_removePeer("enode://…")`. Confirm first.
+5. **Trusted peers** (🟡) — `admin_addTrustedPeer` / `admin_removeTrustedPeer` to
+   keep a peer connected past normal limits (private/consortium pinning).
+6. **Capacity** (🟡) — `admin_maxPeers(<n>)` to raise/lower the cap. Note effect on
+   bandwidth/memory before raising.
+7. **Static / bootstrap nodes** (🔴 — config edit, restart) — for permanent
+   pinning set static nodes in `fukuii.conf`; see static-nodes runbook and the
+   `fukuii-cli sync-static-nodes` helper for multi-client test nets.
+
+## Decision guide
+| Symptom | Action |
+| :-- | :-- |
+| 0 peers, `net_listening` false | ports/discovery misconfigured → fix config/firewall |
+| Few peers, ports open | `admin_addPeer` known-good enodes; check bootstrap list |
+| Need a peer to never drop | `admin_addTrustedPeer` (🟡) or static node (🔴) |
+| Abusive/bad peer | `admin_removePeer` then consider `fukuii-security-hardening` blockIP |
+
+## Deep reference
+- `docs/runbooks/peering.md`, `docs/runbooks/network-management.md`
+- `docs/for-operators/static-nodes-configuration.md`
+
+## Output
+CONVENTIONS §4 block. Evidence = before/after peer counts and the specific enodes
+touched; list every 🟡/🔴 call executed.

--- a/.claude/skills/fukuii-security-hardening/SKILL.md
+++ b/.claude/skills/fukuii-security-hardening/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fukuii-security-hardening
+description: >-
+  Review and tighten a Fukuii node's security posture — block/unblock abusive
+  peer IPs, manage trusted peers, audit which RPC namespaces and interfaces are
+  exposed, and apply RPC/TLS exposure best practices. Use when responding to
+  abusive peers, before exposing a node, during a security/audit review, or to
+  lock down RPC. IP blocking and trusted-peer changes are reversible writes;
+  config/exposure changes that need a restart are irreversible — all under the
+  guarded-write protocol.
+---
+
+# Fukuii security hardening
+
+Read `../CONVENTIONS.md` first. Block/trusted-peer calls are 🟡; RPC-exposure
+config changes (restart) are 🔴.
+
+## When to use
+- An abusive/misbehaving peer or IP needs blocking.
+- About to expose RPC/P2P beyond localhost, or doing a hardening pass.
+- Audit asks "what's exposed and to whom?"
+
+## Procedure
+1. **Audit exposure first** (🟢) —
+   - RPC namespaces: `rpc_modules` (or read `network.rpc.apis`). Disable what you
+     don't need — `admin`, `personal`, `debug`, `qa` are powerful; don't expose
+     them publicly.
+   - Bind interfaces: confirm `network.rpc.http.interface` is `localhost` unless a
+     firewall/proxy fronts it; same scrutiny for WS and Engine API ports.
+   - TLS: if reachable off-host, RPC must be `https` (`fukuii-tls-operations`).
+2. **Block an abusive IP** (🟡) — `admin_blockIP("<ip>")`; verify with
+   `admin_listBlockedIPs`; reverse with `admin_unblockIP("<ip>")`. (Equivalent
+   `net_addToBlacklist` / `net_removeFromBlacklist` / `net_listBlacklistedPeers`
+   exist if that namespace is enabled.)
+3. **Pin / drop peers** (🟡) — `admin_addTrustedPeer` to keep a vetted peer;
+   `admin_removePeer` to drop a bad one (→ `fukuii-peer-management`).
+4. **Protect secrets** (🔴) — `node.key` and `keystore/` must be permission-
+   restricted and backed up off-box (`fukuii-key-management`,
+   `fukuii-backup-restore`). Never commit or log key material.
+5. **Re-audit** (🟢) — confirm the exposed surface matches intent; document it.
+
+## Exposure quick rules
+- Public RPC: TLS on, `admin`/`personal`/`debug`/`qa` off, auth/proxy in front.
+- Never bind `0.0.0.0` for RPC without a firewall and authentication.
+- Least privilege: enable only the namespaces a consumer actually calls.
+
+## Deep reference
+- `docs/runbooks/security.md`, `docs/runbooks/tls-operations.md`
+- `AdminService` block/trusted-peer methods; `base/network.conf` (rpc block)
+
+## Output
+CONVENTIONS §4 block. Evidence = the exposed surface before/after and any IPs/
+peers blocked or trusted; list every 🟡/🔴 action and its confirmation.

--- a/.claude/skills/fukuii-sync-troubleshooting/SKILL.md
+++ b/.claude/skills/fukuii-sync-troubleshooting/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: fukuii-sync-troubleshooting
+description: >-
+  Diagnose and fix stalled, slow, or stuck blockchain synchronization on a
+  Fukuii node — SNAP sync and full/regular sync alike — covering pivot stalls,
+  account/storage-range progress, peer starvation, and performance tuning. Use
+  when sync is "stuck", "not progressing", "too slow", block height isn't
+  advancing, or after a restart that won't catch up. Diagnosis is read-only;
+  tuning changes config (restart required) under the guarded-write protocol.
+---
+
+# Fukuii sync troubleshooting
+
+Read `../CONVENTIONS.md` first. Diagnosis is 🟢; config/tuning edits are 🔴
+(require restart) — gate them.
+
+## When to use
+- `eth_syncing` shows no forward progress over several minutes.
+- SNAP sync stuck at the pivot, or account/storage ranges not completing.
+- Sync is healthy but far slower than the hardware should allow.
+
+## Inputs to gather first
+Network, RPC port, datadir, sync mode (SNAP vs full), hardware (cores, RAM, disk
+type). See CONVENTIONS §1.
+
+## Procedure
+1. **Confirm it's actually stalled** (🟢) — sample `eth_blockNumber` and
+   `eth_syncing` ~30s apart. Use `mcp_sync_status` for SNAP phase/pivot detail.
+   No movement at all → stall; slow movement → tuning problem.
+2. **Check peers first** (🟢) — sync needs peers. `net_peerCount` < 5 means the
+   problem is peering, not sync → `fukuii-peer-management`. Verify peers actually
+   serve the protocol/snap capability.
+3. **Scan logs** (🟢) — `fukuii-log-triage` for `ERROR`/timeout/`AccountRange`/
+   `pivot`/RocksDB lines around the stall window.
+4. **SNAP-specific** — pivot moves as the chain advances; a stuck pivot or stalled
+   `AccountRangeCoordinator` is a known failure family. Check progress of account
+   vs storage ranges. If genuinely wedged, the documented recovery is a clean
+   restart (🔴 — stops the node) or, last resort, a fast-sync reset via
+   `fukuii_resetFastSync` / `fukuii_restartFastSync` (🔴 — discards progress).
+5. **Performance tuning** (🔴 — edits `fukuii.conf`, needs restart) — match
+   concurrency to CPU before touching anything else:
+
+   | CPU | `snap-sync.account-concurrency` | `snap-sync.storage-concurrency` |
+   | :-- | :-- | :-- |
+   | 2 cores | 8 | 4 |
+   | 4 cores (default) | 16 | 8 |
+   | 8+ cores | 32 | 16 |
+
+   Also relevant: disk must be SSD/NVMe (HDD will starve SNAP), adequate RAM,
+   and network bandwidth. Apply **one** change at a time and re-measure.
+
+## Decision guide
+| Symptom | Likely cause | Action |
+| :-- | :-- | :-- |
+| 0 peers / < 5 | peering | `fukuii-peer-management` |
+| Pivot/account-range wedged, errors in log | SNAP stall | restart (🔴) per runbook; re-sync if persistent |
+| Progressing but slow, HDD | I/O bound | move datadir to SSD/NVMe |
+| Slow on capable HW, low concurrency | under-tuned | raise concurrency to CPU table (🔴 restart) |
+
+## Deep reference
+- `docs/runbooks/snap-sync-user-guide.md`, `snap-sync-faq.md`,
+  `snap-sync-performance-tuning.md`
+- `docs/operations/monitoring-snap-sync.md`
+- `docs/runbooks/known-issues.md` (known SNAP failure modes)
+
+## Output
+CONVENTIONS §4 block. State the **measured** progress rate as evidence, list any
+config change made (and that a restart is required), and the re-measure result.

--- a/.claude/skills/fukuii-tls-operations/SKILL.md
+++ b/.claude/skills/fukuii-tls-operations/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: fukuii-tls-operations
+description: >-
+  Secure Fukuii's JSON-RPC endpoint with TLS/HTTPS — switch the RPC server to
+  https, configure the certificate keystore and password, and rotate certs. Use
+  when exposing RPC beyond localhost, hardening an endpoint, fixing TLS/cert
+  errors, or meeting an audit requirement for encrypted RPC. Changing the RPC
+  mode is a config edit that requires a restart — an irreversible/disruptive
+  action under the guarded-write protocol.
+---
+
+# Fukuii TLS operations
+
+Read `../CONVENTIONS.md` first. TLS config lives in the node config and a change
+needs a restart → 🔴 (confirm; the RPC endpoint drops during restart).
+
+## When to use
+- The RPC endpoint will be reachable off-host (always use TLS then).
+- Audit/compliance requires encrypted RPC.
+- Diagnosing `SSL`/certificate errors in logs (`fukuii-log-triage`).
+
+## Config (under `network.rpc.http`, see `base/network.conf`)
+`mode` switches the endpoint; the cert lives in a nested `certificate { … }`
+object (default `certificate = null` = HTTPS off). Exact shape:
+
+```hocon
+network.rpc.http {
+  mode = "https"            # "http" (default) or "https"
+  interface = "localhost"   # bind address
+  port = 8546               # default RPC port
+  certificate {
+    keystore-path = "tls/fukuiiCA.p12"   # PKCS#12/JKS keystore
+    keystore-type = "pkcs12"             # keystore type
+    password-file = "tls/password"       # file holding the keystore password
+  }
+}
+```
+
+> Note: these are **nested** keys under `certificate`. The flat
+> `certificate-keystore-path` / `certificate-password-file` form is the separate
+> **faucet** config (`conf/faucet.conf`), not the node RPC — don't mix them up.
+
+## Procedure
+1. **Obtain a certificate** — a CA-issued cert for public endpoints, or a
+   self-signed keystore for internal use. Store the keystore + password file
+   under a permission-restricted path (treat like keys — see
+   `fukuii-key-management`).
+2. **Configure** (🔴) — set `mode = "https"` and populate the nested
+   `certificate { keystore-path, keystore-type, password-file }` block in
+   `fukuii.conf` (replacing `certificate = null`). Keep `interface` as restrictive
+   as the use case allows; do not bind `0.0.0.0` without a firewall + auth in front.
+3. **Restart & verify** (🔴) — restart the node, then verify the endpoint speaks
+   TLS (`curl -v https://<host>:<port>` → handshake succeeds; a known RPC call
+   returns). Confirm http is no longer served on that port if that was intended.
+4. **Rotate** (🔴) — replace the keystore, update the password file if changed,
+   restart. Plan a brief RPC outage; coordinate with dependents.
+
+## Security notes
+- TLS encrypts transport; it is **not** authentication. Combine with network
+  controls / a reverse proxy for exposed endpoints. See `fukuii-security-hardening`.
+- The faucet has its own separate TLS block (`conf/faucet.conf`) — don't confuse
+  the two.
+
+## Deep reference
+- `docs/runbooks/tls-operations.md`, `docs/runbooks/security.md`
+- `src/main/resources/conf/base/network.conf` (rpc.http block)
+
+## Output
+CONVENTIONS §4 block. Evidence = the TLS handshake/curl result post-restart.

--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,11 @@ ops/*/captured-logs/
 *.conf.backup.*
 
 # Claude Code
-# Ignore local Claude settings/state, but track the project's shared subagents.
+# Ignore local Claude settings/state, but track the project's shared subagents
+# and operations skills.
 .claude/*
 !.claude/agents/
+!.claude/skills/
 
 # Planning & internal docs
 SESSION_NOTES.md


### PR DESCRIPTION
## What & why

Reviewed Fukuii's API surface (JSON-RPC `admin_*`/`eth_*`/`miner_*`/`net_*`/`fukuii_*`, the in-process MCP server, the `fukuii cli` subcommands) and the maintenance/node-management runbooks, then converted the operational procedures into **14 project-scoped [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)** under `.claude/skills/`.

Goal: **consistent prompting and control** — operators and agents run the *same* validated procedure against the *same* node interfaces, with the *same* safety gates, instead of improvising one-off commands. Skills sit on top of the existing tools and reference the runbooks (they don't replace them).

### Why skills (per the best-practices doc)
- **Tools** = atomic, deterministic calls — Fukuii already has these (JSON-RPC + 15 read-only MCP tools + CLI).
- **Skills** = multi-step *workflows* that orchestrate tools + judgement + safety, loaded on demand (progressive disclosure). The runbooks are exactly this shape, so each runbook → one skill.
- Mirrors the `.claude/agents/` subagent pattern already on `staging`.

## Skills added

`node-health-check`, `sync-troubleshooting`, `peer-management`, `backup-restore`, `disk-management`, `log-triage`, `mining-operations`, `key-management`, `tls-operations`, `checkpoint-service`, `node-configuration`, `first-start`, `security-hardening`, `custom-networks`.

- **`CONVENTIONS.md`** — shared contract: how to locate/call the node and the **guarded-write protocol** (🟢 read-only / 🟡 reversible / 🔴 irreversible, with confirmation-before-write and backup-first rules). Per the answered scoping: read + guarded writes.
- **`README.md`** — index + when-to-use map + authoring template.

## Validation (the node must still match the skills)

`VALIDATION.md` cross-checks **every interface the skills name** against the node source on this branch, with a reproducible script:

| Surface | Result |
| :-- | :-- |
| 41 JSON-RPC methods | all registered in `JsonRpcController.scala` |
| 6 MCP read tools + 1 prompt | all present in `McpTools.scala` / `McpPrompts.scala` |
| 5 `fukuii cli` subcommands | all wired in `CliCommands.scala` |
| 12 config keys | all present under `conf/base/*.conf` |
| 27 doc/source links | all resolve |

The check also caught **runbook-vs-code drift**, which the skills correct to the code's truth:
1. RPC port default is **8546** (not 8545).
2. P2P port default is **30303** (the peering runbook's `9076` is stale).
3. `mcp` is **not** in the default `apis` list — must be added to use MCP tools.
4. RPC TLS uses a **nested** `network.rpc.http.certificate { keystore-path, keystore-type, password-file }` block — not the flat faucet-style keys.
5. **No `compact-database` CLI** exists (commented example only) — disk skill says so.
6. Checkpoint sync is **config-driven** (`sync.checkpoint-sync-file`/`-url`), no `checkpoint_*` RPC.

**Caveat:** this validates that every named interface exists and is spelled correctly in the current source. It does **not** execute the skills against a live node (none runs in this environment). End-to-end behavioral validation — start a node, exercise each skill's read path, dry-run the guarded writes — should be done in a staging deployment before relying on the 🔴 write steps in production. Re-run the `VALIDATION.md` script whenever the RPC surface, CLI, or config schema changes.

## Notes
- Branch is based on `staging` and targets `staging`.
- `.gitignore` updated to track `.claude/skills/` alongside `.claude/agents/`.
- Docs/skills only — no Scala/behavioral changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaDQZa54pCgD8YukbM7h7Y)_