### PR TITLE
chore: bump version to 0.7.0 (release)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.6.22"
+(ThisBuild / version) := "0.7.0"


### PR DESCRIPTION
Sets `version.sbt` to **0.7.0** for the release, following the staging→main promotion (#1326).

Release notes: `docs/releases/0.7.0.md`. After merge: tag `v0.7.0` on main → `release.yml` builds and publishes the release artifacts.

(Same flow as the 0.6.0 release, #1292 — auto-version cannot push to main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)