### PR TITLE
fix(snap): HEAL-PULSE walkRunning reflects any active frontier walk

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -631,10 +631,15 @@ class TrieNodeHealingCoordinator(
       val recentHealed = totalNodesHealed - lastPulseHealedCount
       val healTotal = completedTaskCount.toLong + pendingTasks.size.toLong + activeRequests.size.toLong
       val healPct = if (healTotal > 0) ((completedTaskCount.toDouble / healTotal) * 100).toInt else 0
+      // walkRunning must reflect ANY active frontier walk (inline trie walk OR the BFS
+      // rebuild/verification Future) — the same OR the watchdog gates use. Rendering only
+      // trieWalkInProgress reported walkRunning=false during a live BFS rebuild, which misled
+      // operators (and matched the pre-fix watchdog bug that double-started walks).
+      val anyWalkRunning = trieWalkInProgress || verificationDFSRunning
       log.info(
         s"[HEAL-PULSE] $healPct% (est) | healed=$totalNodesHealed (+$recentHealed last 2min) | " +
           s"pending=${pendingTasks.size} active=${activeRequests.size} peers=${knownAvailablePeers.size} | " +
-          s"rate=${healRate.toInt} nodes/s walkRunning=$trieWalkInProgress pivotRefreshPending=$pivotRefreshRequested"
+          s"rate=${healRate.toInt} nodes/s walkRunning=$anyWalkRunning pivotRefreshPending=$pivotRefreshRequested"
       )
       val (newM, crossed) =
         com.chipprbots.ethereum.blockchain.sync.ProgressMilestones


### PR DESCRIPTION
## What

`[HEAL-PULSE] ... walkRunning=` rendered only `trieWalkInProgress`, so a live BFS rebuild/verification walk (which holds `verificationDFSRunning`) logged `walkRunning=false`. That's the same blind spot that let the dead-pulse watchdog double-start walks before the single-flight fix — the gates were corrected to OR both flags; this aligns the operator-facing pulse line with them.

One-line semantic fix: `walkRunning = trieWalkInProgress || verificationDFSRunning`. Field name and pulse format unchanged (log-contract additions-only rule).

## Testing

`TrieNodeHealingCoordinatorSpec` — pass (see CI).

Observed on the barad-dûr node during the current Level-7 walk: pulse says `walkRunning=false` while `[HEAL-BFS]` progress lines stream — this PR makes those agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)