### PR TITLE
fix(snap): skip the rebuild walk on restart when snapshot is complete and fully healed

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -362,12 +362,25 @@ class TrieNodeHealingCoordinator(
           val resumed: Option[Seq[HealingEntry]] = frontierStore.flatMap { store =>
             try {
               val loaded = store.loadAll().map { case (h, ps) => HealingEntry(pathset = ps, hash = h) }
-              if (loaded.nonEmpty && store.isComplete) {
+              if (store.isComplete && loaded.nonEmpty) {
                 // COMPLETE snapshot (the prior rebuild DFS finished) — safe to skip the full-state walk.
                 log.info(
                   s"[HEAL-RESTART] Resumed ${loaded.size} frontier entries from a complete persisted snapshot — skipping full-state DFS"
                 )
                 Some(loaded)
+              } else if (store.isComplete) {
+                // COMPLETE snapshot with an EMPTY frontier: the prior rebuild ran to completion AND every
+                // node it discovered was healed (entries are unpersisted as they heal). This is the
+                // best-possible restart state, but the old `loaded.nonEmpty && isComplete` gate fell
+                // through to a ~119M-node full re-walk (~24-36h on ETC mainnet) that can discover
+                // nothing new. Nothing to re-queue — skip the rebuild and run the verification pass,
+                // which still gates StateHealingComplete. (A pivot refresh clears the marker, so the
+                // marker being set implies the current root is the one the completed walk covered.)
+                log.info(
+                  "[HEAL-RESTART] Complete persisted snapshot with empty frontier (all discovered nodes " +
+                    "healed) — skipping full-state walk, running verification pass directly"
+                )
+                Some(Seq.empty)
               } else if (loaded.nonEmpty) {
                 // PARTIAL frontier: the prior rebuild DFS was interrupted before completion, so the un-walked
                 // region's missing nodes are not yet recorded. Skipping the DFS would silently leave gaps —
@@ -388,8 +401,11 @@ class TrieNodeHealingCoordinator(
             }
           }
           resumed match {
-            case Some(entries) =>
+            case Some(entries) if entries.nonEmpty =>
               selfRef ! FrontierRebuilt(entries)
+            case Some(_) =>
+              // Complete-and-empty: rebuild already proven done; verification alone decides completion.
+              startVerificationDFS(root, emptyPath)
             case None =>
               // Mark the persisted frontier authoritative when the full walk is done (all workers complete).
               startFrontierBFS(root, emptyPath, isStor = false, () => selfRef ! FrontierRebuildComplete)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -1269,6 +1269,11 @@ class TrieNodeHealingCoordinator(
       )
       SNAPSyncMetrics.setHealingRebuildVisited(visitedCount.get())
 
+      // Free the consumed level immediately (one range tombstone). Levels are processed exactly
+      // once and never re-read, and on ETC mainnet the live queue otherwise accumulates the whole
+      // walk (~140M entries, >10 GB) until the end-of-walk clear().
+      queue.deleteRange(levelStart, levelEnd)
+
       levelStart = levelEnd
       levelEnd = queue.counter
       levelIndex += 1

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/DataSource.scala
@@ -50,6 +50,15 @@ trait DataSource {
   def multiGetOptimized(namespace: Namespace, keys: Seq[Array[Byte]]): Seq[Option[Array[Byte]]] =
     keys.map(k => getOptimized(namespace, k))
 
+  /** Delete every key in `[fromKey, toKeyExclusive)` (lexicographic byte order) within `namespace`.
+    *
+    * Implementations should prefer a storage-native range delete over per-key tombstones: RocksDB writes a SINGLE range
+    * tombstone and reclaims space during compaction, whereas deleting N keys point-by-point writes N tombstones —
+    * observed live at ~140M keys this ground for ~30 minutes at full CPU and drove the container to the edge of its
+    * memory cgroup before the BFS healing walk could start.
+    */
+  def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit
+
   /** This function updates the DataSource by deleting, updating and inserting new (key-value) pairs. Implementations
     * should guarantee that the whole operation is atomic.
     */

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/EphemDataSource.scala
@@ -25,6 +25,30 @@ class EphemDataSource(var storage: Map[ByteBuffer, Array[Byte]]) extends DataSou
   override def getOptimized(namespace: Namespace, key: Array[Byte]): Option[Array[Byte]] =
     get(namespace, key.toIndexedSeq).map(_.toArray)
 
+  override def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit =
+    synchronized {
+      def cmp(a: Array[Byte], b: Array[Byte]): Int = {
+        val n = math.min(a.length, b.length)
+        var i = 0
+        var d = 0
+        while (i < n && d == 0) {
+          d = (a(i) & 0xff) - (b(i) & 0xff)
+          i += 1
+        }
+        if (d != 0) d else a.length - b.length
+      }
+      val ns = namespace.toArray
+      storage = storage.filter { case (k, _) =>
+        val raw = k.array()
+        val inNamespace = raw.length >= ns.length && raw.take(ns.length).sameElements(ns)
+        if (!inNamespace) true
+        else {
+          val suffix = raw.drop(ns.length)
+          !(cmp(suffix, fromKey) >= 0 && cmp(suffix, toKeyExclusive) < 0)
+        }
+      }
+    }
+
   override def update(dataSourceUpdates: Seq[DataUpdate]): Unit = synchronized {
     dataSourceUpdates.foreach {
       case DataSourceUpdate(namespace, toRemove, toUpsert) =>

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -108,6 +108,21 @@ class RocksDbDataSource(
   override def updateSync(dataSourceUpdates: Seq[DataUpdate]): Unit =
     doWrite(dataSourceUpdates, sync = true)
 
+  override def deleteRange(namespace: Namespace, fromKey: Array[Byte], toKeyExclusive: Array[Byte]): Unit = {
+    dbLock.writeLock().lock()
+    try {
+      assureNotClosed()
+      // One native range tombstone for the whole interval — O(1) write, lazily reclaimed by
+      // compaction. Never expand a range into per-key deletes here (see DataSource.deleteRange).
+      db.deleteRange(handles(namespace), fromKey, toKeyExclusive)
+    } catch {
+      case error: RocksDbDataSourceClosedException =>
+        throw error
+      case NonFatal(error) =>
+        throw RocksDbDataSourceException(s"DataSource error while deleting range", error)
+    } finally dbLock.writeLock().unlock()
+  }
+
   private def doWrite(dataSourceUpdates: Seq[DataUpdate], sync: Boolean): Unit = {
     dbLock.writeLock().lock()
     try {

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
@@ -120,20 +120,19 @@ class RocksDbBfsQueueStorage(dataSource: DataSource, namespace: Namespace) exten
     }
   }
 
-  def deleteRange(from: Long, to: Long): Unit = {
-    val BatchSize = 10_000
-    var i = from
-    while (i < to) {
-      val end = math.min(to, i + BatchSize)
-      val keys = (i until end).map(longToBytes)
-      dataSource.update(Seq(DataSourceUpdateOptimized(namespace, toRemove = keys, toUpsert = Seq.empty)))
-      i = end
-    }
-  }
+  def deleteRange(from: Long, to: Long): Unit =
+    // Single native range tombstone — O(1) regardless of (to - from). The previous
+    // implementation expanded the range into 10K-key point-delete batches; clearing the
+    // ~140M-entry queue after a full ETC-mainnet walk wrote ~140M tombstones over ~30 minutes
+    // at full CPU (observed live 2026-06-12) while the next walk waited.
+    if (from < to) dataSource.deleteRange(namespace, longToBytes(from), longToBytes(to))
 
   def clear(): Unit = {
-    val current = writeCounter.get()
-    if (current > 0) deleteRange(0L, current)
+    // Tombstone the ENTIRE keyspace, not just [0, counter): the counter is in-memory only, so
+    // after a crash-restart it reads 0 while the column family still holds the dead walk's
+    // entries. The old `if (counter > 0)` guard skipped deletion entirely in that state,
+    // leaving the garbage on disk forever. Long.MaxValue exceeds any key ever assigned.
+    dataSource.deleteRange(namespace, longToBytes(0L), longToBytes(Long.MaxValue))
     writeCounter.set(0L)
   }
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/HealingFrontierResumeSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/HealingFrontierResumeSpec.scala
@@ -73,7 +73,7 @@ class HealingFrontierResumeSpec
       prePopulate: Seq[(ByteString, Seq[ByteString])] = Nil,
       markComplete: Boolean = false,
       rootInStorage: Boolean = true
-  )(body: (ActorRef, ByteString, HealingFrontierStorage) => Unit): Unit = {
+  )(body: (ActorRef, ByteString, HealingFrontierStorage, TestProbe) => Unit): Unit = {
     val pool = Executors.newSingleThreadExecutor()
     val ec = ExecutionContext.fromExecutorService(pool)
     val dbPath = Files.createTempDirectory("healing-frontier-resume-rocksdb").toAbsolutePath.toString
@@ -95,6 +95,7 @@ class HealingFrontierResumeSpec
     if (prePopulate.nonEmpty) store.update(Nil, prePopulate).commit()
     if (markComplete) store.markComplete() // simulate a prior rebuild DFS that ran to completion
 
+    val controllerProbe = TestProbe()
     val storage = new TestMptStorage()
     val root = if (rootInStorage) storedRoot(storage) else kec256(ByteString("write-on-queue-root"))
     val coordinator = system.actorOf(
@@ -104,14 +105,14 @@ class HealingFrontierResumeSpec
         requestTracker = new SNAPRequestTracker()(system.scheduler),
         mptStorage = storage,
         batchSize = 16,
-        snapSyncController = TestProbe().ref,
+        snapSyncController = controllerProbe.ref,
         healingFrontierStorage = if (persistence) Some(store) else None,
         healingWriterEcOverride = Some(ec)
       )
     )
     val death = TestProbe()
     death.watch(coordinator)
-    try body(coordinator, root, store)
+    try body(coordinator, root, store, controllerProbe)
     finally {
       // 1) No more actor-thread RocksDB ops. 2) Drain the EC so the resume `loadAll` iterator is closed.
       system.stop(coordinator)
@@ -125,14 +126,18 @@ class HealingFrontierResumeSpec
   }
 
   private def pendingTasks(coordinator: ActorRef): Int = {
-    coordinator ! Messages.HealingGetProgress
-    expectMsgType[HealingStatistics](2.seconds).pendingTasks
+    // Dedicated probe per query: the shared ImplicitSender inbox steals replies across tests when
+    // the suite runs with test parallelism — one test's awaitAssert can consume another test's
+    // HealingStatistics (observed as a deterministic-looking "0 was not equal to 7").
+    val probe = TestProbe()
+    coordinator.tell(Messages.HealingGetProgress, probe.ref)
+    probe.expectMsgType[HealingStatistics](2.seconds).pendingTasks
   }
 
   "TrieNodeHealingCoordinator (Layer 2)" should
     "resume from a COMPLETE persisted frontier and skip the full-state DFS" taggedAs UnitTest in {
       val entries = (0 until 7).map(i => hash(i) -> pathset(i))
-      withResumeFixture(persistence = true, prePopulate = entries, markComplete = true) { (coordinator, root, _) =>
+      withResumeFixture(persistence = true, prePopulate = entries, markComplete = true) { (coordinator, root, _, _) =>
         coordinator ! Messages.StartTrieNodeHealing(root)
         // Resume loads the 7 persisted entries (a childless-leaf-root DFS would have found 0).
         awaitAssert(pendingTasks(coordinator) shouldBe entries.size, 3.seconds, 100.millis)
@@ -143,7 +148,7 @@ class HealingFrontierResumeSpec
     // A frontier persisted by an interrupted rebuild has entries but no marker. Resuming it would skip the
     // un-walked region and leave gaps; the coordinator must fall back to the full DFS instead.
     val partial = (0 until 5).map(i => hash(i) -> pathset(i))
-    withResumeFixture(persistence = true, prePopulate = partial, markComplete = false) { (coordinator, root, _) =>
+    withResumeFixture(persistence = true, prePopulate = partial, markComplete = false) { (coordinator, root, _, _) =>
       coordinator ! Messages.StartTrieNodeHealing(root)
       // No resume of the 5 partial entries; the childless-leaf-root DFS finds nothing → pendingTasks stays 0.
       awaitAssert(pendingTasks(coordinator) shouldBe 0, 2.seconds, 100.millis)
@@ -153,7 +158,7 @@ class HealingFrontierResumeSpec
   it should "fall back to the full-state DFS when persistence is disabled (Layer-1 parity)" taggedAs UnitTest in {
     // Store HAS entries, but the coordinator is wired with None — they must be ignored.
     withResumeFixture(persistence = false, prePopulate = (0 until 5).map(i => hash(i) -> pathset(i))) {
-      (coordinator, root, _) =>
+      (coordinator, root, _, _) =>
         coordinator ! Messages.StartTrieNodeHealing(root)
         // No resume; the childless-leaf-root DFS finds nothing. Contrast with the resume test (reaches 7).
         awaitAssert(pendingTasks(coordinator) shouldBe 0, 2.seconds, 100.millis)
@@ -161,13 +166,25 @@ class HealingFrontierResumeSpec
   }
 
   it should "fall back to the full-state DFS when the persisted frontier is empty" taggedAs UnitTest in
-    withResumeFixture(persistence = true) { (coordinator, root, _) =>
+    withResumeFixture(persistence = true) { (coordinator, root, _, _) =>
       coordinator ! Messages.StartTrieNodeHealing(root)
       awaitAssert(pendingTasks(coordinator) shouldBe 0, 2.seconds, 100.millis)
     }
 
+  it should "skip the walk and complete via verification when the snapshot is complete and the frontier empty" taggedAs UnitTest in {
+    // Marker set + zero entries = the prior rebuild finished AND everything it found was healed
+    // (entries are unpersisted on heal). The old gate required loaded.nonEmpty and fell through to a
+    // full re-walk (~24-36h at mainnet scale). The fix skips the rebuild and runs the verification
+    // pass directly; on the childless-leaf root it finds nothing and completion flows to the
+    // controller — under the old behavior nothing reaches the controller until the watchdog era.
+    withResumeFixture(persistence = true, markComplete = true) { (coordinator, root, _, controller) =>
+      coordinator ! Messages.StartTrieNodeHealing(root)
+      controller.expectMsg(10.seconds, SNAPSyncController.StateHealingComplete)
+    }
+  }
+
   it should "mirror newly-queued nodes into the persisted frontier (write-on-queue)" taggedAs UnitTest in
-    withResumeFixture(persistence = true, rootInStorage = false) { (coordinator, _, store) =>
+    withResumeFixture(persistence = true, rootInStorage = false) { (coordinator, _, store, _) =>
       val queued = (10 until 16).map(i => pathset(i) -> hash(i))
       coordinator ! Messages.QueueMissingNodes(queued)
       // queueNodes persists synchronously on the actor thread; the store should gain the queued hashes.

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
@@ -1,0 +1,145 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.db.dataSource.{EphemDataSource, RocksDbConfig, RocksDbDataSource}
+import com.chipprbots.ethereum.testing.Tags._
+
+import java.io.File
+import java.nio.file.Files
+
+/** BfsQueueStorage over a real RocksDB instance — exercises the native range-tombstone delete path
+  * (`DataSource.deleteRange`) that replaced per-key tombstone batches. The per-key implementation wrote ~140M
+  * tombstones (~30 min at full CPU, observed live on ETC mainnet 2026-06-12) when clearing the queue after a full-state
+  * healing walk; the range tombstone is a single O(1) write.
+  *
+  * Also covers the crash-restart contract: the write counter is in-memory only, so a fresh storage instance over a
+  * column family still holding a dead walk's entries must `clear()` them despite `counter == 0`.
+  */
+class BfsQueueStorageSpec extends AnyFlatSpec with Matchers {
+
+  private def entry(i: Int): (Array[Byte], Seq[Array[Byte]], Boolean) =
+    (Array.fill(32)(i.toByte), Seq(Array(i.toByte, (i + 1).toByte)), i % 2 == 0)
+
+  private def drain(it: Iterator[Seq[BfsEntry]]): Seq[BfsEntry] = it.flatten.toSeq
+
+  private def withRocksDb(test: RocksDbDataSource => Unit): Unit = {
+    val dbPath = Files.createTempDirectory("bfs-queue-rocksdb").toAbsolutePath.toString
+    val dataSource = RocksDbDataSource(
+      new RocksDbConfig {
+        override val createIfMissing: Boolean = true
+        override val paranoidChecks: Boolean = true
+        override val path: String = dbPath
+        override val maxThreads: Int = 1
+        override val maxOpenFiles: Int = 32
+        override val verifyChecksums: Boolean = true
+        override val levelCompaction: Boolean = true
+        override val blockSize: Long = 16384
+        override val blockCacheSize: Long = 33554432
+      },
+      Namespaces.nsSeq
+    )
+    try test(dataSource)
+    finally {
+      dataSource.destroy()
+      val dir = new File(dbPath)
+      !dir.exists() || dir.delete()
+    }
+  }
+
+  "RocksDbBfsQueueStorage" should "round-trip entries through enqueueBatch/iterateRange" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 100).map(entry))
+      q.counter shouldBe 100L
+      val got = drain(q.iterateRange(0L, 100L, chunkSize = 7))
+      got.size shouldBe 100
+      got.head.hash.toSeq shouldBe Array.fill(32)(0.toByte).toSeq
+      got.last.pathset.head.toSeq shouldBe Seq(99.toByte, 100.toByte)
+      got.map(_.isStorage).count(identity) shouldBe 50
+    }
+
+  it should "delete exactly [from, to) with a native range tombstone" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 100).map(entry))
+      q.deleteRange(0L, 50L)
+      drain(q.iterateRange(0L, 50L)) shouldBe empty
+      drain(q.iterateRange(50L, 100L)).size shouldBe 50
+      // boundary: deleting an empty range is a no-op
+      q.deleteRange(70L, 70L)
+      drain(q.iterateRange(50L, 100L)).size shouldBe 50
+    }
+
+  it should "clear() the keyspace and reset the counter" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      q.enqueueBatch((0 until 64).map(entry))
+      q.clear()
+      q.counter shouldBe 0L
+      drain(q.iterateRange(0L, 64L)) shouldBe empty
+    }
+
+  it should "clear() a dead walk's entries after a simulated crash-restart (counter == 0)" taggedAs UnitTest in
+    withRocksDb { ds =>
+      // Walk 1 writes 100 entries, then the process "crashes" (instance dropped, no clear()).
+      val before = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      before.enqueueBatch((0 until 100).map(entry))
+
+      // Restart: fresh instance, in-memory counter back at 0 while the CF still holds 100 keys.
+      // The old guard (`if (counter > 0) deleteRange`) skipped deletion entirely here.
+      val after = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      after.counter shouldBe 0L
+      after.clear()
+
+      after.enqueueBatch((200 until 210).map(entry))
+      val fresh = drain(after.iterateRange(0L, 10L))
+      fresh.size shouldBe 10
+      fresh.head.hash.toSeq shouldBe Array.fill(32)(200.toByte).toSeq
+      // keys beyond the fresh writes must NOT resurrect the dead walk's entries
+      drain(after.iterateRange(10L, 100L)) shouldBe empty
+    }
+
+  it should "leave other namespaces untouched by deleteRange" taggedAs UnitTest in
+    withRocksDb { ds =>
+      val q = new RocksDbBfsQueueStorage(ds, Namespaces.BfsQueueNamespace)
+      val frontier = new HealingFrontierStorage(ds)
+      import org.apache.pekko.util.ByteString
+      val h = ByteString(Array.fill(32)(7.toByte))
+      frontier.put(h, Seq(ByteString(1.toByte))).commit()
+      q.enqueueBatch((0 until 10).map(entry))
+      q.clear()
+      frontier.get(h) shouldBe Some(Seq(ByteString(1.toByte)))
+    }
+
+  "EphemDataSource.deleteRange" should "honor namespace isolation and range boundaries" taggedAs UnitTest in {
+    val ds = EphemDataSource()
+    val nsA: IndexedSeq[Byte] = IndexedSeq('a'.toByte)
+    val nsB: IndexedSeq[Byte] = IndexedSeq('b'.toByte)
+    def key(i: Int): Array[Byte] = BfsQueueStorage.longToBytes(i.toLong)
+    (0 until 10).foreach(i => ds.update(keyUpsert(nsA, key(i))))
+    (0 until 10).foreach(i => ds.update(keyUpsert(nsB, key(i))))
+
+    ds.deleteRange(nsA, key(3), key(7))
+
+    (0 until 10).map(i => ds.getOptimized(nsA, key(i)).isDefined) shouldBe
+      Seq(true, true, true, false, false, false, false, true, true, true)
+    (0 until 10).forall(i => ds.getOptimized(nsB, key(i)).isDefined) shouldBe true
+  }
+
+  private def keyUpsert(ns: IndexedSeq[Byte], k: Array[Byte]) = {
+    import com.chipprbots.ethereum.db.dataSource.DataSourceUpdateOptimized
+    Seq(DataSourceUpdateOptimized(ns, toRemove = Seq.empty, toUpsert = Seq((k, Array(1.toByte)))))
+  }
+
+  "InMemoryBfsQueueStorage" should "match RocksDb semantics for deleteRange and clear" taggedAs UnitTest in {
+    val q = new InMemoryBfsQueueStorage()
+    q.enqueueBatch((0 until 20).map(entry))
+    q.deleteRange(5L, 15L)
+    drain(q.iterateRange(0L, 20L)).size shouldBe 10
+    q.clear()
+    q.counter shouldBe 0L
+    drain(q.iterateRange(0L, 20L)) shouldBe empty
+  }
+}


### PR DESCRIPTION
## What

**Stacked on #1334** — merge that first; this PR's diff reduces to the resume fix once it lands.

The Layer-2 resume gate required `loaded.nonEmpty && isComplete`. But frontier entries are **unpersisted as they heal**, so the best-possible restart state — *walk complete, everything healed* — leaves the CF empty and fell through to a **full ~119M-node re-walk (24–36 h on ETC mainnet)** that cannot discover anything new. This is exactly the state our live node is in right now; a restart today would pay that price.

New gate:

| State | Behavior |
|---|---|
| marker + entries | resume entries (unchanged) |
| **marker + empty** | **skip the rebuild, run the verification pass directly** — verification still gates `StateHealingComplete`; pivot refreshes clear the marker so marker-set implies the root matches the completed walk |
| partial / no marker | full walk (unchanged — never trust a partial frontier) |

## Testing

- New test: marker + empty frontier → `StateHealingComplete` reaches the controller within seconds (old behavior: full walk, then idle). Fixture extended to expose the controller probe.
- All four pre-existing resume-semantics tests unchanged and green (including "empty *without* marker still walks").
- **Bonus flake fix**: the spec's `pendingTasks` helper read replies via the shared `ImplicitSender` inbox — under test parallelism, tests steal each other's `HealingStatistics` replies (manifested as a deterministic-looking `0 was not equal to 7` the moment this suite gained a sixth test). Now a dedicated probe per query.
- Suite run twice back-to-back for interleaving stability: 31/31 + 6/6 pass, scalafmt clean.

## Operational impact

Together with #1334: healing-phase restarts become cheap at every stage — resume when entries remain, skip-to-verification when fully healed, no tombstone grind between walks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)