### PR TITLE
fix(ops): mitigate heal-walk cgroup OOM on barad-dur (serial heal + MALLOC_ARENA_MAX)

### DIFF
--- a/ops/barad-dur/docker-compose.yml
+++ b/ops/barad-dur/docker-compose.yml
@@ -142,6 +142,12 @@ services:
     volumes:
       - ${FUKUII_DATA_DIR:-./data/fukuii}:/app/data
       - ./fukuii-conf-1:/app/conf:ro
+    environment:
+      # MALLOC_ARENA_MAX=2: cap glibc malloc arenas to slash native/off-heap RSS (RocksDB + JNI),
+      # the dominant non-heap growth on this memory-tight 16GB host. Keeps total RSS under mem_limit
+      # so the ~9.6g L6/L7 walk peak no longer trips systemd-oomd / host memory pressure (the
+      # documented over-subscription fix). Off-heap reduction, not a heap change — the walk keeps its heap.
+      MALLOC_ARENA_MAX: "2"
     # Override the image entrypoint (`java -jar <jar>`) — that puts -jar
     # before any flags we add via `command`, which makes the JVM treat all
     # our -X / -D flags as program args. We need JVM args BEFORE -jar, so

--- a/ops/barad-dur/fukuii-conf-1/etc.conf
+++ b/ops/barad-dur/fukuii-conf-1/etc.conf
@@ -25,6 +25,19 @@ fukuii {
       # Evict up to 5 non-SNAP peers per cycle (base: 3) — more aggressive for faster
       # SNAP peer discovery on barad-dur where only ~2 SNAP servers are reachable.
       max-evictions-per-cycle = 5
+
+      # Force SERIAL post-SNAP healing on this memory-tight 16GB host (2026-06-14).
+      # PR #1348 (spec 002, US3) moved the BFS sub-range readers off the parent walk's
+      # dispatcher onto a dedicated healing-reader-dispatcher. v0.7.7 ran them on the
+      # parent's pool where they queued behind the parked Await (an accidental throttle);
+      # making them truly concurrent raised peak anon-RSS at the L5/L6 memory peak from
+      # just-under-8GiB to ~8.33GiB, crossing the 8GiB cgroup cap → kernel cgroup OOM-kill
+      # (SIGKILL, exit 137) mid-L5 every cycle. parallelism=1 takes the serial walk branch
+      # (no reader split), restoring the lower peak so the walk fits under the cap. The
+      # 4-core host only gave effectiveParallelism=2 anyway and the walk is disk-bound, so
+      # the throughput cost is small. Remove once the durable fix (bound reader/RocksDB
+      # native footprint) lands. See spec 002 follow-up.
+      healing-traversal-parallelism = 1
     }
   }
 


### PR DESCRIPTION
Ops-config mitigation for the cgroup OOM restart-loop that hit `fukuii-primary` after the v0.7.8 (spec 002 / #1348) deploy. **Validated on the live node**: with these changes it cleared L5/L6 (the death zone for 17 prior cycles), restarts frozen at 0, cgroup memory stable 60–85% of the cap.

## Root cause
US3 (#1348) moved the BFS sub-range readers onto a dedicated `healing-reader-dispatcher` (the correct Await-on-same-pool **deadlock fix**), which removed an *accidental memory throttle* — v0.7.7 ran them on the parent's pool where they queued behind the parked `Await`. Truly-concurrent readers raised peak anon-RSS at the L5/L6 memory peak over the cgroup cap → kernel cgroup-v2 OOM-kill (SIGKILL, exit 137) mid-L5. Full analysis + the durable code fix are in **#1350**.

## Changes (config-only, reversible)
- `docker-compose.yml`: `MALLOC_ARENA_MAX=2` on `fukuii-primary` — caps glibc arenas → lower native/off-heap RSS.
- `fukuii-conf-1/etc.conf`: `healing-traversal-parallelism = 1` → **serial healing** (no reader split), restoring the lower peak. Disk-bound walk (~948/s serial vs ~1170/s parallel), so small throughput cost. **Temporary** — remove once #1350 lands.

`mem_limit` stays at the compose default (10g); the operator `.env` override to 8g was the trigger (too tight for `-Xmx6g` + native) and was reverted to 10g (`.env` is gitignored).

## Runbook note (for whoever debugs the next OOM)
On cgroup-v2 + `restart: unless-stopped`, `docker inspect .State.OOMKilled`/`ExitCode` and in-container `memory.events` are **false-negatives** (container restarts ~350ms post-kill). Trust `journalctl -k` (`Killed process java`, `CONSTRAINT_MEMCG`), host `/sys/fs/cgroup/.../docker-<id>.scope/memory.current` vs `memory.max`, and `docker events --filter event=oom`.

Refs #1350, #1348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)