### PR TITLE
fix(snap): close three frontier-walk holes in the BFS traversal (#1323 follow-up)

### DIFF
--- a/ops/grafana/ETC Node/fukuii-node-health.json
+++ b/ops/grafana/ETC Node/fukuii-node-health.json
@@ -1,1331 +1,974 @@
 {
- "annotations": {
-  "list": [
-   {
-    "builtIn": 1,
-    "datasource": {
-     "type": "grafana",
-     "uid": "-- Grafana --"
-    },
-    "enable": true,
-    "hide": true,
-    "iconColor": "rgba(0, 211, 255, 1)",
-    "name": "Annotations & Alerts",
-    "type": "dashboard"
-   }
-  ]
- },
- "description": "At-a-glance node health: is it up, is it syncing, are peers connected, is the JVM healthy.",
- "editable": true,
- "fiscalYearStartMonth": 0,
- "graphTooltip": 1,
- "id": null,
- "links": [
-  {
-   "asDropdown": false,
-   "icon": "external link",
-   "includeVars": true,
-   "keepTime": true,
-   "tags": [
-    "fukuii"
-   ],
-   "targetBlank": false,
-   "title": "Fukuii dashboards",
-   "type": "dashboards"
-  }
- ],
- "liveNow": false,
- "panels": [
-  {
-   "type": "stat",
-   "title": "Node Up",
-   "id": 1,
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 0,
-    "y": 0
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "up{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "mappings": [
+  "annotations": {
+    "list": [
       {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "DOWN",
-         "color": "red"
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
         },
-        "1": {
-         "text": "UP",
-         "color": "green"
-        }
-       }
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-     ],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "green",
-        "value": 1
-       }
-      ]
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "none",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "Current Block",
-   "id": 2,
-   "gridPos": {
-    "h": 4,
-    "w": 5,
-    "x": 4,
-    "y": 0
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"} or app_sync_block_number_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "light-blue"
-     },
-     "decimals": 0
-    }
-   },
-   "options": {
-    "colorMode": "value",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "Best Known Block",
-   "id": 3,
-   "gridPos": {
-    "h": 4,
-    "w": 5,
-    "x": 9,
-    "y": 0
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "semi-dark-purple"
-     },
-     "decimals": 0
-    }
-   },
-   "options": {
-    "colorMode": "value",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "Blocks Behind",
-   "id": 4,
-   "gridPos": {
-    "h": 4,
-    "w": 5,
-    "x": 14,
-    "y": 0
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "clamp_min((app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}) - (app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}), 0)",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "decimals": 0,
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 16
-       },
-       {
-        "color": "orange",
-        "value": 128
-       },
-       {
-        "color": "red",
-        "value": 1024
-       }
-      ]
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "Handshaked Peers",
-   "id": 5,
-   "gridPos": {
-    "h": 4,
-    "w": 5,
-    "x": 19,
-    "y": 0
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"} + app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "decimals": 0,
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "orange",
-        "value": 1
-       },
-       {
-        "color": "yellow",
-        "value": 3
-       },
-       {
-        "color": "green",
-        "value": 5
-       }
-      ]
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Block height over time",
-   "id": 10,
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 0,
-    "y": 4
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} current (regular)"
-    },
-    {
-     "expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} best known"
-    },
-    {
-     "expr": "app_sync_block_number_gauge{instance=~\"$instance\"}",
-     "refId": "C",
-     "legendFormat": "{{instance}} last executed"
-    },
-    {
-     "expr": "app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}",
-     "refId": "D",
-     "legendFormat": "{{instance}} fast-sync best"
-    },
-    {
-     "expr": "app_fastsync_block_bestHeader_number_gauge{instance=~\"$instance\"}",
-     "refId": "E",
-     "legendFormat": "{{instance}} fast-sync headers"
-    },
-    {
-     "expr": "app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}",
-     "refId": "F",
-     "legendFormat": "{{instance}} fast-sync pivot"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "decimals": 0,
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 5
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "table",
-     "placement": "bottom",
-     "calcs": [
-      "lastNotNull"
-     ]
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Import rate (blocks/sec)",
-   "id": 11,
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 12,
-    "y": 4
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[1m])",
-     "refId": "A",
-     "legendFormat": "{{instance}} 1m"
-    },
-    {
-     "expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[5m])",
-     "refId": "B",
-     "legendFormat": "{{instance}} 5m"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "ops",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "table",
-     "placement": "bottom",
-     "calcs": [
-      "lastNotNull",
-      "max",
-      "mean"
-     ]
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Peers",
-   "id": 20,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 0,
-    "y": 12
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} outgoing"
-    },
-    {
-     "expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} incoming"
-    },
-    {
-     "expr": "app_network_peers_pending_gauge{instance=~\"$instance\"}",
-     "refId": "C",
-     "legendFormat": "{{instance}} pending"
-    },
-    {
-     "expr": "app_network_discovery_foundPeers_gauge{instance=~\"$instance\"}",
-     "refId": "D",
-     "legendFormat": "{{instance}} discovery"
-    },
-    {
-     "expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}",
-     "refId": "E",
-     "legendFormat": "{{instance}} blacklisted"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "decimals": 0,
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 5
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "table",
-     "placement": "bottom",
-     "calcs": [
-      "lastNotNull"
-     ]
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Network message rate",
-   "id": 21,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 12,
-    "y": 12
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "sum by (instance) (rate(app_network_messages_sent_counter_total{instance=~\"$instance\"}[1m]))",
-     "refId": "A",
-     "legendFormat": "{{instance}} sent/s"
-    },
-    {
-     "expr": "sum by (instance) (rate(app_network_messages_received_counter_total{instance=~\"$instance\"}[1m]))",
-     "refId": "B",
-     "legendFormat": "{{instance}} received/s"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "ops",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10
-     }
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Block time (seconds between parent blocks)",
-   "id": 30,
-   "gridPos": {
-    "h": 7,
-    "w": 8,
-    "x": 0,
-    "y": 19
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_sync_block_timeBetweenParent_seconds_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "s",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10
-     }
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Transactions per block",
-   "id": 31,
-   "gridPos": {
-    "h": 7,
-    "w": 8,
-    "x": 8,
-    "y": 19
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_sync_block_transactions_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} tx"
-    },
-    {
-     "expr": "app_sync_block_uncles_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} uncles"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 5
-     }
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Gas per block",
-   "id": 32,
-   "gridPos": {
-    "h": 7,
-    "w": 8,
-    "x": 16,
-    "y": 19
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_sync_block_gasUsed_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} used"
-    },
-    {
-     "expr": "app_sync_block_gasLimit_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} limit"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 5
-     }
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "JVM heap (bytes used vs committed)",
-   "id": 40,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 0,
-    "y": 26
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "jvm_memory_bytes_used{area=\"heap\",instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} used"
-    },
-    {
-     "expr": "jvm_memory_bytes_committed{area=\"heap\",instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} committed"
-    },
-    {
-     "expr": "jvm_memory_bytes_max{area=\"heap\",instance=~\"$instance\"}",
-     "refId": "C",
-     "legendFormat": "{{instance}} max"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "bytes",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 5
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "table",
-     "placement": "bottom",
-     "calcs": [
-      "lastNotNull",
-      "max"
-     ]
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "GC time (s/s \u2014 fraction of CPU in GC)",
-   "id": 41,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 12,
-    "y": 26
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "rate(jvm_gc_collection_seconds_sum{instance=~\"$instance\"}[1m])",
-     "refId": "A",
-     "legendFormat": "{{instance}} {{gc}}"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percentunit",
-     "max": 1,
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10
-     }
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Errors / validation failures (rate/s)",
-   "id": 50,
-   "gridPos": {
-    "h": 6,
-    "w": 12,
-    "x": 0,
-    "y": 33
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])",
-     "refId": "A",
-     "legendFormat": "{{instance}} snap errors"
-    },
-    {
-     "expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])",
-     "refId": "B",
-     "legendFormat": "{{instance}} snap validation"
-    },
-    {
-     "expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])",
-     "refId": "C",
-     "legendFormat": "{{instance}} snap timeouts"
-    },
-    {
-     "expr": "rate(app_network_peers_blacklisted_regularSyncGroup_counter_total{instance=~\"$instance\"}[1m])",
-     "refId": "D",
-     "legendFormat": "{{instance}} blacklist rate"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "ops",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10
-     }
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "JVM threads",
-   "id": 51,
-   "gridPos": {
-    "h": 6,
-    "w": 6,
-    "x": 12,
-    "y": 33
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "jvm_threads_current{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}} current"
-    },
-    {
-     "expr": "jvm_threads_deadlocked{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "{{instance}} DEADLOCKED"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "red",
-        "value": 1
-       }
-      ]
-     }
-    },
-    "overrides": [
-     {
-      "matcher": {
-       "id": "byFrameRefID",
-       "options": "A"
-      },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "light-blue"
-        }
-       }
-      ]
-     }
     ]
-   },
-   "options": {
-    "colorMode": "value",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
   },
-  {
-   "type": "stat",
-   "title": "SNAP phase",
-   "id": 52,
-   "gridPos": {
-    "h": 6,
-    "w": 6,
-    "x": 18,
-    "y": 33
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
+  "description": "At-a-glance node health: is it up, is it syncing, are peers connected, is the JVM healthy.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
     {
-     "expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "{{instance}}"
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "fukuii"
+      ],
+      "targetBlank": false,
+      "title": "Fukuii dashboards",
+      "type": "dashboards"
     }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "mappings": [
-      {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "Idle",
-         "color": "grey"
-        },
-        "1": {
-         "text": "AccountRange",
-         "color": "blue"
-        },
-        "3": {
-         "text": "ByteCode+Storage",
-         "color": "purple"
-        },
-        "5": {
-         "text": "Healing",
-         "color": "yellow"
-        },
-        "6": {
-         "text": "Validation",
-         "color": "orange"
-        },
-        "7": {
-         "text": "Chain",
-         "color": "cyan"
-        },
-        "8": {
-         "text": "Completed",
-         "color": "green"
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Node Up",
+      "id": 1,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "up{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
         }
-       }
-      }
-     ]
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "none",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "row",
-   "title": "Post-SNAP State Recovery (bytecode + storage scan)",
-   "id": 53,
-   "gridPos": {
-    "h": 1,
-    "w": 24,
-    "x": 0,
-    "y": 40
-   },
-   "collapsed": false,
-   "panels": []
-  },
-  {
-   "type": "stat",
-   "title": "Storage Recovery Phase",
-   "id": 54,
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 0,
-    "y": 41
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_storage_phase_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "phase"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "mappings": [
-      {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "Idle",
-         "color": "text"
-        },
-        "1": {
-         "text": "Scanning",
-         "color": "yellow"
-        },
-        "2": {
-         "text": "Downloading",
-         "color": "blue"
-        },
-        "3": {
-         "text": "Complete",
-         "color": "green"
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         }
-       }
-      }
-     ],
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "text"
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "none",
-    "textMode": "value",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "stat",
-   "title": "Bytecode Recovery Phase",
-   "id": 55,
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 4,
-    "y": 41
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_bytecode_phase_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "phase"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "mappings": [
-      {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "Idle",
-         "color": "text"
-        },
-        "1": {
-         "text": "Scanning",
-         "color": "yellow"
-        },
-        "2": {
-         "text": "Downloading",
-         "color": "blue"
-        },
-        "3": {
-         "text": "Complete",
-         "color": "green"
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         }
-       }
       }
-     ],
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "text"
-     }
+    },
+    {
+      "type": "stat",
+      "title": "Current Block",
+      "id": 2,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"} or app_sync_block_number_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "light-blue"
+          },
+          "decimals": 0
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Best Known Block",
+      "id": 3,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "semi-dark-purple"
+          },
+          "decimals": 0
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Blocks Behind",
+      "id": 4,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "clamp_min((app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"} or app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}) - (app_regularsync_block_current_number_gauge{instance=~\"$instance\"} or app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}), 0)",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 16
+              },
+              {
+                "color": "orange",
+                "value": 128
+              },
+              {
+                "color": "red",
+                "value": 1024
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Handshaked Peers",
+      "id": 5,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"} + app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Block height over time",
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_regularsync_block_current_number_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} current (regular)"
+        },
+        {
+          "expr": "app_regularsync_block_bestKnown_number_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} best known"
+        },
+        {
+          "expr": "app_sync_block_number_gauge{instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} last executed"
+        },
+        {
+          "expr": "app_fastsync_block_bestFullBlock_number_gauge{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} fast-sync best"
+        },
+        {
+          "expr": "app_fastsync_block_bestHeader_number_gauge{instance=~\"$instance\"}",
+          "refId": "E",
+          "legendFormat": "{{instance}} fast-sync headers"
+        },
+        {
+          "expr": "app_fastsync_block_pivotBlock_number_gauge{instance=~\"$instance\"}",
+          "refId": "F",
+          "legendFormat": "{{instance}} fast-sync pivot"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Import rate (blocks/sec)",
+      "id": 11,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[1m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} 1m"
+        },
+        {
+          "expr": "rate(app_regularsync_blocks_imported_total{instance=~\"$instance\"}[5m])",
+          "refId": "B",
+          "legendFormat": "{{instance}} 5m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Peers",
+      "id": 20,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} outgoing"
+        },
+        {
+          "expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} incoming"
+        },
+        {
+          "expr": "app_network_peers_pending_gauge{instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} pending"
+        },
+        {
+          "expr": "app_network_discovery_foundPeers_gauge{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} discovery"
+        },
+        {
+          "expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}",
+          "refId": "E",
+          "legendFormat": "{{instance}} blacklisted"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Network message rate",
+      "id": 21,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(app_network_messages_sent_counter_total{instance=~\"$instance\"}[1m]))",
+          "refId": "A",
+          "legendFormat": "{{instance}} sent/s"
+        },
+        {
+          "expr": "sum by (instance) (rate(app_network_messages_received_counter_total{instance=~\"$instance\"}[1m]))",
+          "refId": "B",
+          "legendFormat": "{{instance}} received/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Block time (seconds between parent blocks)",
+      "id": 30,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_sync_block_timeBetweenParent_seconds_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Transactions per block",
+      "id": 31,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_sync_block_transactions_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} tx"
+        },
+        {
+          "expr": "app_sync_block_uncles_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} uncles"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Gas per block",
+      "id": 32,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_sync_block_gasUsed_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} used"
+        },
+        {
+          "expr": "app_sync_block_gasLimit_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} limit"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM heap (bytes used vs committed)",
+      "id": 40,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "jvm_memory_bytes_used{area=\"heap\",instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} used"
+        },
+        {
+          "expr": "jvm_memory_bytes_committed{area=\"heap\",instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} committed"
+        },
+        {
+          "expr": "jvm_memory_bytes_max{area=\"heap\",instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} max"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "GC time (s/s \u2014 fraction of CPU in GC)",
+      "id": 41,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_collection_seconds_sum{instance=~\"$instance\"}[1m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} {{gc}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors / validation failures (rate/s)",
+      "id": 50,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} snap errors"
+        },
+        {
+          "expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])",
+          "refId": "B",
+          "legendFormat": "{{instance}} snap validation"
+        },
+        {
+          "expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])",
+          "refId": "C",
+          "legendFormat": "{{instance}} snap timeouts"
+        },
+        {
+          "expr": "rate(app_network_peers_blacklisted_regularSyncGroup_counter_total{instance=~\"$instance\"}[1m])",
+          "refId": "D",
+          "legendFormat": "{{instance}} blacklist rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "JVM threads",
+      "id": 51,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "jvm_threads_current{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} current"
+        },
+        {
+          "expr": "jvm_threads_deadlocked{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} DEADLOCKED"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "light-blue"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "SNAP phase",
+      "id": 52,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Idle",
+                  "color": "grey"
+                },
+                "1": {
+                  "text": "AccountRange",
+                  "color": "blue"
+                },
+                "3": {
+                  "text": "ByteCode+Storage",
+                  "color": "purple"
+                },
+                "5": {
+                  "text": "Healing",
+                  "color": "yellow"
+                },
+                "6": {
+                  "text": "Validation",
+                  "color": "orange"
+                },
+                "7": {
+                  "text": "Chain",
+                  "color": "cyan"
+                },
+                "8": {
+                  "text": "Completed",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "none",
-    "textMode": "value",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "fukuii",
+    "health",
+    "overview"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(up{job=~\".*fukuii.*\"}, instance)",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "options": [],
+        "hide": 0
+      }
+    ]
   },
-  {
-   "type": "stat",
-   "title": "Missing Storage Tries",
-   "id": 56,
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 8,
-    "y": 41
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_storage_missing_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "missing"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "none",
-     "decimals": 0,
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "orange",
-        "value": 1
-       }
-      ]
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
+  "time": {
+    "from": "now-30m",
+    "to": "now"
   },
-  {
-   "type": "stat",
-   "title": "Missing Bytecodes",
-   "id": 57,
-   "gridPos": {
-    "h": 4,
-    "w": 4,
-    "x": 12,
-    "y": 41
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_bytecode_missing_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "missing"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "none",
-     "decimals": 0,
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "orange",
-        "value": 1
-       }
-      ]
-     }
-    }
-   },
-   "options": {
-    "colorMode": "background",
-    "graphMode": "area",
-    "textMode": "value_and_name",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Recovery Scan Progress (accounts walked)",
-   "id": 58,
-   "gridPos": {
-    "h": 8,
-    "w": 8,
-    "x": 16,
-    "y": 41
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_storage_accountsScanned_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "storage scan"
-    },
-    {
-     "expr": "app_recovery_bytecode_accountsScanned_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "bytecode scan"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "none",
-     "decimals": 0,
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10,
-      "showPoints": "never"
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true
-    }
-   }
-  },
-  {
-   "type": "timeseries",
-   "title": "Recovery: contracts found & gaps",
-   "id": 59,
-   "gridPos": {
-    "h": 4,
-    "w": 16,
-    "x": 0,
-    "y": 45
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "targets": [
-    {
-     "expr": "app_recovery_storage_contractsFound_gauge{instance=~\"$instance\"}",
-     "refId": "A",
-     "legendFormat": "storage contracts"
-    },
-    {
-     "expr": "app_recovery_storage_missing_gauge{instance=~\"$instance\"}",
-     "refId": "B",
-     "legendFormat": "storage missing"
-    },
-    {
-     "expr": "app_recovery_bytecode_missing_gauge{instance=~\"$instance\"}",
-     "refId": "C",
-     "legendFormat": "bytecode missing"
-    },
-    {
-     "expr": "app_recovery_storage_downloaded_gauge{instance=~\"$instance\"}",
-     "refId": "D",
-     "legendFormat": "storage downloaded"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "none",
-     "decimals": 0,
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10,
-      "showPoints": "never"
-     }
-    }
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true
-    }
-   }
-  }
- ],
- "refresh": "10s",
- "schemaVersion": 38,
- "style": "dark",
- "tags": [
-  "fukuii",
-  "health",
-  "overview"
- ],
- "templating": {
-  "list": [
-   {
-    "name": "instance",
-    "label": "Instance",
-    "type": "query",
-    "datasource": {
-     "type": "prometheus",
-     "uid": "prometheus"
-    },
-    "query": {
-     "query": "label_values(up{job=~\".*fukuii.*\"}, instance)",
-     "refId": "Prometheus-instance-Variable-Query"
-    },
-    "refresh": 1,
-    "sort": 1,
-    "includeAll": true,
-    "allValue": ".*",
-    "multi": true,
-    "current": {
-     "selected": false,
-     "text": "All",
-     "value": "$__all"
-    },
-    "options": [],
-    "hide": 0
-   }
-  ]
- },
- "time": {
-  "from": "now-30m",
-  "to": "now"
- },
- "timepicker": {},
- "timezone": "",
- "title": "Fukuii Node Health",
- "uid": "fukuii-node-health",
- "version": 1,
- "weekStart": ""
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fukuii Node Health",
+  "uid": "fukuii-node-health",
+  "version": 2,
+  "weekStart": ""
 }

--- a/ops/grafana/Sync/fukuii-snap-sync.json
+++ b/ops/grafana/Sync/fukuii-snap-sync.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -11,7 +14,10 @@
         "type": "dashboard"
       },
       {
-        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "enable": true,
         "expr": "changes(app_snapsync_phase_current_gauge{instance=~\"$instance\"}[1m]) > 0",
         "iconColor": "orange",
@@ -21,7 +27,10 @@
         "useValueForTime": false
       },
       {
-        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "enable": true,
         "expr": "changes(app_snapsync_pivot_refreshed_total{instance=~\"$instance\"}[1m]) > 0",
         "iconColor": "purple",
@@ -31,7 +40,10 @@
         "useValueForTime": false
       },
       {
-        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "enable": true,
         "expr": "changes(app_network_lagging_peer_evicted_total{instance=~\"$instance\"}[1m]) > 0",
         "iconColor": "red",
@@ -42,13 +54,24 @@
       }
     ]
   },
-  "description": "SNAP sync — phases, throughput, backpressure (PR #1233/#1241), pivot refresh (PR #1234/#1236), peer-pool hygiene (PR #1237/#1238/#1239/#1240/#1242).",
+  "description": "SNAP sync \u2014 phases, throughput, backpressure (PR #1233/#1241), pivot refresh (PR #1234/#1236), peer-pool hygiene (PR #1237/#1238/#1239/#1240/#1242).",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    {"asDropdown": false, "icon": "external link", "includeVars": true, "keepTime": true, "tags": ["fukuii"], "targetBlank": false, "title": "Fukuii dashboards", "type": "dashboards"}
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "fukuii"
+      ],
+      "targetBlank": false,
+      "title": "Fukuii dashboards",
+      "type": "dashboards"
+    }
   ],
   "liveNow": false,
   "panels": [
@@ -56,7 +79,12 @@
       "type": "row",
       "title": "Phase & Pivot",
       "id": 100,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "collapsed": false,
       "panels": []
     },
@@ -64,83 +92,278 @@
       "type": "stat",
       "title": "Current Phase",
       "id": 1,
-      "gridPos": {"h": 5, "w": 5, "x": 0, "y": 1},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_phase_current_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "options": {
-              "0": {"text": "Idle", "color": "grey"},
-              "1": {"text": "AccountRange", "color": "blue"},
-              "3": {"text": "ByteCode + Storage", "color": "purple"},
-              "5": {"text": "Healing", "color": "yellow"},
-              "6": {"text": "Validation", "color": "orange"},
-              "7": {"text": "Chain Download", "color": "cyan"},
-              "8": {"text": "Completed", "color": "green"}
-            }}
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Idle",
+                  "color": "grey"
+                },
+                "1": {
+                  "text": "AccountRange",
+                  "color": "blue"
+                },
+                "3": {
+                  "text": "ByteCode + Storage",
+                  "color": "purple"
+                },
+                "5": {
+                  "text": "Healing",
+                  "color": "yellow"
+                },
+                "6": {
+                  "text": "Validation",
+                  "color": "orange"
+                },
+                "7": {
+                  "text": "Chain Download",
+                  "color": "cyan"
+                },
+                "8": {
+                  "text": "Completed",
+                  "color": "green"
+                }
+              }
+            }
           ],
-          "color": {"mode": "fixed", "fixedColor": "blue"}
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
         }
       },
-      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Time in Phase",
       "id": 2,
-      "gridPos": {"h": 5, "w": 5, "x": 5, "y": 1},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_phase_time_seconds_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_phase_time_seconds_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [
-            {"color": "green", "value": null},
-            {"color": "yellow", "value": 600},
-            {"color": "orange", "value": 1800}
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "orange",
+                "value": 1800
+              }
+            ]
+          }
         }
       },
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Total Sync Time",
       "id": 3,
-      "gridPos": {"h": 5, "w": 4, "x": 10, "y": 1},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_totaltime_minutes_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "m", "color": {"mode": "fixed", "fixedColor": "light-blue"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 10,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_totaltime_minutes_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "light-blue"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Pivot Block",
       "id": 4,
-      "gridPos": {"h": 5, "w": 5, "x": 14, "y": 1},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_pivot_block_number_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "semi-dark-purple"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_pivot_block_number_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "semi-dark-purple"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Pivot Refreshes (total)",
       "id": 5,
-      "gridPos": {"h": 5, "w": 5, "x": 19, "y": 1},
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
       "description": "Total pivot refreshes since SNAP sync start. Rising during long account-phase runs is normal (snap serve window ~28min). Each refresh releases storage backpressure if engaged (PR #1241).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_pivot_refreshed_total{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "purple"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_pivot_refreshed_total{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "row",
-      "title": "Backpressure (PR #1233 / #1241) — what's blocking the account phase",
+      "title": "Backpressure (PR #1233 / #1241) \u2014 what's blocking the account phase",
       "id": 101,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
       "collapsed": false,
       "panels": []
     },
@@ -148,64 +371,166 @@
       "type": "stat",
       "title": "Storage Backpressure",
       "id": 60,
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 7},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
       "description": "1 = ENGAGED (storage queue exceeded high-water 100K). Account dispatch is paused until pivot refresh releases (PR #1241) or queue drains below low-water 50K.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_storage_backpressure_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_storage_backpressure_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "options": {
-              "0": {"text": "RELEASED", "color": "green"},
-              "1": {"text": "ENGAGED", "color": "red"}
-            }}
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "RELEASED",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "ENGAGED",
+                  "color": "red"
+                }
+              }
+            }
           ],
-          "color": {"mode": "fixed"}
+          "color": {
+            "mode": "fixed"
+          }
         }
       },
-      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "ByteCode Backpressure",
       "id": 61,
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 7},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 7
+      },
       "description": "1 = ENGAGED (bytecode queue exceeded high-water 50K). Account dispatch is paused. Similar release semantics to storage (PR #1233/#1241).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_bytecode_backpressure_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_bytecode_backpressure_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "options": {
-              "0": {"text": "RELEASED", "color": "green"},
-              "1": {"text": "ENGAGED", "color": "red"}
-            }}
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "RELEASED",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "ENGAGED",
+                  "color": "red"
+                }
+              }
+            }
           ],
-          "color": {"mode": "fixed"}
+          "color": {
+            "mode": "fixed"
+          }
         }
       },
-      "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Storage Queue Depth (with watermarks)",
       "id": 62,
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 7},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
       "description": "Pending storage tasks in the coordinator queue. Crossing 100K engages backpressure; dropping to 50K releases it. Pivot refresh also force-releases (PR #1241).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_storage_queue_depth_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} depth"}
+        {
+          "expr": "app_snapsync_storage_queue_depth_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} depth"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
-          "thresholds": {"mode": "absolute", "steps": [
-            {"color": "green", "value": null},
-            {"color": "yellow", "value": 50000},
-            {"color": "red", "value": 100000}
-          ]},
-          "custom.thresholdsStyle": {"mode": "line"}
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50000
+              },
+              {
+                "color": "red",
+                "value": 100000
+              }
+            ]
+          },
+          "custom.thresholdsStyle": {
+            "mode": "line"
+          }
         }
       }
     },
@@ -213,42 +538,101 @@
       "type": "timeseries",
       "title": "ByteCode Queue Depth (with watermarks)",
       "id": 63,
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 7},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
       "description": "Pending bytecode tasks. Watermarks: 50K engage, 25K release.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_bytecode_queue_depth_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} depth"}
+        {
+          "expr": "app_snapsync_bytecode_queue_depth_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} depth"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
-          "thresholds": {"mode": "absolute", "steps": [
-            {"color": "green", "value": null},
-            {"color": "yellow", "value": 25000},
-            {"color": "red", "value": 50000}
-          ]}
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25000
+              },
+              {
+                "color": "red",
+                "value": 50000
+              }
+            ]
+          }
         }
       }
     },
     {
       "type": "timeseries",
-      "title": "Backpressure State (timeseries — engage/release cycles)",
+      "title": "Backpressure State (timeseries \u2014 engage/release cycles)",
       "id": 64,
-      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
       "description": "Stepped state changes. Each step-up corresponds to a queue overflow, each step-down to a pivot refresh release.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_storage_backpressure_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} storage"},
-        {"expr": "app_snapsync_bytecode_backpressure_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} bytecode"}
+        {
+          "expr": "app_snapsync_storage_backpressure_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} storage"
+        },
+        {
+          "expr": "app_snapsync_bytecode_backpressure_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} bytecode"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "bool", "custom": {"drawStyle": "line", "lineInterpolation": "stepAfter", "lineWidth": 2, "fillOpacity": 30}}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "fillOpacity": 30
+          }
+        }
+      }
     },
     {
       "type": "row",
       "title": "Progress",
       "id": 102,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 15},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
       "collapsed": false,
       "panels": []
     },
@@ -256,88 +640,299 @@
       "type": "gauge",
       "title": "Accounts Progress",
       "id": 10,
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "100 * app_snapsync_accounts_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "100 * app_snapsync_accounts_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}, 1)",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent", "min": 0, "max": 100,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}, {"color": "green", "value": 100}]}
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          }
         }
       },
-      "options": {"orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "gauge",
       "title": "Bytecodes Progress",
       "id": 11,
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "100 * app_snapsync_bytecodes_downloaded_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_bytecodes_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "100 * app_snapsync_bytecodes_downloaded_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_bytecodes_estimated_total_gauge{instance=~\"$instance\"}, 1)",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent", "min": 0, "max": 100,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "purple", "value": null}, {"color": "green", "value": 100}]}
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          }
         }
       },
-      "options": {"orientation": "auto", "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "orientation": "auto",
+        "showThresholdMarkers": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "gauge",
       "title": "Storage Slots Progress",
       "id": 12,
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "100 * app_snapsync_storage_slots_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_storage_slots_estimated_total_gauge{instance=~\"$instance\"}, 1)", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "100 * app_snapsync_storage_slots_synced_gauge{instance=~\"$instance\"} / clamp_min(app_snapsync_storage_slots_estimated_total_gauge{instance=~\"$instance\"}, 1)",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent", "min": 0, "max": 100,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "orange", "value": null}, {"color": "green", "value": 100}]}
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          }
         }
       },
-      "options": {"orientation": "auto", "showThresholdMarkers": true, "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "orientation": "auto",
+        "showThresholdMarkers": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Nodes Healed",
       "id": 13,
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_nodes_healed_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "yellow"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_nodes_healed_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Accounts Synced (cumulative)",
       "id": 20,
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_accounts_synced_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} synced"},
-        {"expr": "app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} estimated"}
+        {
+          "expr": "app_snapsync_accounts_synced_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} synced"
+        },
+        {
+          "expr": "app_snapsync_accounts_estimated_total_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} estimated"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
-      "title": "Throughput — Accounts / Bytecodes / Storage / Healing (recent)",
+      "title": "Throughput \u2014 Accounts / Bytecodes / Storage / Healing (recent)",
       "id": 21,
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_accounts_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} accounts/s"},
-        {"expr": "app_snapsync_bytecodes_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} bytecodes/s"},
-        {"expr": "app_snapsync_storage_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} storage/s"},
-        {"expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} healing/s"}
+        {
+          "expr": "app_snapsync_accounts_throughput_recent_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} accounts/s"
+        },
+        {
+          "expr": "app_snapsync_bytecodes_throughput_recent_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} bytecodes/s"
+        },
+        {
+          "expr": "app_snapsync_storage_throughput_recent_gauge{instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} storage/s"
+        },
+        {
+          "expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} healing/s"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      }
     },
     {
       "type": "row",
       "title": "Peer Pool Health (PR #1237 / #1238 / #1239 / #1240 / #1242)",
       "id": 103,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 30},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
       "collapsed": false,
       "panels": []
     },
@@ -345,471 +940,398 @@
       "type": "stat",
       "title": "Active Account Peers",
       "id": 70,
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 31},
-      "description": "Peers eligible to serve account ranges right now: knownAvailable - stateless - snapless - cooling. The number to watch — when this drops below 2 we're peer-bottlenecked.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_accounts_active_peers_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 31
+      },
+      "description": "Peers eligible to serve account ranges right now: knownAvailable - stateless - snapless - cooling. The number to watch \u2014 when this drops below 2 we're peer-bottlenecked.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_accounts_active_peers_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [
-            {"color": "red", "value": null},
-            {"color": "orange", "value": 2},
-            {"color": "yellow", "value": 3},
-            {"color": "green", "value": 5}
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          }
         }
       },
-      "options": {"colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "SNAP-Capable Peers",
       "id": 71,
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 31},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 31
+      },
       "description": "Peers that negotiated SNAP/1 (regardless of demotion state). The pool from which active peers are drawn.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_peers_capable_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "blue"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_peers_capable_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Lagging Peers Evicted (total)",
       "id": 72,
-      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 31},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 31
+      },
       "description": "PR #1239 chronic-laggard evictions. Each is a peer that lagged >4096 blocks behind CL head for 10 min. Held in blacklist 30 min (PR #1242) so they don't immediately re-evict.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_network_lagging_peer_evicted_total{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "red"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_network_lagging_peer_evicted_total{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Snapless Demoted (total)",
       "id": 73,
-      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 31},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 31
+      },
       "description": "PR #1237 strike-counted demotions. A peer that returned empty proof-of-absence 3 times is moved to snapless (no longer dispatched account-range tasks).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_peers_snapless_confirmed_total{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "orange"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_peers_snapless_confirmed_total{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Stateless Demoted (total)",
       "id": 74,
-      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 31},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 31
+      },
       "description": "PR #1237 strike-counted demotions. A peer that responded with empty 3 times (no state for our root) is moved to stateless. Cleared on pivot refresh.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_peers_stateless_confirmed_total{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "yellow"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_peers_stateless_confirmed_total{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Blacklisted Peers (live)",
       "id": 75,
-      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 31},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "dark-red"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 31
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_network_peers_blacklisted_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "dark-red"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "timeseries",
-      "title": "Peer Pool — capacity vs active vs handshaked",
+      "title": "Peer Pool \u2014 capacity vs active vs handshaked",
       "id": 76,
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 35},
-      "description": "The gap between handshaked and active is peer waste — peers we maintain a connection to but can't dispatch work to (stateless/snapless/cooling). PR #1237+#1239 narrow this gap.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "description": "The gap between handshaked and active is peer waste \u2014 peers we maintain a connection to but can't dispatch work to (stateless/snapless/cooling). PR #1237+#1239 narrow this gap.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_accounts_active_peers_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} active"},
-        {"expr": "app_snapsync_peers_capable_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} snap-capable"},
-        {"expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} outgoing handshaked"},
-        {"expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} incoming handshaked"}
+        {
+          "expr": "app_snapsync_accounts_active_peers_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} active"
+        },
+        {
+          "expr": "app_snapsync_peers_capable_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} snap-capable"
+        },
+        {
+          "expr": "app_network_peers_outgoing_handshaked_gauge{instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} outgoing handshaked"
+        },
+        {
+          "expr": "app_network_peers_incoming_handshaked_gauge{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} incoming handshaked"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Demotion + Eviction Rate (per min)",
       "id": 77,
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 35},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
       "description": "Rate of peer demotions/evictions. A steady non-zero rate of lagging-peer evictions indicates the chronic-laggard recycler (PR #1239) is doing its job. Snapless/stateless transitions should be rare with the strike threshold (PR #1237).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "60 * rate(app_network_lagging_peer_evicted_total{instance=~\"$instance\"}[5m])", "refId": "A", "legendFormat": "{{instance}} lagging/min"},
-        {"expr": "60 * rate(app_snapsync_peers_snapless_confirmed_total{instance=~\"$instance\"}[5m])", "refId": "B", "legendFormat": "{{instance}} snapless/min"},
-        {"expr": "60 * rate(app_snapsync_peers_stateless_confirmed_total{instance=~\"$instance\"}[5m])", "refId": "C", "legendFormat": "{{instance}} stateless/min"},
-        {"expr": "60 * rate(app_snapsync_peers_blacklisted_total{instance=~\"$instance\"}[5m])", "refId": "D", "legendFormat": "{{instance}} blacklists/min"}
+        {
+          "expr": "60 * rate(app_network_lagging_peer_evicted_total{instance=~\"$instance\"}[5m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} lagging/min"
+        },
+        {
+          "expr": "60 * rate(app_snapsync_peers_snapless_confirmed_total{instance=~\"$instance\"}[5m])",
+          "refId": "B",
+          "legendFormat": "{{instance}} snapless/min"
+        },
+        {
+          "expr": "60 * rate(app_snapsync_peers_stateless_confirmed_total{instance=~\"$instance\"}[5m])",
+          "refId": "C",
+          "legendFormat": "{{instance}} stateless/min"
+        },
+        {
+          "expr": "60 * rate(app_snapsync_peers_blacklisted_total{instance=~\"$instance\"}[5m])",
+          "refId": "D",
+          "legendFormat": "{{instance}} blacklists/min"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "short"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
     },
     {
       "type": "row",
       "title": "Request Health",
       "id": 104,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 43},
-      "collapsed": false,
-      "panels": []
-    },
-    {
-      "type": "timeseries",
-      "title": "Request Health — timeouts / retries / failures",
-      "id": 30,
-      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 44},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} timeouts"},
-        {"expr": "rate(app_snapsync_requests_retries_total{instance=~\"$instance\"}[1m])", "refId": "B", "legendFormat": "{{instance}} retries"},
-        {"expr": "rate(app_snapsync_accounts_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "C", "legendFormat": "{{instance}} account fails"},
-        {"expr": "rate(app_snapsync_bytecodes_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "D", "legendFormat": "{{instance}} bytecode fails"},
-        {"expr": "rate(app_snapsync_storage_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "E", "legendFormat": "{{instance}} storage fails"},
-        {"expr": "rate(app_snapsync_healing_requests_failed_total{instance=~\"$instance\"}[1m])", "refId": "F", "legendFormat": "{{instance}} healing fails"}
-      ],
-      "fieldConfig": {"defaults": {"unit": "ops"}}
-    },
-    {
-      "type": "timeseries",
-      "title": "Data Integrity — proofs / validation / missing nodes",
-      "id": 31,
-      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 44},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "rate(app_snapsync_proofs_invalid_total{instance=~\"$instance\"}[1m])", "refId": "A", "legendFormat": "{{instance}} invalid proofs"},
-        {"expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])", "refId": "B", "legendFormat": "{{instance}} validation fails"},
-        {"expr": "rate(app_snapsync_responses_malformed_total{instance=~\"$instance\"}[1m])", "refId": "C", "legendFormat": "{{instance}} malformed"},
-        {"expr": "app_snapsync_validation_missing_nodes_gauge{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} missing nodes"},
-        {"expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])", "refId": "E", "legendFormat": "{{instance}} errors"}
-      ],
-      "fieldConfig": {"defaults": {"unit": "ops"}}
-    },
-    {
-      "type": "timeseries",
-      "title": "Request Latency — max download timer (s)",
-      "id": 41,
-      "gridPos": {"h": 7, "w": 24, "x": 0, "y": 51},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "app_snapsync_accounts_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} accounts"},
-        {"expr": "app_snapsync_bytecodes_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} bytecodes"},
-        {"expr": "app_snapsync_storage_download_timer_seconds_max{instance=~\"$instance\"}", "refId": "C", "legendFormat": "{{instance}} storage"},
-        {"expr": "app_snapsync_healing_timer_seconds_max{instance=~\"$instance\"}", "refId": "D", "legendFormat": "{{instance}} healing"}
-      ],
-      "fieldConfig": {"defaults": {"unit": "s"}}
-    },
-    {
-      "type": "row",
-      "title": "Post-SNAP State Recovery (bytecode + storage scan)",
-      "id": 253,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 43
       },
       "collapsed": false,
       "panels": []
     },
     {
-      "type": "stat",
-      "title": "Storage Recovery Phase",
-      "id": 254,
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 59
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "app_recovery_storage_phase_gauge{instance=~\"$instance\"}",
-          "refId": "A",
-          "legendFormat": "phase"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "Idle",
-                  "color": "text"
-                },
-                "1": {
-                  "text": "Scanning",
-                  "color": "yellow"
-                },
-                "2": {
-                  "text": "Downloading",
-                  "color": "blue"
-                },
-                "3": {
-                  "text": "Complete",
-                  "color": "green"
-                }
-              }
-            }
-          ],
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "text"
-          }
-        }
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "textMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Bytecode Recovery Phase",
-      "id": 255,
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 4,
-        "y": 59
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "app_recovery_bytecode_phase_gauge{instance=~\"$instance\"}",
-          "refId": "A",
-          "legendFormat": "phase"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "Idle",
-                  "color": "text"
-                },
-                "1": {
-                  "text": "Scanning",
-                  "color": "yellow"
-                },
-                "2": {
-                  "text": "Downloading",
-                  "color": "blue"
-                },
-                "3": {
-                  "text": "Complete",
-                  "color": "green"
-                }
-              }
-            }
-          ],
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "text"
-          }
-        }
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "textMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Missing Storage Tries",
-      "id": 256,
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 59
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "app_recovery_storage_missing_gauge{instance=~\"$instance\"}",
-          "refId": "A",
-          "legendFormat": "missing"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none",
-          "decimals": 0,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          }
-        }
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "textMode": "value_and_name",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Missing Bytecodes",
-      "id": 257,
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 59
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "app_recovery_bytecode_missing_gauge{instance=~\"$instance\"}",
-          "refId": "A",
-          "legendFormat": "missing"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none",
-          "decimals": 0,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          }
-        }
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "textMode": "value_and_name",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        }
-      }
-    },
-    {
       "type": "timeseries",
-      "title": "Recovery Scan Progress (accounts walked)",
-      "id": 258,
+      "title": "Request Health \u2014 timeouts / retries / failures",
+      "id": 30,
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 59
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "app_recovery_storage_accountsScanned_gauge{instance=~\"$instance\"}",
-          "refId": "A",
-          "legendFormat": "storage scan"
-        },
-        {
-          "expr": "app_recovery_bytecode_accountsScanned_gauge{instance=~\"$instance\"}",
-          "refId": "B",
-          "legendFormat": "bytecode scan"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none",
-          "decimals": 0,
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 2,
-            "fillOpacity": 10,
-            "showPoints": "never"
-          }
-        }
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Recovery: contracts found & gaps",
-      "id": 259,
-      "gridPos": {
-        "h": 4,
-        "w": 16,
+        "h": 7,
+        "w": 12,
         "x": 0,
-        "y": 63
+        "y": 44
       },
       "datasource": {
         "type": "prometheus",
@@ -817,51 +1339,141 @@
       },
       "targets": [
         {
-          "expr": "app_recovery_storage_contractsFound_gauge{instance=~\"$instance\"}",
+          "expr": "rate(app_snapsync_requests_timeouts_total{instance=~\"$instance\"}[1m])",
           "refId": "A",
-          "legendFormat": "storage contracts"
+          "legendFormat": "{{instance}} timeouts"
         },
         {
-          "expr": "app_recovery_storage_missing_gauge{instance=~\"$instance\"}",
+          "expr": "rate(app_snapsync_requests_retries_total{instance=~\"$instance\"}[1m])",
           "refId": "B",
-          "legendFormat": "storage missing"
+          "legendFormat": "{{instance}} retries"
         },
         {
-          "expr": "app_recovery_bytecode_missing_gauge{instance=~\"$instance\"}",
+          "expr": "rate(app_snapsync_accounts_requests_failed_total{instance=~\"$instance\"}[1m])",
           "refId": "C",
-          "legendFormat": "bytecode missing"
+          "legendFormat": "{{instance}} account fails"
         },
         {
-          "expr": "app_recovery_storage_downloaded_gauge{instance=~\"$instance\"}",
+          "expr": "rate(app_snapsync_bytecodes_requests_failed_total{instance=~\"$instance\"}[1m])",
           "refId": "D",
-          "legendFormat": "storage downloaded"
+          "legendFormat": "{{instance}} bytecode fails"
+        },
+        {
+          "expr": "rate(app_snapsync_storage_requests_failed_total{instance=~\"$instance\"}[1m])",
+          "refId": "E",
+          "legendFormat": "{{instance}} storage fails"
+        },
+        {
+          "expr": "rate(app_snapsync_healing_requests_failed_total{instance=~\"$instance\"}[1m])",
+          "refId": "F",
+          "legendFormat": "{{instance}} healing fails"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "none",
-          "decimals": 0,
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 2,
-            "fillOpacity": 10,
-            "showPoints": "never"
-          }
+          "unit": "ops"
         }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Data Integrity \u2014 proofs / validation / missing nodes",
+      "id": 31,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 44
       },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(app_snapsync_proofs_invalid_total{instance=~\"$instance\"}[1m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} invalid proofs"
+        },
+        {
+          "expr": "rate(app_snapsync_validation_failures_total{instance=~\"$instance\"}[1m])",
+          "refId": "B",
+          "legendFormat": "{{instance}} validation fails"
+        },
+        {
+          "expr": "rate(app_snapsync_responses_malformed_total{instance=~\"$instance\"}[1m])",
+          "refId": "C",
+          "legendFormat": "{{instance}} malformed"
+        },
+        {
+          "expr": "app_snapsync_validation_missing_nodes_gauge{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} missing nodes"
+        },
+        {
+          "expr": "rate(app_snapsync_errors_total{instance=~\"$instance\"}[1m])",
+          "refId": "E",
+          "legendFormat": "{{instance}} errors"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Latency \u2014 max download timer (s)",
+      "id": 41,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_accounts_download_timer_seconds_max{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} accounts"
+        },
+        {
+          "expr": "app_snapsync_bytecodes_download_timer_seconds_max{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} bytecodes"
+        },
+        {
+          "expr": "app_snapsync_storage_download_timer_seconds_max{instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "{{instance}} storage"
+        },
+        {
+          "expr": "app_snapsync_healing_timer_seconds_max{instance=~\"$instance\"}",
+          "refId": "D",
+          "legendFormat": "{{instance}} healing"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
         }
       }
     },
     {
       "type": "row",
-      "title": "State Healing — frontier rebuild + heal (PR #1319)",
+      "title": "State Healing \u2014 BFS frontier rebuild + heal (PR #1319 / #1323)",
       "id": 110,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 64},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
       "collapsed": false,
       "panels": []
     },
@@ -869,128 +1481,484 @@
       "type": "stat",
       "title": "Nodes Healed",
       "id": 311,
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 65},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 65
+      },
       "description": "Total trie nodes fetched + stored during the post-SNAP healing phase.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_nodes_healed_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "green"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_nodes_healed_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Frontier Backlog (pending)",
       "id": 312,
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 65},
-      "description": "Missing nodes queued and awaiting fetch (pendingTasks). Drains to 0 as healing completes.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_frontier_pending_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1000}, {"color": "orange", "value": 50000}]}}},
-      "options": {"colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 65
+      },
+      "description": "Missing nodes discovered but not yet healed (pending heal tasks). Pulses with each \"[HEAL-FRONTIER]\" batch; drains to 0 as peers serve GetTrieNodes. Watchdog: 3 dead HEAL-PULSE cycles with this at 0 force-starts a verification walk.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_frontier_pending_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "orange",
+                "value": 50000
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
       "title": "Active Heal Requests",
       "id": 313,
-      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 65},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 65
+      },
       "description": "In-flight GetTrieNodes requests to peers.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_active_requests_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "blue"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_active_requests_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
     },
     {
       "type": "stat",
-      "title": "Frontier-Rebuild DFS Visited",
+      "title": "Frontier-Rebuild BFS Visited",
       "id": 314,
-      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 65},
-      "description": "Nodes walked by the one-time [HEAL-RESTART-DFS] full-state rebuild on restart. Climbs only during the rebuild; flat/0 once healing is steady-state or resumed from a complete persisted frontier (Layer 2, PR #1319).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_rebuild_visited_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}}"}],
-      "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "purple"}}},
-      "options": {"colorMode": "value", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}}
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 65
+      },
+      "description": "Nodes visited by the level-order BFS frontier rebuild/verification walk (logs: \"[HEAL-BFS] Level N complete: ...\"). Counter resets when a new walk starts. Compare against ~119M total trie nodes on ETC mainnet.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_rebuild_visited_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 319,
+      "type": "stat",
+      "title": "BFS Walk Progress (est. % of ~119M nodes)",
+      "description": "healing_rebuild_visited / 119M (June-2026 estimate of total ETC-mainnet trie nodes from the last full walk: 118.75M). Estimate only \u2014 resets to 0 when a new walk starts. Level-by-level detail is log-only for now: grep '[HEAL-BFS] Level'.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * app_snapsync_healing_rebuild_visited_gauge / 119000000",
+          "legendFormat": "walk progress (est %)",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 65
+      }
     },
     {
       "type": "timeseries",
       "title": "Healing Throughput (nodes/s)",
       "id": 315,
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 69},
-      "description": "Overall and recent (last-60s) node-heal rate. Recent dropping toward 0 with a non-empty backlog signals a stall (peer-starved or stagnation).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "description": "Healing download throughput (nodes healed/s, recent vs overall). Bursty by design: idle while the BFS walk discovers, bursts when frontier batches dispatch (logs: \"[HEAL-FRONTIER] N missing nodes identified\").",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_healing_throughput_overall_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} overall"},
-        {"expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} recent"}
+        {
+          "expr": "app_snapsync_healing_throughput_overall_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} overall"
+        },
+        {
+          "expr": "app_snapsync_healing_throughput_recent_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} recent"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}},
-      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Frontier Backlog & In-flight",
       "id": 316,
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 69},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
       "description": "Pending frontier (backlog) vs in-flight requests. Backlog trending down = healing converging.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "app_snapsync_healing_frontier_pending_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} pending"},
-        {"expr": "app_snapsync_healing_active_requests_gauge{instance=~\"$instance\"}", "refId": "B", "legendFormat": "{{instance}} in-flight"}
+        {
+          "expr": "app_snapsync_healing_frontier_pending_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} pending"
+        },
+        {
+          "expr": "app_snapsync_healing_active_requests_gauge{instance=~\"$instance\"}",
+          "refId": "B",
+          "legendFormat": "{{instance}} in-flight"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}},
-      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
     },
     {
       "type": "timeseries",
-      "title": "Frontier-Rebuild DFS Progress (nodes visited)",
+      "title": "Frontier-Rebuild BFS Progress & Rate",
       "id": 317,
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 77},
-      "description": "Progress of the one-time full-state rebuild walk. A monotonic climb that then flattens = walk completed; bounded memory (Layer 1) means it no longer OOM-loops. 0/flat = resumed from a complete persisted frontier (Layer 2).",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{"expr": "app_snapsync_healing_rebuild_visited_gauge{instance=~\"$instance\"}", "refId": "A", "legendFormat": "{{instance}} visited"}],
-      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}}},
-      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "description": "Raw visited count plus its 5m derivative (nodes/s). The BFS issues one multiGet per 50K-node chunk \u2014 sustained rate is the headline number for the PR #1323 speedup (serial DFS baseline was ~600-1,100 nodes/s).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "app_snapsync_healing_rebuild_visited_gauge{instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}} visited"
+        },
+        {
+          "datasource": null,
+          "expr": "deriv(app_snapsync_healing_rebuild_visited_gauge[5m])",
+          "legendFormat": "visit rate (nodes/s, 5m deriv)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Healing Request Rate (req/s)",
       "id": 318,
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 77},
-      "description": "GetTrieNodes request and failure rates. A rising failure rate indicates peers without the requested state (stateless) — expect a pivot refresh.",
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "description": "GetTrieNodes request and failure rates. A rising failure rate indicates peers without the requested state (stateless) \u2014 expect a pivot refresh.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "rate(app_snapsync_healing_requests_total{instance=~\"$instance\"}[5m])", "refId": "A", "legendFormat": "{{instance}} requests/s"},
-        {"expr": "rate(app_snapsync_healing_requests_failed_total{instance=~\"$instance\"}[5m])", "refId": "B", "legendFormat": "{{instance}} failures/s"}
+        {
+          "expr": "rate(app_snapsync_healing_requests_total{instance=~\"$instance\"}[5m])",
+          "refId": "A",
+          "legendFormat": "{{instance}} requests/s"
+        },
+        {
+          "expr": "rate(app_snapsync_healing_requests_failed_total{instance=~\"$instance\"}[5m])",
+          "refId": "B",
+          "legendFormat": "{{instance}} failures/s"
+        }
       ],
-      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}}},
-      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
     }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["fukuii", "snap", "sync"],
+  "tags": [
+    "fukuii",
+    "snap",
+    "sync"
+  ],
   "templating": {
     "list": [
       {
         "name": "instance",
         "label": "Instance",
         "type": "query",
-        "datasource": {"type": "prometheus", "uid": "prometheus"},
-        "query": {"query": "label_values(up{job=~\".*fukuii.*\"}, instance)", "refId": "Prometheus-instance-Variable-Query"},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(up{job=~\".*fukuii.*\"}, instance)",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
         "refresh": 1,
         "sort": 1,
         "includeAll": true,
         "allValue": ".*",
         "multi": true,
-        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "options": [],
         "hide": 0
       }
     ]
   },
-  "time": {"from": "now-30m", "to": "now"},
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
   "title": "Fukuii SNAP Sync",
   "uid": "fukuii-snap-sync",
-  "version": 2,
+  "version": 4,
   "weekStart": ""
 }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -84,9 +84,15 @@ class TrieNodeHealingCoordinator(
   private var trieWalkInProgress: Boolean = false
   // Verification DFS state: gates StateHealingComplete and catches storage sub-trie gaps (Fix BUG-1/BUG-2).
   // verificationPassComplete = true only after a DFS traversal finds zero missing nodes.
-  // verificationDFSRunning = true while the DFS Future is executing on healingWriterEc.
+  // verificationDFSRunning = true while ANY frontier walk Future (crash-recovery rebuild OR
+  // verification) is executing on healingWriterEc. Set inside startFrontierBFS so both walk kinds
+  // are covered — the crash-recovery rebuild previously set NO flag, so HEAL-PULSE reported
+  // walkRunning=false and the dead-pulse watchdog force-started a verification walk 6 minutes into
+  // a running rebuild (observed live 2026-06-11): two walks interleaving on the shared bfsQueue,
+  // both producing garbage coverage. @volatile: set from the walk's EC thread, read on the actor
+  // thread by the watchdog/completion/pivot gates.
   private var verificationPassComplete: Boolean = false
-  private var verificationDFSRunning: Boolean = false
+  @volatile private var verificationDFSRunning: Boolean = false
   // Dead-loop watchdog (Fix BUG-2): consecutive HEAL-PULSE cycles with no walk/pending/active/healed.
   private var consecutiveDeadPulses: Int = 0
   // Inline child discovery counter (Besu-aligned scheduler approach)
@@ -413,6 +419,7 @@ class TrieNodeHealingCoordinator(
     case FrontierRebuildComplete =>
       // The full-state rebuild DFS walked the entire trie; every still-missing node is now persisted.
       // Mark the snapshot complete so a future restart may resume it instead of re-walking (Layer 2).
+      verificationDFSRunning = false // rebuild walk finished — release the single-flight gate
       healingFrontierStorage.foreach { store =>
         store.markComplete()
         log.info("[HEAL-RESTART] Full-state rebuild complete — persisted frontier marked as a complete snapshot")
@@ -1285,6 +1292,11 @@ class TrieNodeHealingCoordinator(
       HealingTraversalParallelism,
       math.max(1, Runtime.getRuntime.availableProcessors() - 2)
     )
+    // Guard BOTH walk kinds (rebuild + verification): the watchdog, HealingCheckCompletion and the
+    // pivot-refresh path gate on this flag, and the bfsQueue is shared (cleared on walk entry), so
+    // a second concurrent walk corrupts the first. Cleared by FrontierRebuildComplete /
+    // VerificationDFSComplete / FrontierWalkFailed.
+    verificationDFSRunning = true
     Future {
       try {
         rebuildFrontierBFS(root, Seq(rootPath), isStor, selfRef, bfsQueue, effectiveParallelism)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -279,6 +279,12 @@ class TrieNodeHealingCoordinator(
   // Sent after the final FrontierRebuilt so the completeness marker is set only once every node is persisted.
   private case object FrontierRebuildComplete
 
+  // A frontier walk Future died with an exception. Resets the walk flags WITHOUT setting any
+  // completion marker, so the watchdog / HealingCheckCompletion gates can start a fresh walk.
+  // Without this, an exception skips onComplete() and verificationDFSRunning stays true forever,
+  // permanently blocking every future walk (including the watchdog) until restart.
+  private case object FrontierWalkFailed
+
   /** Synchronous flush — used only for final completion flush (small buffer, safe to block). */
   private def flushRawNodesSync(): Unit =
     if (rawNodeBuffer.nonEmpty) {
@@ -412,6 +418,14 @@ class TrieNodeHealingCoordinator(
         log.info("[HEAL-RESTART] Full-state rebuild complete — persisted frontier marked as a complete snapshot")
       }
 
+    case FrontierWalkFailed =>
+      verificationDFSRunning = false
+      trieWalkInProgress = false
+      log.warning(
+        "[HEAL-BFS] Frontier walk failed — flags reset; verification will be retried by " +
+          "HealingCheckCompletion or the dead-pulse watchdog (no completion marker was set)"
+      )
+
     case QueueMissingNodes(nodes) =>
       log.info(s"Queuing ${nodes.size} missing nodes for healing")
       queueNodes(nodes)
@@ -519,11 +533,22 @@ class TrieNodeHealingCoordinator(
         // Without this, walkRunning stays false and pending stays 0 → 316-pulse dead loop (RUN10).
         // discoverMissingChildren skips locally-held storage roots without recursing into their
         // children, so the new pivot root may be local yet have gaps in storage sub-tries.
-        log.info(
-          s"[HEAL] New root ${Hex.toHexString(newStateRoot.take(4).toArray)} already in storage " +
-            s"— starting verification DFS to find missing children"
-        )
-        startVerificationDFS(newStateRoot, pivotReseedPath)
+        if (trieWalkInProgress || verificationDFSRunning) {
+          // A walk is already running on the SHARED bfsQueue — rebuildFrontierBFS clears the queue
+          // on entry, so starting a second walk here would corrupt the running one. The pivot's
+          // verificationPassComplete=false (set above) guarantees HealingCheckCompletion starts a
+          // fresh verification once the current walk's flags clear.
+          log.info(
+            s"[HEAL] New root ${Hex.toHexString(newStateRoot.take(4).toArray)} already in storage, " +
+              s"but a frontier walk is running — verification deferred until it completes"
+          )
+        } else {
+          log.info(
+            s"[HEAL] New root ${Hex.toHexString(newStateRoot.take(4).toArray)} already in storage " +
+              s"— starting verification DFS to find missing children"
+          )
+          startVerificationDFS(newStateRoot, pivotReseedPath)
+        }
       }
 
     case TrieNodesResponseMsg(response) =>
@@ -1077,15 +1102,23 @@ class TrieNodeHealingCoordinator(
     import com.chipprbots.ethereum.domain.Account
     import scala.util.control.NonFatal
 
-    // ConcurrentHashMap for visited: thread-safe putIfAbsent prevents duplicate queue entries
-    // under parallel sub-range processing. Bounded by approximate cap — no LRU eviction, but
-    // additions stop at HealingVisitedCap to keep heap bounded.
-    val visitedCHM = new java.util.concurrent.ConcurrentHashMap[ByteString, java.lang.Boolean](
-      math.min(HealingVisitedCap, 4_000_000),
-      0.75f,
-      effectiveParallelism
-    )
-    visitedCHM.put(startHash, java.lang.Boolean.TRUE)
+    // LRU-bounded visited set (companion boundedVisitedSet): at the cap the ELDEST entry is
+    // evicted instead of refusing new entries. Refusing (the previous ConcurrentHashMap gate)
+    // silently TRUNCATED the traversal on tries larger than the cap — children past the cap were
+    // never enqueued, the queue drained early, and the walk reported "Complete" (and set the
+    // Layer-2 completeness marker) having covered only `cap` of the trie. Eviction trades that
+    // correctness hole for bounded re-walks of shared subtries (de-duplicated downstream by
+    // pendingHashSet). Access is synchronized: worker threads only touch it via markIfNew, and
+    // per-check lock cost is negligible against the 50K-node multiGet I/O per chunk.
+    val visitedLru = TrieNodeHealingCoordinator.boundedVisitedSet(HealingVisitedCap)
+    def markIfNew(h: ByteString): Boolean = visitedLru.synchronized {
+      if (visitedLru.contains(h)) false
+      else {
+        visitedLru += h
+        true
+      }
+    }
+    markIfNew(startHash)
 
     val visitedCount = new java.util.concurrent.atomic.AtomicLong(0L)
     val frontierCount = new java.util.concurrent.atomic.AtomicLong(0L)
@@ -1123,10 +1156,7 @@ class TrieNodeHealingCoordinator(
                     for (i <- 0 until 16) branch.children(i) match {
                       case hashChild: HashNode =>
                         val childHash = ByteString(hashChild.hashNode)
-                        if (
-                          visitedCHM.size() < HealingVisitedCap &&
-                          visitedCHM.putIfAbsent(childHash, java.lang.Boolean.TRUE) == null
-                        ) {
+                        if (markIfNew(childHash)) {
                           val childNibbles = nibbles :+ i.toByte
                           val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
                           val childPathset =
@@ -1141,10 +1171,7 @@ class TrieNodeHealingCoordinator(
                     ext.next match {
                       case hashChild: HashNode =>
                         val childHash = ByteString(hashChild.hashNode)
-                        if (
-                          visitedCHM.size() < HealingVisitedCap &&
-                          visitedCHM.putIfAbsent(childHash, java.lang.Boolean.TRUE) == null
-                        ) {
+                        if (markIfNew(childHash)) {
                           val childNibbles = nibbles ++ ext.sharedKey.toArray
                           val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
                           val childPathset =
@@ -1159,8 +1186,7 @@ class TrieNodeHealingCoordinator(
                     Account(leaf.value).foreach { account =>
                       if (
                         account.storageRoot != Account.EmptyStorageRootHash &&
-                        visitedCHM.size() < HealingVisitedCap &&
-                        visitedCHM.putIfAbsent(account.storageRoot, java.lang.Boolean.TRUE) == null
+                        markIfNew(account.storageRoot)
                       ) {
                         val allNibbles = nibbles ++ leaf.key.toArray
                         if (allNibbles.length == 64) {
@@ -1260,8 +1286,17 @@ class TrieNodeHealingCoordinator(
       math.max(1, Runtime.getRuntime.availableProcessors() - 2)
     )
     Future {
-      rebuildFrontierBFS(root, Seq(rootPath), isStor, selfRef, bfsQueue, effectiveParallelism)
-      onComplete()
+      try {
+        rebuildFrontierBFS(root, Seq(rootPath), isStor, selfRef, bfsQueue, effectiveParallelism)
+        onComplete()
+      } catch {
+        case scala.util.control.NonFatal(e) =>
+          // Never call onComplete() on failure — for the crash-recovery rebuild that would set the
+          // Layer-2 completeness marker on a walk that did NOT cover the full state. Reset flags
+          // through the actor instead so a fresh walk can be started.
+          log.error(e, "[HEAL-BFS] Frontier walk FAILED before completion — sending FrontierWalkFailed")
+          selfRef ! FrontierWalkFailed
+      }
     }(healingWriterEc)
   }
 


### PR DESCRIPTION
## What

The three deploy-blockers identified in the [#1323 review](https://github.com/chippr-robotics/fukuii/pull/1323#issuecomment-4680116067), as minimal patches on the merged BFS traversal:

1. **LRU visited set instead of a truncating gate** — the `ConcurrentHashMap` `size() < cap` gate stopped enqueueing children at the cap (default 4M), silently truncating the walk on tries larger than the cap (ETC mainnet ≈ 119M nodes) and then setting the Layer-2 completeness marker on the partial result. Reuses the companion `boundedVisitedSet` (insertion-order LRU) under synchronization: bounded memory, never truncates — eviction only costs re-walks, de-duplicated downstream by `pendingHashSet`.
2. **Guard `HealingPivotRefreshed → startVerificationDFS`** on `trieWalkInProgress/verificationDFSRunning` — both walks share `bfsQueue` and `rebuildFrontierBFS` clears it on entry, so an unguarded second walk corrupts the running one. Deferred verification is guaranteed by `verificationPassComplete = false`.
3. **`FrontierWalkFailed`** — a walk `Future` that throws skipped `onComplete()`, leaving `verificationDFSRunning = true` forever and permanently gating all future walks (watchdog included). Failures now reset flags through the actor without ever setting a completion marker.

## Validation

- Live on the barad-dûr ETC-mainnet node (85 GB state, mid-healing) since 11:47 UTC running exactly this code: BFS walk sustaining **~6,200 nodes/s (~8× the serial DFS baseline)**, L6 queue of 3.8M entries absorbed flat by the CF-backed queue, no OOM, restarts=0.
- `sbt testOnly` — `TrieNodeHealingCoordinatorSpec` (incl. #1323's new cases), `FrontierRebuildSpec`, `HealingFrontierResumeSpec`: **54/54 PASS** with these patches applied.

## Notes

- Staging currently carries the truncation issue (merged with #1323) — this should land before the next nightly/release cut.
- No wire, storage-format, or consensus changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)