### PR TITLE
fix(network): tolerant 3-arm Status69 decode for eth/69 peers

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
@@ -240,7 +240,13 @@ object ETHPackets {
       }
 
       implicit class Status69Dec(val bytes: Array[Byte]) extends AnyVal {
+        // Tolerant 3-arm decode (restored from ETH69.Status.StatusDec.toETH69Status — PR #1316
+        // regressed this to a single canonical arm, which threw DECODE_ERROR on every peer that
+        // announces eth/69 but emits an ETH/68-shaped or legacy STATUS — chiefly off-network
+        // peers, who should be rejected cleanly as UselessPeer at the networkId/genesis check
+        // rather than crash the codec).
         def toStatus69: Status69 = rawDecode(bytes) match {
+          // (1) Canonical 7-field EIP-7642 — geth/besu/reth/nethermind on a real eth/69 chain.
           case RLPList(
                 RLPValue(protocolVersionBytes),
                 RLPValue(networkIdBytes),
@@ -258,6 +264,44 @@ object ETHPackets {
               ByteUtils.bytesToBigInt(earliestBlockBytes),
               ByteUtils.bytesToBigInt(latestBlockBytes),
               ByteString(latestBlockHashBytes)
+            )
+          // (2) 6-field ETH/68-shape on the eth/69 channel (forkId at idx 5): peers that
+          // announce eth/69 but send an ETH/68 STATUS. Accept so the genesis/networkId check
+          // can reject them as UselessPeer instead of emitting a noisy DECODE_ERROR.
+          case RLPList(
+                RLPValue(protocolVersionBytes),
+                RLPValue(networkIdBytes),
+                RLPValue(_totalDifficultyBytes),
+                RLPValue(bestHashBytes),
+                RLPValue(genesisHashBytes),
+                forkIdRlp: RLPList
+              ) =>
+            Status69(
+              ByteUtils.bytesToBigInt(protocolVersionBytes).toInt,
+              ByteUtils.bytesToBigInt(networkIdBytes).toLong,
+              ByteString(genesisHashBytes),
+              decode[ForkId](forkIdRlp),
+              earliestBlock = BigInt(0),
+              latestBlock = BigInt(0),
+              latestBlockHash = ByteString(bestHashBytes)
+            )
+          // (3) 6-field legacy fukuii shape (forkId at idx 3, no earliestBlock).
+          case RLPList(
+                RLPValue(protocolVersionBytes),
+                RLPValue(networkIdBytes),
+                RLPValue(genesisHashBytes),
+                forkIdRlp: RLPList,
+                RLPValue(latestBlockBytes),
+                RLPValue(latestBlockHashBytes)
+              ) =>
+            Status69(
+              ByteUtils.bytesToBigInt(protocolVersionBytes).toInt,
+              ByteUtils.bytesToBigInt(networkIdBytes).toLong,
+              ByteString(genesisHashBytes),
+              decode[ForkId](forkIdRlp),
+              earliestBlock = BigInt(0),
+              latestBlock = ByteUtils.bytesToBigInt(latestBlockBytes),
+              latestBlockHash = ByteString(latestBlockHashBytes)
             )
           case other => throw new RuntimeException(s"Cannot decode Status69 from: $other")
         }

--- a/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
@@ -373,4 +373,83 @@ class ETH69ComplianceSpec extends AnyWordSpec with Matchers {
       }
     }
   }
+
+  // ── Status69 tolerant decode — live peers announce eth/69 but emit non-canonical STATUS shapes.
+  // The codec must decode them so the networkId/genesis handshake check can reject off-network
+  // peers as UselessPeer; a codec throw disconnects + blacklists the peer and starves the pool.
+
+  "ETH69 Status69 tolerant decode" when {
+
+    "receiving an ETH/68-shaped 6-field STATUS on the eth/69 channel" should {
+      "decode it (forkId at index 5, bestHash mapped to latestBlockHash)" taggedAs UnitTest in {
+        import ETHPackets.Status68.Status68._
+        val genesisHash = ByteString(Array.fill(32)(0xcd.toByte))
+        val bestHash = ByteString(Array.fill(32)(0xab.toByte))
+        val eth68Shaped = ETHPackets.Status68.Status68(
+          protocolVersion = 69, // announces eth/69 in the payload, but the shape is ETH/68
+          networkId = 7L,
+          totalDifficulty = BigInt("167378406679735"),
+          bestHash = bestHash,
+          genesisHash = genesisHash,
+          forkId = ForkId(0xbe46d57cL, None)
+        )
+        val encoded = eth68Shaped.toBytes
+        val decoded = decoder(Capability.ETH69).fromBytes(Codes.StatusCode, encoded)
+        decoded match {
+          case Right(s: ETHPackets.Status69.Status69) =>
+            s.protocolVersion shouldEqual 69
+            s.networkId shouldEqual 7L
+            s.genesisHash shouldEqual genesisHash
+            s.forkId shouldEqual ForkId(0xbe46d57cL, None)
+            s.earliestBlock shouldEqual BigInt(0)
+            s.latestBlock shouldEqual BigInt(0)
+            s.latestBlockHash shouldEqual bestHash
+          case other => fail(s"Expected tolerant Status69 decode, got $other")
+        }
+      }
+    }
+
+    "receiving the legacy 6-field shape (forkId at index 3, no earliestBlock)" should {
+      "decode it with earliestBlock defaulted to 0" taggedAs UnitTest in {
+        import com.chipprbots.ethereum.rlp._
+        import ETHPackets.Status69.Status69._
+        val genesisHash = ByteString(Array.fill(32)(0x11.toByte))
+        val latestHash = ByteString(Array.fill(32)(0x22.toByte))
+        val canonical = ETHPackets.Status69.Status69(
+          protocolVersion = 69,
+          networkId = 7L,
+          genesisHash = genesisHash,
+          forkId = ForkId(0xfc64ec04L, Some(1150000L)),
+          earliestBlock = BigInt(0),
+          latestBlock = BigInt(424242),
+          latestBlockHash = latestHash
+        )
+        // Rearrange the canonical 7-field wire form [v, netId, genesis, forkId, earliest, latest,
+        // latestHash] into the legacy 6-field form [v, netId, genesis, forkId, latest, latestHash].
+        val canonicalRlp = rawDecode(canonical.toBytes).asInstanceOf[RLPList]
+        val i = canonicalRlp.items
+        val legacyBytes = encode(RLPList(i(0), i(1), i(2), i(3), i(5), i(6)))
+        val decoded = decoder(Capability.ETH69).fromBytes(Codes.StatusCode, legacyBytes)
+        decoded match {
+          case Right(s: ETHPackets.Status69.Status69) =>
+            s.networkId shouldEqual 7L
+            s.genesisHash shouldEqual genesisHash
+            s.forkId shouldEqual ForkId(0xfc64ec04L, Some(1150000L))
+            s.earliestBlock shouldEqual BigInt(0)
+            s.latestBlock shouldEqual BigInt(424242)
+            s.latestBlockHash shouldEqual latestHash
+          case other => fail(s"Expected tolerant legacy Status69 decode, got $other")
+        }
+      }
+    }
+
+    "receiving a STATUS that matches no known shape" should {
+      "still be rejected" taggedAs UnitTest in {
+        import com.chipprbots.ethereum.rlp._
+        val garbage = encode(RLPList(RLPValue(Array[Byte](69)), RLPValue(Array[Byte](7))))
+        val decoded = decoder(Capability.ETH69).fromBytes(Codes.StatusCode, garbage)
+        decoded.isLeft shouldBe true
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What

Restores the tolerant 3-arm `Status69` decode in `ETHPackets.scala` that #1316 reduced to the single canonical arm, and adds compliance tests for the tolerant arms.

1. **Canonical 7-field EIP-7642** — `[v, netId, genesis, forkId, earliest, latest, latestHash]` (geth/besu/reth/nethermind).
2. **ETH/68-shaped 6-field on the eth/69 channel** — `[v, netId, td, best, genesis, forkId]`: peers that announce eth/69 but send an ETH/68 STATUS.
3. **Legacy 6-field** — `[v, netId, genesis, forkId, latest, latestHash]`.

Unknown shapes still fail loudly (reject path covered by a test).

## Why

With the single-arm decoder, every eth/69 peer emitting a non-canonical STATUS crashed the codec with `DECODE_ERROR`, was disconnected and blacklisted, and retried — shredding the peer pool. Decoding tolerantly lets the **networkId/genesis handshake check** reject off-network peers cleanly as `UselessPeer` instead of churning the codec.

Observed on a Mordor node (0.6.18) doing a ~180K-block regular-sync catch-up:

| Metric | single-arm (HEAD) | with this fix |
|---|---|---|
| `Status69` DECODE_ERROR rate | 105 / 10 min | ~0 |
| p2p blacklist counter | 13K and climbing | quiet |
| Import rate | ~1 block/s | **~130 blocks/s** |

## Testing

- `ETH69ComplianceSpec`: 3 new cases (ETH/68-shape arm, legacy arm, reject path) — suite 20/20 green: `sbt "testOnly com.chipprbots.ethereum.network.p2p.messages.ETH69ComplianceSpec"`.
- `scalafmtCheckAll` clean.
- **Live validation**: deployed on the barad-dûr Mordor node; numbers above are from that run.

## Notes

- Wire-format/decode only — no consensus impact, no encoding changes (we still emit canonical 7-field Status69).
- No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)