### PR TITLE
ci: make PR-management / dependency-check fork-PR-friendly (unblock fork work into staging)

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -64,7 +64,10 @@ jobs:
           retention-days: 30
       
       - name: Comment on PR with dependency info
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs — createComment needs a write token forks don't get (read-only
+        # GITHUB_TOKEN → "Resource not accessible by integration"). The dependency report is
+        # still uploaded as an artifact above, so no information is lost for fork PRs.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -8,6 +8,10 @@ jobs:
   label-pr:
     name: Auto-label PR
     runs-on: ubuntu-latest
+    # Fork PRs (e.g. from contributor forks merging into staging) get a read-only GITHUB_TOKEN, so
+    # actions/labeler can't write labels — it fails with "Resource not accessible by integration".
+    # Only run on same-repo PRs; fork PRs are labeled manually by a maintainer.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write
@@ -46,7 +50,8 @@ jobs:
   link-issue:
     name: Check Issue Linking
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    # Skip on fork PRs — posting the reminder comment needs a write token forks don't get.
+    if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     


### PR DESCRIPTION
## Why
Contributor **fork PRs** merging into `staging` (e.g. chris's `white-b0x/fukuii:june-sprint`, PR #1321) get a **read-only `GITHUB_TOKEN`** — GitHub forcibly downgrades write perms for PRs from forks. So the write steps in two workflows fail with `HttpError: Resource not accessible by integration`, leaving spurious red checks on every fork PR even though the code is fine (Test+Build passes).

Note: `staging` has no protection ruleset, so these reds don't *block* merge (they're non-required), but they're noise and make "all green" review harder for fork-based work.

## What
Guard the write-requiring jobs/steps to run only on same-repo PRs (`github.event.pull_request.head.repo.full_name == github.repository`); they're skipped (green) on forks:
- **pr-management**: `Auto-label PR` (`actions/labeler`) and the `Check Issue Linking` reminder comment.
- **dependency-check**: the `Comment on PR with dependency info` step (`issues.createComment`). The dependency-report **artifact is still uploaded** for fork PRs, so no info is lost.

No token elevation / `pull_request_target` (kept the safe, read-only-token path). Fork PRs are labeled manually by a maintainer.

## Result
Fork PRs into `staging` come back green; chris/white-b0x fork work flows without CI noise. Internal (same-repo) PRs are unchanged — they still get auto-label, issue-link, and the dependency comment.

## Alternative considered
Converting `actions/labeler` to `pull_request_target` would let fork PRs get auto-labeled too, but it runs in the base-repo context with a write token — more security surface. Skip-on-fork is the lower-risk choice; happy to switch if maintainers want labels on fork PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)