### PR TITLE
perf(snap): native range tombstones for the BFS level queue

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -1269,6 +1269,11 @@ class TrieNodeHealingCoordinator(
       )
       SNAPSyncMetrics.setHealingRebuildVisited(visitedCount.get())
 
+      // Free the consumed level immediately (one range tombstone). Levels are processed exactly
+      // once and never re-read, and on ETC mainnet the live queue otherwise accumulates the whole
+      // walk (~140M entries, >10 GB) until the end-of-walk clear().
+      queue.deleteRange(levelStart, levelEnd)
+
       levelStart = levelEnd
       levelEnd = queue.counter
       levelIndex += 1

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
@@ -50,6 +50,15 @@ trait DataSource {
   def multiGetOptimized(namespace: Namespace, keys: Seq[Array[Byte]]): Seq[Option[Array[Byte]]] =
     keys.map(k => getOptimized(namespace, k))
 
+  /** Delete every key in `[fromKey, toKeyExclusive)` (lexicographic byte order) within `namespace`.
+    *
+    * Implementations should prefer a storage-native range delete over per-key tombstones: RocksDB writes a SINGLE range
+    * tombstone and reclaims space during compaction, whereas deleting N keys point-by-point writes N tombstones —
+    * observed live at ~140M keys this ground for ~30 minutes at full CPU and drove the container to the edge of its
+    * memory cgroup before the BFS healing walk could start.
+    */
+  def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit
+
   /** This function updates the DataSource by deleting, updating and inserting new (key-value) pairs. Implementations
     * should guarantee that the whole operation is atomic.
     */

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/EphemDataSource.scala
@@ -25,6 +25,30 @@ class EphemDataSource(var storage: Map[ByteBuffer, Array[Byte]]) extends DataSou
   override def getOptimized(namespace: Namespace, key: Array[Byte]): Option[Array[Byte]] =
     get(namespace, key.toIndexedSeq).map(_.toArray)
 
+  override def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit =
+    synchronized {
+      def cmp(a: Array[Byte], b: Array[Byte]): Int = {
+        val n = math.min(a.length, b.length)
+        var i = 0
+        var d = 0
+        while (i < n && d == 0) {
+          d = (a(i) & 0xff) - (b(i) & 0xff)
+          i += 1
+        }
+        if (d != 0) d else a.length - b.length
+      }
+      val ns = namespace.toArray
+      storage = storage.filter { case (k, _) =>
+        val raw = k.array()
+        val inNamespace = raw.length >= ns.length && raw.take(ns.length).sameElements(ns)
+        if (!inNamespace) true
+        else {
+          val suffix = raw.drop(ns.length)
+          !(cmp(suffix, fromKey) >= 0 && cmp(suffix, toKeyExclusive) < 0)
+        }
+      }
+    }
+
   override def update(dataSourceUpdates: Seq[DataUpdate]): Unit = synchronized {
     dataSourceUpdates.foreach {
       case DataSourceUpdate(namespace, toRemove, toUpsert) =>

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -108,6 +108,21 @@ class RocksDbDataSource(
   override def updateSync(dataSourceUpdates: Seq[DataUpdate]): Unit =
     doWrite(dataSourceUpdates, sync = true)
 
+  override def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit = {
+    dbLock.writeLock().lock()
+    try {
+      assureNotClosed()
+      // One native range tombstone for the whole interval — O(1) write, lazily reclaimed by
+      // compaction. Never expand a range into per-key deletes here (see DataSource.deleteRange).
+      db.deleteRange(handles(namespace), fromKey, toKeyExclusive)
+    } catch {
+      case error: RocksDbDataSourceClosedException =>
+        throw error
+      case NonFatal(error) =>
+        throw RocksDbDataSourceException(s"DataSource error while deleting range", error)
+    } finally dbLock.writeLock().unlock()
+  }
+
   private def doWrite(dataSourceUpdates: Seq[DataUpdate], sync: Boolean): Unit = {
     dbLock.writeLock().lock()
     try {

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
@@ -120,20 +120,19 @@ class RocksDbBfsQueueStorage(dataSource: DataSource, namespace: Namespace) exten
     }
   }
 
-  def deleteRange(from: Long, to: Long): Unit = {
-    val BatchSize = 10_000
-    var i = from
-    while (i < to) {
-      val end = math.min(to, i + BatchSize)
-      val keys = (i until end).map(longToBytes)
-      dataSource.update(Seq(DataSourceUpdateOptimized(namespace, toRemove = keys, toUpsert = Seq.empty)))
-      i = end
-    }
-  }
+  def deleteRange(from: Long, to: Long): Unit =
+    // Single native range tombstone — O(1) regardless of (to - from). The previous
+    // implementation expanded the range into 10K-key point-delete batches; clearing the
+    // ~140M-entry queue after a full ETC-mainnet walk wrote ~140M tombstones over ~30 minutes
+    // at full CPU (observed live 2026-06-12) while the next walk waited.
+    if (from < to) dataSource.deleteRange(namespace, longToBytes(from), longToBytes(to))
 
   def clear(): Unit = {
-    val current = writeCounter.get()
-    if (current > 0) deleteRange(0L, current)
+    // Tombstone the ENTIRE keyspace, not just [0, counter): the counter is in-memory only, so
+    // after a crash-restart it reads 0 while the column family still holds the dead walk's
+    // entries. The old `if (counter > 0)` guard skipped deletion entirely in that state,
+    // leaving the garbage on disk forever. Long.MaxValue exceeds any key ever assigned.
+    dataSource.deleteRange(namespace, longToBytes(0L), longToBytes(Long.MaxValue))
     writeCounter.set(0L)
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
@@ -1,0 +1,145 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.db.dataSource.{EphemDataSource, RocksDbConfig, RocksDbDataSource}
+import com.chipprbots.ethereum.testing.Tags._
+
+import java.io.File
+import java.nio.file.Files
+
+/** BfsQueueStorage over a real RocksDB instance — exercises the native range-tombstone delete path
+  * (`DataSource.deleteRange`) that replaced per-key tombstone batches. The per-key implementation wrote ~140M
+  * tombstones (~30 min at full CPU, observed live on ETC mainnet 2026-06-12) when clearing the queue after a full-state
+  * healing walk; the range tombstone is a single O(1) write.
+  *
+  * Also covers the crash-restart contract: the write counter is in-memory only, so a fresh storage instance over a
+  * column family still holding a dead walk's entries must `clear()` them despite `counter == 0`.
+  */
+class BfsQueueStorageSpec extends AnyFlatSpec with Matchers {
+
+  private def entry(i: Int): (Array[Byte], Seq[Array[Byte]], Boolean) =
+    (Array.fill(32)(i.toByte), Seq(Array(i.toByte, (i + 1).toByte)), i % 2 == 0)
+
+  private def drain(it: Iterator[Seq[BfsEntry]]): Seq[BfsEntry] = it.flatten.toSeq
+
+  private def withRocksDb(test: RocksDbDataSource => Unit): Unit = {
+    val dbPath = Files.createTempDirectory("bfs-queue-rocksdb").toAbsolutePath.toString
+    val dataSource = RocksDbDataSource(
+      new RocksDbConfig {
+        override val createIfMissing: Boolean = true
+        override val paranoidChecks: Boolean = true
+        override val path: String = dbPath
+        override val maxThreads: Int = 1
+        override val maxOpenFiles: Int = 32
+        override val verifyChecksums: Boolean = true
+        override val levelCompaction: Boolean = true
+        override val blockSize: Long = 16384
+        override val blockCacheSize: Long = 33554432
+      },
+      Namespaces.nsSeq
+    )
+    try test(dataSource)
+    finally {
+      dataSource.destroy()
+      val dir = new File(dbPath)
+      !dir.exists() || dir.delete()
+    }
+  }
+
+  "RocksDbBfsQueueStorage" should "round-trip entries through enqueueBatch/iterateRange" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 100).map(entry))
+      q.counter shouldBe 100L
+      val got = drain(q.iterateRange(0L, 100L, chunkSize = 7))
+      got.size shouldBe 100
+      got.head.hash.toSeq shouldBe Array.fill(32)(0.toByte).toSeq
+      got.last.pathset.head.toSeq shouldBe Seq(99.toByte, 100.toByte)
+      got.map(_.isStorage).count(identity) shouldBe 50
+    }
+
+  it should "delete exactly [from, to) with a native range tombstone" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 100).map(entry))
+      q.deleteRange(0L, 50L)
+      drain(q.iterateRange(0L, 50L)) shouldBe empty
+      drain(q.iterateRange(50L, 100L)).size shouldBe 50
+      // boundary: deleting an empty range is a no-op
+      q.deleteRange(70L, 70L)
+      drain(q.iterateRange(50L, 100L)).size shouldBe 50
+    }
+
+  it should "clear() the keyspace and reset the counter" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 64).map(entry))
+      q.clear()
+      q.counter shouldBe 0L
+      drain(q.iterateRange(0L, 64L)) shouldBe empty
+    }
+
+  it should "clear() a dead walk's entries after a simulated crash-restart (counter == 0)" taggedAs UnitTest in
+    withRocksDb { ds =>
+      // Walk 1 writes 100 entries, then the process "crashes" (instance dropped, no clear()).
+      val before = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      before.enqueueBatch((0 until 100).map(entry))
+
+      // Restart: fresh instance, in-memory counter back at 0 while the CF still holds 100 keys.
+      // The old guard (`if (counter > 0) deleteRange`) skipped deletion entirely here.
+      val after = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      after.counter shouldBe 0L
+      after.clear()
+
+      after.enqueueBatch((200 until 210).map(entry))
+      val fresh = drain(after.iterateRange(0L, 10L))
+      fresh.size shouldBe 10
+      fresh.head.hash.toSeq shouldBe Array.fill(32)(200.toByte).toSeq
+      // keys beyond the fresh writes must NOT resurrect the dead walk's entries
+      drain(after.iterateRange(10L, 100L)) shouldBe empty
+    }
+
+  it should "leave other namespaces untouched by deleteRange" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      val frontier = new HealingFrontierStorage(ds)
+      import org.apache.pekko.util.ByteString
+      val h = ByteString(Array.fill(32)(7.toByte))
+      frontier.put(h, Seq(ByteString(1.toByte))).commit()
+      q.enqueueBatch((0 until 10).map(entry))
+      q.clear()
+      frontier.get(h) shouldBe Some(Seq(ByteString(1.toByte)))
+    }
+
+  "EphemDataSource.deleteRange" should "honor namespace isolation and range boundaries" taggedAs UnitTest in {
+    val ds = EphemDataSource()
+    val nsA: IndexedSeq[Byte] = IndexedSeq('a'.toByte)
+    val nsB: IndexedSeq[Byte] = IndexedSeq('b'.toByte)
+    def key(i: Int): Array[Byte] = BfsQueueStorage.longToBytes(i.toLong)
+    (0 until 10).foreach(i => ds.update(keyUpsert(nsA, key(i))))
+    (0 until 10).foreach(i => ds.update(keyUpsert(nsB, key(i))))
+
+    ds.deleteRange(nsA, key(3), key(7))
+
+    (0 until 10).map(i => ds.getOptimized(nsA, key(i)).isDefined) shouldBe
+      Seq(true, true, true, false, false, false, false, true, true, true)
+    (0 until 10).forall(i => ds.getOptimized(nsB, key(i)).isDefined) shouldBe true
+  }
+
+  private def keyUpsert(ns: IndexedSeq[Byte], k: Array[Byte]) = {
+    import com.chipprbots.ethereum.db.dataSource.DataSourceUpdateOptimized
+    Seq(DataSourceUpdateOptimized(ns, toRemove = Seq.empty, toUpsert = Seq((k, Array(1.toByte)))))
+  }
+
+  "InMemoryBfsQueueStorage" should "match RocksDb semantics for deleteRange and clear" taggedAs UnitTest in {
+    val q = new InMemoryBfsQueueStorage()
+    q.enqueueBatch((0 until 20).map(entry))
+    q.deleteRange(5L, 15L)
+    drain(q.iterateRange(0L, 20L)).size shouldBe 10
+    q.clear()
+    q.counter shouldBe 0L
+    drain(q.iterateRange(0L, 20L)) shouldBe empty
+  }
+}


### PR DESCRIPTION
## What / Why

Live finding (ETC mainnet, 2026-06-12, during the first complete BFS healing walk): `BfsQueueStorage.clear()` expands the queue's full key range into **10K-key point-delete batches**. After the 119M-node walk the queue counter sat at ~140M — the clear wrote **~140M individual tombstones over ~30 minutes at full CPU**, drove the container to **91% of its memory cgroup**, and the follow-up verification walk sat silently blocked inside `clear()` the whole time (no logs, watchdog gated — looked like a hang).

| Layer | Change |
|---|---|
| `DataSource` | new `deleteRange(namespace, from, toExclusive)` primitive |
| `RocksDbDataSource` | native `db.deleteRange` — **one range tombstone**, O(1) write, compaction reclaims lazily; same write-lock/error pattern as `update` |
| `EphemDataSource` | in-map lexicographic range filter (test parity) |
| `BfsQueueStorage.deleteRange` | one DataSource call (fixed-width big-endian keys ⇒ byte order ≡ numeric order) |
| `BfsQueueStorage.clear()` | tombstones the **entire keyspace unconditionally** — the old `if (counter > 0)` guard silently no-opped after a crash-restart (counter is in-memory only), stranding the dead walk's ~14 GB on disk forever |
| `rebuildFrontierBFS` | **incremental cleanup**: each consumed level is tombstoned the moment it completes (≤18 tombstones/walk) — live queue disk bounded at ~2 levels instead of the whole walk |

## Testing

New `BfsQueueStorageSpec` (real RocksDB fixture): round-trip, exact `[from,to)` boundary semantics on the native path, **simulated crash-restart** (fresh instance, counter=0, stale CF — `clear()` must still purge), cross-namespace isolation (queue tombstone can't touch the healing-frontier CF), InMemory parity. Plus `TrieNodeHealingCoordinatorSpec` green. **32/32 pass**, scalafmt clean.

## Operational note

The node currently mid-verification runs the old code and just paid the 30-minute toll; this lands for the next walk-cycle and removes both the grind and the memory redline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)