### PR TITLE
docs: post-0.7.0 audit — align docs with implementation, archive stale pages

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -112,7 +112,7 @@ Response:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "tools": {},
       "resources": {},

--- a/docs/adr/protocols/ADR-SNAP-001-protocol-infrastructure.md
+++ b/docs/adr/protocols/ADR-SNAP-001-protocol-infrastructure.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed** - 2025-11-23
+**Accepted** - 2025-11-23 (status updated 2026-06-12)
 
 ## Context
 

--- a/docs/analysis/CORE_GETH_SNAP_SYNC_GENESIS_ANALYSIS.md
+++ b/docs/analysis/CORE_GETH_SNAP_SYNC_GENESIS_ANALYSIS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Core-Geth SNAP Sync Genesis Starting Sequence Analysis
 
 **Date**: 2025-12-15  

--- a/docs/analysis/EIP-2124_IMPLEMENTATION_ANALYSIS.md
+++ b/docs/analysis/EIP-2124_IMPLEMENTATION_ANALYSIS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # EIP-2124 ForkID Implementation Analysis
 
 ## Overview

--- a/docs/analysis/RLPX_HANDSHAKE_AND_MESSAGE_ENCODING_ANALYSIS.md
+++ b/docs/analysis/RLPX_HANDSHAKE_AND_MESSAGE_ENCODING_ANALYSIS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # RLPx Handshake and Message Encoding Comparative Analysis
 
 ## Overview

--- a/docs/analysis/rlpx-hello-regression.md
+++ b/docs/analysis/rlpx-hello-regression.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # RLPx Hello Regression Investigation
 
 ## Summary

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -14,7 +14,7 @@ Welcome to the Fukuii JSON-RPC API documentation. This directory contains compre
    - **Use this for**: Exploring the API interactively, testing endpoints, integration planning
 
 2. **[JSON-RPC API Reference](./JSON_RPC_API_REFERENCE.md)**
-   - Complete reference for all JSON-RPC endpoints
+   - Reference for the JSON-RPC API (97 endpoints cataloged, 77 with full reference documentation)
    - Request/response examples for each method
    - Parameter descriptions and validation rules
    - Error codes and handling

--- a/docs/architecture/PROTOCOL_CAPABILITY_NEGOTIATION.md
+++ b/docs/architecture/PROTOCOL_CAPABILITY_NEGOTIATION.md
@@ -8,45 +8,39 @@ This document explains how Fukuii negotiates protocol capabilities with peers, p
 
 ### Current Support (as of this update)
 
-Fukuii supports the following protocol capabilities:
+Fukuii advertises the following protocol capabilities (`src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala`):
 
 ```scala
 val supportedCapabilities: List[Capability] = List(
-  Capability.ETH66,  // ETH protocol version 66
-  Capability.ETH67,  // ETH protocol version 67
-  Capability.ETH68,  // ETH protocol version 68 (latest)
+  Capability.ETH68,  // ETH protocol version 68
+  Capability.ETH69,  // ETH protocol version 69 (latest)
   Capability.SNAP1   // SNAP/1 protocol (satellite protocol for state sync)
 )
 ```
 
-### Legacy Support
+### Legacy Versions (not advertised)
 
-While not actively advertised, Fukuii can also decode messages from:
-- **ETH63**: Legacy protocol without ForkId support
-- **ETH64**: Adds ForkId support
-- **ETH65**: Adds transaction pool messages
-
-These are supported for backward compatibility during the negotiation phase but are not advertised in the Hello message.
+ETH63 through ETH67 are **not advertised** in the Hello message. Message definitions for
+those versions still exist in the codebase (e.g. for parsing peer capability strings), but
+Fukuii will not negotiate them. Note that **ETH68 removed `GetNodeData`/`NodeData`** — those
+messages do not exist in ETH68+; state retrieval uses the SNAP/1 satellite protocol instead.
 
 ## Why Advertise Multiple Versions?
 
-### Incorrect Previous Approach
+### Why a version list at all?
 
-Previously, Fukuii only advertised `ETH68` and `SNAP1`, based on a misunderstanding that:
-> "Per DevP2P spec: advertise only the highest version of each protocol family"
+The DevP2P Hello message carries a *list* of capabilities, and clients advertise every
+version they actively support so both sides can find the highest common one. Current Geth
+releases advertise `eth/68`, `eth/69`, `snap/1` — exactly the set Fukuii advertises.
 
-This was **incorrect** and caused negotiation failures with peers that only supported older protocol versions.
-
-### Correct Approach (Aligned with Geth)
-
-**Geth and other Ethereum clients advertise ALL supported protocol versions**, not just the highest one. For example:
-- Geth advertises: `eth/66`, `eth/67`, `eth/68`, `snap/1`
-- Besu advertises: `eth/66`, `eth/67`, `eth/68`, `snap/1`
-
-This approach ensures:
+Advertising the full supported set ensures:
 1. **Maximum compatibility** with peers supporting different protocol versions
 2. **Proper negotiation** where both sides can find a common version
-3. **Backward compatibility** with older clients that may only support ETH65 or ETH66
+3. **Graceful coexistence** with peers that have not yet adopted the newest version (e.g. an
+   eth/68-only peer still negotiates `eth/68` with us)
+
+Versions older than ETH68 are deliberately excluded: the live ETC peer set negotiates
+ETH68+/SNAP1, and carrying decoders for retired versions adds surface area without benefit.
 
 ## Protocol Negotiation Algorithm
 
@@ -54,24 +48,17 @@ The negotiation algorithm in `Capability.negotiate()` works as follows:
 
 ```scala
 def negotiate(c1: List[Capability], c2: List[Capability]): Option[Capability] = {
-  // ETH protocol versions are backward compatible
-  // If we advertise ETH68 and peer advertises ETH64, we should negotiate ETH64
-  // This means we need to find the highest common version for each protocol family
-
-  val ethVersions1 = c1.collect { case cap @ (ETH63 | ETH64 | ETH65 | ETH66 | ETH67 | ETH68) => cap }
-  val ethVersions2 = c2.collect { case cap @ (ETH63 | ETH64 | ETH65 | ETH66 | ETH67 | ETH68) => cap }
+  val ethVersions1 = c1.collect { case cap @ (ETH63 | ETH64 | ETH65 | ETH66 | ETH67 | ETH68 | ETH69) => cap }
+  val ethVersions2 = c2.collect { case cap @ (ETH63 | ETH64 | ETH65 | ETH66 | ETH67 | ETH68 | ETH69) => cap }
 
   // For each protocol family, find the highest common version
   val negotiatedCapabilities = List(
-    // ETH: if both support ETH, use the minimum of their maximum versions
+    // ETH: find the highest version that BOTH sides advertise (strict intersection).
+    // We only return a capability from our own set to guarantee we have a decoder for it.
     if (ethVersions1.nonEmpty && ethVersions2.nonEmpty) {
-      val maxVersion = math.min(
-        ethVersions1.maxBy(_.version).version,
-        ethVersions2.maxBy(_.version).version
-      )
-      // Find the capability with that version number from either side
-      ethVersions1.find(_.version == maxVersion)
-        .orElse(ethVersions2.find(_.version == maxVersion))
+      val commonVersions = ethVersions1.map(_.version).toSet.intersect(ethVersions2.map(_.version).toSet)
+      if (commonVersions.isEmpty) None
+      else ethVersions1.find(_.version == commonVersions.max) // always from our side — we have the decoder
     } else None,
     // SNAP: exact match required
     if (snapVersions1.intersect(snapVersions2).nonEmpty) Some(SNAP1) else None
@@ -86,33 +73,31 @@ def negotiate(c1: List[Capability], c2: List[Capability]): Option[Capability] = 
 
 ### Negotiation Examples
 
-#### Example 1: Peer with ETH65 only
-- **Peer advertises**: `eth/65`
-- **We advertise**: `eth/66`, `eth/67`, `eth/68`, `snap/1`
+#### Example 1: Peer with ETH68 only
+- **Peer advertises**: `eth/68`, `snap/1`
+- **We advertise**: `eth/68`, `eth/69`, `snap/1`
 - **Negotiation**:
-  - Our max: 68, Peer max: 65
-  - Common version: min(68, 65) = 65
-  - Find 65 in peer's list: ✓ Found
-- **Result**: `eth/65` (no RequestId wrapper)
-
-#### Example 2: Geth peer with multiple versions
-- **Peer advertises**: `eth/66`, `eth/67`, `eth/68`, `snap/1`
-- **We advertise**: `eth/66`, `eth/67`, `eth/68`, `snap/1`
-- **Negotiation**:
-  - Our max: 68, Peer max: 68
-  - Common version: min(68, 68) = 68
+  - Common ETH versions: {68}
+  - Highest common: 68
   - Find 68 in our list: ✓ Found
 - **Result**: `eth/68` and `snap/1` (both use RequestId wrapper)
 
-#### Example 3: Legacy peer with ETH64 only
-- **Peer advertises**: `eth/64`
-- **We advertise**: `eth/66`, `eth/67`, `eth/68`, `snap/1`
+#### Example 2: Geth peer with multiple versions
+- **Peer advertises**: `eth/68`, `eth/69`, `snap/1`
+- **We advertise**: `eth/68`, `eth/69`, `snap/1`
 - **Negotiation**:
-  - Our max: 68, Peer max: 64
-  - Common version: min(68, 64) = 64
-  - Find 64 in our list: ✗ Not found
-  - Find 64 in peer's list: ✓ Found
-- **Result**: `eth/64` (no RequestId wrapper)
+  - Common ETH versions: {68, 69}
+  - Highest common: 69
+  - Find 69 in our list: ✓ Found
+- **Result**: `eth/69` and `snap/1` (both use RequestId wrapper)
+
+#### Example 3: Legacy peer with ETH66 or older
+- **Peer advertises**: `eth/66`
+- **We advertise**: `eth/68`, `eth/69`, `snap/1`
+- **Negotiation**:
+  - Common ETH versions: ∅ (we do not advertise anything below 68)
+  - No common version
+- **Result**: negotiation fails — the peer is disconnected with `IncompatibleP2pProtocolVersion`
 
 ## Protocol Differences
 
@@ -127,15 +112,16 @@ A critical difference between protocol versions is the use of RequestId wrapper:
 | ETH65    | ❌ No     | Adds tx pool messages, no request tracking |
 | ETH66    | ✅ Yes    | Adds RequestId to all request/response pairs |
 | ETH67    | ✅ Yes    | Enhanced tx announcements with types/sizes |
-| ETH68    | ✅ Yes    | Removes GetNodeData/NodeData (use SNAP instead) |
+| ETH68    | ✅ Yes    | **Removes GetNodeData/NodeData** — these messages no longer exist; state is fetched via SNAP instead |
+| ETH69    | ✅ Yes    | No total difficulty in Status — chain weight is derived via calibration instead |
 | SNAP1    | ✅ Yes    | State sync protocol (satellite to ETH) |
 
 The code checks this using `Capability.usesRequestId()`:
 
 ```scala
 def usesRequestId(capability: Capability): Boolean = capability match {
-  case ETH66 | ETH67 | ETH68 | SNAP1 => true
-  case _                             => false
+  case ETH66 | ETH67 | ETH68 | ETH69 | SNAP1 => true
+  case _                                     => false
 }
 ```
 
@@ -163,28 +149,28 @@ Enhanced logging has been added to help diagnose protocol negotiation issues:
 
 ### Capability Exchange
 ```
-[INFO] PEER_CAPABILITIES: clientId=Geth/v1.13.5, p2pVersion=5, capabilities=[eth/66, eth/67, eth/68, snap/1]
-[INFO] OUR_CAPABILITIES: capabilities=[ETH66, ETH67, ETH68, SNAP1]
+[INFO] PEER_CAPABILITIES: clientId=Geth/v1.16.1, p2pVersion=5, capabilities=[eth/68, eth/69, snap/1]
+[INFO] OUR_CAPABILITIES: capabilities=[ETH68, ETH69, SNAP1]
 ```
 
 ### Negotiation Result
 ```
-[INFO] CAPABILITY_NEGOTIATION: peerCaps=[eth/66, eth/67, eth/68, snap/1], ourCaps=[ETH66, ETH67, ETH68, SNAP1], negotiated=ETH68
-[INFO] PROTOCOL_NEGOTIATED: clientId=Geth/v1.13.5, protocol=ETH68, usesRequestId=true
+[INFO] CAPABILITY_NEGOTIATION: peerCaps=[eth/68, eth/69, snap/1], ourCaps=[ETH68, ETH69, SNAP1], negotiated=ETH69
+[INFO] PROTOCOL_NEGOTIATED: clientId=Geth/v1.16.1, protocol=ETH69, usesRequestId=true
 ```
 
 ### Negotiation Failure
 ```
-[WARN] PROTOCOL_NEGOTIATION_FAILED: clientId=OldClient, peerCaps=[eth/62], ourCaps=[ETH66, ETH67, ETH68, SNAP1], reason=IncompatibleP2pProtocolVersion
+[WARN] PROTOCOL_NEGOTIATION_FAILED: clientId=OldClient, peerCaps=[eth/62], ourCaps=[ETH68, ETH69, SNAP1], reason=IncompatibleP2pProtocolVersion
 ```
 
 ## Troubleshooting
 
-### Symptom: "eth/65 is being selected" when expecting eth/68
+### Symptom: peer disconnects with IncompatibleP2pProtocolVersion
 
-**Cause**: The peer only advertises `eth/65`, so negotiation correctly selects the highest common version.
+**Cause**: The peer only advertises versions below `eth/68` (e.g. `eth/65`). Fukuii advertises `eth/68`, `eth/69`, `snap/1` only, so there is no common version and negotiation fails.
 
-**Solution**: This is expected behavior. The peer needs to be upgraded to support newer protocols.
+**Solution**: This is expected behavior. The peer needs to be upgraded to support eth/68 or newer.
 
 **Verification**: Check the logs:
 ```bash

--- a/docs/architecture/PROTOCOL_VERSION_ALIGNMENT.md
+++ b/docs/architecture/PROTOCOL_VERSION_ALIGNMENT.md
@@ -9,7 +9,7 @@ The problem statement requested:
 
 Fukuii was only advertising **ETH68** and **SNAP1** as supported capabilities, based on an incorrect assumption that only the highest protocol version should be advertised. This caused several issues:
 
-1. **Incompatible with Geth's behavior**: Geth advertises multiple versions (eth/66, eth/67, eth/68, snap/1)
+1. **Incompatible with Geth's behavior**: Geth advertised multiple versions (at the time, eth/66, eth/67, eth/68, snap/1; current releases advertise eth/68, eth/69, snap/1)
 2. **Negotiation failures**: When peers advertised only ETH65 or ETH66, negotiation would fail or produce unexpected results
 3. **Unclear protocol selection**: Without proper logging, it was unclear why certain protocol versions were being selected
 
@@ -25,15 +25,13 @@ val supportedCapabilities: List[Capability] = List(Capability.ETH68, Capability.
 **After:**
 ```scala
 val supportedCapabilities: List[Capability] = List(
-  Capability.ETH65,
-  Capability.ETH66,
-  Capability.ETH67,
   Capability.ETH68,
+  Capability.ETH69,
   Capability.SNAP1
 )
 ```
 
-This aligns with Geth's approach and ensures proper negotiation with peers supporting any of these protocol versions.
+This aligns with Geth's approach (current Geth releases advertise `eth/68`, `eth/69`, `snap/1`) and ensures proper negotiation with peers supporting any of these protocol versions. ETH63-67 are no longer advertised: the live peer set negotiates ETH68+, and ETH68 removed `GetNodeData`/`NodeData` in favour of SNAP.
 
 ### 2. Enhanced Protocol Negotiation Logging
 
@@ -55,24 +53,26 @@ Created two comprehensive documents:
 - **docs/architecture/PROTOCOL_CAPABILITY_NEGOTIATION.md**: Explains the negotiation algorithm, protocol differences, and how RequestId wrapping works
 - **docs/troubleshooting/PROTOCOL_VERSION_SELECTION.md**: Quick reference guide for understanding why specific protocol versions are selected
 
-## Why ETH 65 Might Be Selected
+## Why ETH 65 Was Being Selected (historical)
 
-When you see "eth/65 is being selected", it's because:
+When "eth/65 is being selected" was observed, it was because:
 
-1. The peer only advertises support for ETH65 (or lower)
-2. Negotiation correctly selects the highest common version
-3. Both sides can communicate using ETH65
+1. The peer only advertised support for ETH65 (or lower)
+2. Negotiation correctly selected the highest common version
+3. Both sides could communicate using ETH65
 
-This is **expected and correct behavior** when connecting to older peers.
+That was expected behavior **while ETH65-67 were still advertised**. With the current
+capability set (ETH68, ETH69, SNAP1), peers advertising only eth/67 or below have no common
+version with us and are disconnected during negotiation instead.
 
 ## Protocol Compatibility Matrix
 
 | Our Version | Peer Versions | Negotiated | RequestId | Notes |
 |-------------|---------------|------------|-----------|-------|
-| ETH65-68 | eth/65 | eth/65 | No | Older peer, no request tracking |
-| ETH65-68 | eth/66, eth/67 | eth/67 | Yes | Modern peer, request tracking enabled |
-| ETH65-68 | eth/66, eth/67, eth/68 | eth/68 | Yes | Latest protocol, optimal |
-| ETH65-68 | eth/63 | eth/63 | No | Very old peer, no ForkId |
+| ETH68-69 | eth/68 | eth/68 | Yes | Highest common version |
+| ETH68-69 | eth/68, eth/69 | eth/69 | Yes | Latest protocol, optimal |
+| ETH68-69 | eth/66, eth/67 | — | — | No common version, peer disconnected |
+| ETH68-69 | eth/63 | — | — | Very old peer, no common version, disconnected |
 
 ## Decode Flow Verification
 
@@ -87,7 +87,7 @@ All protocol decoders (ETH63-ETH68) were verified to be correctly implemented:
 
 ### Benefits
 - ✅ Better compatibility with Geth and other Ethereum clients
-- ✅ Proper negotiation with peers supporting ETH65, ETH66, or ETH67
+- ✅ Proper negotiation with modern peers (eth/68, eth/69, snap/1)
 - ✅ Enhanced debugging through comprehensive logging
 - ✅ Clear documentation for operators
 
@@ -98,8 +98,8 @@ All protocol decoders (ETH63-ETH68) were verified to be correctly implemented:
 
 ## Testing Recommendations
 
-1. **Test with Geth nodes**: Verify negotiation selects ETH68 when both sides support it
-2. **Test with older clients**: Verify negotiation falls back to ETH65/66 gracefully
+1. **Test with Geth nodes**: Verify negotiation selects ETH69 when both sides support it (ETH68 with eth/68-only peers)
+2. **Test with older clients**: Verify peers advertising only eth/67 or below are cleanly disconnected (`IncompatibleP2pProtocolVersion`)
 3. **Review logs**: Check that CAPABILITY_NEGOTIATION logs show expected behavior
 4. **Monitor block sync**: Ensure different protocol versions all sync correctly
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -132,7 +132,7 @@ The main production-ready image for running Fukuii.
 
 **Features:**
 - Multi-stage build for optimal size and security
-- Based on `eclipse-temurin:17-jre-jammy` (slim JRE)
+- Based on `eclipse-temurin:25-jre-noble` (slim JRE)
 - Runs as non-root user (`fukuii:fukuii`, UID/GID 1000)
 - Includes built-in healthcheck script
 - Exposes standard Ethereum ports (8545, 8546, 30303)
@@ -319,7 +319,7 @@ Pre-configured as a bootnode for peer discovery and network health.
 - Minimal resource footprint (2-4GB RAM, ~5GB disk)
 - No RPC endpoints (reduced attack surface)
 - In-memory pruning for minimal disk usage
-- Exposes only P2P ports (30303/udp, 9076/tcp)
+- Exposes only P2P ports (30303/udp, 30303/tcp)
 
 **Purpose:**
 Bootnodes serve as network infrastructure, helping new nodes discover peers and join the network faster. They focus exclusively on:
@@ -342,7 +342,7 @@ Bootnodes serve as network infrastructure, helping new nodes discover peers and 
 docker run -d \
   --name fukuii-bootnode \
   -p 30303:30303/udp \
-  -p 9076:9076/tcp \
+  -p 30303:30303/tcp \
   -v fukuii-bootnode-data:/app/data \
   -e JAVA_OPTS="-Xmx2g -Xms2g" \
   chipprbots/fukuii-bootnode:latest
@@ -351,7 +351,7 @@ docker run -d \
 docker run -d \
   --name fukuii-bootnode \
   -p 30303:30303/udp \
-  -p 9076:9076/tcp \
+  -p 30303:30303/tcp \
   -v fukuii-bootnode-data:/app/data \
   -e JAVA_OPTS="-Xmx2g -Xms2g" \
   ghcr.io/chippr-robotics/fukuii-bootnode:latest
@@ -373,7 +373,7 @@ services:
     restart: unless-stopped
     ports:
       - "30303:30303/udp"  # P2P discovery
-      - "9076:9076/tcp"    # P2P networking
+      - "30303:30303/tcp"    # P2P networking
     volumes:
       - bootnode-data:/app/data
     environment:
@@ -408,12 +408,12 @@ After starting the bootnode, you can share its enode URL with others:
 
 Ensure these ports are open:
 - UDP 30303 (discovery protocol) - REQUIRED
-- TCP 9076 (P2P connections) - REQUIRED
+- TCP 30303 (P2P connections) - REQUIRED
 
 Example firewall rules:
 ```bash
 sudo ufw allow 30303/udp
-sudo ufw allow 9076/tcp
+sudo ufw allow 30303/tcp
 ```
 
 **Monitoring Your Bootnode:**

--- a/docs/design/healing-frontier-scale.md
+++ b/docs/design/healing-frontier-scale.md
@@ -3,24 +3,27 @@
 ## Problem
 
 After SNAP sync, `TrieNodeHealingCoordinator` heals the residual missing trie nodes. On
-restart (`[HEAL-RESTART]`, `TrieNodeHealingCoordinator.scala:260`), when the state root is
-already in local storage, it rediscovers the missing-node *frontier* by walking the **entire
-state trie** (accounts + every storage trie) depth-first in `rebuildFrontierDFS`
-(`TrieNodeHealingCoordinator.scala:877`), reading each node one at a time via
-`mptStorage.get`.
+restart (`[HEAL-RESTART]`), when the state root is already in local storage, it rediscovers
+the missing-node *frontier* by walking the **entire state trie** (accounts + every storage
+trie). The original implementation did this depth-first in `rebuildFrontierDFS`, reading each
+node one at a time via `mptStorage.get`. That walk has since been replaced by a **level-order
+BFS** (`rebuildFrontierBFS`): nodes are processed level by level out of a RocksDB-backed
+level queue, with `multiGetNodes` batch reads instead of per-node point reads, behind a
+single-flight gate so only one walk can run at a time (DFS → BFS evolution landed via
+PR #1323/#1325; log prefixes are now `[HEAL-BFS]` / `[HEAL-RESTART]` / `[HEAL-PULSE]`).
 
-On ETC mainnet this does not scale. Live diagnosis of `fukuii-primary` (block ~24.68M, 77 GB
-RocksDB) found:
+On ETC mainnet the original DFS did not scale. Live diagnosis of `fukuii-primary`
+(block ~24.68M, 77 GB RocksDB) found:
 
 - The DFS had visited **36.6M+ nodes and was still climbing** (the full account + storage
   state, far more than the ~12.9M accounts-only walk older builds completed).
 - Throughput **~142 nodes/s** — `mptStorage.get` is a random point-read over the 77 GB DB and
   is I/O-bound. One full pass would take **days**.
-- The in-memory `visited: mutable.Set[ByteString]` (`:270`) had grown to ~36.6M hashes
+- The in-memory `visited: mutable.Set[ByteString]` had grown to ~36.6M hashes
   ≈ **2.9 GB**, pushing the heap to **5.18 / 5.37 GB (96%)**.
 
-With `-XX:+ExitOnOutOfMemoryError`, the terminal behaviour is: heap fills → **OOM → restart →
-DFS from zero → OOM** — an unrecoverable OOM-restart loop. The node never reaches regular sync.
+With `-XX:+ExitOnOutOfMemoryError`, the terminal behaviour was: heap fills → **OOM → restart →
+walk from zero → OOM** — an unrecoverable OOM-restart loop. The node never reaches regular sync.
 This is a *performance/scalability* wedge, distinct from the older recovery-download abandon
 loop ([[project_recovery_recent_root_roll]]).
 
@@ -28,17 +31,17 @@ loop ([[project_recovery_recent_root_roll]]).
 
 ### 1. Bounded `visited` set — this PR (the OOM-stopper)
 
-Replace the unbounded `mutable.Set[ByteString]` at `:270` with a fixed-capacity LRU set
+Replace the unbounded `mutable.Set[ByteString]` with a fixed-capacity LRU set
 (insertion-order eviction via `LinkedHashMap.removeEldestEntry`). Default cap **4M entries
 ≈ 320 MB** (configurable).
 
 **Why it's correct (never misses a missing node):** the frontier is de-duplicated downstream
-by `pendingHashSet` (`:130`) when entries are queued, so re-discovering a missing node is
+by `pendingHashSet` when entries are queued, so re-discovering a missing node is
 harmless. Bounding `visited` only means a node evicted from the cache may be *re-walked* if it
 is reached again via another reference. In a Merkle trie the walk is tree-shaped except for
 content-addressed sharing; for ETC state the dominant shared node is the empty-storage-root
-(no children → a cheap re-read), so re-walk overhead is small. The DFS still terminates (the
-explicit stack drains; re-walks add bounded work, not cycles).
+(no children → a cheap re-read), so re-walk overhead is small. The walk still terminates (the
+work queue drains; re-walks add bounded work, not cycles).
 
 **Effect:** converts the OOM-restart loop into a walk that **completes without crashing** —
 recoverable. It does not by itself make the first walk fast (see 3).
@@ -52,29 +55,31 @@ restart must rebuild it from scratch. Persist it so restart resumes instead of r
   `hash → pathset`. Write on `queueNodes`; delete when a node is healed
   (`rawNodeBuffer` flush / heal-complete path).
 - Plumb a small `HealingFrontierStorage` into the `TrieNodeHealingCoordinator` constructor
-  (`:28`) from `SNAPSyncController` (mirrors how `FlatSlotStorage` was wired).
+  from `SNAPSyncController` (mirrors how `FlatSlotStorage` was wired).
 - On `[HEAL-RESTART]`: if the persisted frontier is non-empty, load it via `queueNodes` and
-  **skip the full DFS**; only fall back to the DFS when no persisted frontier exists (first
-  post-SNAP run or a corrupt/missing frontier CF).
+  **skip the full-state walk**; only fall back to the full walk when no persisted frontier
+  exists (first post-SNAP run or a corrupt/missing frontier CF).
 
 Makes restart **O(frontier)** instead of **O(full state)** — the days-long re-walk happens at
 most once.
 
-### 3. First-walk throughput — optional, separate
+### 3. First-walk throughput — delivered via the BFS rewrite
 
-The initial full DFS is I/O-bound (~142 nodes/s) because of serial random point-reads. Options
-(out of scope here): batch/parallelise the reads across the healing-writer EC; RocksDB tuning
-(`max-open-files`, larger block cache) — noting the open-files/block-cache memory trade-off
-documented for the recovery scan ([[snap_etc_host_freeze_oversubscription]]).
+The initial full walk was I/O-bound (~142 nodes/s) under the serial depth-first
+implementation because of serial random point-reads. The originally sketched options here
+(batch/parallelise reads across the healing-writer EC; RocksDB tuning) were superseded by the
+**level-order BFS rewrite** (`rebuildFrontierBFS`, PR #1323): each level is read in
+`multiGetNodes` batches (50K-hash chunks) instead of one `get` per node, and the level queue
+lives in a RocksDB column family so queue memory stays bounded regardless of state size.
 
 ## Rollout
 
-1 ships first (small, localized, immediately makes the node recoverable). 2 follows as a
-separate change (new CF + constructor wiring + tests). 3 is an optimization if the first walk
-is still too slow after 1+2. Operationally, checkpoint import remains the fast unblock for an
-already-wedged node.
+1 shipped first (small, localized, immediately made the node recoverable). 2 followed as a
+separate change (new CF + constructor wiring + tests). 3 was originally gated on measuring
+the first walk after 1+2, and ultimately shipped as the BFS + `multiGet` rewrite (see Status).
+Operationally, checkpoint import remains the fast unblock for an already-wedged node.
 
-## Status (as built — 2026-06-06)
+## Status (as built — updated 2026-06)
 
 Spec/plan/tasks: `specs/001-healing-frontier-scale/`.
 
@@ -82,21 +87,27 @@ Spec/plan/tasks: `specs/001-healing-frontier-scale/`.
 with the cap extracted to the testable companion seam `TrieNodeHealingCoordinator.boundedVisitedSet(cap)`
 and made operator-tunable via `sync.snap-sync.healing-visited-cap` (default
 `TrieNodeHealingCoordinator.DefaultVisitedCap = 4_000_000`), threaded through `SNAPSyncConfig`.
-Unit-tested in `FrontierRebuildSpec` (eviction bound, insertion-order eviction, set semantics).
+Now used by `rebuildFrontierBFS`. Unit-tested in `FrontierRebuildSpec` (eviction bound,
+insertion-order eviction, set semantics).
 
-**Layer 2 — DONE, default-off.** Persisted frontier in a dedicated column family
+**Layer 2 — DONE, default-on.** Persisted frontier in a dedicated column family
 (`Namespaces.HealingFrontierNamespace = 'g'`, `hash → RLP(pathset)`) via `HealingFrontierStorage`,
 wired from `SNAPSyncController` (`flatSlotStorage.dataSource`, gated by
-`sync.snap-sync.healing-frontier-persistence`, default `false`). Write-on-enqueue at all three
+`sync.snap-sync.healing-frontier-persistence` — **default `true`** in base `sync.conf`
+(`src/main/resources/conf/base/sync.conf`)). Write-on-enqueue at all three
 growth sites (`queueNodes`, inline child discovery, pivot reseed); delete-on-heal-flush (never on
 dispatch); clear on force-complete / pivot-refresh; resume on `[HEAL-RESTART]` loads the frontier
-and skips the DFS, with a fail-safe fallback to the full walk on empty/absent/corrupt. No datadir
-migration (`setCreateMissingColumnFamilies(true)`). Tested in `HealingFrontierStorageSpec` (storage
-round-trip) and `HealingFrontierResumeSpec` (resume / fallback / write-on-queue). Ships dark; flip
-`healing-frontier-persistence = true` after operational validation on a large-state node.
+and skips the full-state walk, with a fail-safe fallback to the full walk on empty/absent/corrupt.
+No datadir migration (`setCreateMissingColumnFamilies(true)`). Tested in `HealingFrontierStorageSpec`
+(storage round-trip) and `HealingFrontierResumeSpec` (resume / fallback / write-on-queue).
+Enabled by default after operational validation.
 
-**Layer 3 — NOT STARTED (gated).** Measure the first-walk throughput on a large-state node first
-(`tasks.md` T021); pursue `multiGet` batching only if the one-time full walk is still too slow.
+**Layer 3 — DELIVERED (superseded plan).** First-walk throughput landed via the DFS → BFS
+rewrite (PR #1323, with follow-up #1325) rather than the originally planned parallel
+point-reads: `rebuildFrontierBFS` walks the state level-order with one `multiGetNodes` batch
+per 50K-hash chunk, a RocksDB CF-backed level queue, the Layer-1 LRU-bounded visited set, and
+a single-flight gate (one walk at a time). Progress is visible under the `[HEAL-BFS]` /
+`[HEAL-PULSE]` log prefixes (the old `rebuildFrontierDFS` and its log lines are gone).
 
-Remaining before merge: `sbt pp`, and operational validation of L1 (no OOM loop) and L2 (resume in
-minutes, CF auto-creates) on a large-state node — both require a live node, out of the build session.
+All three layers have shipped; the remaining-before-merge items (`sbt pp`, live-node validation
+of L1/L2) were completed prior to release.

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -33,13 +33,13 @@ This directory contains the GitHub Actions workflows for continuous integration,
 **Purpose:** Ensures code quality and tests pass before merging
 
 **Matrix Build:**
-- **JDK Version:** 21
+- **JDK Version:** 25
 - **Operating System:** ubuntu-latest
 - **Caching:** Coursier, Ivy, and SBT for faster builds
 
 **Steps:**
 1. Checks out code with submodules
-2. Sets up Java (21) with Temurin distribution
+2. Sets up Java (25) with Temurin distribution
 3. Configures Coursier and Ivy caching
 4. Installs SBT
 5. Compiles all modules (bytes, crypto, rlp, node)

--- a/docs/development/scala-build.md
+++ b/docs/development/scala-build.md
@@ -6,7 +6,7 @@ This document explains how the Fukuii build works after the Scala 3 migration a
 
 | Tool | Version | Purpose |
 | --- | --- | --- |
-| JDK | 21 (Temurin) | Runtime/toolchain for Scala 3 and Pekko |
+| JDK | 25 (Temurin) | Runtime/toolchain for Scala 3 and Pekko |
 | sbt | 1.10.7 | Single build driver (no nested builds) |
 | Scala | 3.3.7 (LTS) | Only Scala version compiled in this repo |
 | scalafmt / scalafix | 2.5.2 / 0.13.0 | Formatting and linting (invoked via sbt) |
@@ -51,7 +51,7 @@ We intentionally removed auto-generated `metals.sbt` files and the recursive `pr
 
 ## Dev container / Metals notes
 
-1. The dev container already installs sbt and JDK 21; you only need to run `sbt sbtVersion` once to warm the caches.
+1. The dev container already installs sbt and JDK 25; you only need to run `sbt sbtVersion` once to warm the caches.
 2. `.gitignore` now blocks `project/metals.sbt` and the entire `project/project/` hierarchy. If Metals asks to create those files, let it—they will appear as untracked artifacts and should stay that way.
 3. To refresh Metals/BSP after dependency changes, run:
 

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -5,7 +5,7 @@
 **Repository**: chippr-robotics/fukuii  
 **Purpose**: Inventory current static analysis toolchain for state, versioning, appropriateness, ordering, and current issues
 
-> **Note**: This document was originally created during the Scala 2 to 3 migration. The migration was completed in October 2025, and Phase 5 cleanup has been completed. The project now uses Scala 3.3.4 exclusively with all Scala 2 cross-compilation support removed.
+> **Note**: This document was originally created during the Scala 2 to 3 migration. The migration was completed in October 2025, and Phase 5 cleanup has been completed. The project now uses Scala 3.3.7 exclusively with all Scala 2 cross-compilation support removed.
 
 ---
 
@@ -20,7 +20,7 @@ The Fukuii project uses a comprehensive static analysis toolchain for Scala deve
 6. **SBT Sonar** - Integration with SonarQube
 
 **Current State**: The toolchain is in excellent condition for Scala 3:
-- ✅ **COMPLETED**: Scala 3.3.4 (LTS) exclusive support
+- ✅ **COMPLETED**: Scala 3.3.7 (LTS) exclusive support
 - ✅ **COMPLETED**: Phase 5 cleanup - Scala 2 cross-compilation removed
 - ✅ **UPDATED**: Scalafmt 2.7.5 → 3.8.3 (Scala 3 native dialect)
 - ✅ **UPDATED**: sbt-scalafmt 2.4.2 → 2.5.2 (Scala 3 support)
@@ -31,14 +31,14 @@ The Fukuii project uses a comprehensive static analysis toolchain for Scala deve
 - ✅ **REMOVED**: Abandoned scaluzzi dependency
 - ✅ **RESOLVED**: All scalafmt formatting violations
 - ✅ **REMOVED**: Scalastyle (unmaintained since 2017) - functionality migrated to Scalafix
-- ✅ **COMPLETED**: Migration to Scala 3.3.4 (October 2025)
+- ✅ **COMPLETED**: Migration to Scala 3.3.7 (October 2025)
 - ✅ **COMPLETED**: Phase 5 cleanup (November 2025)
 
 ---
 
 ## Scala Version Support
 
-**Primary Version:** Scala 3.3.4 (LTS)
+**Primary Version:** Scala 3.3.7 (LTS)
 
 **Migration Status:**
 - ✅ Migration from Scala 2.13 completed in October 2025
@@ -213,7 +213,7 @@ OrganizeImports {
 **Status**: ✅ **REMOVED** (November 2025 - Phase 5 cleanup)
 
 **Reason for Removal**: 
-- Migration to Scala 3.3.4 completed in October 2025
+- Migration to Scala 3.3.7 completed in October 2025
 - Plugin no longer needed for Scala 3-only project
 - Command aliases removed as part of Phase 5 cleanup
 
@@ -223,7 +223,7 @@ OrganizeImports {
 - All migration tasks completed successfully
 
 **Recommendation**: 
-- ✅ COMPLETED: Successfully migrated from Scala 2.13 to Scala 3.3.4
+- ✅ COMPLETED: Successfully migrated from Scala 2.13 to Scala 3.3.7
 - ✅ COMPLETED: Removed plugin and command aliases (Phase 5)
 
 ---
@@ -391,7 +391,7 @@ coverageExcludedFiles := Seq(
 
 ### Current CI Workflow (`.github/workflows/ci.yml`)
 
-**Build Strategy**: ✅ Scala 3.3.4 only (Phase 5 cleanup completed)
+**Build Strategy**: ✅ Scala 3.3.7 only (Phase 5 cleanup completed)
 
 **Execution Order**:
 1. **Compile** - `sbt compile-all` (compiles all modules)
@@ -401,13 +401,13 @@ coverageExcludedFiles := Seq(
 5. **Build** - `sbt assembly` + `sbt dist` (distribution artifacts)
 
 **Configuration**:
-- **Scala 3.3.4 LTS**: Single version pipeline (compilation, formatting, Scapegoat, tests, coverage, build artifacts)
+- **Scala 3.3.7 LTS**: Single version pipeline (compilation, formatting, Scapegoat, tests, coverage, build artifacts)
 
 **Missing from CI**:
 - ❌ SonarQube integration (optional enhancement)
 
 **Integrated in CI**:
-- ✅ Scala 3.3.4 LTS (single version)
+- ✅ Scala 3.3.7 LTS (single version)
 - ✅ Scapegoat analysis (Scala 3 compatible)
 - ✅ Code coverage measurement with Scoverage
 - ✅ Coverage reports published as artifacts (30-day retention)
@@ -500,7 +500,7 @@ compile-all → scapegoat (all modules)
 **Notes**: 
 - Scalastyle has been removed (October 26, 2025) as it was unmaintained since 2017. Its functionality has been migrated to Scalafix and Scalafmt.
 - Scala3-Migrate has been removed (November 2025 - Phase 5) as migration is complete
-- CI runs on Scala 3.3.4 LTS only (no cross-compilation)
+- CI runs on Scala 3.3.7 LTS only (no cross-compilation)
 - All tools are now Scala 3 compatible
 
 ---
@@ -509,7 +509,7 @@ compile-all → scapegoat (all modules)
 
 ### Resolved Issues ✅
 0. **Scala 3 Support**: ✅ **ADDED** (October 26, 2025)
-   - Added Scala 3.3.4 (LTS) cross-compilation support
+   - Added Scala 3.3.7 (LTS) cross-compilation support
    - Updated Scalafmt to 3.8.3 with Scala 3 support
    - Updated sbt-scalafmt to 2.5.2
    - Added scala3-migrate plugin (0.6.1)
@@ -599,7 +599,7 @@ compile-all → scapegoat (all modules)
    - ✅ Updated documentation (CONTRIBUTING.md, STATIC_ANALYSIS_INVENTORY.md)
 
 6. **Scala 3 Cross-Compilation Setup**: ✅ **COMPLETED** (October 26, 2025)
-   - ✅ Added Scala 3.3.4 (LTS) to supported versions
+   - ✅ Added Scala 3.3.7 (LTS) to supported versions
    - ✅ Updated Scalafmt to 3.8.3 with Scala 3 support
    - ✅ Updated sbt-scalafmt plugin to 2.5.2
    - ✅ Added scala3-migrate plugin (0.6.1)
@@ -676,8 +676,8 @@ Based on CI logs and manual runs (per Scala version in matrix):
 - **Scapegoat**: ~43s (Scala 2.13 only)
 - **Tests with Coverage**: Variable (several minutes, longer than without coverage)
 
-**Total CI time**: ~5-8 minutes (single Scala 3.3.4 version)
-- Scala 3.3.4: ~5-8 minutes (full pipeline)
+**Total CI time**: ~5-8 minutes (single Scala 3.3.7 version)
+- Scala 3.3.7: ~5-8 minutes (full pipeline)
 
 **Note**: 
 - Coverage instrumentation adds ~20-30% overhead to test execution time, but provides valuable metrics
@@ -695,7 +695,7 @@ The Fukuii project has a comprehensive static analysis toolchain with excellent 
 4. ✅ **Updated tools** (Scapegoat to 3.1.4, Scoverage to 2.0.10, Scalafmt to 3.8.3)
 5. ✅ **Fixed legitimate code issues** (6 critical unsafe code patterns resolved)
 6. ✅ **Comprehensive code coverage** (Scoverage 2.0.10 with 70% threshold)
-7. ✅ **Scala 3 exclusive** (Scala 3.3.4 LTS only, no cross-compilation)
+7. ✅ **Scala 3 exclusive** (Scala 3.3.7 LTS only, no cross-compilation)
 8. ✅ **Phase 5 cleanup complete** (All Scala 2 artifacts removed)
 
 **Overall Assessment**: 🟢 **Excellent - Complete, modern, Scala 3 native toolchain**
@@ -705,7 +705,7 @@ The toolchain has been fully modernized and simplified for Scala 3:
 - Scapegoat updated to 3.1.4 for Scala 3 support
 - Scoverage updated to 2.0.10 and integrated into CI with coverage thresholds
 - Scalafmt updated to 3.8.3 with Scala 3 native dialect
-- Scala 3.3.4 (LTS) exclusive support
+- Scala 3.3.7 (LTS) exclusive support
 - scala3-migrate plugin removed (migration complete)
 - All Scala 2 cross-compilation removed (Phase 5 cleanup)
 - All static analysis tools now running in CI pipeline and passing
@@ -761,7 +761,7 @@ Based on this inventory, the following items have been addressed:
    - ✅ COMPLETED: Updated documentation (CONTRIBUTING.md, STATIC_ANALYSIS_INVENTORY.md)
 
 6. **Setup Scala 3 Cross-Compilation** ✅ **COMPLETED** (October 26, 2025)
-   - ✅ COMPLETED: Added Scala 3.3.4 (LTS) to build.sbt
+   - ✅ COMPLETED: Added Scala 3.3.7 (LTS) to build.sbt
    - ✅ COMPLETED: Updated Scalafmt to 3.8.3 with Scala 3 support
    - ✅ COMPLETED: Updated sbt-scalafmt plugin to 2.5.2
    - ✅ COMPLETED: Added scala3-migrate plugin (0.6.1)

--- a/docs/fixes/SNAP_SYNC_COLD_START_IMPLEMENTATION_SUMMARY.md
+++ b/docs/fixes/SNAP_SYNC_COLD_START_IMPLEMENTATION_SUMMARY.md
@@ -36,13 +36,19 @@ val pivotBlockNumber = networkBestBlock - snapSyncConfig.pivotBlockOffset
 - Reduces catch-up time after SNAP sync completes
 
 ### 3. Genesis Start Support
+When the network height is confirmed to be at or below the pivot offset (64 blocks), SNAP sync uses genesis (block 0) as the pivot and syncs from the genesis state root — effectively a full sync for the early chain (`SNAPSyncController.startSnapSync`):
+
 ```scala
-// If chain height <= 64 blocks, use genesis as pivot
+// If chain height <= pivot offset (64), consider using genesis as pivot
 if (baseBlockForPivot <= snapSyncConfig.pivotBlockOffset) {
-  // Use genesis (block 0) as pivot
-  // SNAP sync effectively performs full sync for early blocks
+  // Guarded: only commit to genesis when peers genuinely confirm low network height
 }
 ```
+
+**Important guards** (added after the original fix) prevent committing to a genesis pivot when heights are merely uninitialized:
+- **No peers connected** (local pivot source): the network height is unknown — the controller schedules a retry instead of assuming the network is at genesis.
+- **Peers connected but all report height 0**: heights have not been populated by the ETH status exchange yet — treated as "heights unknown" and retried rather than committing to genesis.
+- Only when connected peers genuinely confirm a low network height does the node set pivot = block 0 and start account-range sync from the genesis state root; if the genesis header is unavailable it falls back to fast sync.
 
 ### 4. Extended Bootstrap
 - If pivot header not available locally, continue syncing to reach it

--- a/docs/for-developers/index.md
+++ b/docs/for-developers/index.md
@@ -26,7 +26,7 @@ sbt test
 
 | Resource | Description |
 |----------|-------------|
-| [JSON-RPC Reference](../api/JSON_RPC_API_REFERENCE.md) | 77 documented methods |
+| [JSON-RPC Reference](../api/JSON_RPC_API_REFERENCE.md) | 97 endpoints cataloged, 77 with full reference documentation |
 | [Coverage Analysis](../api/JSON_RPC_COVERAGE_ANALYSIS.md) | Gap analysis vs specification |
 | [MCP Integration](../MCP.md) | Model Context Protocol tools and resources |
 

--- a/docs/for-node-operators/index.md
+++ b/docs/for-node-operators/index.md
@@ -12,14 +12,14 @@ sbt assembly
 java -Xmx4g \
   -Dfukuii.datadir=~/.fukuii/mordor \
   -Dfukuii.network=mordor \
-  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar mordor
+  -jar target/scala-3.3.7/fukuii-assembly-0.7.0.jar mordor
 
 # Run on ETC mainnet
 java -Xmx4g \
   -Dfukuii.datadir=~/.fukuii/etc \
   -Dfukuii.network=etc \
   -Dfukuii.sync.do-fast-sync=true \
-  -jar target/scala-3.3.7/fukuii-assembly-0.1.240.jar etc
+  -jar target/scala-3.3.7/fukuii-assembly-0.7.0.jar etc
 ```
 
 ## Runbooks

--- a/docs/for-operators/index.md
+++ b/docs/for-operators/index.md
@@ -7,6 +7,9 @@ This section contains guides for deploying, monitoring, and managing Fukuii in p
 1. **[Docker Compose](../deployment/docker.md)** — Deploy Fukuii with Docker
 2. **[Metrics & Monitoring](../operations/metrics-and-monitoring.md)** — Set up Prometheus and Grafana
 3. **[Log Triage](../runbooks/log-triage.md)** — Understand log messages and alerts
+4. **[Sync Lifecycle](../operations/sync-lifecycle.md)** — What a syncing node does, phase by phase, and what "normal" looks like
+5. **[State Healing — Operator's Guide](../operations/state-healing-operations.md)** — The long post-SNAP phase: logs, knobs, dashboards, healthy-vs-stuck
+6. **[Metrics Reference](../operations/metrics-reference.md)** — Every exported Prometheus metric and what it means
 
 ## Deployment Options
 

--- a/docs/for-operators/static-nodes-configuration.md
+++ b/docs/for-operators/static-nodes-configuration.md
@@ -48,8 +48,8 @@ The file should contain a JSON array of enode URLs:
 
 ```json
 [
-  "enode://6eecbdcc74c0b672ce505b9c639c3ef2e8ee8cddd8447ca7ab82c65041932db64a9cd4d7e723ba180b0c3d88d1f0b2913fda48972cdd6742fea59f900af084af@192.168.1.1:9076",
-  "enode://a335a7e86eab05929266de232bec201a49fdcfc1115e8f8b861656e8afb3a6e5d3ffd172d153ae6c080401a56e3d620db2ac0695038a19e9b0c5220212651493@192.168.1.2:9076"
+  "enode://6eecbdcc74c0b672ce505b9c639c3ef2e8ee8cddd8447ca7ab82c65041932db64a9cd4d7e723ba180b0c3d88d1f0b2913fda48972cdd6742fea59f900af084af@192.168.1.1:30303",
+  "enode://a335a7e86eab05929266de232bec201a49fdcfc1115e8f8b861656e8afb3a6e5d3ffd172d153ae6c080401a56e3d620db2ac0695038a19e9b0c5220212651493@192.168.1.2:30303"
 ]
 ```
 
@@ -63,9 +63,9 @@ In private networks, the peer list may change frequently. Instead of modifying c
 # Update static nodes
 cat > ~/.fukuii/gorgoroth/static-nodes.json << EOF
 [
-  "enode://<node-id-1>@192.168.1.10:9076",
-  "enode://<node-id-2>@192.168.1.11:9076",
-  "enode://<node-id-3>@192.168.1.12:9076"
+  "enode://<node-id-1>@192.168.1.10:30303",
+  "enode://<node-id-2>@192.168.1.11:30303",
+  "enode://<node-id-3>@192.168.1.12:30303"
 ]
 EOF
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -61,7 +61,7 @@ Get up and running with Fukuii quickly. Choose the installation method that best
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | 30303 | UDP | Discovery protocol |
-| 9076 | TCP | Ethereum P2P |
+| 30303 | TCP | Ethereum P2P |
 | 8546 | TCP | JSON-RPC (internal only!) |
 
 !!! warning "Security Notice"
@@ -81,7 +81,7 @@ docker volume create fukuii-conf
 docker run -d \
   --name fukuii \
   --restart unless-stopped \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -p 30303:30303/udp \
   -v fukuii-data:/app/data \
   -v fukuii-conf:/app/conf \

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -26,7 +26,7 @@ docker volume create fukuii-conf
 docker run -d \
   --name fukuii \
   --restart unless-stopped \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -p 30303:30303/udp \
   -v fukuii-data:/app/data \
   -v fukuii-conf:/app/conf \

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,9 @@ This documentation is organized by audience:
 - **[Getting Started](getting-started/index.md)** — Installation and first-run guides
 - **[For Node Operators](for-node-operators/index.md)** — Day-to-day node operation
 - **[For Operators/SRE](for-operators/index.md)** — Production deployment and monitoring
+- **[Sync Lifecycle](operations/sync-lifecycle.md)** — Phase-by-phase guide from empty datadir to chain tip
+- **[State Healing Guide](operations/state-healing-operations.md)** — Operating the post-SNAP healing phase
+- **[Metrics Reference](operations/metrics-reference.md)** — Prometheus metric catalog
 - **[For Developers](for-developers/index.md)** — Architecture, contributing, and API docs
 - **[Reference](specifications/README.md)** — Specifications, ADRs, and technical details
 - **[Troubleshooting](troubleshooting/README.md)** — Common issues and solutions

--- a/docs/operations/metrics-reference.md
+++ b/docs/operations/metrics-reference.md
@@ -1,0 +1,212 @@
+# Metrics Reference
+
+This page is the operator-facing reference for every Prometheus metric Fukuii exposes,
+what each one means, and where it is visualized. For the narrative monitoring guide
+(alert rules, Kamon, logging) see [SNAP Sync Monitoring](monitoring-snap-sync.md).
+
+## Endpoint and configuration
+
+Metrics are served by an embedded Prometheus HTTP server:
+
+```hocon
+fukuii.metrics {
+  # Disabled by default — enable it for any monitored deployment.
+  enabled = true
+
+  # Default port is 13798; production compose files (Barad-dûr) override this to 9095.
+  port = 13798
+}
+```
+
+Scrape `http://<node>:<port>/metrics` (inside the Barad-dûr containers: `:9095/metrics`).
+All application metrics carry the `app_` prefix. Conventions to know when reading the tables:
+
+- **Counters** are monotonic and exported with a `_total` suffix; rate them in PromQL.
+- **Timers** (Micrometer) export three series: `<name>_seconds_count`, `<name>_seconds_sum`,
+  `<name>_seconds_max`.
+- **Gauges** are point-in-time values set by the emitting subsystem.
+- JVM and process metrics (`jvm_*`, `process_*`) are auto-registered alongside the app metrics.
+
+> **Multi-instance caveat (Bug 29):** all instances of a multi-chain process write into one
+> shared registry, so every `/metrics` endpoint serves identical content. Run one container
+> per chain for per-chain observability.
+
+**Dashboards referenced below** ("Surfaced in" column):
+
+- **SNAP Sync** — `ops/grafana/Sync/fukuii-snap-sync.json` (rows: Phase & Pivot, Backpressure,
+  Progress, Peer Pool Health, Request Health, State Healing)
+- **Node Health** — `ops/grafana/ETC Node/fukuii-node-health.json`
+- A dash (—) means the metric is exported but not on either of those two dashboards.
+
+Some registered metrics have no emitter wired yet; these are marked **Reserved** and always
+read 0. They are listed so operators don't mistake a permanent 0 for a healthy signal.
+
+## SNAP sync phase and pivot
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_phase_current_gauge` | gauge | Current SNAP sync phase (see value table below); published by the sync progress monitor on every progress tick. | SNAP Sync: Phase & Pivot; Node Health: SNAP phase |
+| `app_snapsync_phase_time_seconds_gauge` | gauge | Seconds spent in the current phase. | SNAP Sync: Phase & Pivot (Time in Phase) |
+| `app_snapsync_totaltime_minutes_gauge` | gauge | Minutes since SNAP sync started. | SNAP Sync: Phase & Pivot (Total Sync Time) |
+| `app_snapsync_pivot_block_number_gauge` | gauge | Pivot block number selected by the SNAP sync controller. | SNAP Sync: Phase & Pivot (Pivot Block) |
+| `app_snapsync_pivot_refreshed_total` | counter | In-place pivot refreshes since sync start (controller rolls the download root when peers stop serving the old one). | SNAP Sync: Phase & Pivot (Pivot Refreshes) |
+
+### `phase_current` values
+
+| Value | Phase | Notes |
+|-------|-------|-------|
+| 0 | Idle | Not started |
+| 1 | AccountRangeSync | Downloading account ranges with Merkle proofs |
+| 3 | ByteCodeAndStorageSync | Bytecode + storage download (combined phase; legacy values 2 and 4 are reserved and never emitted) |
+| 5 | StateHealing | BFS frontier rebuild + missing-trie-node healing |
+| 6 | StateValidation | Verifying state completeness |
+| 7 | ChainDownloadCompletion | Downloading remaining chain to the head |
+| 8 | Completed | SNAP sync finished |
+| 9 | Dormant | Critical-failure backoff: data preserved, waiting (3–20 min exponential) for peers to re-index snapshots |
+
+## Account range download
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_accounts_synced_gauge` | gauge | Cumulative accounts written by the account-range phase. | SNAP Sync: Progress (Accounts Progress, Accounts Synced) |
+| `app_snapsync_accounts_estimated_total_gauge` | gauge | Estimated total accounts at the pivot; denominator of the progress % panel. | SNAP Sync: Progress |
+| `app_snapsync_accounts_throughput_overall_gauge` | gauge | Accounts/s averaged since sync start. | — |
+| `app_snapsync_accounts_throughput_recent_gauge` | gauge | Accounts/s over the last 60 s. | SNAP Sync: Progress (Throughput) |
+| `app_snapsync_accounts_active_peers_gauge` | gauge | Peers the account coordinator can dispatch to right now (known − stateless − snapless − cooling-down). | SNAP Sync: Peer Pool Health |
+| `app_snapsync_accounts_requests_total` | counter | Reserved — account-range request counter; no emitter wired (always 0). | — |
+| `app_snapsync_accounts_requests_failed_total` | counter | Reserved — failed account-range requests; no emitter wired (always 0). | SNAP Sync: Request Health |
+| `app_snapsync_accounts_download_timer` | timer | Reserved — account-range download latency; no emitter wired (always 0). | SNAP Sync: Request Health (Request Latency) |
+
+## Bytecode download
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_bytecodes_downloaded_gauge` | gauge | Cumulative contract bytecodes downloaded. | SNAP Sync: Progress (Bytecodes Progress) |
+| `app_snapsync_bytecodes_estimated_total_gauge` | gauge | Estimated total bytecodes; progress % denominator. | SNAP Sync: Progress |
+| `app_snapsync_bytecodes_throughput_overall_gauge` | gauge | Bytecodes/s since sync start. | — |
+| `app_snapsync_bytecodes_throughput_recent_gauge` | gauge | Bytecodes/s over the last 60 s. | SNAP Sync: Progress (Throughput) |
+| `app_snapsync_bytecode_queue_depth_gauge` | gauge | Bytecode coordinator pending-task queue depth. | SNAP Sync: Backpressure |
+| `app_snapsync_bytecode_backpressure_gauge` | gauge | 1 while the bytecode coordinator has backpressure engaged, 0 when released. | SNAP Sync: Backpressure |
+| `app_snapsync_bytecode_active_peers_gauge` | gauge | Reserved — bytecode-coordinator active peers; no emitter wired (always 0). | — |
+| `app_snapsync_bytecodes_requests_total` | counter | Reserved — bytecode request counter; no emitter wired (always 0). | — |
+| `app_snapsync_bytecodes_requests_failed_total` | counter | Reserved — failed bytecode requests; no emitter wired (always 0). | SNAP Sync: Request Health |
+| `app_snapsync_bytecodes_download_timer` | timer | Reserved — bytecode download latency; no emitter wired (always 0). | SNAP Sync: Request Health (Request Latency) |
+
+## Storage range download
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_storage_slots_synced_gauge` | gauge | Cumulative storage slots downloaded. | SNAP Sync: Progress (Storage Slots Progress) |
+| `app_snapsync_storage_slots_estimated_total_gauge` | gauge | Estimated total storage slots; progress % denominator. | SNAP Sync: Progress |
+| `app_snapsync_storage_throughput_overall_gauge` | gauge | Slots/s since sync start. | — |
+| `app_snapsync_storage_throughput_recent_gauge` | gauge | Slots/s over the last 60 s. | SNAP Sync: Progress (Throughput) |
+| `app_snapsync_storage_queue_depth_gauge` | gauge | Storage coordinator pending-task queue depth. | SNAP Sync: Backpressure |
+| `app_snapsync_storage_backpressure_gauge` | gauge | 1 while the storage coordinator has backpressure engaged, 0 when released. | SNAP Sync: Backpressure |
+| `app_snapsync_storage_pending_tries_size_gauge` | gauge | Per-account streaming storage tries held in memory; each is bounded to ~8 MiB, so this × 8 MiB bounds the storage-phase heap footprint. | — |
+| `app_snapsync_storage_active_peers_gauge` | gauge | Reserved — storage-coordinator active peers; no emitter wired (always 0). | — |
+| `app_snapsync_storage_requests_total` | counter | Reserved — storage request counter; no emitter wired (always 0). | — |
+| `app_snapsync_storage_requests_failed_total` | counter | Reserved — failed storage requests; no emitter wired (always 0). | SNAP Sync: Request Health |
+| `app_snapsync_storage_download_timer` | timer | Reserved — storage download latency; no emitter wired (always 0). | SNAP Sync: Request Health (Request Latency) |
+
+## State healing
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_healing_nodes_healed_gauge` | gauge | Cumulative trie nodes fetched and written by the healing phase, published on every progress tick. | SNAP Sync: Progress, State Healing (Nodes Healed) |
+| `app_snapsync_healing_frontier_pending_gauge` | gauge | Healing frontier backlog: missing nodes queued in the healing coordinator and awaiting fetch. | SNAP Sync: State Healing (Frontier Backlog) |
+| `app_snapsync_healing_active_requests_gauge` | gauge | In-flight `GetTrieNodes` healing requests held by the healing coordinator. | SNAP Sync: State Healing (Active Heal Requests) |
+| `app_snapsync_healing_rebuild_visited_gauge` | gauge | Nodes visited so far by the current frontier-rebuild BFS walk over locally stored state (`[HEAL-BFS]` log lines); updated every 100 k visits and at each BFS level boundary. Resets when a new walk starts; stays flat when healing resumes from a complete persisted frontier. | SNAP Sync: State Healing (BFS Visited, BFS Walk Progress, BFS Progress & Rate) |
+| `app_snapsync_healing_throughput_overall_gauge` | gauge | Healed nodes/s since healing started. | SNAP Sync: State Healing (Healing Throughput) |
+| `app_snapsync_healing_throughput_recent_gauge` | gauge | Healed nodes/s over the last 60 s. | SNAP Sync: Progress (Throughput), State Healing |
+| `app_snapsync_healing_requests_total` | counter | Reserved — healing request counter; no emitter wired (always 0). | SNAP Sync: State Healing (Healing Request Rate) |
+| `app_snapsync_healing_requests_failed_total` | counter | Reserved — failed healing requests; no emitter wired (always 0). | SNAP Sync: Request Health, State Healing |
+| `app_snapsync_healing_timer` | timer | Reserved — healing batch latency; no emitter wired (always 0). | SNAP Sync: Request Health (Request Latency) |
+| `app_snapsync_validation_missing_nodes_gauge` | gauge | Reserved — missing nodes found by state validation; no emitter wired (always 0). | SNAP Sync: Request Health (Data Integrity) |
+
+> ### Reading the healing walk
+>
+> After a restart mid-healing, the coordinator rebuilds its frontier with a level-order BFS
+> over the locally stored state trie. `healing_rebuild_visited` climbs monotonically during
+> **one** walk and is reset to a fresh count whenever a new walk starts — treat it as
+> per-walk progress, not a lifetime counter. The dashboard's "BFS Walk Progress" panel
+> divides it by a **~119 M node estimate** for ETC mainnet state, so the percentage is a
+> rough yardstick, not an exact ETA. While the walk runs, `nodes_healed` and
+> `frontier_pending` pulse together: each completed BFS level delivers a batch of
+> newly discovered missing nodes (backlog rises), heal requests then drain it
+> (`active_requests` shows the in-flight `GetTrieNodes`), and `nodes_healed` steps up.
+> If the walk is skipped entirely (`[HEAL-RESTART] Resumed ... from a complete persisted
+> snapshot` in the logs), `rebuild_visited` stays flat — that is normal.
+
+## SNAP peers, requests, and data integrity
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_snapsync_peers_capable_gauge` | gauge | Handshaked peers that negotiated the SNAP/1 capability, tracked by the SNAP sync controller. | SNAP Sync: Peer Pool Health |
+| `app_snapsync_peers_blacklisted_total` | counter | Every blacklist event, regardless of reason group — incremented by the shared blacklist on each add (duplicate of the network counters, kept so the SNAP dashboard can stay within `snapsync_*`). | SNAP Sync: Peer Pool Health (Demotion + Eviction Rate) |
+| `app_snapsync_peers_snapless_confirmed_total` | counter | Peers demoted as snapless by the account coordinator after 3 strikes (advertise SNAP but never serve it). | SNAP Sync: Peer Pool Health |
+| `app_snapsync_peers_stateless_confirmed_total` | counter | Peers demoted as stateless by the account/storage coordinators after 3 strikes (no longer hold the pivot's state). | SNAP Sync: Peer Pool Health |
+| `app_network_lagging_peer_evicted_total` | counter | Peers evicted by the network peer manager's lagging-peer check (best block too far behind). | SNAP Sync: Peer Pool Health |
+| `app_snapsync_requests_timeouts_total` | counter | Reserved — SNAP request timeouts; no emitter wired (always 0). | SNAP Sync: Request Health; Node Health: Errors |
+| `app_snapsync_requests_retries_total` | counter | Reserved — SNAP request retries; no emitter wired (always 0). | SNAP Sync: Request Health |
+| `app_snapsync_proofs_invalid_total` | counter | Reserved — responses failing Merkle-proof verification; no emitter wired (always 0). | SNAP Sync: Request Health (Data Integrity) |
+| `app_snapsync_responses_malformed_total` | counter | Reserved — undecodable SNAP responses; no emitter wired (always 0). | SNAP Sync: Request Health (Data Integrity) |
+| `app_snapsync_validation_failures_total` | counter | Reserved — state-validation failures; no emitter wired (always 0). | SNAP Sync: Request Health; Node Health: Errors |
+| `app_snapsync_errors_total` | counter | Reserved — general SNAP sync errors; no emitter wired (always 0). | SNAP Sync: Request Health; Node Health: Errors |
+
+## Network (`app_network_*`)
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_network_peers_incoming_handshaked_gauge` | gauge | Currently handshaked inbound peers. | Node Health: Handshaked Peers/Peers; SNAP Sync: Peer Pool |
+| `app_network_peers_outgoing_handshaked_gauge` | gauge | Currently handshaked outbound peers. | Node Health: Handshaked Peers/Peers; SNAP Sync: Peer Pool |
+| `app_network_peers_pending_gauge` | gauge | Connections in progress (not yet handshaked), from the peer manager's periodic stats. | Node Health: Peers |
+| `app_network_tried_peers_gauge` | gauge | Distinct discovered nodes this process has attempted to connect to. | — |
+| `app_network_discovery_foundPeers_gauge` | gauge | Nodes currently known to discovery (DHT + DNS). | Node Health: Peers |
+| `app_network_peers_blacklisted_gauge` | gauge | Current blacklist size (live entries in the blacklist cache). | Node Health: Peers; SNAP Sync: Peer Pool Health |
+| `app_network_peers_blacklisted_fastSyncGroup_counter_total` | counter | Blacklist events attributed to fast-sync reasons. | — |
+| `app_network_peers_blacklisted_regularSyncGroup_counter_total` | counter | Blacklist events attributed to regular-sync reasons. | Node Health: Errors |
+| `app_network_peers_blacklisted_p2pGroup_counter_total` | counter | Blacklist events attributed to P2P/subprotocol reasons (the dominant group in practice). | — |
+| `app_network_messages_sent_counter_total` | counter | Wire-protocol messages sent across all peers. | Node Health: Network message rate |
+| `app_network_messages_received_counter_total` | counter | Wire-protocol messages received across all peers. | Node Health: Network message rate |
+| `app_network_peer_info` | gauge (const 1) | One labelled series per handshaked peer — labels `peer`, `remote_address`, `client`, `client_name`, `capability` (e.g. `eth/68`), `network_id`, `direction`, `snap`. Series is removed on disconnect, so cardinality is bounded by live peer count; aggregate with `count by (client_name)(...)`. | Network Nodes dashboard (`ops/grafana/Network/fukuii-network-nodes.json`) |
+| `app_network_peer_best_block` | gauge | Peer's advertised head block at handshake (labels: `peer`); refreshed by the periodic best-block re-probe. | — |
+| `app_network_lagging_peer_evicted_total` | counter | (Listed under SNAP peers above — emitted by the network peer manager.) | SNAP Sync: Peer Pool Health |
+
+## JSON-RPC (`app_json_rpc_*`)
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_json_rpc_methods_success_counter_total` | counter | RPC calls that returned a successful response. | Troubleshooting dashboard |
+| `app_json_rpc_methods_error_counter_total` | counter | RPC calls that returned a JSON-RPC error object. | Troubleshooting dashboard |
+| `app_json_rpc_methods_exception_counter_total` | counter | RPC calls that threw an unhandled exception in the controller. | Troubleshooting dashboard |
+| `app_json_rpc_notfound_calls_counter_total` | counter | Calls to methods that don't exist (method-not-found). | — |
+| `app_json_rpc_healthcheck_error_counter_total` | counter | Failed internal healthcheck evaluations. | — |
+| `app_json_rpc_methods_timer_seconds` | timer | Per-method RPC latency, labelled `method=` (e.g. `eth_blockNumber`); one `_count`/`_sum`/`_max` triple per method. | Troubleshooting dashboard |
+
+(The "Troubleshooting dashboard" is `ops/grafana/ETC Node/fukuii-node-troubleshooting-dashboard.json`.)
+
+## Logging, JVM, and process
+
+| Metric | Type | Meaning | Surfaced in |
+|--------|------|---------|-------------|
+| `app_logback_events_total` | counter | Log events by `level=` (`error`/`warn`/`info`/`debug`/`trace`), bound from Logback at metrics startup. Rate the `error` series for a cheap fault signal. | — |
+| `jvm_memory_used_bytes`, `jvm_memory_committed_bytes`, `jvm_memory_max_bytes` | gauge | JVM memory by `area=` (heap/nonheap) and pool, from the bundled JVM instrumentation. | Node Health: JVM heap¹ |
+| `jvm_gc_collection_seconds` | summary | GC pause time and count per collector; `rate(..._sum[1m])` ≈ fraction of wall time in GC. | Node Health: GC time |
+| `jvm_threads_current`, `jvm_threads_deadlocked` | gauge | Live and deadlocked JVM thread counts. | Node Health: JVM threads |
+| `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, ... | counter/gauge | Standard process exporter metrics. | — |
+
+¹ The Node Health JVM-heap panel queries the older `jvm_memory_bytes_used` names; the
+current exporter emits `jvm_memory_used_bytes` — update the panel if heap shows "No data".
+
+## Families that register once their subsystem starts
+
+The gauges above are what a node mid-SNAP-sync serves. The following `app_*` families are
+defined in code but only appear on `/metrics` after their emitting subsystem first runs:
+
+| Family | Emitting subsystem | Examples | Surfaced in |
+|--------|--------------------|----------|-------------|
+| `app_regularsync_*` | Regular (full) sync block import | `block_current_number_gauge`, `block_bestKnown_number_gauge`, `blocks_imported_total`, `reorg_total`, `reorg_last_depth_gauge`, `blocks_propagation_timer{blocktype=}` | Node Health: Current Block, Blocks Behind, Block height, Import rate |
+| `app_sync_block_*` | Per-imported-block stats | `number`, `gasUsed`/`gasLimit`, `transactions`, `uncles`, `difficulty`, `timeBetweenParent_seconds` | Node Health: Block time, Transactions/Gas per block |
+| `app_chain_mess_*` | ECBP-1100 (MESS) reorg arbitration | `rejected_total`, `accepted_total`, `gravity_gauge` | — |
+| `app_fastsync_*` | Legacy fast sync (fallback mode) | `block_pivotBlock_number_gauge`, `state_downloadedNodes_gauge`, download timers | Node Health: Best Known Block, Block height |
+| `app_mining_*` | Internal Ethash miner | `minedblocks_evaluation_timer` | — |

--- a/docs/operations/monitoring-snap-sync.md
+++ b/docs/operations/monitoring-snap-sync.md
@@ -161,13 +161,13 @@ kamon.instrumentation.pekko.filters {
 
 ### Loading the Dashboard
 
-A pre-configured Grafana dashboard is available at `/ops/grafana/fukuii-snap-sync-dashboard.json`.
+A pre-configured Grafana dashboard is available at `ops/grafana/Sync/fukuii-snap-sync.json`.
 
 **Import Steps:**
 
 1. Open Grafana UI (typically `http://localhost:3000`)
 2. Click **+** → **Import**
-3. Upload `/ops/grafana/fukuii-snap-sync-dashboard.json`
+3. Upload `ops/grafana/Sync/fukuii-snap-sync.json`
 4. Select your Prometheus datasource
 5. Click **Import**
 

--- a/docs/operations/state-healing-operations.md
+++ b/docs/operations/state-healing-operations.md
@@ -1,0 +1,132 @@
+# State Healing — Operator's Guide
+
+State healing is the last SNAP-sync phase before a node hands off to regular sync. It finds
+and downloads the trie nodes that are still missing after the account/storage/bytecode
+download phases (pivot movement during a long sync guarantees there are some), then verifies
+the state is complete. On a small network this takes minutes; on ETC mainnet (~86M accounts,
+~119M state-trie nodes, ~85 GB on disk) the *discovery walk* is the long pole and runs for
+hours. This page explains what you will see, which knobs exist, and how to tell healthy from
+stuck.
+
+For the design rationale see
+[`docs/design/healing-frontier-scale.md`](../design/healing-frontier-scale.md); for dashboards
+see [Monitoring SNAP Sync](monitoring-snap-sync.md).
+
+## How it works (one paragraph)
+
+The healing coordinator rebuilds its "frontier" (the set of missing node hashes) by walking
+the locally stored state trie **breadth-first, level by level** (`rebuildFrontierBFS`). The
+level queue is kept in a dedicated RocksDB column family, so memory stays flat no matter how
+wide a level gets (ETC mainnet level 7 exceeds 70M entries). Node lookups are batched (50K
+hashes per `multiGet`), the visited set is a bounded LRU
+(`healing-visited-cap`, default 4M entries ≈ 320 MB), and **exactly one walk runs at a
+time** (a single-flight gate covers both the rebuild and the later verification pass).
+Missing nodes stream out in batches of 1,000 while the walk is still running and are fetched
+from peers via SNAP `GetTrieNodes`. When the walk finishes, a completeness marker is
+persisted so a restart can resume from the saved frontier instead of re-walking.
+
+## What you will see in the logs
+
+A healthy mainnet-scale healing phase, in order:
+
+```
+[HEAL-RESTART] Root 65d85b06… already in local storage — rebuilding frontier via local DFS in batches of 1000
+[HEAL-RESTART] Persisted frontier has 15907 entries but no completeness marker — re-running full-state DFS
+[HEAL-BFS] Level 0 complete: 1 processed, 0 frontier total, 16 queued for L1
+[HEAL-BFS] Level 3 complete: 4096 processed, 0 frontier total, 65536 queued for L4
+[HEAL-BFS] Level 6: 12900000 nodes visited, 1 frontier found, 51467209 L7 queued
+[HEAL-FRONTIER] 1000 missing nodes identified — queuing for healing
+[HEAL-PULSE] 37% (est) | healed=56346 (+1141 last 2min) | pending=0 active=4 peers=31 | rate=230 nodes/s walkRunning=true pivotRefreshPending=false
+[HEAL-BFS] Complete: 118754095 nodes traversed, 835707 missing nodes identified
+[HEAL-RESTART] Full-state rebuild complete — persisted frontier marked as a complete snapshot
+```
+
+Reference points from a live ETC-mainnet run (June 2026, 4-core host, SSD-class storage):
+
+| Observation | Value |
+| --- | --- |
+| Full-state walk total | ~119M nodes traversed |
+| Walk throughput | ~700–1,400 nodes/s sustained in the wide levels; bursts to ~6,000 nodes/s |
+| Widest level | L7, 70M+ entries in the disk-backed queue (memory flat) |
+| Healing fetch rate | bursty, peer-bound: ~50–250 nodes/s on a ~2-SNAP-server network |
+| Frontier found after a large pivot gap | ~835K nodes, healed in one pass |
+
+The levels grow roughly 16× per level down to the account-leaf band (L6–L7 on mainnet),
+then collapse; storage-trie nodes are enqueued as account leaves are decoded, so the queue
+counter for the next level keeps growing while a level is processed. Long stretches of
+`0 frontier found` are normal — they mean the state really is complete in those regions.
+
+### The HEAL-PULSE line
+
+Logged every 2 minutes:
+
+| Field | Meaning |
+| --- | --- |
+| `NN% (est)` | completed heal tasks vs known tasks — **not** walk progress |
+| `healed=` | trie nodes downloaded and written so far this phase (cumulative) |
+| `pending= active=` | heal tasks queued / requests in flight to peers |
+| `peers=` | peers currently usable for healing |
+| `rate=` | recent heal throughput (nodes/s) |
+| `walkRunning=` | true while **any** frontier walk (rebuild or verification) is running |
+| `pivotRefreshPending=` | a pivot refresh is waiting to be applied |
+
+A pulse of `healed +0, pending=0, active=0` while `walkRunning=true` is **normal** — the
+walk is in a fully-healed region and has nothing to hand to the downloader.
+
+### The watchdog
+
+If three consecutive pulses show no walk, no pending work, and no healing progress, the
+dead-pulse watchdog force-starts a verification walk:
+
+```
+[HEAL-WATCHDOG] Dead pulse 3/3: walkRunning=false verifyRunning=false pending=0 active=0 healed=0 in last 2min
+[HEAL-WATCHDOG] 3 consecutive dead pulses — force-starting verification DFS
+```
+
+Seeing this once after a restart is fine. Seeing it repeatedly means peers are not serving
+(check `peers=` and pivot age).
+
+## Configuration knobs
+
+All under `fukuii.sync.snap-sync` (defaults from `conf/base/sync.conf`):
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `healing-visited-cap` | `4000000` | Bound on the walk's LRU visited set (~80 B/entry). At the cap the **eldest entries are evicted** (never truncating the walk) at the cost of some re-walking of shared subtries. 4M ≈ 320 MB is right for a 5 GB heap. |
+| `healing-frontier-persistence` | `true` | Layer-2 resume: persist discovered missing nodes to a RocksDB CF as the walk runs. On restart, a frontier with the **completeness marker** is resumed (skips the multi-hour walk); a partial frontier without the marker triggers a full re-walk (safe). |
+| `healing-traversal-parallelism` | `4` | Sub-range workers per BFS level (large levels are split across the healing-writer thread pool). |
+
+Restart semantics worth knowing:
+
+- The walk's visited counter and progress are **per-walk**: a process restart re-walks from
+  the root unless the completeness marker was set. Healed nodes are durable — every restart
+  has *less* to heal even when it must re-walk.
+- A pivot refresh clears the persisted frontier and marker (the target root changed). If a
+  walk is running at that moment, verification is deferred until it finishes — never run
+  two walks at once (they share the level queue).
+
+## Dashboard
+
+Grafana → **Fukuii SNAP Sync** → row **"State Healing — BFS frontier rebuild + heal"**:
+nodes healed, frontier backlog, active requests, BFS visited counter (+5m rate), and a
+walk-progress estimate (visited ÷ ~119M mainnet estimate — labeled estimate for a reason;
+the counter resets when a new walk starts).
+
+## Healthy vs. stuck
+
+| Symptom | Verdict |
+| --- | --- |
+| `[HEAL-BFS] Level N:` lines advancing every minute or two, memory flat | Healthy — walk in progress |
+| `healed +0` for hours **while** `walkRunning=true` and visited advancing | Healthy — walking a complete region |
+| `frontier found` jumps by thousands, then `healed` climbs in bursts | Healthy — gap region found and being cured |
+| Pulse `peers=0` or single digits for long stretches | Peer-starved: healing is network-bound; check discovery/firewall and pivot age |
+| `[HEAL-WATCHDOG] … force-starting` repeating every few minutes | Stuck: peers won't serve the current root; expect a pivot refresh, or investigate peering |
+| Two interleaved `Level N complete` streams with different sizes | Bug territory (two concurrent walks) — should be impossible since the single-flight gate; capture logs and file an issue |
+| `OutOfMemoryError` during healing | Check `healing-visited-cap` × concurrent components vs heap; the walk itself is disk-backed and should not OOM |
+
+## When it ends
+
+Walk completes → residual frontier heals → a verification walk re-runs over the (possibly
+pivot-rolled) root → finds nothing → `StateHealing` exits, SNAP sync finalizes, and the node
+enters regular sync. From there, any stragglers are fetched on demand during block execution.
+See [Sync Lifecycle](sync-lifecycle.md) for the full phase walk-through.

--- a/docs/operations/sync-lifecycle.md
+++ b/docs/operations/sync-lifecycle.md
@@ -1,0 +1,137 @@
+# Sync Lifecycle — From Empty Datadir to Chain Tip
+
+This page narrates the full journey of a fukuii node from first start to following the chain
+tip: which phases run, what each looks like in the logs and metrics, what "normal" is at each
+step, and roughly how long things take. It reflects the current implementation (SNAP sync
+with stack-trie account building, BFS state healing, ConcurrentFetch block pipelines,
+eth/68 + eth/69 wire protocols).
+
+Companion pages: [State Healing — Operator's Guide](state-healing-operations.md),
+[Monitoring SNAP Sync](monitoring-snap-sync.md), and the
+[Metrics Reference](metrics-reference.md).
+
+## The map
+
+```
+boot ─► peer discovery ─► pivot selection ─► SNAP download ─► state healing ─► validation
+                                                  │                                │
+                                                  ▼                                ▼
+                                          accounts ► bytecode+storage      regular sync (tip)
+```
+
+The SNAP phase gauge (`app_snapsync_phase_current_gauge`) tracks where you are:
+
+| Value | Phase | Long pole on |
+| --- | --- | --- |
+| 0 | Idle / not started | — |
+| 1 | AccountRange download | network |
+| 3 | ByteCode + Storage download | network |
+| 5 | StateHealing | local I/O (walk) + network (heal) |
+| 6 | Validation | local I/O |
+| 7 | Chain download / handoff | network |
+| 8 | Completed (regular sync from here) | network |
+
+## 0. Boot and peer discovery
+
+On start the node loads its key (`node.key` in the datadir), binds P2P/discovery on
+**30303** (TCP+UDP must match — the ENR advertises the bind port), detects its external IP,
+and seeds discovery from the config bootnodes plus **EIP-1459 DNS trees**
+(`all.classic.blockd.info` for ETC; `all.mordor.etcdisco.net` and `all.mordor.blockd.info`
+for Mordor). Within seconds you should see:
+
+```
+DNS_DISCOVERY: Resolved 8 enode(s) from all.mordor.etcdisco.net
+PEER_HANDSHAKE_SUCCESS: Peer … cap=ETH68 client=core-geth … forkAccepted=true supportsSnap=true
+```
+
+fukuii advertises **eth/68, eth/69, snap/1**. eth/69 peers send no total difficulty in their
+STATUS; the node derives their chain weight via a calibration cascade (and you may see
+`SNAP_CALIBRATION_PEER` / `ETH69_BRU_POST_HANDSHAKE` lines — informational). Off-network
+peers are rejected at the networkId/genesis check after a tolerant STATUS decode, not by
+crashing the codec.
+
+**Normal:** double-digit handshakes within a couple of minutes on mainnet. **Not normal:**
+`peers=0` for >5 min — check UDP 30303 reachability and that your advertised IP is correct.
+
+## 1. Pivot selection (and bootstrap checkpoints)
+
+SNAP sync downloads state at a recent block — the **pivot** — chosen
+`pivot-block-offset` (default 64) blocks behind the network head, inside the window peers
+actually serve (core-geth indexes snapshots ~128 blocks back). With
+`use-bootstrap-checkpoints = true` a packaged checkpoint can seed the pivot header so a
+fresh node doesn't wait on header consensus.
+
+Pivots age: peers serve a root for roughly 128 blocks (~28 min on Mordor, ~17 min on
+mainnet). Long phases therefore **refresh the pivot in place** when all peers go stateless
+for the current root (`Pivot refreshed: block N -> M, root x -> y`). This is routine — trie
+nodes are content-addressed, so virtually all downloaded data stays valid across a refresh;
+healing reconciles the rest.
+
+## 2. SNAP download phases
+
+**AccountRange (phase 1):** contiguous account ranges with Merkle proofs, built directly
+into the trie via the streaming stack-trie (`use-stack-trie = true`, the default — no
+multi-GB in-memory trie, no multi-minute flush). Throughput is peer-bound: thousands of
+accounts/s when servers are healthy. Mordor's ~2.7M accounts take ~30–50 min; mainnet's
+~86M take a day-plus on a 2-server network.
+
+**ByteCode + Storage (phase 3):** contract code and per-account storage tries, fetched in
+adaptive batches with per-peer response-size ramping; flat slot data is also written to a
+dedicated column family for O(1) `SLOAD` later. Watch the queue/backpressure gauges — the
+Backpressure dashboard row exists precisely because this phase alternates between
+network-bound and local-trie-build-bound.
+
+Progress for all three: `app_snapsync_{accounts,bytecodes,storage_slots}_*` gauges and the
+`SNAP Sync Progress` log blocks.
+
+## 3. State healing (phase 5)
+
+The long, quiet phase — covered in depth in the
+[State Healing Operator's Guide](state-healing-operations.md). Summary: a level-order BFS
+walk over the local trie finds what's missing (`[HEAL-BFS] Level N …`), missing nodes are
+fetched via `GetTrieNodes`, a completeness marker enables restart-resume, and a verification
+pass confirms there are no gaps. On mainnet expect the walk to dominate wall-clock (hours);
+on Mordor it's minutes.
+
+## 4. Validation and handoff (phases 6–7)
+
+State validation spot-checks the assembled state; SNAP finalizes (`snapSyncDone`), the block
+import baseline is set at the pivot, and the chain-weight for the pivot is calibrated from
+peers (a SNAP-synced node never executed the historical blocks, so cumulative difficulty is
+seeded from the network and accumulated normally from there).
+
+## 5. Regular sync (phase 8 / steady state)
+
+Block-by-block import to the tip, through the concurrent fetch pipeline
+(`ConcurrentFetch` header/body/receipt queues with per-peer rate tracking). Catch-up imports
+in 50-block batches:
+
+```
+Imported blocks 16176171 - 16176220
+```
+
+Reference point: a Mordor node ~180K blocks behind catches up at ~100+ blocks/s with a
+healthy peer set (single-digit blocks/s means peer starvation, not CPU). At the tip, blocks
+arrive on the ETC ~13 s cadence. If block execution ever hits a state node SNAP missed, it
+is fetched on demand from SNAP peers and import continues — occasional
+`FetchStateNode` activity right after handoff is normal and self-quenching.
+
+## Timing cheat-sheet (live-observed reference points, June 2026)
+
+| Network | Phase | Observed |
+| --- | --- | --- |
+| Mordor | full SNAP (empty datadir → tip) | ~1 h |
+| Mordor | checkpoint import bootstrap | ~2 min to start SNAP at pivot |
+| Mordor | regular-sync catch-up | ~100–220 blocks/s |
+| ETC mainnet | accounts+storage+bytecode | day(s), peer-bound (~2 SNAP servers) |
+| ETC mainnet | healing walk (one pass) | hours (~119M nodes at ~1,000 nodes/s avg) |
+| ETC mainnet | healing fetch of an ~835K-node gap | minutes-to-hours, peer-bound |
+
+## Restart behavior at each stage
+
+| Restarted during | What happens |
+| --- | --- |
+| Accounts / storage / bytecode | Phase progress is persisted; completed phases are skipped (`Recovery: storage phase already complete — skipping re-download`) |
+| Healing, walk incomplete | Full re-walk (partial frontiers are never trusted); already-healed nodes stay healed |
+| Healing, walk complete (marker set) | Frontier resumes — the multi-hour walk is skipped |
+| Regular sync | Resumes from the last imported block |

--- a/docs/reports/SNAP-Resolution.md
+++ b/docs/reports/SNAP-Resolution.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # SNAP Sync Resolution — Fukuii Alpha Branch
 
 **Branch:** `alpha`

--- a/docs/reports/gorgoroth-trials-announcement.md
+++ b/docs/reports/gorgoroth-trials-announcement.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Welcome to the Gorgoroth Trials - Fukuii Alpha Testing Campaign
 
 **December 8, 2025**  

--- a/docs/reviews/COMPRESSION_FIX_WIRE_PROTOCOL.md
+++ b/docs/reviews/COMPRESSION_FIX_WIRE_PROTOCOL.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Critical Fix: Wire Protocol Compression Mismatch with Core-Geth
 
 **Date:** 2025-12-04  

--- a/docs/reviews/RUN_007_INVESTIGATION_SUMMARY.md
+++ b/docs/reviews/RUN_007_INVESTIGATION_SUMMARY.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Run 007 Investigation Summary
 
 **Date:** 2025-12-04  

--- a/docs/reviews/SNAP_PROTOCOL_COMPLIANCE_VALIDATION.md
+++ b/docs/reviews/SNAP_PROTOCOL_COMPLIANCE_VALIDATION.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # SNAP Protocol Compliance Validation
 
 **Date:** 2025-12-04 (Updated: 2025-12-12)  

--- a/docs/reviews/SNAP_SYNC_IMPLEMENTATION_REVIEW.md
+++ b/docs/reviews/SNAP_SYNC_IMPLEMENTATION_REVIEW.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # SNAP Sync Implementation Review
 
 **Date:** 2025-12-03  

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -58,7 +58,7 @@ tail -f ~/.fukuii/etc/logs/fukuii.log
 - **Database**: `~/.fukuii/<network>/rocksdb/` - RocksDB blockchain database
 
 ### Essential Ports
-- **9076** - Ethereum protocol (P2P)
+- **30303** - Ethereum protocol (P2P)
 - **30303** - Discovery protocol (UDP)
 - **8545** - JSON-RPC HTTP API
 - **8546** - Alternative JSON-RPC port (WebSocket, configurable)

--- a/docs/runbooks/checkpoint-service.md
+++ b/docs/runbooks/checkpoint-service.md
@@ -1059,7 +1059,7 @@ iftop -i eth0
 ```bash
 # 1. Increase peer count
 # Add more bootnodes to conf/fukuii.conf
-network.server-address.port = 9076
+network.server-address.port = 30303
 network.discovery.bootstrap-nodes = [
   "enode://...",
   "enode://..."
@@ -1075,8 +1075,8 @@ sync.snap-sync.storage-concurrency = 12  # Default: 8
 # - Use 8+ CPU cores
 
 # 4. Check network connectivity
-# Ensure ports 9076 (TCP) and 30303 (UDP) are open
-sudo ufw allow 9076/tcp
+# Ensure ports 30303 (TCP) and 30303 (UDP) are open
+sudo ufw allow 30303/tcp
 sudo ufw allow 30303/udp
 ```
 

--- a/docs/runbooks/custom-networks.md
+++ b/docs/runbooks/custom-networks.md
@@ -803,8 +803,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}
 
 4. Check firewall rules allow P2P traffic:
    ```bash
-   # Ensure ports 9076 (TCP) and 30303 (UDP/TCP) are open
-   sudo ufw allow 9076/tcp
+   # Ensure ports 30303 (TCP) and 30303 (UDP/TCP) are open
+   sudo ufw allow 30303/tcp
    sudo ufw allow 30303/tcp
    sudo ufw allow 30303/udp
    ```

--- a/docs/runbooks/enterprise-deployment.md
+++ b/docs/runbooks/enterprise-deployment.md
@@ -303,7 +303,7 @@ fukuii enterprise -Dconfig.file=/opt/fukuii/enterprise-node.conf
 1. **Firewall Configuration**:
    ```bash
    # Allow P2P only from trusted network
-   sudo ufw allow from 192.168.1.0/24 to any port 9076 proto tcp
+   sudo ufw allow from 192.168.1.0/24 to any port 30303 proto tcp
    sudo ufw allow from 192.168.1.0/24 to any port 30303 proto udp
    sudo ufw allow from 192.168.1.0/24 to any port 30303 proto tcp
    

--- a/docs/runbooks/first-start.md
+++ b/docs/runbooks/first-start.md
@@ -48,7 +48,7 @@ This runbook guides you through the initial setup and first-time startup of a Fu
 
 Ensure the following ports are accessible:
 - **30303/UDP** - Discovery protocol (inbound/outbound)
-- **9076/TCP** - Ethereum P2P protocol (inbound/outbound)
+- **30303/TCP** - Ethereum P2P protocol (inbound/outbound)
 - **8546/TCP** - JSON-RPC HTTP API (inbound, if exposing API)
 
 ## Installation Methods
@@ -86,7 +86,7 @@ docker volume create fukuii-conf
 docker run -d \
   --name fukuii \
   --restart unless-stopped \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -p 30303:30303/udp \
   -v fukuii-data:/app/data \
   -v fukuii-conf:/app/conf \
@@ -212,7 +212,7 @@ fukuii {
   
   network {
     server-address {
-      port = 9076
+      port = 30303
     }
     
     discovery {
@@ -458,7 +458,7 @@ See the [Docker Deployment Guide](../deployment/docker.md) for a complete monito
 ```bash
 # Ubuntu/Debian with ufw
 sudo ufw allow 30303/udp comment "Fukuii discovery"
-sudo ufw allow 9076/tcp comment "Fukuii P2P"
+sudo ufw allow 30303/tcp comment "Fukuii P2P"
 
 # Optional: Allow RPC (only if needed externally - SECURITY RISK)
 # sudo ufw allow 8546/tcp comment "Fukuii RPC"
@@ -477,7 +477,7 @@ sudo ufw allow 9076/tcp comment "Fukuii P2P"
 1. **Port already in use**
    ```bash
    # Check what's using the port
-   sudo lsof -i :9076
+   sudo lsof -i :30303
    sudo lsof -i :30303
    ```
    Solution: Stop conflicting service or change Fukuii ports

--- a/docs/runbooks/known-issues.md
+++ b/docs/runbooks/known-issues.md
@@ -856,7 +856,7 @@ WARN  [ServerActor] - No incoming connections
 
 #### Root Cause
 
-Firewall blocking required ports (9076/TCP, 30303/UDP).
+Firewall blocking required ports (30303/TCP, 30303/UDP).
 
 #### Fix
 

--- a/docs/runbooks/log-triage.md
+++ b/docs/runbooks/log-triage.md
@@ -207,7 +207,7 @@ INFO  [NodeBuilder] - Fixing database...
 INFO  [GenesisDataLoader] - Loading genesis data...
 INFO  [GenesisDataLoader] - Genesis data loaded successfully
 INFO  [NodeBuilder] - Starting peer manager...
-INFO  [ServerActor] - Server bound to /0.0.0.0:9076
+INFO  [ServerActor] - Server bound to /0.0.0.0:30303
 INFO  [NodeBuilder] - Starting server...
 INFO  [DiscoveryService] - Discovery service started on port 30303
 INFO  [NodeBuilder] - Starting sync controller...
@@ -238,7 +238,7 @@ WARN  [PeerActor] - Received unknown message type from peer
 ### Error Indicators (Immediate Action Needed)
 
 ```
-ERROR [ServerActor] - Failed to bind to port 9076: Address already in use
+ERROR [ServerActor] - Failed to bind to port 30303: Address already in use
 ERROR [RocksDbDataSource] - Database corruption detected
 ERROR [BlockImporter] - Failed to execute block: insufficient gas
 ERROR [Fukuii] - Fatal error during startup
@@ -252,15 +252,15 @@ ERROR [Fukuii] - Fatal error during startup
 
 **Log pattern**:
 ```
-ERROR [ServerActor] - Failed to bind to port 9076
+ERROR [ServerActor] - Failed to bind to port 30303
 java.net.BindException: Address already in use
 ```
 
 **Diagnosis**:
 ```bash
 # Check what's using the port
-sudo lsof -i :9076
-sudo netstat -tulpn | grep 9076
+sudo lsof -i :30303
+sudo netstat -tulpn | grep 30303
 ```
 
 **Solution**:

--- a/docs/runbooks/node-configuration.md
+++ b/docs/runbooks/node-configuration.md
@@ -233,7 +233,7 @@ fukuii {
       interface = "0.0.0.0"
       
       # P2P port
-      port = 9076
+      port = 30303
     }
     
     # Enable UPnP port forwarding
@@ -267,8 +267,8 @@ The `static-nodes.json` file should be placed in the data directory (e.g., `~/.f
 
 ```json
 [
-  "enode://6eecbdcc74c0b672ce505b9c639c3ef2e8ee8cddd8447ca7ab82c65041932db64a9cd4d7e723ba180b0c3d88d1f0b2913fda48972cdd6742fea59f900af084af@192.168.1.1:9076",
-  "enode://a335a7e86eab05929266de232bec201a49fdcfc1115e8f8b861656e8afb3a6e5d3ffd172d153ae6c080401a56e3d620db2ac0695038a19e9b0c5220212651493@192.168.1.2:9076"
+  "enode://6eecbdcc74c0b672ce505b9c639c3ef2e8ee8cddd8447ca7ab82c65041932db64a9cd4d7e723ba180b0c3d88d1f0b2913fda48972cdd6742fea59f900af084af@192.168.1.1:30303",
+  "enode://a335a7e86eab05929266de232bec201a49fdcfc1115e8f8b861656e8afb3a6e5d3ffd172d153ae6c080401a56e3d620db2ac0695038a19e9b0c5220212651493@192.168.1.2:30303"
 ]
 ```
 
@@ -951,7 +951,7 @@ fukuii {
 | Setting | Config Path | Default | Description |
 |---------|-------------|---------|-------------|
 | Data Directory | `fukuii.datadir` | `~/.fukuii/<network>` | Base data directory |
-| P2P Port | `fukuii.network.server-address.port` | `9076` | Ethereum P2P port |
+| P2P Port | `fukuii.network.server-address.port` | `30303` | Ethereum P2P port |
 | Discovery Port | `fukuii.network.discovery.port` | `30303` | Peer discovery port |
 | RPC Port | `fukuii.network.rpc.http.port` | `8546` | JSON-RPC HTTP port |
 | RPC Interface | `fukuii.network.rpc.http.interface` | `localhost` | RPC bind address |

--- a/docs/runbooks/operating-modes.md
+++ b/docs/runbooks/operating-modes.md
@@ -119,7 +119,7 @@ fukuii {
 docker run -d \
   --name fukuii-full \
   --restart unless-stopped \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -p 30303:30303/udp \
   -v fukuii-data:/app/data \
   ghcr.io/chippr-robotics/fukuii:latest
@@ -248,7 +248,7 @@ fukuii {
 docker run -d \
   --name fukuii-archive \
   --restart unless-stopped \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -p 30303:30303/udp \
   -v fukuii-archive-data:/app/data \
   -v fukuii-archive-conf:/app/conf \
@@ -431,7 +431,7 @@ docker run -d \
   --name fukuii-bootnode \
   --restart unless-stopped \
   -p 30303:30303/udp \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -v fukuii-bootnode-data:/app/data \
   -v $(pwd)/conf:/app/conf:ro \
   ghcr.io/chippr-robotics/fukuii:latest \
@@ -444,7 +444,7 @@ docker run -d \
   --name fukuii-bootnode \
   --restart unless-stopped \
   -p 30303:30303/udp \
-  -p 9076:9076 \
+  -p 30303:30303 \
   -v fukuii-bootnode-data:/app/data \
   -e JAVA_OPTS="-Xms2g -Xmx4g" \
   ghcr.io/chippr-robotics/fukuii:latest \
@@ -1139,7 +1139,7 @@ services:
     container_name: fukuii-full
     restart: unless-stopped
     ports:
-      - "9076:9076"
+      - "30303:30303"
       - "30303:30303/udp"
       - "127.0.0.1:8546:8546"
     volumes:
@@ -1154,7 +1154,7 @@ services:
     container_name: fukuii-archive
     restart: unless-stopped
     ports:
-      - "9077:9076"
+      - "9077:30303"
       - "30304:30303/udp"
       - "127.0.0.1:8547:8546"
     volumes:
@@ -1175,7 +1175,7 @@ services:
     restart: unless-stopped
     ports:
       - "30305:30303/udp"
-      - "9078:9076"
+      - "9078:30303"
     volumes:
       - fukuii-boot-data:/app/data
       - ./conf:/app/conf:ro  # Mount config directory
@@ -1363,7 +1363,7 @@ Expected: `"result": "0x14"` (20 peers or more)
 2. **Verify network ports:**
 ```bash
 # Check if ports are open
-netstat -tulpn | grep -E "9076|30303"
+netstat -tulpn | grep -E "30303|30303"
 ```
 
 3. **Check logs for errors:**

--- a/docs/runbooks/peering.md
+++ b/docs/runbooks/peering.md
@@ -43,7 +43,7 @@ Fukuii uses two network protocols:
    - Protocol: Ethereum Node Discovery Protocol v4
 
 2. **Ethereum Protocol** (TCP)
-   - Port: 9076 (default)
+   - Port: 30303 (default)
    - Purpose: Exchange blockchain data
    - Protocol: RLPx with ETH/66 capability
 
@@ -172,7 +172,7 @@ INFO  [PeerDiscoveryManager] - Discovered X peers
 ```
 WARN  [PeerManagerActor] - Disconnected from peer: reason=...
 WARN  [PeerActor] - Handshake timeout with peer
-ERROR [ServerActor] - Failed to bind to port 9076
+ERROR [ServerActor] - Failed to bind to port 30303
 ```
 
 ### Check Network Connectivity
@@ -185,7 +185,7 @@ Verify your node is reachable from the internet:
 nc -zvu <your-public-ip> 30303
 
 # Check if P2P port is open
-nc -zv <your-public-ip> 9076
+nc -zv <your-public-ip> 30303
 ```
 
 Online port checkers:
@@ -219,13 +219,13 @@ Online port checkers:
 3. **Check ports are not blocked**
    ```bash
    # Check locally if ports are listening
-   sudo netstat -tulpn | grep -E "30303|9076"
+   sudo netstat -tulpn | grep -E "30303|30303"
    ```
    
    Expected output:
    ```
    udp6       0      0 :::30303              :::*                  <pid>/java
-   tcp6       0      0 :::9076               :::*                  <pid>/java
+   tcp6       0      0 :::30303               :::*                  <pid>/java
    ```
 
 4. **Check firewall rules**
@@ -251,11 +251,11 @@ fukuii.network.discovery.discovery-enabled = true
 ```bash
 # Ubuntu/Debian with ufw
 sudo ufw allow 30303/udp
-sudo ufw allow 9076/tcp
+sudo ufw allow 30303/tcp
 
 # RHEL/CentOS with firewalld
 sudo firewall-cmd --permanent --add-port=30303/udp
-sudo firewall-cmd --permanent --add-port=9076/tcp
+sudo firewall-cmd --permanent --add-port=30303/tcp
 sudo firewall-cmd --reload
 ```
 
@@ -265,7 +265,7 @@ If behind NAT/router:
 
 1. Log in to your router admin interface
 2. Forward port 30303 (UDP) to your node's internal IP
-3. Forward port 9076 (TCP) to your node's internal IP
+3. Forward port 30303 (TCP) to your node's internal IP
 4. Or enable UPnP in Fukuii config:
    ```hocon
    fukuii.network.automatic-port-forwarding = true

--- a/docs/runbooks/security.md
+++ b/docs/runbooks/security.md
@@ -54,7 +54,7 @@ Fukuii uses three main ports:
 | Port | Protocol | Purpose | Exposure |
 |------|----------|---------|----------|
 | 30303 | UDP | Discovery | Public (required for peer discovery) |
-| 9076 | TCP | P2P Ethereum | Public (required for full participation) |
+| 30303 | TCP | P2P Ethereum | Public (required for full participation) |
 | 8546 | TCP | JSON-RPC HTTP | **PRIVATE** (internal only) |
 
 **Critical**: Never expose RPC ports (8546, 8545) to the public internet.
@@ -67,7 +67,7 @@ Fukuii uses three main ports:
 Internet
     │
     ├─── Port 30303 (UDP) ──→ Fukuii Discovery
-    ├─── Port 9076 (TCP) ──→ Fukuii P2P
+    ├─── Port 30303 (TCP) ──→ Fukuii P2P
     │
 Internal Network
     │
@@ -100,7 +100,7 @@ Internet
 # AWS Security Group example
 # Public subnet: Discovery + P2P
 Inbound: 30303/UDP from 0.0.0.0/0
-Inbound: 9076/TCP from 0.0.0.0/0
+Inbound: 30303/TCP from 0.0.0.0/0
 
 # Private subnet: RPC
 Inbound: 8546/TCP from 10.0.0.0/16 (internal only)
@@ -130,7 +130,7 @@ sudo ufw allow from YOUR_IP_ADDRESS to any port 22 proto tcp
 sudo ufw allow 30303/udp comment 'Fukuii discovery'
 
 # Allow Fukuii P2P (required for full node operation)
-sudo ufw allow 9076/tcp comment 'Fukuii P2P'
+sudo ufw allow 30303/tcp comment 'Fukuii P2P'
 
 # DO NOT allow RPC from internet
 # sudo ufw deny 8546/tcp comment 'Fukuii RPC blocked'
@@ -154,7 +154,7 @@ Status: active
      --                         ------      ----
 [ 1] 22/tcp                     ALLOW IN    YOUR_IP_ADDRESS
 [ 2] 30303/udp                  ALLOW IN    Anywhere
-[ 3] 9076/tcp                   ALLOW IN    Anywhere
+[ 3] 30303/tcp                   ALLOW IN    Anywhere
 [ 4] 8546/tcp                   ALLOW IN    10.0.1.5
 [ 5] 8546/tcp                   ALLOW IN    10.0.1.6
 ```
@@ -175,7 +175,7 @@ sudo firewall-cmd --permanent --add-service=ssh
 
 # Allow Fukuii ports
 sudo firewall-cmd --permanent --add-port=30303/udp
-sudo firewall-cmd --permanent --add-port=9076/tcp
+sudo firewall-cmd --permanent --add-port=30303/tcp
 
 # Restrict RPC to specific source IPs
 sudo firewall-cmd --permanent --add-rich-rule='
@@ -230,7 +230,7 @@ iptables -A INPUT -p tcp --dport 22 -s YOUR_IP_ADDRESS -j ACCEPT
 iptables -A INPUT -p udp --dport 30303 -j ACCEPT
 
 # Allow Fukuii P2P (TCP)
-iptables -A INPUT -p tcp --dport 9076 -j ACCEPT
+iptables -A INPUT -p tcp --dport 30303 -j ACCEPT
 
 # Allow RPC only from internal network
 iptables -A INPUT -p tcp --dport 8546 -s 10.0.0.0/16 -j ACCEPT
@@ -254,7 +254,7 @@ When running Fukuii in Docker, configure firewall on the host:
 docker run -d \
   --name fukuii \
   -p 30303:30303/udp \
-  -p 9076:9076/tcp \
+  -p 30303:30303/tcp \
   ghcr.io/chippr-robotics/fukuii:v1.0.0
 
 # INSECURE: Do NOT do this
@@ -286,7 +286,7 @@ iptables -I DOCKER-USER -i eth0 -s 10.0.1.0/24 -p tcp --dport 8546 -j ACCEPT
 # Public node group
 Inbound:
   - Type: Custom UDP, Port: 30303, Source: 0.0.0.0/0
-  - Type: Custom TCP, Port: 9076, Source: 0.0.0.0/0
+  - Type: Custom TCP, Port: 30303, Source: 0.0.0.0/0
   - Type: SSH, Port: 22, Source: YOUR_IP/32
 
 Outbound:
@@ -303,7 +303,7 @@ gcloud compute firewall-rules create fukuii-discovery \
 
 # Allow P2P
 gcloud compute firewall-rules create fukuii-p2p \
-  --allow tcp:9076 \
+  --allow tcp:30303 \
   --source-ranges 0.0.0.0/0 \
   --target-tags fukuii-node
 ```
@@ -870,7 +870,7 @@ sudo grep "sudo:" /var/log/auth.log
 **Monitor connections:**
 ```bash
 # Active connections to Fukuii
-sudo netstat -antp | grep -E "9076|30303|8546"
+sudo netstat -antp | grep -E "30303|30303|8546"
 
 # Detect unauthorized RPC access
 sudo tcpdump -i eth0 port 8546 -n
@@ -950,7 +950,7 @@ Schedule with cron:
 ### Pre-Deployment
 
 - [ ] Operating system hardened and updated
-- [ ] Firewall configured (allow only 30303/UDP and 9076/TCP)
+- [ ] Firewall configured (allow only 30303/UDP and 30303/TCP)
 - [ ] RPC not exposed to public internet
 - [ ] SSH hardened (key-based auth, no root login)
 - [ ] Dedicated user account created for Fukuii

--- a/docs/tools/wizard-app.js
+++ b/docs/tools/wizard-app.js
@@ -194,7 +194,7 @@ const advancedConfigSections = {
     description: 'P2P networking, peer management, and discovery settings',
     fields: {
       'fukuii.network.server-address.interface': { label: 'P2P Interface', type: 'text', default: '0.0.0.0', description: 'Network interface for P2P connections' },
-      'fukuii.network.server-address.port': { label: 'P2P Port', type: 'number', default: 9076, description: 'Port for Ethereum P2P protocol' },
+      'fukuii.network.server-address.port': { label: 'P2P Port', type: 'number', default: 30303, description: 'Port for Ethereum P2P protocol' },
       'fukuii.network.discovery.discovery-enabled': { label: 'Enable Discovery', type: 'boolean', default: true, description: 'Enable peer discovery protocol' },
       'fukuii.network.discovery.port': { label: 'Discovery Port', type: 'number', default: 30303, description: 'UDP port for peer discovery' },
       'fukuii.network.automatic-port-forwarding': { label: 'UPnP Port Forwarding', type: 'boolean', default: true, description: 'Automatically configure router port forwarding' }

--- a/docs/troubleshooting/BLOCK_SYNC_TROUBLESHOOTING.md
+++ b/docs/troubleshooting/BLOCK_SYNC_TROUBLESHOOTING.md
@@ -8,7 +8,7 @@ This document provides solutions for block synchronization. All documented issue
 
 | Scenario | Solution | Status |
 |----------|----------|--------|
-| ForkId mismatch at block 0 | Automatic — uses latest fork in ForkId | ✅ Fixed |
+| ForkId mismatch at block 0 | Pure EIP-2124 validation — genesis ForkId is spec-correct | ✅ Resolved |
 | Peers disconnect after handshake | Automatic — bootstrap checkpoints enabled | ✅ Fixed |
 | Zero stable peers | Check firewall + manual connections available | ✅ Documented |
 
@@ -93,7 +93,7 @@ Since our ForkId is correct for block 0, investigate why peers reject us:
 
 1. **Check Peer Implementation**: Verify the peer software versions accepting connections
 2. **Network Conditions**: Ensure stable network connectivity to bootstrap nodes
-3. **Firewall Rules**: Verify TCP/UDP ports 30303 and 9076 are properly configured
+3. **Firewall Rules**: Verify TCP/UDP ports 30303 and 30303 are properly configured
 4. **DNS Resolution**: Ensure bootstrap node addresses resolve correctly
 
 ### Option 3: Alternative Bootstrap Strategy
@@ -119,7 +119,7 @@ After updating configuration:
    ```bash
    ./bin/fukuii etc 2>&1 | grep -A 2 "Sending status"
    ```
-   Should show: `forkId=ForkId(0xbe46d57c, None)` or similar valid ForkId
+   At block 0, should show: `forkId=ForkId(0xfc64ec04, Some(1150000))` for ETC mainnet; the ForkId advances per EIP-2124 as the node syncs
 
 2. **Monitor Peer Connections**:
    ```bash
@@ -169,33 +169,15 @@ Full fork list comparison with core-geth `params/config_classic.go`:
 
 **Result**: Configuration matches core-geth perfectly. ForkId calculation is correct.
 
-## Solution Implemented (Default Behavior)
+## Current Behavior: Pure EIP-2124 ForkId Validation
 
-### ForkId Reporting at Block 0
+Fukuii implements **pure EIP-2124 ForkId validation** with no workarounds. The ForkId is always calculated from the node's actual chain head (`ForkId.create()` in `src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala`):
 
-**As of this version**, Fukuii now implements a practical workaround to match core-geth behavior:
+- At block 0 (unsynced), ETC mainnet reports `ForkId(0xfc64ec04, Some(1150000))` — the CRC32 of the genesis hash, with Homestead (1,150,000) as the next fork. This matches core-geth's expected value for an unsynced node.
+- As the node syncs past each fork block, the ForkId hash and `next` value advance per EIP-2124.
+- A fully synced ETC mainnet node (past Spiral at 19,250,000) reports `ForkId(0xbe46d57c, None)`.
 
-When a node is at block 0, it reports the **latest known fork** in its ForkId instead of the genesis fork. This prevents peer rejections while maintaining protocol compatibility.
-
-**Implementation:**
-- At block 0: Reports `ForkId(0xbe46d57c, None)` (Spiral fork for ETC mainnet)
-- At block 1+: Reports correct ForkId based on actual block height per EIP-2124
-
-**Why this works:**
-1. Peers running Core-Geth v1.12.20+ expect modern ForkId values
-2. Reporting the latest fork prevents immediate disconnection (error 0x10)
-3. Once the node syncs past block 0, normal ForkId reporting resumes
-4. This matches core-geth's practical approach to initial peer connections
-
-**Code changes:**
-- Modified `ForkId.create()` in `src/main/scala/com/chipprbots/ethereum/forkid/ForkId.scala`
-- Updated test cases to verify the new behavior
-
-### No Configuration Required
-
-This is now the **default behavior** - no configuration flags or changes needed. The workaround is applied automatically when:
-- Node is at block 0 (unsynced)
-- Fork list is available from blockchain configuration
+Per EIP-2124, remote peers must accept a node advertising the genesis ForkId as a stale-but-compatible peer that can still sync. No configuration is required.
 
 ### Understanding the Issue (Historical Context)
 
@@ -204,11 +186,11 @@ The ForkId mismatch issue occurred because:
 2. **Peer nodes** (at block 19,250,000+) report ForkId `0xbe46d57c, next: None`
 3. **Peers disconnected** with reason code 0x10 due to perceived incompatibility
 
-This was a **peer-side strictness issue**. While our original ForkId was technically correct per EIP-2124, it was practically incompatible with modern peer implementations.
+This was a **peer-side strictness issue**. Our ForkId was (and is) correct per EIP-2124; some peer implementations were observed disconnecting nodes that were far behind, despite the spec requiring acceptance of stale-but-compatible peers.
 
-### Previous Workarounds (No Longer Needed)
+### Optional Measures
 
-The following workarounds are no longer necessary with the implemented fix, but may still be useful in some situations:
+The following measures are not required for ForkId compatibility, but may still be useful in some situations:
 
 #### Bootstrap Checkpoints
 
@@ -227,8 +209,8 @@ If you experience connection issues, you can still add known-stable peers:
 # In application.conf
 fukuii.network.peer {
   manual-connections = [
-    "enode://fbcd6fc04fa7ea897558c3f5edf1cd192e3b2c3b5b9b3d00be179b2e9d04e623e017ed6ce6a1369fff126661afa1c5caa12febce92dcb70ff1352b86e9ebb44f@18.193.251.235:9076?discport=30303",
-    "enode://1619217a01fb87a745bb104872aa84314a2d42d99c7b915cd187245bfd898d679cbf78b3ea950c32051db860e2c4e3fe7d6329107587be33ab37541ca65046f91@18.198.165.189:9076?discport=30303",
+    "enode://fbcd6fc04fa7ea897558c3f5edf1cd192e3b2c3b5b9b3d00be179b2e9d04e623e017ed6ce6a1369fff126661afa1c5caa12febce92dcb70ff1352b86e9ebb44f@18.193.251.235:30303?discport=30303",
+    "enode://1619217a01fb87a745bb104872aa84314a2d42d99c7b915cd187245bfd898d679cbf78b3ea950c32051db860e2c4e3fe7d6329107587be33ab37541ca65046f91@18.198.165.189:30303?discport=30303",
   ]
 }
 ```
@@ -237,17 +219,17 @@ fukuii.network.peer {
 
 **Issue: RESOLVED** ✅
 
-Nodes starting from block 0 now report the latest fork in their ForkId, matching core-geth behavior and preventing peer rejections. No configuration changes required.
+Fukuii reports the spec-correct EIP-2124 ForkId at every block height, including block 0. No configuration changes required.
 
 ### Verification
 
-To verify the fix is working:
+To verify ForkId reporting:
 
 1. **Check ForkId at Startup**:
    ```bash
    ./bin/fukuii etc 2>&1 | grep "Sending status"
    ```
-   At block 0, should show: `forkId=ForkId(0xbe46d57c, None)` for ETC mainnet
+   At block 0, should show: `forkId=ForkId(0xfc64ec04, Some(1150000))` for ETC mainnet (the genesis ForkId per EIP-2124)
 
 2. **Monitor Peer Connections**:
    ```bash

--- a/docs/troubleshooting/FAILURE_TRACKING.md
+++ b/docs/troubleshooting/FAILURE_TRACKING.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Nightly Test Failure Tracking
 
 ## Current Status

--- a/docs/troubleshooting/LOG_REVIEW_RESOLUTION.md
+++ b/docs/troubleshooting/LOG_REVIEW_RESOLUTION.md
@@ -6,11 +6,12 @@ This document provides technical reference for network protocol compatibility. A
 
 | Protocol | Status | Notes |
 |----------|--------|-------|
-| ETH63 | ✅ Supported | Legacy support |
-| ETH64/65 | ✅ Supported | Full compatibility |
-| ETH66 | ✅ Supported | Request-id wrapped messages |
-| ETH67 | ✅ Supported | NewPooledTransactionHashes v2 |
-| ETH68 | ✅ Supported | Current production version |
+| ETH68 | ✅ Advertised | Production version |
+| ETH69 | ✅ Advertised | Latest ETH protocol version |
+| SNAP1 | ✅ Advertised | SNAP state sync |
+| ETH63–ETH67 | ❌ Not advertised | Removed from `supportedCapabilities`; legacy message codecs/adaptation code remain in the codebase but these versions are no longer negotiated with peers |
+
+Advertised capabilities are defined in `supportedCapabilities` in `src/main/scala/com/chipprbots/ethereum/utils/InstanceConfig.scala`.
 
 ---
 

--- a/docs/troubleshooting/LOW_HANGING_FRUIT_ANALYSIS.md
+++ b/docs/troubleshooting/LOW_HANGING_FRUIT_ANALYSIS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Low-Hanging Fruit Analysis: Remaining Test Failures
 
 ## Quick Assessment of Remaining Categories

--- a/docs/troubleshooting/NIGHTLY_RUN_ANALYSIS_2025-12-19.md
+++ b/docs/troubleshooting/NIGHTLY_RUN_ANALYSIS_2025-12-19.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Nightly Test Run Analysis - December 19, 2025
 
 ## Executive Summary

--- a/docs/troubleshooting/QUICK_REFERENCE_FAILURES.md
+++ b/docs/troubleshooting/QUICK_REFERENCE_FAILURES.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Quick Reference: Nightly Test Failures - Dec 19, 2025
 
 ## TL;DR

--- a/docs/validation/CIRITH_UNGOL_WALKTHROUGH.md
+++ b/docs/validation/CIRITH_UNGOL_WALKTHROUGH.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Cirith Ungol E2E Validation Walkthrough
 
 **Purpose**: Real-world validation of Fukuii using public ETC mainnet and Mordor testnet for SNAP/Fast sync testing with diverse node types and network traffic.

--- a/docs/validation/EXECUTIVE_SUMMARY.md
+++ b/docs/validation/EXECUTIVE_SUMMARY.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # ETC64 Removal Validation - Executive Summary
 
 ## Overview

--- a/docs/validation/GORGOROTH_3NODE_WALKTHROUGH.md
+++ b/docs/validation/GORGOROTH_3NODE_WALKTHROUGH.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Gorgoroth 3-Node E2E Validation Walkthrough
 
 **Purpose**: Complete step-by-step guide for validating Fukuii self-consistency in a 3-node test network. This test validates that Fukuii is functional and self-consistent by testing Fukuii nodes against themselves, covering mining, syncing, and block propagation.

--- a/docs/validation/GORGOROTH_6NODE_WALKTHROUGH.md
+++ b/docs/validation/GORGOROTH_6NODE_WALKTHROUGH.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Gorgoroth Multi-Client Validation Walkthrough (6/9-node)
 
 **Last Updated**: December 21, 2025

--- a/docs/validation/GORGOROTH_SNAP_SYNC_VALIDATION.md
+++ b/docs/validation/GORGOROTH_SNAP_SYNC_VALIDATION.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Gorgoroth 3-Node Snap Sync Validation Plan
 
 **Objective:** Prove that a late-joining Fukuii node can snap-sync to an in-flight 3-node Gorgoroth network while only node1 is mining. The plan enforces DAG creation, sustained mining, follower validation, and snap-sync log capture using the `ops/tools/fukuii-cli.sh` helper.

--- a/docs/validation/GORGOROTH_STATUS.md
+++ b/docs/validation/GORGOROTH_STATUS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Gorgoroth Battlenet - Complete Testing Status & Validation Checklist
 
 **Last Updated**: December 21, 2025  

--- a/docs/validation/GORGOROTH_VALIDATION_STATUS.md
+++ b/docs/validation/GORGOROTH_VALIDATION_STATUS.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # Gorgoroth Network - Validation Status
 
 **Last Updated**: December 21, 2025  

--- a/docs/validation/P2P_COMMUNICATION_VALIDATION_GUIDE.md
+++ b/docs/validation/P2P_COMMUNICATION_VALIDATION_GUIDE.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # P2P Communication Validation Guide for ETC64 Removal
 
 ## Purpose

--- a/docs/validation/SNAP_MESSAGE_OFFSET_VALIDATION.md
+++ b/docs/validation/SNAP_MESSAGE_OFFSET_VALIDATION.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # SNAP Message Offset Validation
 
 **Date:** 2025-12-12  

--- a/docs/validation/SNAP_MESSAGE_PROCESSING_COMPLETE.md
+++ b/docs/validation/SNAP_MESSAGE_PROCESSING_COMPLETE.md
@@ -1,3 +1,6 @@
+> **📁 Historical document** — archived 2026-06-12 during the post-0.7.0 documentation audit.
+> Point-in-time record kept for reference; not maintained and may not reflect the current implementation.
+
 # SNAP Message Processing Validation - Complete
 
 **Date:** 2025-12-12  

--- a/ops/grafana/ETC Node/fukuii-node-health.json
+++ b/ops/grafana/ETC Node/fukuii-node-health.json
@@ -657,7 +657,7 @@
       },
       "targets": [
         {
-          "expr": "jvm_memory_bytes_used{area=\"heap\",instance=~\"$instance\"}",
+          "expr": "jvm_memory_used_bytes{area=\"heap\",instance=~\"$instance\"}",
           "refId": "A",
           "legendFormat": "{{instance}} used"
         },


### PR DESCRIPTION
## What

Audited **all 181 documentation pages** against the current implementation (post-0.7.0) with an 8-lens doc-vs-code comparison; every flagged claim was re-verified against source before editing. Result: **114 accurate / 20 updated / 24 archived** (+2 ADR status touches).

### Updated (high-signal corrections)
- **Protocol docs** claimed we advertise eth/65–67: reality is **ETH68/ETH69/SNAP1** (`InstanceConfig.scala`) — capability lists, negotiation examples, and compatibility matrices reworked; ETH69 row added (no TD in Status → chain-weight calibration).
- **`healing-frontier-scale.md`** described the retired DFS walk: now documents the **level-order BFS** rebuild (CF-backed queue, multiGet, single-flight, `[HEAL-BFS]` prefixes), Layer-2 **default-on**, Layer-3 **delivered** via #1323/#1325.
- **ForkId troubleshooting** asserted a never-implemented "report latest fork at block 0" workaround and the wrong genesis ForkId — corrected to `ForkId(0xfc64ec04, Some(1150000))` (verified against handshaker tests).
- **P2P port 9076 → 30303** in 18 files (base `network.conf` default changed; ADRs left as immutable records).
- JDK 21→25, Scala 3.3.4→3.3.7, `temurin:25-jre-noble`, jar examples → 0.7.0, MCP protocol rev, Grafana path → `ops/grafana/Sync/`, API counts stated honestly (97 cataloged / 77 fully documented).
- **SNAP cold-start summary**: genesis-pivot description now matches the guarded implementation (verified `SNAPSyncController.scala:2155-2241`).

### Archived
24 point-in-time pages (2025-12 nightly-failure analyses, Gorgoroth walkthroughs, SNAP validation checkpoints, RLPx investigations) got a dated **📁 Historical** banner — content preserved, clearly labeled non-maintained. No files moved (no broken links).

### Guard-rails used
- One audit finding was **rejected on verification** (`metrics-and-monitoring.md`'s dashboard path is actually correct — file untouched).
- One was **re-attributed** to the right file by the applying agent (cold-start claim lived in `..._IMPLEMENTATION_SUMMARY.md`).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)