### PR TITLE
ci(auto-version): stop [skip ci] from blocking promotion PRs; guard branch resets

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -32,6 +32,19 @@ concurrency:
 jobs:
   auto-version:
     name: Auto Increment Version
+    # Guards (2026-06-11, the 0.7.0 promotion postmortem):
+    #  - head-commit guard: replaces the old `[skip ci]` in the bump commit message as loop
+    #    prevention. `[skip ci]` at a branch HEAD also suppresses ALL pull_request-event
+    #    workflows for PRs whose head is that branch, which permanently blocked the
+    #    staging->main promotion PR's required checks.
+    #  - forced/created guards: a branch reset (force-push) or branch (re)creation is not a
+    #    code merge — bumping+tagging+dispatching a release off it minted a spurious v0.7.1
+    #    while v0.7.0 was being released.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!startsWith(github.event.head_commit.message, 'chore: bump version to') &&
+       github.event.forced != true &&
+       github.event.created != true)
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -154,7 +167,10 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          # No [skip ci]: it poisons the branch HEAD for pull_request-event workflows (see job
+          # guard above). The duplicate-CI cost is avoided by the bump-commit guards in ci.yml /
+          # autofix.yml / this workflow instead.
+          git commit -m "chore: bump version to $NEW_VERSION"
           git push
 
           echo "version_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -45,7 +45,10 @@ jobs:
     name: Apply scalafmt
     # Skip PRs from forks — GITHUB_TOKEN is read-only on fork branches, so the fix
     # cannot be pushed back. The ci.yml scalafmtCheckAll gate still catches those.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Bump-commit clause: skip pure auto-version pushes (no [skip ci] in those anymore).
+    if: >-
+      (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version to'))
+      || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ concurrency:
 jobs:
   test:
     name: Test and Build (JDK 25, Scala 3.3.7)
+    # Skip pure version-bump pushes (auto-version) — the merge that caused the bump already
+    # ran full CI. pull_request events are unaffected (head_commit is empty there).
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore: bump version to')
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## What

Postmortem fixes from the 0.7.0 release (2026-06-11), where the auto-version ↔ `[skip ci]` interaction bit three times:

1. **`[skip ci]` at staging HEAD blocked the promotion PR.** GitHub honors skip-ci directives in the *head commit* for `pull_request`-event workflows too — so whenever auto-version's bump sat at staging HEAD (i.e. always), the staging→main promotion PR's **required** checks could never start (`mergeStateStatus: BLOCKED` forever). We worked around it twice with docs-only commits.
   **Fix:** drop `[skip ci]` from the bump commit. Loop-prevention moves to a head-commit-message guard on the auto-version job; `ci.yml` and `autofix.yml` get matching guards so pure bump pushes still don't burn duplicate CI.

2. **Branch resets minted spurious releases.** Recreating staging from main (force-push) triggered bump+tag+release dispatch — v0.7.1 was tagged and a release run started *while v0.7.0 was being released* (cancelled + tag deleted manually).
   **Fix:** auto-version skips `forced` pushes and branch-`created` events.

## Behavior table

| Event | Before | After |
|---|---|---|
| PR merge to staging | bump `[skip ci]` → promotion PRs blocked | bump (no skip-ci) → ci/autofix skip via guard; promotion PRs run checks normally |
| Force-push / branch recreate | bump + tag + release dispatch | skipped |
| Bump commit push (self) | skipped via `[skip ci]` | skipped via head-commit guard |
| `workflow_dispatch` | runs | runs (unchanged) |

All three YAMLs parse-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)