### PR TITLE
fix(snap): backpressure the healing frontier walk to prevent heap OOM

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -121,6 +121,15 @@ sync {
     # Effective = min(this, availableProcessors - 2): auto-throttles on smaller hardware.
     # Set to 1 to force sequential processing.
     healing-traversal-parallelism = 4
+
+    # Frontier-emission backpressure (OOM gate, 2026-06-13 incident). The BFS healing walk reads
+    # the local trie far faster than healing fetches missing nodes from a peer-scarce SNAP network;
+    # without a gate, a walk that re-discovers a large frontier floods the actor mailbox / pending
+    # queue until the JVM heap is exhausted. The walk pauses emitting once the healing backlog
+    # reaches the high-water mark and resumes below the low-water mark (geth trie.Sync
+    # maxFetchesPerDepth analogue). ~100K entries bounds discovered-but-unhealed heap to tens of MB.
+    healing-frontier-high-water = 100000
+    healing-frontier-low-water = 50000
     # Whether to validate state completeness before transitioning to regular sync
     # When enabled, walks the entire state trie to detect missing nodes
     # Recommended: true for production (ensures correctness)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3309,7 +3309,9 @@ class SNAPSyncController(
               traversalParallelism = snapSyncConfig.healingTraversalParallelism,
               bfsQueueStorageOpt = Some(bfsQueueStorage),
               storageScheme = snapSyncConfig.storageScheme,
-              pathNodeStorageOpt = pathNodeStorageOpt
+              pathNodeStorageOpt = pathNodeStorageOpt,
+              frontierHighWater = snapSyncConfig.healingFrontierHighWater,
+              frontierLowWater = snapSyncConfig.healingFrontierLowWater
             )
             .withDispatcher("sync-dispatcher"),
           s"trie-node-healing-coordinator-$coordinatorGeneration"
@@ -3368,7 +3370,9 @@ class SNAPSyncController(
                   traversalParallelism = snapSyncConfig.healingTraversalParallelism,
                   bfsQueueStorageOpt = Some(bfsQueueStorage),
                   storageScheme = snapSyncConfig.storageScheme,
-                  pathNodeStorageOpt = pathNodeStorageOpt
+                  pathNodeStorageOpt = pathNodeStorageOpt,
+                  frontierHighWater = snapSyncConfig.healingFrontierHighWater,
+                  frontierLowWater = snapSyncConfig.healingFrontierLowWater
                 )
                 .withDispatcher("sync-dispatcher"),
               s"trie-node-healing-coordinator-$coordinatorGeneration"
@@ -4680,6 +4684,8 @@ case class SNAPSyncConfig(
     healingFrontierPersistence: Boolean = false,
     // Operator ceiling for BFS level parallelism. Effective = min(this, availableProcessors - 2).
     healingTraversalParallelism: Int = actors.TrieNodeHealingCoordinator.DefaultDfsParallelism,
+    healingFrontierHighWater: Int = actors.TrieNodeHealingCoordinator.DefaultFrontierHighWater,
+    healingFrontierLowWater: Int = actors.TrieNodeHealingCoordinator.DefaultFrontierLowWater,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,
     timeout: FiniteDuration = 30.seconds,
@@ -4789,6 +4795,14 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("healing-traversal-parallelism"))
           snapConfig.getInt("healing-traversal-parallelism")
         else actors.TrieNodeHealingCoordinator.DefaultDfsParallelism,
+      healingFrontierHighWater =
+        if (snapConfig.hasPath("healing-frontier-high-water"))
+          snapConfig.getInt("healing-frontier-high-water")
+        else actors.TrieNodeHealingCoordinator.DefaultFrontierHighWater,
+      healingFrontierLowWater =
+        if (snapConfig.hasPath("healing-frontier-low-water"))
+          snapConfig.getInt("healing-frontier-low-water")
+        else actors.TrieNodeHealingCoordinator.DefaultFrontierLowWater,
       stateValidationEnabled = snapConfig.getBoolean("state-validation-enabled"),
       maxRetries = snapConfig.getInt("max-retries"),
       timeout = snapConfig.getDuration("timeout").toMillis.millis,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -49,7 +49,10 @@ class TrieNodeHealingCoordinator(
     traversalParallelism: Int = TrieNodeHealingCoordinator.DefaultDfsParallelism,
     bfsQueueStorageOpt: Option[BfsQueueStorage] = None,
     storageScheme: StorageScheme = StorageScheme.Hash,
-    pathNodeStorageOpt: Option[PathNodeStorage] = None
+    pathNodeStorageOpt: Option[PathNodeStorage] = None,
+    frontierHighWater: Int = TrieNodeHealingCoordinator.DefaultFrontierHighWater,
+    frontierLowWater: Int = TrieNodeHealingCoordinator.DefaultFrontierLowWater,
+    frontierBackpressureMaxWaitMs: Long = TrieNodeHealingCoordinator.FrontierBackpressureMaxWaitMs
 ) extends Actor
     with ActorLogging {
 
@@ -60,6 +63,13 @@ class TrieNodeHealingCoordinator(
   // immutable `Seq` did O(n) on every `:+` and head-drop — quadratic at healing scale.
   private case class HealingEntry(pathset: Seq[ByteString], hash: ByteString)
   private val pendingTasks: mutable.ArrayDeque[HealingEntry] = mutable.ArrayDeque.empty
+  // Thread-safe mirror of pendingTasks.size, refreshed by emitHealingFrontierGauges() on the actor
+  // thread. The frontier-rebuild BFS walk runs on healingWriterEc and reads this (never pendingTasks
+  // directly) to apply backpressure — it pauses emission when the healing backlog is large so a
+  // peer-scarce drain rate can't let discovered-but-unhealed nodes pile up to an OOM (see
+  // awaitFrontierDrain). geth bounds the analogous queue with trie.Sync maxFetchesPerDepth.
+  private val pendingBackpressure: java.util.concurrent.atomic.AtomicInteger =
+    new java.util.concurrent.atomic.AtomicInteger(0)
   private var completedTaskCount: Int = 0
   private var healingMilestonePct: Int = -1
 
@@ -200,9 +210,42 @@ class TrieNodeHealingCoordinator(
 
   /** Publish the live healing backlog/in-flight gauges for the Grafana healing-analytics section. */
   private def emitHealingFrontierGauges(): Unit = {
+    pendingBackpressure.set(pendingTasks.size)
     SNAPSyncMetrics.setHealingFrontierPending(pendingTasks.size.toLong)
     SNAPSyncMetrics.setHealingActiveRequests(activeRequests.size.toLong)
   }
+
+  /** Frontier-emission backpressure, called from the BFS walk thread (healingWriterEc) before each FrontierRebuilt
+    * batch. The walk reads the locally-stored trie fast (thousands of nodes/s) while healing drains over the network on
+    * a handful of SNAP peers (tens-to-hundreds/s). With no gate, a verification walk that re-discovers a large frontier
+    * floods pendingTasks/the actor mailbox until the heap is exhausted (observed live 2026-06-13: OOM at L7 under peer
+    * scarcity). This pauses the walk when the backlog reaches the high-water mark and resumes once it drains below the
+    * low-water mark. Reads only the AtomicInteger mirror + immutable vals — touches no actor state. Blocking is safe
+    * here: healingWriterEc is the blocking healing dispatcher. A hard timeout guarantees the walk can never deadlock if
+    * the drain stalls (fail loud, then resume).
+    */
+  private def awaitFrontierDrain(): Unit =
+    if (pendingBackpressure.get() >= frontierHighWater) {
+      val startWait = System.currentTimeMillis()
+      log.info(
+        s"[HEAL-BFS] Backpressure: healing backlog ${pendingBackpressure.get()} >= high-water " +
+          s"$frontierHighWater — pausing frontier emission until it drains below $frontierLowWater"
+      )
+      while (
+        pendingBackpressure.get() > frontierLowWater &&
+        System.currentTimeMillis() - startWait < frontierBackpressureMaxWaitMs
+      )
+        Thread.sleep(200)
+      val waitedMs = System.currentTimeMillis() - startWait
+      if (pendingBackpressure.get() > frontierLowWater)
+        log.warning(
+          s"[HEAL-BFS] Backpressure wait hit the " +
+            s"${frontierBackpressureMaxWaitMs / 1000}s safety timeout " +
+            s"(backlog still ${pendingBackpressure.get()}) — resuming emission to avoid deadlock"
+        )
+      else
+        log.info(s"[HEAL-BFS] Backpressure released after ${waitedMs}ms — resuming frontier emission")
+    }
 
   // Track last known available peers for re-dispatch after failures
   private val knownAvailablePeers = mutable.Set[Peer]()
@@ -1299,7 +1342,10 @@ class TrieNodeHealingCoordinator(
           futures.flatMap(f => Await.result(f, Duration.Inf))
         }
 
-      allFrontier.grouped(FrontierBatchSize).foreach(batch => selfRef ! FrontierRebuilt(batch))
+      allFrontier.grouped(FrontierBatchSize).foreach { batch =>
+        awaitFrontierDrain() // pause the walk if the healing backlog is over the high-water mark
+        selfRef ! FrontierRebuilt(batch)
+      }
 
       val fc = frontierCount.get()
       val queued = queue.counter - levelEnd
@@ -1514,6 +1560,16 @@ object TrieNodeHealingCoordinator {
     */
   val DefaultVisitedCap: Int = 4_000_000
 
+  // Frontier-emission backpressure watermarks (entries in pendingTasks). The BFS walk pauses
+  // emitting discovered missing nodes once the healing backlog reaches the high-water mark and
+  // resumes below the low-water mark, bounding discovered-but-unhealed heap to ~high-water entries
+  // (~100K HealingEntry ≈ tens of MB) instead of growing unbounded under a peer-scarce drain rate.
+  val DefaultFrontierHighWater: Int = 100_000
+  val DefaultFrontierLowWater: Int = 50_000
+  // Safety valve: the walk never blocks on backpressure longer than this before resuming (and
+  // warning), so a stalled drain (no peers, dead actor) can't deadlock the walk.
+  val FrontierBackpressureMaxWaitMs: Long = 10.minutes.toMillis
+
   /** Operator-configurable ceiling for BFS level parallelism. Effective parallelism is `min(DefaultDfsParallelism,
     * max(1, availableProcessors - 2))` so large levels are split across sub-ranges on `healingWriterEc`. See
     * `healing-traversal-parallelism` in `sync.conf`.
@@ -1552,7 +1608,10 @@ object TrieNodeHealingCoordinator {
       traversalParallelism: Int = DefaultDfsParallelism,
       bfsQueueStorageOpt: Option[BfsQueueStorage] = None,
       storageScheme: StorageScheme = StorageScheme.Hash,
-      pathNodeStorageOpt: Option[PathNodeStorage] = None
+      pathNodeStorageOpt: Option[PathNodeStorage] = None,
+      frontierHighWater: Int = DefaultFrontierHighWater,
+      frontierLowWater: Int = DefaultFrontierLowWater,
+      frontierBackpressureMaxWaitMs: Long = FrontierBackpressureMaxWaitMs
   ): Props =
     Props(
       new TrieNodeHealingCoordinator(
@@ -1569,7 +1628,10 @@ object TrieNodeHealingCoordinator {
         traversalParallelism,
         bfsQueueStorageOpt,
         storageScheme,
-        pathNodeStorageOpt
+        pathNodeStorageOpt,
+        frontierHighWater,
+        frontierLowWater,
+        frontierBackpressureMaxWaitMs
       )
     )
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
@@ -709,6 +709,77 @@ class TrieNodeHealingCoordinatorSpec
     )
   }
 
+  it should "not deadlock under sustained frontier backpressure — the safety timeout resumes the walk" taggedAs UnitTest in {
+    import com.chipprbots.ethereum.mpt.{BranchNode, HashNode, NullNode, MptNode}
+    import java.util.concurrent.Executors
+
+    // Reproduces the 2026-06-13 OOM scenario in miniature: a BFS walk discovers missing nodes while
+    // the healing backlog is already over the high-water mark and CANNOT drain (no peers, low-water
+    // never reached). With high=1/low=0 the walk pauses on backpressure; the safety timeout must fire
+    // and let it resume so it still delivers its frontier instead of hanging forever. (At production
+    // defaults of 100K/50K this gate never trips in normal operation.)
+    val missing0 = kec256(ByteString("bp-missing-0"))
+    val missing3 = kec256(ByteString("bp-missing-3"))
+    val missing7 = kec256(ByteString("bp-missing-7"))
+    val children: Array[MptNode] = Array.fill[MptNode](16)(NullNode)
+    children(0) = HashNode(missing0.toArray)
+    children(3) = HashNode(missing3.toArray)
+    children(7) = HashNode(missing7.toArray)
+    val branch = BranchNode(children, None)
+    val storage = new TestMptStorage()
+    storage.putNode(branch)
+    val root = ByteString(branch.hash)
+
+    // Dedicated EC so the walk's blocking backpressure sleep cannot starve the actor thread.
+    val pool = Executors.newSingleThreadExecutor()
+    val ec = scala.concurrent.ExecutionContext.fromExecutorService(pool)
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = root,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = storage,
+        batchSize = 16,
+        snapSyncController = TestProbe().ref,
+        healingWriterEcOverride = Some(ec),
+        frontierHighWater = 1,
+        frontierLowWater = 0,
+        frontierBackpressureMaxWaitMs = 800L
+      )
+    )
+    try {
+      // Pre-load the backlog ABOVE the high-water mark with no peers, so it can never drain below
+      // low-water — the walk's emit gate will block until the safety timeout fires.
+      coordinator ! Messages.QueueMissingNodes(
+        Seq((Seq(ByteString(Array[Byte](0x09))), kec256(ByteString("bp-preload"))))
+      )
+      awaitAssert(
+        {
+          coordinator ! Messages.HealingGetProgress
+          expectMsgType[HealingStatistics](2.seconds).pendingTasks shouldBe 1
+        },
+        max = 3.seconds,
+        interval = 100.millis
+      )
+
+      coordinator ! Messages.StartTrieNodeHealing(root)
+
+      // The walk must still complete and deliver its 3 discovered children (preload + 3 = 4),
+      // proving the safety timeout fired and resumed it rather than deadlocking on the gate.
+      awaitAssert(
+        {
+          coordinator ! Messages.HealingGetProgress
+          expectMsgType[HealingStatistics](2.seconds).pendingTasks shouldBe 4
+        },
+        max = 8.seconds,
+        interval = 200.millis
+      )
+    } finally {
+      system.stop(coordinator)
+      pool.shutdownNow()
+    }
+  }
+
   it should "traverse multiple BFS levels and find frontier nodes deep in the trie" taggedAs UnitTest in {
     import com.chipprbots.ethereum.mpt.{BranchNode, HashNode, NullNode, MptNode}
 


### PR DESCRIPTION
## Root cause (live OOM, 2026-06-13)

The ETC-mainnet validation node OOM'd (`Java heap space`, `-Xmx5g`) during the post-SNAP healing **verification walk**. A 4-lens investigation converged: the BFS walk reads the local trie *fast* and emits every discovered missing node as a `FrontierRebuilt` actor message at `TrieNodeHealingCoordinator.scala:1279` with **zero backpressure**, while healing drains over the network on peer-scarce SNAP peers (~50–250 nodes/s) — a ~40× mismatch. A walk that re-discovers a large frontier (the verification pass did, after a pivot refresh cleared the completeness marker) floods `pendingTasks`/the actor mailbox until the heap is exhausted. The bounded visited set, disk-backed level queue, and `rawNodeBuffer` were explicitly ruled out — this is the only unbounded accumulator. Same mechanism go-ethereum gates with `trie.Sync` `maxFetchesPerDepth = 16384`.

The current node confirms it from the other side: the fresh *rebuild* re-walk finds ≈0 missing (state is persisted-healed) → no emission flood → no OOM. The risk is specifically a **verification re-discovery under peer scarcity**.

## Fix — high/low-water backpressure

- `pendingBackpressure` (AtomicInteger) mirrors `pendingTasks.size`, refreshed by the existing `emitHealingFrontierGauges()` grow+drain hook → the walk thread reads the backlog safely.
- `awaitFrontierDrain()` before each emit: pause the walk at `healing-frontier-high-water` (**100K**), resume below `healing-frontier-low-water` (**50K**) → bounds discovered-but-unhealed heap to tens of MB.
- **Hard safety timeout** (default 10 min): the walk never blocks longer than this before resuming + warning — a stalled drain can never deadlock healing.
- Config in `sync.conf` + `SNAPSyncConfig` + both construction sites.

Defaults never trip in normal operation; the gate engages only under the exact peer-scarce + large-frontier conditions that OOM'd.

## Testing

New test reproduces the OOM scenario in miniature (sustained backpressure, no drain) and asserts the walk **completes via the safety timeout rather than hanging** — the riskiest path. `TrieNodeHealingCoordinatorSpec` + `HealingFrontierResumeSpec`: **32/32 PASS**, scalafmt clean.

## Operational

Completes the healing-phase memory-safety trio with #1334 (range tombstones) and #1335 (resume-skip). Deploying all three to the validation node — so a walk that reaches the finish line under peer scarcity stays bounded instead of OOMing at the near-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)