### PR TITLE
feat(snap): wire the registered-but-never-emitted SNAP metrics

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/MerkleProofVerifier.scala
@@ -29,6 +29,12 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
 
   // ─── Public API ────────────────────────────────────────────────────────────
 
+  /** Emit the invalid-proof counter for any verification failure surfaced to callers. */
+  private def counted(result: Either[String, Unit]): Either[String, Unit] = {
+    if (result.isLeft) SNAPSyncMetrics.incrementInvalidProof()
+    result
+  }
+
   def verifyAccountRange(
       accounts: Seq[(ByteString, Account)],
       proof: Seq[ByteString],
@@ -40,16 +46,16 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
       val leaves = accounts.map { case (h, a) => h -> ByteString(Account.accountSerializer.toBytes(a)) }
       if (proof.isEmpty) {
         // Nil proof: full trie response, verify by streaming hash (geth: StackTrie path)
-        return verifyCompleteRange(leaves)
+        return counted(verifyCompleteRange(leaves))
       }
       val proofRawMap = buildProofRawMap(proof)
-      verifyRangeProofByReconstruction(startHash, endHash, leaves, proofRawMap)
+      counted(verifyRangeProofByReconstruction(startHash, endHash, leaves, proofRawMap))
     } catch {
       case e: Throwable =>
         // Catch Throwable (not just Exception) — StackOverflowError from deep recursive insertion
         // must be surfaced as a verification failure rather than silently hanging the caller.
         log.warn(s"Merkle proof verification error: ${e.getClass.getSimpleName}: ${e.getMessage}")
-        Left(s"Verification error: ${e.getClass.getSimpleName}: ${e.getMessage}")
+        counted(Left(s"Verification error: ${e.getClass.getSimpleName}: ${e.getMessage}"))
     }
   }
 
@@ -62,14 +68,14 @@ class MerkleProofVerifier(rootHash: ByteString) extends Logger {
     if (proof.isEmpty && slots.isEmpty) return Right(())
     try {
       if (proof.isEmpty) {
-        return verifyCompleteRange(slots)
+        return counted(verifyCompleteRange(slots))
       }
       val proofRawMap = buildProofRawMap(proof)
-      verifyRangeProofByReconstruction(startHash, endHash, slots, proofRawMap)
+      counted(verifyRangeProofByReconstruction(startHash, endHash, slots, proofRawMap))
     } catch {
       case e: Throwable =>
         log.warn(s"Storage Merkle proof verification error: ${e.getClass.getSimpleName}: ${e.getMessage}")
-        Left(s"Storage verification error: ${e.getClass.getSimpleName}: ${e.getMessage}")
+        counted(Left(s"Storage verification error: ${e.getClass.getSimpleName}: ${e.getMessage}"))
     }
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPRequestTracker.scala
@@ -33,6 +33,32 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
   /** Per-peer adaptive rate tracker (geth msgrate port) */
   val rateTracker: PeerRateTracker = new PeerRateTracker()
 
+  // ── Prometheus wiring ────────────────────────────────────────────────────────────────────
+  // The tracker sees every SNAP request (dispatch, completion, timeout) with its type, so the
+  // per-phase request counters, download timers, and the timeout counter are emitted here in
+  // one place instead of in each coordinator. Validation methods below emit the malformed-
+  // response counter on structural violations (late responses are NOT counted as malformed).
+  private def recordDispatchMetric(t: RequestType): Unit = t match {
+    case RequestType.GetAccountRange  => SNAPSyncMetrics.incrementAccountRangeRequests()
+    case RequestType.GetStorageRanges => SNAPSyncMetrics.incrementStorageRangeRequests()
+    case RequestType.GetByteCodes     => SNAPSyncMetrics.incrementBytecodeRequests()
+    case RequestType.GetTrieNodes     => SNAPSyncMetrics.incrementHealingRequests()
+  }
+
+  private def recordFailureMetric(t: RequestType): Unit = t match {
+    case RequestType.GetAccountRange  => SNAPSyncMetrics.incrementAccountRangeFailures()
+    case RequestType.GetStorageRanges => SNAPSyncMetrics.incrementStorageRangeFailures()
+    case RequestType.GetByteCodes     => SNAPSyncMetrics.incrementBytecodeFailures()
+    case RequestType.GetTrieNodes     => SNAPSyncMetrics.incrementHealingFailures()
+  }
+
+  private def recordDownloadTime(t: RequestType, elapsedMs: Long): Unit = t match {
+    case RequestType.GetAccountRange  => SNAPSyncMetrics.recordAccountRangeDownloadTime(elapsedMs)
+    case RequestType.GetStorageRanges => SNAPSyncMetrics.recordStorageRangeDownloadTime(elapsedMs)
+    case RequestType.GetByteCodes     => SNAPSyncMetrics.recordBytecodeDownloadTime(elapsedMs)
+    case RequestType.GetTrieNodes     => SNAPSyncMetrics.recordStateHealingTime(elapsedMs)
+  }
+
   private def compareUnsignedLexicographically(a: ByteString, b: ByteString): Int = {
     val minLen = math.min(a.length, b.length)
     var i = 0
@@ -84,6 +110,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
       timeout: FiniteDuration = Duration.Zero // Zero = use adaptive
   )(onTimeout: => Unit): PendingRequest = synchronized {
     val effectiveTimeout = if (timeout == Duration.Zero) rateTracker.targetTimeout() else timeout
+    recordDispatchMetric(requestType)
     val request = PendingRequest(
       requestId = requestId,
       peer = peer,
@@ -103,6 +130,8 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
           // Record timeout in rate tracker (items=0 slashes capacity to zero)
           val msgType = requestTypeToMsgType(req.requestType)
           rateTracker.update(peer.id.value, msgType, elapsed, items = 0)
+          SNAPSyncMetrics.incrementRequestTimeout()
+          recordFailureMetric(req.requestType)
           pendingRequests.remove(requestId)
           onTimeout
         }
@@ -153,6 +182,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
       // Record measurement in rate tracker
       val msgType = requestTypeToMsgType(request.requestType)
       rateTracker.update(request.peer.id.value, msgType, elapsed, responseItems)
+      recordDownloadTime(request.requestType, elapsed)
 
       log.debug(
         s"SNAP request ${request.requestType} completed for request ID $requestId " +
@@ -178,6 +208,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
 
       // Verify it's the expected type
       if (pending.requestType != RequestType.GetAccountRange) {
+        SNAPSyncMetrics.incrementMalformedResponse()
         Left(s"Expected ${RequestType.GetAccountRange} but got response for ${pending.requestType}")
       } else {
         // Check accounts are monotonically increasing
@@ -187,8 +218,10 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
           compareUnsignedLexicographically(prevHash, currHash) >= 0
         }
         violation match {
-          case Some(i) => Left(s"Accounts not monotonically increasing at index $i")
-          case None    => Right(response)
+          case Some(i) =>
+            SNAPSyncMetrics.incrementMalformedResponse()
+            Left(s"Accounts not monotonically increasing at index $i")
+          case None => Right(response)
         }
       }
     }
@@ -206,6 +239,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
     } else {
       val pending = getPendingRequest(response.requestId).get
       if (pending.requestType != RequestType.GetStorageRanges) {
+        SNAPSyncMetrics.incrementMalformedResponse()
         Left(s"Expected ${RequestType.GetStorageRanges} but got response for ${pending.requestType}")
       } else {
         // Validate storage slots are monotonically increasing within each account
@@ -220,6 +254,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
         }.flatten
         violation match {
           case Some((accountIdx, i)) =>
+            SNAPSyncMetrics.incrementMalformedResponse()
             Left(s"Storage slots not monotonically increasing for account $accountIdx at index $i")
           case None => Right(response)
         }
@@ -240,6 +275,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
 
     val pending = getPendingRequest(response.requestId).get
     if (pending.requestType != RequestType.GetByteCodes) {
+      SNAPSyncMetrics.incrementMalformedResponse()
       return Left(s"Expected ${RequestType.GetByteCodes} but got response for ${pending.requestType}")
     }
 
@@ -260,6 +296,7 @@ class SNAPRequestTracker(implicit scheduler: Scheduler) extends Logger {
 
     val pending = getPendingRequest(response.requestId).get
     if (pending.requestType != RequestType.GetTrieNodes) {
+      SNAPSyncMetrics.incrementMalformedResponse()
       return Left(s"Expected ${RequestType.GetTrieNodes} but got response for ${pending.requestType}")
     }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1178,11 +1178,13 @@ class SNAPSyncController(
         log.warning(
           s"Account trie validation found ${missing.size} missing nodes — triggering healing"
         )
+        SNAPSyncMetrics.setMissingNodesDetected(missing.size.toLong)
         validationInProgress = false
         triggerHealingForMissingNodes(missing)
       }
 
     case ValidateAccountTrieResult(_, Left(error), _) if currentPhase == StateValidation =>
+      SNAPSyncMetrics.incrementValidationFailure()
       log.error(s"Account trie validation failed: $error")
       if (error.contains("Missing root node")) {
         validationRetryCount += 1
@@ -1225,6 +1227,7 @@ class SNAPSyncController(
     // Storage trie validation result handlers.
     case ValidateStorageTriesResult(_, Right(missing), elapsedMs) if currentPhase == StateValidation =>
       validationInProgress = false
+      SNAPSyncMetrics.setMissingNodesDetected(missing.size.toLong)
       if (missing.isEmpty) {
         log.info(s"Storage trie validation successful - no missing nodes (${elapsedMs}ms)")
         log.info("✅ State validation COMPLETE - all tries are intact")
@@ -1237,6 +1240,7 @@ class SNAPSyncController(
       }
 
     case ValidateStorageTriesResult(_, Left(error), _) if currentPhase == StateValidation =>
+      SNAPSyncMetrics.incrementValidationFailure()
       log.error(s"Storage trie validation failed: $error. Recovering through healing phase")
       validationInProgress = false
       currentPhase = StateHealing
@@ -2428,6 +2432,7 @@ class SNAPSyncController(
     *   true if we should fallback to fast sync
     */
   private def recordCriticalFailure(reason: String): Boolean = {
+    SNAPSyncMetrics.incrementSyncError()
     criticalFailureCount += 1
     accountsAtLastCriticalFailure = progressMonitor.currentProgress.accountsSynced
     log.warning(s"Critical SNAP sync failure ($criticalFailureCount/${snapSyncConfig.maxSnapSyncFailures}): $reason")

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
@@ -173,8 +173,9 @@ object SNAPSyncMetrics extends MetricsContainer {
   final private val HealingActiveRequestsGauge =
     metrics.registry.gauge("snapsync.healing.active.requests.gauge", new AtomicLong(0L))
 
-  /** Nodes visited so far by the post-SNAP frontier-rebuild DFS (`[HEAL-RESTART-DFS]`). Climbs during the one-time
-    * full-state walk on restart; flat/zero once healing is steady-state or resumed from a persisted frontier.
+  /** Nodes visited so far by the post-SNAP frontier-rebuild BFS walk (`[HEAL-BFS]` log lines). Climbs during a
+    * full-state walk (resets when a new walk starts); flat once healing is steady-state or resumed from a complete
+    * persisted frontier.
     */
   final private val HealingRebuildVisitedGauge =
     metrics.registry.gauge("snapsync.healing.rebuild.visited.gauge", new AtomicLong(0L))

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/AccountRangeCoordinator.scala
@@ -1315,6 +1315,7 @@ class AccountRangeCoordinator(
     */
   private def requeueOrEscalate(task: AccountTask, reason: String): Unit = {
     task.requeueCount += 1
+    com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.incrementRequestRetry()
     if (task.requeueCount > AccountRangeCoordinator.MaxRequeuesPerTask) {
       log.error(
         s"Account task ${task.rangeString} exhausted requeue budget " +

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/ByteCodeCoordinator.scala
@@ -448,6 +448,7 @@ class ByteCodeCoordinator(
   private def notifyBackpressureIfChanged(): Unit = {
     val pending = pendingTasks.size
     com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setByteCodeQueueDepth(pending.toLong)
+    com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setByteCodeActivePeers(knownAvailablePeers.size)
     if (!backpressureActive && pending >= backpressureHighWatermark) {
       backpressureActive = true
       com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setByteCodeBackpressure(true)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/StorageRangeCoordinator.scala
@@ -565,6 +565,9 @@ class StorageRangeCoordinator(
   private def notifyBackpressureIfChanged(): Unit = {
     val pending = tasks.size
     com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setStorageQueueDepth(pending.toLong)
+    com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setStorageActivePeers(
+      (knownAvailablePeers.size - statelessPeers.size).max(0)
+    )
     if (!backpressureActive && pending >= backpressureHighWatermark) {
       backpressureActive = true
       com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncMetrics.setStorageBackpressure(true)


### PR DESCRIPTION
## What

The [post-0.7.0 metrics audit](https://github.com/chippr-robotics/fukuii/pull/1330) found **17 SNAP metrics registered but never emitted** — the SNAP dashboard's *Request Health* and *Data Integrity* rows have been rendering flat zeros since they were added. This wires all of them at natural chokepoints:

| Metrics | Wired at | Rationale |
|---|---|---|
| `*_requests_total` ×4 | `SNAPRequestTracker.trackRequest` | every request of every phase passes through the tracker — one switch, not 4 coordinators |
| download timers ×4 | `SNAPRequestTracker.completeRequest` | tracker already measures per-request `elapsed` with type |
| `requests_timeouts_total` + `*_failed_total` ×4 | tracker timeout callback | a timeout **is** a failed request; single emit point |
| `responses_malformed_total` | tracker `validate*` structural-violation branches | late responses deliberately **not** counted as malformed |
| `proofs_invalid_total` | `MerkleProofVerifier` public API | one definition of "proof failed" for accounts + storage |
| `requests_retries_total` | `AccountRangeCoordinator.requeueOrEscalate` | the codebase's one explicit requeue counter |
| `storage/bytecode_active_peers` | beside the wired queue-depth gauges | same cadence as proven siblings |
| `validation_missing_nodes` / `validation_failures_total` | `Validate*Result` handlers | account + storage validation outcomes |
| `errors_total` | `recordCriticalFailure` | crisp semantics: critical sync failures only |

Drive-by: `HealingRebuildVisitedGauge` doc-comment updated from the retired DFS/`[HEAL-RESTART-DFS]` to BFS/`[HEAL-BFS]`.

## Testing

- `SNAPRequestTrackerSpec`, `MerkleProofVerifierSpec`, `TrieNodeHealingCoordinatorSpec`: **68/68 PASS**
- `scalafmtCheckAll` clean
- No behavior changes — pure metric emission on existing code paths (all increments are Micrometer counter/gauge/timer ops, no hot per-item loops; request-level cadence only).

## After this lands

The metrics-reference page (#1330) can drop its 17 "Reserved (always 0)" annotations, and the Request Health / Data Integrity dashboard rows become live. Suggest merging #1330 first (it documents current reality), then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)