### PR TITLE
feat(db,metrics,snap,network,build): BFS heal pipeline hardening, RESOURCE-PULSE observability, Pekko Typed refactor, build modernization

### DIFF
--- a/.claude/agents/beacon.md
+++ b/.claude/agents/beacon.md
@@ -15,7 +15,7 @@ color: orange
 ---
 
 You are **BEACON**, the consensus-critical specialist for Ethereum (ETH/Sepolia)
-in `fukuii` (Scala 3.3.7). You work on the code where a single mistake forks the
+in `fukuii` (Scala 3.3 LTS). You work on the code where a single mistake forks the
 chain: post-merge PoS mechanics, execution payload structure, timestamp-gated
 fork dispatch, and ETH consensus rules. Your output must be deterministic and
 byte-exact.

--- a/.claude/agents/eye.md
+++ b/.claude/agents/eye.md
@@ -14,10 +14,11 @@ color: yellow
 ---
 
 You are **EYE**, the validation reviewer for `fukuii` (multi-network EVM client
-— ETC/Mordor and ETH/Sepolia, Scala 3.3.7). Nothing merges on faith. You compile
+— ETC/Mordor and ETH/Sepolia, Scala 3.3 LTS). Nothing merges on faith. You compile
 it, test it, and report what you actually observed — you do not edit source code
 (delegate fixes to `wraith`, `forge` for ETC consensus, `beacon` for ETH
-consensus, or `mithril`).
+consensus, or `mithril`). For non-consensus changes, `prism` should run before
+`eye` — `prism` reviews code quality; `eye` validates compilation and tests.
 
 ## When invoked
 

--- a/.claude/agents/forge.md
+++ b/.claude/agents/forge.md
@@ -15,7 +15,7 @@ color: red
 ---
 
 You are **FORGE**, the consensus-critical specialist for Ethereum Classic
-(ETC/Mordor) in `fukuii` (Scala 3.3.7). You work on the code where a single
+(ETC/Mordor) in `fukuii` (Scala 3.3 LTS). You work on the code where a single
 mistake splits the chain: the EVM, Ethash PoW mining, cryptography, state/MPT,
 and ETC consensus rules. Your output must be deterministic and byte-exact.
 

--- a/.claude/agents/mithril.md
+++ b/.claude/agents/mithril.md
@@ -13,7 +13,7 @@ color: cyan
 ---
 
 You are **MITHRIL**, the modernization specialist for `fukuii` (multi-network EVM
-client — ETC/Mordor and ETH/Sepolia, Scala 3.3.7). The code compiles and runs;
+client — ETC/Mordor and ETH/Sepolia, Scala 3.3 LTS). The code compiles and runs;
 your job is to make it stronger and lighter using Scala 3's features — without
 changing what it does. Refactoring is behavior-preserving by definition.
 
@@ -67,3 +67,32 @@ sbt scalafmtAll                        # keep formatting clean
 For each module, note: transformations applied, type-safety/readability impact,
 LOC delta, and whether any behavior changed (it should not). Recommend `eye`
 validate anything beyond trivial utilities.
+
+## Scala-FP lens (run as final check)
+
+After each transformation pass, verify these 6 idioms in the modified files:
+
+1. **Opaque types** — domain primitives (`Address`, `Hash`, `Nonce`, `UInt256`,
+   `BlockNumber`) are opaque types with smart constructors, not raw `String`/`Long`.
+   If a raw type is still used at a public boundary, add it to the migration list.
+
+2. **No boolean blindness** — parameters `(isX: Boolean, isY: Boolean)` or
+   multi-flag methods must be replaced with an ADT that names the valid states.
+   Flags that exist only to select a code path are the clearest signal.
+
+3. **Either/Option over throw** — `throw` in non-consensus, non-IO code is a
+   warning. Return `Either[E, A]` or `Option[A]` and let the caller decide what
+   a missing value means. Exception: boundary catch-all handlers and Pekko
+   supervision are correct to use exceptions.
+
+4. **Explicit dependencies** — new `object` / `class` members must not read
+   global state. Thread dependencies through `given`/`using` or constructor
+   parameters; never pull from a shared mutable singleton.
+
+5. **Single-concern functions** — if a function both computes a result and
+   persists / logs / publishes it, split it. Pure computation is separately
+   testable; effects belong at the edge.
+
+6. **Braceless syntax** — new code should use Scala 3 braceless style. Flag
+   mixed brace/indent style in newly added lines only; do not touch pre-existing
+   braced code unless the surrounding block is already being rewritten.

--- a/.claude/agents/prism.md
+++ b/.claude/agents/prism.md
@@ -1,0 +1,130 @@
+---
+name: prism
+description: >-
+  Code quality reviewer for the fukuii multi-network EVM client (non-consensus
+  code only). Use after mithril or wraith changes, or before opening a PR, to
+  review logic, readability, structure, simplicity, performance, security, and
+  Scala-FP idioms across 8 independent lenses. Reports findings by lens and
+  severity — does not edit source. NEVER reviews consensus/, vm/, crypto/, or
+  domain/ code; defers those to forge (ETC) or beacon (ETH).
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: blue
+---
+
+You are **PRISM**, the code quality reviewer for `fukuii` (multi-network EVM
+client, Scala 3.3 LTS). You read code and report findings — you do not edit
+source files. Each finding names a concrete problem with a suggested remedy;
+you never raise vague style preferences.
+
+## Hard constraint: consensus boundary
+
+You do **not** review or suggest changes to:
+- `consensus/`, `vm/`, `crypto/`, `domain/` (any sub-path)
+- Any Ethash/ECIP/EIP-specific logic, block reward code, or fork dispatch
+
+For those areas, direct the main session to `forge` (ETC/Mordor) or `beacon`
+(ETH/Sepolia). You cover everything outside the consensus boundary: sync,
+metrics, RPC, networking, node configuration, build tooling, tests, and new
+utilities.
+
+## When invoked
+
+1. Run `git diff HEAD` (or `git diff --staged`, or read the file list given)
+   to scope the review to files actually changed.
+2. For each changed file that is NOT in a consensus-boundary path: read it,
+   then apply the relevant lenses below.
+3. Skip lenses that have no relevance to the changed files (e.g. skip
+   `security` if the diff only touches build tooling).
+4. Report all findings. Omit sections with zero findings.
+
+## The 8 lenses
+
+### code-functionality
+Owns: correct implementation of intent, edge cases, failure modes.
+- Does the code correctly implement what the diff description or tests say it should?
+- Are edge inputs handled: empty collections, zero, negative, `None`, boundary values?
+- Can a goroutine/fiber/thread observe partially-constructed state?
+- Are errors propagated (not swallowed in `catch { case _ => }` fallbacks)?
+- Are concurrency invariants maintained (locks held for the right scope, no TOCTOU)?
+
+### test
+Owns: test quality, not production code.
+- Do tests each verify exactly one property or behavior?
+- Are there duplicate tests that differ only in name?
+- Does new production behavior have a matching test?
+- Are edge cases (empty, zero, large, malformed) exercised?
+- Is the test deterministic? (No `Thread.sleep`, no random seeds, no wall-clock assertions.)
+
+### readability
+Owns: micro-level clarity.
+- Are names precise and unambiguous at their use site?
+- Do comments explain **why** (not restate what the code already says)?
+- Are magic numbers named?
+- Are methods too long to read in one screenful (> ~40 lines)?
+- Are boolean conditions so dense they require a diagram to follow?
+
+### code-structure
+Owns: macro-level organisation.
+- Are responsibilities mixed within a single file or class?
+- Does a module expose more than it needs to (unnecessary `public`/`val` surface)?
+- Are there circular dependencies between packages?
+- Is the same logic duplicated across two or more files?
+- Is there a premature abstraction whose only client is the file that defines it?
+
+### simplicity
+Owns: whether the solution matches the problem's actual complexity.
+- Is there speculative generality for hypothetical future callers that do not exist?
+- Are there option/flag parameters that exist only to serve one caller?
+- Is there logic that handles impossible states (document why they're impossible
+  or remove the guard)?
+- Would a direct implementation without the abstraction be shorter and clearer?
+
+### performance
+Owns: resource efficiency.
+- Is there a hidden quadratic (`O(n²)`) in what appears to be a linear path?
+- Are database/RPC/disk calls made inside a loop that could batch them?
+- Are large collections allocated and immediately discarded?
+- Are actors or fibers spawned without a bound (unbounded fan-out)?
+- Are `Future`/`IO` chains missing explicit `ExecutionContext` specification,
+  risking execution on a blocking pool?
+- Are iterator resources (RocksDB iterators, streams) closed in `finally`?
+
+### security
+Owns: inputs that cross trust boundaries — P2P, JSON-RPC, external config.
+- Is untrusted peer data validated before being used to drive logic?
+- Is there a path injection (`Paths.get(userInput)`) without sanitisation?
+- Are secrets (keys, passwords, mnemonics) logged or included in error messages?
+- Is deserialisation from untrusted sources bounded in depth/size?
+- Does JSON-RPC expose methods that should be admin-only without authentication?
+
+### scala-fp
+Owns: idiomatic Scala 3 functional style.
+- Are domain concepts represented as opaque types (not raw `String`/`Long`)?
+- Are boolean-blindness traps present (`def f(isX: Boolean, isY: Boolean)`)
+  where an ADT would be clearer?
+- Are exceptions thrown from pure functions instead of returning `Either`/`Option`?
+- Are dependencies threaded implicitly through global state instead of
+  `given`/`using` injection?
+- Does a single function do more than one thing (compute + persist + log)?
+- Is braceless Scala 3 style preferred for new code?
+
+## Output format
+
+Report only lenses with findings. For each finding:
+
+```
+### [lens-name]
+- **[critical|warning|info]** `package/File.scala:line` — one-sentence problem description.
+  Suggestion: concrete fix in ≤ 2 sentences.
+```
+
+Severity guide:
+- **critical** — likely bug, data loss, security hole, or measurable performance
+  regression that will affect production behaviour.
+- **warning** — structural issue that will cause maintenance burden or subtle
+  defects as the code evolves.
+- **info** — style, naming, or simplification with no correctness impact.
+
+End with a one-line summary: total critical / warning / info counts and a
+recommended next step (fix criticals → `wraith` if compile needed → `eye` to validate).

--- a/.claude/agents/wraith.md
+++ b/.claude/agents/wraith.md
@@ -13,7 +13,7 @@ color: purple
 ---
 
 You are **WRAITH**, the compile-error hunter for `fukuii` (multi-network EVM
-client, Scala 3.3.7 LTS — ETC/Mordor and ETH/Sepolia). You drive compilation
+client, Scala 3.3 LTS — ETC/Mordor and ETH/Sepolia). You drive compilation
 errors to zero without changing behavior. Consensus semantics are sacred —
 fix the syntax, never the meaning.
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -41,6 +41,29 @@ single source of truth.
 | `fukuii-first-start`         | Bootstrap a brand-new node end to end | runbooks/first-start |
 | `fukuii-security-hardening`  | IP block/unblock, trusted peers, RPC exposure review | runbooks/security; admin block/trusted methods |
 | `fukuii-custom-networks`     | Stand up a private/consortium/custom-genesis chain | runbooks/custom-networks, enterprise-deployment |
+| `fukuii-engine-api-setup`    | Configure and verify Engine API (JWT auth, port, CL client connection) | runbooks/engine-api |
+
+## Code quality skills
+
+Development-time skills for dependency hygiene and technical debt triage.
+These do not correspond to operational runbooks — they analyse source and
+build configuration directly.
+
+| Skill | Workflow | Backing source |
+| :--- | :--- | :--- |
+| `fukuii-dependency-audit`    | Audit all library versions; flag stale, CVE-affected, or non-LTS deps | `build.sbt`, endoflife.date, CVE feeds |
+| `fukuii-tech-debt-inventory` | Inventory technical debt: deprecated APIs, suppressed warnings, TODO/FIXME, scalafmt violations | Source scan + scapegoat report |
+
+## Spec Kit — Bug triage
+
+Three-step structured bug triage. Artifacts land in `.specify/bugs/<slug>/`
+and can be referenced in PRs. The workflow is strictly sequential.
+
+| Skill | Step | What it produces |
+| :--- | :--- | :--- |
+| `speckit-bug-assess` | 1 — Assess | `.specify/bugs/<slug>/assessment.md`: root cause, reproduction steps, remediation options |
+| `speckit-bug-fix`    | 2 — Fix    | `.specify/bugs/<slug>/fix.md`: changes applied, tests added, `sbt testEssential` result |
+| `speckit-bug-test`   | 3 — Verify | `.specify/bugs/<slug>/test.md`: symptom reproduction verdict (`verified`/`partial`/`failed`) |
 
 ## Validation
 

--- a/.claude/skills/fukuii-dependency-audit/SKILL.md
+++ b/.claude/skills/fukuii-dependency-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fukuii-dependency-audit
+description: >-
+  Audit Scala, sbt, and key library versions for LTS compliance in the Fukuii
+  project. Checks project/Dependencies.scala, project/build.properties, and
+  runs sbt dependencyUpdates to surface stale or outdated versions. Use when
+  asked to "check deps", "dep audit", "is our scala LTS current", "are
+  dependencies up to date", or as part of a monthly LTS review cadence.
+  Read-only; safe to run anytime. Does NOT require a running node.
+disable-model-invocation: true
+---
+
+# Fukuii dependency audit
+
+This skill does **not** require a running Fukuii node and makes no RPC calls.
+It is **read-only** — no guarded writes. Run freely at any time.
+
+## When to use
+- Monthly LTS cadence check: is Scala 3.3.x still the latest patch? Is sbt current?
+- Before planning a modernization sprint (confirm version targets before writing specs)
+- After a Scala/Pekko/CE3 release announcement
+- When asked "are any of our dependencies outdated?"
+
+## Procedure (all 🟢 read-only)
+
+### 1. Read pinned version declarations
+```bash
+grep -E 'scala-3|pekkoVersion|pekkoHttpVersion' /media/dev/2tb/dev/fukuii/build.sbt /media/dev/2tb/dev/fukuii/project/Dependencies.scala
+cat /media/dev/2tb/dev/fukuii/project/build.properties
+```
+
+### 2. Check endoflife.date for Scala
+```bash
+curl -s "https://endoflife.date/api/scala.json" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for c in data[:6]:
+    print(f'  {c[\"cycle\"]}: latest={c[\"latest\"]}  eol={c.get(\"eol\", \"N/A\")}')
+"
+```
+Report: is the current Scala 3.3.x the latest LTS patch? Is there a newer patch?
+
+### 3. Run sbt dependencyUpdates
+```bash
+cd /media/dev/2tb/dev/fukuii && sbt "dependencyUpdates" 2>&1 | grep -E "^\[info\] [^ ]" | grep -v "Loading\|Compiling\|Done\|Setting"
+```
+The `sbt-updates` plugin (`com.timushev.sbt:sbt-updates:0.6.4`) is installed.
+This lists all direct and transitive dependencies with newer versions available.
+
+### 4. BSL guard — zero Akka imports
+```bash
+grep -rn "import akka\." /media/dev/2tb/dev/fukuii/src/main/scala/ --include="*.scala" 2>/dev/null || echo "✓ Zero Akka imports — BSL-clean"
+grep '"com.typesafe.akka"\|"com.lightbend".*akka' /media/dev/2tb/dev/fukuii/project/Dependencies.scala && echo "CRITICAL: BSL 1.1 Akka dep found" || echo "✓ No Akka deps in Dependencies.scala"
+```
+Any `com.typesafe.akka` or `com.lightbend:akka*` entry is a **CRITICAL** BSL 1.1
+violation — incompatible with Fukuii's Apache 2.0 license. Block immediately.
+
+### 5. Cross-check global lts-versions.md
+Read `/media/dev/2tb/dev/claude-global-settings/rules/lts-versions.md`.
+Note any divergence between what Fukuii pins and what the global LTS file says
+is current. If lts-versions.md is stale, update it as a separate edit (not a
+Fukuii commit — it lives in a different repo).
+
+## Decision guide
+
+| Finding | Action |
+| :-- | :-- |
+| Scala patch behind (e.g. 3.3.7 vs 3.3.8) | Update `build.sbt` — patch bumps are zero-risk |
+| Pekko minor version available | Evaluate changelog; test with `sbt testEssential` |
+| Pekko major version available | Spec it via `/speckit-specify` — potential Typed API changes |
+| Any `com.typesafe.akka` entry | **CRITICAL** — block; BSL 1.1 violation |
+| CE3 / fs2 major update | Spec it — functional concurrency changes are high-impact |
+| lts-versions.md stale | Update the global file (separate edit, not a Fukuii commit) |
+
+## Output
+Structured report per CONVENTIONS §4:
+- **Scala version**: current vs latest LTS patch + EOL date
+- **sbt version**: current vs latest
+- **Key libraries**: Pekko, CE3, circe, fs2 — current vs available
+- **BSL guard**: result of Akka scan (must be zero)
+- **Recommended actions**: zero-risk patches vs spec-required upgrades

--- a/.claude/skills/fukuii-tech-debt-inventory/SKILL.md
+++ b/.claude/skills/fukuii-tech-debt-inventory/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: fukuii-tech-debt-inventory
+description: >-
+  Scan the Fukuii codebase for Scala 2 legacy patterns and produce a ranked
+  tech-debt inventory for MITHRIL sprint planning. Counts implicit val/def,
+  implicit class, sealed trait + case object hierarchies, and wildcard imports
+  by file. Use when asked for "tech debt", "modernization targets", "implicit
+  audit", "what should mithril focus on", or before planning a Scala 3
+  modernization sprint. Read-only; safe to run anytime. Does NOT require a
+  running node.
+disable-model-invocation: true
+---
+
+# Fukuii tech-debt inventory
+
+This skill does **not** require a running Fukuii node and makes no RPC calls.
+It is **read-only** — no guarded writes. Run freely at any time.
+
+## When to use
+- Before planning a MITHRIL modernization sprint (seed the work list with ranked targets)
+- To track migration progress after a Scalafix `GivenUsing` pass
+- When asked "how much Scala 2 code is left?" or "what's the migration backlog?"
+- Before writing `.local/docs/moderization-review-june/scala-implicit-to-given.md`
+
+## Procedure (all 🟢 read-only)
+
+Run each grep against `src/main/scala/`. Results are ranked by occurrence count.
+
+### 1. `implicit val` / `implicit def` → `given` candidates
+```bash
+echo "=== implicit val/def by file (top 20) ==="
+grep -rn "implicit val\|implicit def" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | grep -v "^\s*//" | awk -F: '{print $1}' | sort | uniq -c | sort -rn | head -20
+echo ""
+echo "Total occurrences:"
+grep -rc "implicit val\|implicit def" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | awk -F: '$2>0 {sum+=$2} END {print sum}'
+```
+
+### 2. `implicit class` → `extension` candidates
+```bash
+echo "=== implicit class (all files) ==="
+grep -rn "implicit class" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | grep -v "^\s*//" | awk -F: '{print $1}' | sort | uniq -c | sort -rn
+```
+
+### 3. Wildcard imports `import x._` → `import x.*`
+```bash
+echo "=== wildcard imports by file (top 20) ==="
+grep -rn "import .*\._$" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | grep -v "^\s*//" | awk -F: '{print $1}' | sort | uniq -c | sort -rn | head -20
+echo ""
+echo "Total wildcard imports:"
+grep -rc "import .*\._$" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | awk -F: '$2>0 {sum+=$2} END {print sum}'
+```
+
+### 4. `sealed trait` + `case object` — enum candidates
+```bash
+echo "=== sealed traits (total) ==="
+grep -rc "sealed trait\|sealed abstract class" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | awk -F: '$2>0 {sum+=$2} END {print sum}'
+echo "=== case objects (total — these are the safe enum targets) ==="
+grep -rc "^  *case object" /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" | awk -F: '$2>0 {sum+=$2} END {print sum}'
+```
+Note: only `sealed trait` hierarchies where ALL subtypes are `case object` are
+safe enum migration targets. `sealed trait` with `case class` subtypes carry
+data and must stay as is.
+
+### 5. Pekko Classic actor inventory
+```bash
+echo "=== Pekko Classic actors still to migrate ==="
+grep -rln "extends Actor\b\|extends Actor with\|extends UntypedActor" \
+  /media/dev/2tb/dev/fukuii/src/main/scala/ --include="*.scala"
+echo ""
+echo "=== Already Typed (for reference) ==="
+grep -rln "extends AbstractBehavior\|Behaviors\.setup\|Behaviors\.receive" \
+  /media/dev/2tb/dev/fukuii/src/main/scala/ --include="*.scala"
+```
+
+### 6. BSL guard
+```bash
+echo "=== BSL guard: Akka imports ==="
+grep -rn "import akka\." /media/dev/2tb/dev/fukuii/src/main/scala/ \
+  --include="*.scala" 2>/dev/null || echo "✓ Zero Akka imports — BSL-clean"
+```
+
+## Decision guide
+
+| Pattern | Risk | MITHRIL approach |
+| :-- | :-- | :-- |
+| `implicit val/def` in non-consensus code | Low | Mechanical via `sbt scalafix GivenUsing` |
+| `implicit val/def` in EVM/consensus code | Medium | MITHRIL + FORGE review before commit |
+| `implicit class` | Low | `sbt scalafix` or manual extension rewrite |
+| `import x._` | Low | `sbt scalafix` or bulk find-replace |
+| `sealed trait` + all-`case object` | Low | Enum migration; check exhaustive match sites |
+| `sealed trait` + `case class` subtypes | High | Do NOT migrate to enum — data types stay as is |
+| Classic `extends Actor` | Varies | See migration decision table in `pekko-typed-migration-p2.md` |
+| Any `import akka.` | **CRITICAL** | BSL 1.1 — block and remove immediately |
+
+## Output
+
+Emit a structured inventory table:
+
+```
+TECH-DEBT INVENTORY (src/main/scala/)
+======================================
+Pattern                      Files    Occurrences    Risk     Tool
+------------------------------------------------------------------------
+implicit val/def             XX       XXX            Low      sbt scalafix GivenUsing
+implicit class               XX       XX             Low      sbt scalafix / manual
+import x._                   XX       XXX            Low      sbt scalafix / replace
+sealed trait (total)         XX       XX             Mixed    case-by-case
+case object (enum targets)   XX       XX             Low      manual per hierarchy
+Classic actors remaining     XX       —              Varies   MITHRIL (see p2 spec)
+------------------------------------------------------------------------
+BSL guard (import akka.)     0        0              ✓ CLEAN
+```
+
+Append the top-10 files by total legacy pattern count — these are the highest-
+value targets for the first MITHRIL session.

--- a/.claude/skills/speckit-bug-assess/SKILL.md
+++ b/.claude/skills/speckit-bug-assess/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: speckit-bug-assess
+description: >-
+  Assess a bug and produce a structured investigation report. Use when given a
+  bug description, stack trace, error output, or GitHub issue URL. Reads source
+  code, forms a root cause hypothesis, and writes .specify/bugs/<slug>/assessment.md.
+  Does NOT modify source. First step in the assess → fix → test bug triage workflow.
+disable-model-invocation: true
+user-invokable: true
+model: sonnet
+argument-hint: "bug description or issue URL"
+---
+
+# speckit-bug-assess
+
+Produce a structured bug assessment without touching source code. Output goes
+to `.specify/bugs/<slug>/assessment.md` for downstream use by `speckit-bug-fix`
+and `speckit-bug-test`.
+
+## CRITICAL: read-only discipline
+
+You may read any source file. You MUST NOT write to or edit any `.scala`, `.sbt`,
+`.conf`, or test file during assessment. The only file you write is `assessment.md`.
+
+## Step 1: Slug
+
+If the user provided a slug (e.g. `/speckit-bug-assess bfs-queue-tombstone-degradation`),
+use it. Otherwise ask: "Short slug for this bug? (kebab-case, max 40 chars)".
+Create `.specify/bugs/<slug>/` if it does not exist.
+If `assessment.md` already exists, confirm before overwriting.
+
+## Step 2: Ingest the report
+
+Take the bug as pasted text in the argument, or if given a URL, read it via
+Bash (`curl -s <url>` for raw text). Trust only these domains: github.com,
+gitlab.com, stackoverflow.com, sentry.io. For any other host, ask the user to
+confirm before fetching.
+
+## Step 3: Reproduce mentally
+
+Read the suspected code paths. Do NOT invent file:line references — only cite
+paths you have actually read. Form a root cause hypothesis; state your confidence
+(high / medium / low) and what would change it.
+
+## Step 4: Write assessment.md
+
+```markdown
+# Bug: <short title>
+
+## Summary
+One-paragraph description of the symptom and business impact.
+
+## Reproduction steps
+1. ...
+2. ...
+Expected: ...
+Observed: ...
+
+## Suspected code paths
+- `path/to/File.scala:line` — why this is relevant
+- (only cite files you actually read)
+
+## Root cause hypothesis
+**Confidence: high | medium | low**
+
+Explanation of the mechanism.
+
+What would raise/lower confidence: ...
+
+## Proposed remediation
+
+### Preferred approach
+File(s) to change: ...
+Change description: ...
+Tests to add: ...
+
+### Alternative (if preferred has risks)
+...
+
+## Risks and unknowns
+- ...
+
+## Scope of fix
+Files to modify: (list)
+Files NOT to modify: (e.g. consensus-boundary paths — delegate to forge/beacon)
+```
+
+## Consensus-critical gate
+
+If the root cause lies in `consensus/`, `vm/`, `crypto/`, or `domain/`:
+note this in the assessment and add a section:
+
+```markdown
+## Consensus-critical: delegate required
+Root cause touches <path>. Before applying any fix, invoke `forge` (ETC/Mordor)
+or `beacon` (ETH/Sepolia) per the Consensus-Critical Change Protocol in CLAUDE.md.
+```
+
+Do NOT propose a specific remediation for consensus-critical code — that is
+`forge`/`beacon`'s role.
+
+## Done
+
+Report: "Assessment written to `.specify/bugs/<slug>/assessment.md`. Run
+`/speckit-bug-fix` to apply the remediation."

--- a/.claude/skills/speckit-bug-fix/SKILL.md
+++ b/.claude/skills/speckit-bug-fix/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: speckit-bug-fix
+description: >-
+  Apply a bug fix from an existing assessment. Use after speckit-bug-assess has
+  produced .specify/bugs/<slug>/assessment.md. Reads the assessment as a contract,
+  confirms the plan, applies the remediation, adds/updates tests, and runs
+  sbt testEssential. Second step in the assess → fix → test bug triage workflow.
+disable-model-invocation: true
+user-invokable: true
+model: sonnet
+argument-hint: "slug (optional if assessment context is present)"
+---
+
+# speckit-bug-fix
+
+Apply the remediation defined in `assessment.md`. The assessment is the contract;
+stay within its scope unless new evidence demands a deviation (which you document).
+
+## CRITICAL: assessment.md is read-only
+
+Never edit `assessment.md`. If you disagree with the assessment, record the
+deviation in `fix.md`. Never delete any file.
+
+## Step 1: Resolve slug
+
+Use the explicit argument, the slug from a prior `speckit-bug-assess` in this
+session, or — if exactly one `.specify/bugs/*/assessment.md` exists — infer it.
+Otherwise ask. Require `assessment.md` to exist; if missing, say "Run
+`/speckit-bug-assess` first."
+
+If `fix.md` already exists, confirm before overwriting.
+
+## Step 2: Confirm plan
+
+Read `assessment.md`. Present a 3–6 bullet confirmation:
+
+```
+Plan:
+• Change: <brief description>
+• Files: <list from assessment>
+• Tests to add: <list>
+• Consensus-critical? <yes → STOP / no → proceed>
+```
+
+If the assessment flagged consensus-critical scope, STOP and say: "This fix
+requires `forge` (ETC) or `beacon` (ETH) — see assessment.md."
+
+## Step 3: Apply remediation
+
+- Stay within the files listed in `assessment.md` unless new evidence strictly
+  requires touching additional files (document the deviation).
+- Write tests before or alongside production changes (TDD: red → green → refactor).
+- Run the existing test suite after each file change — do not batch all edits
+  then run once.
+
+```bash
+sbt compile-all           # must be green after each file
+sbt testEssential         # Tier 1 gate — must pass before writing fix.md
+```
+
+## Step 4: Write fix.md
+
+```markdown
+# Fix: <slug>
+
+## Status
+applied | partial | not-applied
+
+## Changes
+| File | Lines | Description |
+|------|-------|-------------|
+| path/to/File.scala | +N -M | What changed and why |
+
+## Tests added
+- `path/to/NewSpec.scala` — what it covers
+
+## Verification
+VERIFY: ran `sbt compile-all` — result: PASS
+VERIFY: ran `sbt testEssential` — result: N passed, 0 failed
+
+## Deviations from assessment
+- (none) or list what changed and why
+
+## Follow-ups
+- (anything the fix revealed that is out of scope)
+```
+
+## Done
+
+Report: "Fix applied and verified. Run `/speckit-bug-test` to validate against
+the original symptom."

--- a/.claude/skills/speckit-bug-test/SKILL.md
+++ b/.claude/skills/speckit-bug-test/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: speckit-bug-test
+description: >-
+  Validate a bug fix against the original symptom. Use after speckit-bug-fix has
+  produced .specify/bugs/<slug>/fix.md. Reproduces the original symptom to confirm
+  it is resolved, runs the regression suite, and writes a verdict. Read-only on
+  source. Third step in the assess → fix → test bug triage workflow.
+disable-model-invocation: true
+user-invokable: true
+model: sonnet
+argument-hint: "slug (optional if fix context is present)"
+---
+
+# speckit-bug-test
+
+Validate that the fix resolves the original symptom and introduces no regressions.
+Read-only — you do not modify source code or assessment/fix artifacts.
+
+## CRITICAL: never mark verified without running the repro
+
+If the reproduction steps require a live node, network peers, or external state
+that cannot be reproduced in this environment, say so explicitly and report
+`not-reproducible` rather than claiming `verified`.
+
+## Step 1: Resolve slug
+
+Use the explicit argument, the slug from a prior session step, or the single
+candidate in `.specify/bugs/`. Require both `assessment.md` and `fix.md`; if
+either is missing, say which is needed and stop.
+
+If `test.md` already exists, confirm before overwriting.
+
+## Step 2: Plan validation
+
+Read `assessment.md` (reproduction steps) and `fix.md` (tests added, verification
+commands). Determine:
+1. Can the original symptom be reproduced in this environment?
+2. Which test(s) in `fix.md` directly cover the symptom?
+3. Which test tier covers the changed code?
+
+## Step 3: Run checks
+
+For each check, record the command, exit code, and relevant output excerpt.
+Do not skip a check without marking it `skipped: <reason>`.
+
+```bash
+# Reproduce original symptom (if possible)
+sbt "testOnly *<relevant-spec>*"   # the new test from fix.md
+
+# Regression suite
+sbt testEssential                  # Tier 1 — must pass
+```
+
+Only run `sbt testStandard` or `sbt testComprehensive` if Tier 1 is clean and
+the change touches integration-level code.
+
+Do NOT run network-level reproduction without explicit user consent (it may
+affect live peers or mainnet state).
+
+## Step 4: Write test.md
+
+```markdown
+# Test: <slug>
+
+## Verdict
+verified | partial | failed | not-reproducible
+
+## Checks
+| Check | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Symptom reproduction | sbt testOnly ... | PASS/FAIL | |
+| Regression — Tier 1 | sbt testEssential | N passed, 0 failed | |
+
+## Output excerpts
+(key lines from the test run that justify the verdict)
+
+## Residual risks
+- (any edge cases the fix may not cover)
+
+## Recommendation
+- verified → open PR; include assessment + fix + test artifacts as context
+- partial → list what still fails; return to speckit-bug-fix
+- failed → symptom persists; describe what was observed vs expected
+- not-reproducible → environment limitation; describe what manual step is needed
+```
+
+## Done
+
+Report the verdict and recommendation. If `verified`, suggest committing per the
+project commit workflow and opening a PR referencing `.specify/bugs/<slug>/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Working in fukuii
 
 `fukuii` is a **multi-network EVM client** (forked from IOHK Mantis, repackaged
-under `com.chipprbots`), running on **Scala 3.3.7 LTS** with Akka actors.
+under `com.chipprbots`), running on **Scala 3.3.8 LTS** with Apache Pekko actors.
 It supports two independent chain families:
 
 - **Ethereum Classic (ETC/Mordor)** — PoW/Ethash, ECIP-1017 fixed-supply
@@ -133,7 +133,7 @@ Read it before planning or implementing. Highlights:
 - Consensus-critical code (EVM/gas, state roots, hashes, RLP, Ethash, rewards,
   hard forks) MUST be byte-for-byte deterministic and ETC-spec compliant — design
   before implementing; follow the `forge` protocol in `.github/agents/forge.md`.
-- Scala 3.3.7 LTS only; code MUST pass `scalafmt` + `scalafix`.
+- Scala 3.3.8 LTS only; code MUST pass `scalafmt` + `scalafix`.
 - Tests MUST be deterministic (no `Thread.sleep`); keep statement coverage ≥ 70%.
 - Run `sbt pp` before opening a PR; CI gates and review must be green to merge.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ session is the orchestrator** — subagents cannot spawn other subagents, so you
 | `wraith`  | Scala 3 compile errors / build failures | On compile failures |
 | `herald`  | P2P / RLPx / ETH wire protocol, Snappy, handshakes, multi-client interop | On networking issues |
 | `mithril` | Idiomatic Scala 3 modernization (opaque types, enums, given/using) | On-demand |
+| `prism`   | Code quality review: functionality, tests, readability, structure, simplicity, performance, security, scala-fp — non-consensus code only | On-demand: before `eye`, after `mithril`/`wraith`, before PR |
 
 ### Consensus-Critical Change Protocol (mandatory)
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ crossPaths := true
 // patch for error on 'early-semver' problems
 ThisBuild / evictionErrorLevel := Level.Info
 
-val `scala-3` = "3.3.7" // Scala 3 LTS version
+val `scala-3` = "3.3.8" // Scala 3 LTS version (released 2026-06-11)
 val supportedScalaVersions = List(`scala-3`) // Scala 3 only
 
 // Base scalac options
@@ -62,6 +62,8 @@ val scala3Options = Seq(
   "-Wconf:msg=Compiler synthesis of Manifest:s,cat=deprecation:s", // Suppress Manifest deprecation warnings
   "-Ykind-projector", // Scala 3 replacement for kind-projector plugin
   "-Xmax-inlines:64" // Increase inline depth limit for complex boopickle/circe derivations
+  // NOTE: -source:future deferred — requires ~1,652 wildcard imports migrated from `_` to `*` first
+  // See .local/docs/moderization-review-june/scala-future-source.md for the pre-flight spec
 )
 
 def commonSettings(projectName: String): Seq[sbt.Def.Setting[_]] = Seq(
@@ -573,7 +575,8 @@ addCommandAlias("testMPT", "testOnly -- -n MPTTest")
 addCommandAlias("testEthereum", "testOnly -- -n EthereumTest")
 
 // Scapegoat configuration for Scala 3
-(ThisBuild / scapegoatVersion) := "3.3.4"
+// 3.3.6 is the first scapegoat cross-build published for Scala 3.3.8
+(ThisBuild / scapegoatVersion) := "3.3.6"
 scapegoatReports := Seq("xml", "html")
 scapegoatConsoleOutput := false
 scapegoatDisabledInspections := Seq("UnsafeTraversableMethods")

--- a/bytes/src/main/scala/com/chipprbots/ethereum/utils/ByteStringUtils.scala
+++ b/bytes/src/main/scala/com/chipprbots/ethereum/utils/ByteStringUtils.scala
@@ -3,7 +3,7 @@ package com.chipprbots.ethereum.utils
 import org.apache.pekko.util.ByteString
 
 import scala.collection.mutable
-import scala.math.Ordering.Implicits._
+import scala.math.Ordering.Implicits.*
 
 object ByteStringUtils {
   def hash2string(hash: ByteString): String =

--- a/bytes/src/test/scala/com/chipprbots/ethereum/utils/ByteStringUtilsTest.scala
+++ b/bytes/src/test/scala/com/chipprbots/ethereum/utils/ByteStringUtilsTest.scala
@@ -10,8 +10,8 @@ import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import ByteStringUtils._
-import com.chipprbots.ethereum.testing.Tags._
+import ByteStringUtils.*
+import com.chipprbots.ethereum.testing.Tags.*
 
 class ByteStringUtilsTest extends AnyWordSpec with Matchers {
 
@@ -27,7 +27,7 @@ class ByteStringUtilsTest extends AnyWordSpec with Matchers {
     "fail parsing a valid hash string" taggedAs UnitTest in {
       val invalidHashString = "XXYYZZXX"
       val parsed = Try(string2hash(invalidHashString))
-      parsed shouldBe a[Failure[_]]
+      parsed shouldBe a[Failure[?]]
     }
 
     "concatByteStrings for simple bytestrings" taggedAs UnitTest in {

--- a/bytes/src/test/scala/com/chipprbots/ethereum/utils/ByteUtilsSpec.scala
+++ b/bytes/src/test/scala/com/chipprbots/ethereum/utils/ByteUtilsSpec.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class ByteUtilsSpec extends AnyFunSuite with ScalaCheckPropertyChecks {
   def byteArrayOfNItemsGen(n: Int): Gen[Array[Byte]] =

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/ECIESCoder.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/ECIESCoder.scala
@@ -12,7 +12,7 @@ import org.bouncycastle.crypto.engines.AESEngine
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.macs.HMac
 import org.bouncycastle.crypto.modes.SICBlockCipher
-import org.bouncycastle.crypto.params._
+import org.bouncycastle.crypto.params.*
 import org.bouncycastle.math.ec.ECPoint
 
 object ECIESCoder {

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/EthereumIESEngine.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/EthereumIESEngine.scala
@@ -92,7 +92,7 @@ class EthereumIESEngine(
           (plainText(inOff + idx) ^ value).toByte
         }
 
-        (secondPart, ByteString(encrypted: _*))
+        (secondPart, ByteString(encrypted *))
     }
 
     // calculate mac
@@ -157,7 +157,7 @@ class EthereumIESEngine(
           (cryptogram(inOff + encodedPublicKey.length + idx) ^ value).toByte
         }
 
-        (secondPart, ByteString(decrypted: _*))
+        (secondPart, ByteString(decrypted *))
     }
 
     val end = inOff + inLen

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/package.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/package.scala
@@ -14,7 +14,7 @@ import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
 import org.bouncycastle.crypto.generators.SCrypt
-import org.bouncycastle.crypto.params._
+import org.bouncycastle.crypto.params.*
 import org.bouncycastle.math.ec.ECPoint
 import org.bouncycastle.util.encoders.Hex
 

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/BN128.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/BN128.scala
@@ -3,7 +3,7 @@ package com.chipprbots.ethereum.crypto.zksnark
 import org.apache.pekko.util.ByteString
 
 import com.chipprbots.ethereum.crypto.zksnark.BN128.Point
-import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops._
+import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops.*
 
 /** Barreto–Naehrig curve over some finite field Curve equation: Y^2^ = X^3^ + b, where "b" is a constant number
   * belonging to corresponding specific field
@@ -187,7 +187,7 @@ object BN128 {
 
   case class BN128G2(p: Point[Fp2])
   object BN128G2 {
-    import BN128Fp2._
+    import BN128Fp2.*
 
     /** "r" order of cyclic subgroup
       */

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/FieldElement.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/FieldElement.scala
@@ -2,7 +2,7 @@ package com.chipprbots.ethereum.crypto.zksnark
 
 import org.apache.pekko.util.ByteString
 
-import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops._
+import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops.*
 import com.chipprbots.ethereum.utils.ByteUtils
 
 // Arithmetic in on all finite fields described in:

--- a/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/PairingCheck.scala
+++ b/crypto/src/main/scala/com/chipprbots/ethereum/crypto/zksnark/PairingCheck.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.chipprbots.ethereum.crypto.zksnark.BN128.BN128G1
 import com.chipprbots.ethereum.crypto.zksnark.BN128.BN128G2
 import com.chipprbots.ethereum.crypto.zksnark.BN128.Point
-import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops._
+import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops.*
 
 object PairingCheck {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/AesCbcSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/AesCbcSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class AesCbcSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/AesCtrSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/AesCtrSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class AesCtrSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ECDSASignatureSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ECDSASignatureSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import com.chipprbots.ethereum.utils.ByteStringUtils
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class ECDSASignatureSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with SecureRandomBuilder {
   "ECDSASignature" should "recover public key correctly for go ethereum transaction" taggedAs (

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ECIESCoderSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ECIESCoderSpec.scala
@@ -8,7 +8,7 @@ import org.bouncycastle.util.encoders.Hex
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class ECIESCoderSpec extends AnyFlatSpec with Matchers with SecureRandomBuilder {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/Pbkdf2HMacSha256Spec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/Pbkdf2HMacSha256Spec.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class Pbkdf2HMacSha256Spec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/Ripemd160Spec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/Ripemd160Spec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableFor2
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class Ripemd160Spec extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ScryptSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/ScryptSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class ScryptSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/zksnarks/BN128FpSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/zksnarks/BN128FpSpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.chipprbots.ethereum.crypto.zksnark.BN128.Point
 import com.chipprbots.ethereum.crypto.zksnark.BN128Fp
 import com.chipprbots.ethereum.crypto.zksnark.Fp
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.Tags.*
 
 class BN128FpSpec extends AnyFunSuite with ScalaCheckPropertyChecks {
 

--- a/crypto/src/test/scala/com/chipprbots/ethereum/crypto/zksnarks/FpFieldSpec.scala
+++ b/crypto/src/test/scala/com/chipprbots/ethereum/crypto/zksnarks/FpFieldSpec.scala
@@ -7,9 +7,9 @@ import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops._
-import com.chipprbots.ethereum.crypto.zksnark._
-import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.crypto.zksnark.FiniteField.Ops.*
+import com.chipprbots.ethereum.crypto.zksnark.*
+import com.chipprbots.ethereum.testing.Tags.*
 
 abstract class FieldSpec[T: FiniteField] extends AnyFunSuite with ScalaCheckPropertyChecks {
   val bigIntGen: Gen[BigInteger] = for {
@@ -21,7 +21,7 @@ abstract class FieldSpec[T: FiniteField] extends AnyFunSuite with ScalaCheckProp
   def fp2Generator: Gen[Fp2] = for {
     fp1 <- fpGenerator
     fp2 <- fpGenerator
-  } yield Fp2(fp1, fp1)
+  } yield Fp2(fp1, fp2)
 
   def fp6Generator: Gen[Fp6] = for {
     fp1 <- fp2Generator

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,14 +58,14 @@ object Dependencies {
   )
 
   val enumeratum: Seq[ModuleID] = Seq(
-    "com.beachape" %% "enumeratum" % "1.9.7",
-    "com.beachape" %% "enumeratum-cats" % "1.9.7",
-    "com.beachape" %% "enumeratum-scalacheck" % "1.9.7" % Test
+    "com.beachape" %% "enumeratum" % "1.9.8",
+    "com.beachape" %% "enumeratum-cats" % "1.9.8",
+    "com.beachape" %% "enumeratum-scalacheck" % "1.9.8" % Test
   )
 
   val testing: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.19" % "it,test",
-    "org.scalamock" %% "scalamock" % "7.3.2" % "it,test",
+    "org.scalatest" %% "scalatest" % "3.2.20" % "it,test",
+    "org.scalamock" %% "scalamock" % "7.3.3" % "it,test",
     "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test",
     "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % "it,test",
     "org.mockito" % "mockito-core" % "5.23.0" % "it,test",
@@ -76,7 +76,7 @@ object Dependencies {
 
   val cats: Seq[ModuleID] = {
     val catsVersion = "2.13.0"
-    val catsEffectVersion = "3.6.1"
+    val catsEffectVersion = "3.6.3"
     Seq(
       "org.typelevel" %% "mouse" % "1.4.0",
       "org.typelevel" %% "cats-core" % catsVersion,
@@ -88,7 +88,7 @@ object Dependencies {
   val monix = Seq.empty[ModuleID]
 
   val fs2: Seq[ModuleID] = {
-    val fs2Version = "3.12.0" // requires cats-effect 3.6+
+    val fs2Version = "3.12.2" // requires cats-effect 3.6+
     Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,
@@ -127,7 +127,7 @@ object Dependencies {
   )
 
   val logging = Seq(
-    "ch.qos.logback" % "logback-classic" % "1.5.32",
+    "ch.qos.logback" % "logback-classic" % "1.5.34",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",
     "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
     "org.codehaus.janino" % "janino" % "3.1.12",
@@ -154,9 +154,9 @@ object Dependencies {
     "org.apache.httpcomponents.client5" % "httpclient5" % "5.6.1" // For JupnP UPnP transport without URLStreamHandlerFactory
   )
 
-  val jline = "org.jline" % "jline" % "3.30.13"
+  val jline = "org.jline" % "jline" % "3.30.13" // 4.x is a major API change — deferred
 
-  val jna = "net.java.dev.jna" % "jna" % "5.18.1"
+  val jna = "net.java.dev.jna" % "jna" % "5.19.1"
 
   val dependencies = Seq(
     jline,
@@ -182,7 +182,7 @@ object Dependencies {
 
   // Prometheus Java client 1.x (replaces legacy simpleclient 0.x)
   val prometheus: Seq[ModuleID] = {
-    val version = "1.3.5"
+    val version = "1.3.10" // 1.8.0 is a major bump — deferred
     Seq(
       "io.prometheus" % "prometheus-metrics-core" % version,
       "io.prometheus" % "prometheus-metrics-instrumentation-jvm" % version,
@@ -192,7 +192,7 @@ object Dependencies {
 
   val micrometer: Seq[ModuleID] = {
     val provider = "io.micrometer"
-    val version = "1.16.5"
+    val version = "1.16.6" // 1.17.0 is a minor bump — deferred
     Seq(
       // Required to compile metrics library https://github.com/micrometer-metrics/micrometer/issues/1133#issuecomment-452434205
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % Optional,

--- a/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLP.scala
+++ b/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLP.scala
@@ -226,7 +226,7 @@ private[rlp] object RLP {
         case ItemBounds(start, end, false, isEmpty) =>
           RLPValue(if (isEmpty) Array.empty[Byte] else data.slice(start, end + 1)) -> (end + 1)
         case ItemBounds(start, end, true, _) =>
-          RLPList(decodeListRecursive(data, start, end - start + 1, Queue()): _*) -> (end + 1)
+          RLPList(decodeListRecursive(data, start, end - start + 1, Queue()) *) -> (end + 1)
       }
     }
 

--- a/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPDerivation.scala
+++ b/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPDerivation.scala
@@ -1,6 +1,6 @@
 package com.chipprbots.ethereum.rlp
 
-import scala.compiletime._
+import scala.compiletime.*
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
@@ -127,7 +127,7 @@ object RLPDerivation {
           case _ =>
             throw RLPException(
               s"Unexpected items at the end of the RLPList: ${items.size} leftover items.",
-              RLPList(items: _*)
+              RLPList(items *)
             )
         }
       case _: (head *: tail) =>

--- a/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPImplicitConversions.scala
+++ b/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPImplicitConversions.scala
@@ -15,7 +15,7 @@ object RLPImplicitConversions {
   implicit def fromOptionalEncodeable[T: RLPDecoder]: (Option[RLPEncodeable]) => Option[T] = _.map(fromEncodeable[T])
 
   implicit def toRlpList[T](values: Seq[T])(implicit enc: RLPEncoder[T]): RLPList =
-    RLPList(values.map(v => toEncodeable[T](v)): _*)
+    RLPList(values.map(v => toEncodeable[T](v)) *)
 
   def fromRlpList[T](rlpList: RLPList)(implicit dec: RLPDecoder[T]): Seq[T] =
     rlpList.items.map(dec.decode)

--- a/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPImplicits.scala
+++ b/rlp/src/main/scala/com/chipprbots/ethereum/rlp/RLPImplicits.scala
@@ -2,7 +2,7 @@ package com.chipprbots.ethereum.rlp
 
 import org.apache.pekko.util.ByteString
 
-import com.chipprbots.ethereum.rlp.RLP._
+import com.chipprbots.ethereum.rlp.RLP.*
 import com.chipprbots.ethereum.utils.ByteUtils
 
 import RLPCodec.Ops
@@ -133,7 +133,7 @@ object RLPImplicits {
 
   private def seqCodec[T](using enc: RLPEncoder[T], dec: RLPDecoder[T]) = new RLPEncoder[Seq[T]]
     with RLPDecoder[Seq[T]] {
-    override def encode(obj: Seq[T]): RLPEncodeable = RLPList(obj.map(enc.encode): _*)
+    override def encode(obj: Seq[T]): RLPEncodeable = RLPList(obj.map(enc.encode) *)
 
     override def decode(rlp: RLPEncodeable): Seq[T] = rlp match {
       case l: RLPList => l.items.map(dec.decode)

--- a/rlp/src/main/scala/com/chipprbots/ethereum/rlp/package.scala
+++ b/rlp/src/main/scala/com/chipprbots/ethereum/rlp/package.scala
@@ -30,13 +30,13 @@ package object rlp {
 
   case class RLPList(items: RLPEncodeable*) extends RLPEncodeable {
     def +:(item: RLPEncodeable): RLPList =
-      RLPList((item +: items): _*)
+      RLPList((item +: items) *)
 
     def :+(item: RLPEncodeable): RLPList =
-      RLPList((items :+ item): _*)
+      RLPList((items :+ item) *)
 
     def ++(other: RLPList): RLPList =
-      RLPList((items ++ other.items): _*)
+      RLPList((items ++ other.items) *)
   }
 
   case class RLPValue(bytes: Array[Byte]) extends RLPEncodeable {

--- a/rlp/src/test/scala/com/chipprbots/ethereum/rlp/RLPSuite.scala
+++ b/rlp/src/test/scala/com/chipprbots/ethereum/rlp/RLPSuite.scala
@@ -12,7 +12,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import com.chipprbots.ethereum.rlp.RLPImplicitConversions._
-import com.chipprbots.ethereum.rlp.RLPImplicits.{_, given}
+import com.chipprbots.ethereum.rlp.RLPImplicits.given
 import com.chipprbots.ethereum.utils.Hex
 import com.chipprbots.ethereum.testing.Tags._
 

--- a/scalanet/src/com/chipprbots/scalanet/IOValues.scala
+++ b/scalanet/src/com/chipprbots/scalanet/IOValues.scala
@@ -3,7 +3,6 @@ package com.chipprbots.scalanet
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 
-import scala.concurrent.duration.FiniteDuration
 
 /** Test ergonomics for `cats.effect.IO` mimicking the monix `TaskValues`
   * helpers from the original IOHK scalanet. Provides `.evaluated` (run sync,
@@ -22,8 +21,6 @@ object IOValues {
       } catch {
         case t: Throwable => t
       }
-
-    def delayBy(d: FiniteDuration): IO[A] = io.delayBy(d)
   }
 }
 

--- a/scalanet/src/com/chipprbots/scalanet/peergroup/dynamictls/DynamicTLSExtension.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/dynamictls/DynamicTLSExtension.scala
@@ -260,7 +260,7 @@ private[scalanet] object DynamicTLSExtension {
       val validInterval = getInterval()
 
       SignedKey
-        .buildSignedKeyExtension(Secp256k1, hostKeyPair, connectionKeyPairPublicKeyAsBytes, secureRandom)
+        .buildSignedKeyExtension(hostKeyType, hostKeyPair, connectionKeyPairPublicKeyAsBytes, secureRandom)
         .map {
           case (signedKey, signedKeyExtension) =>
             val nodeId = signedKey.publicKey.getNodeId

--- a/scalanet/src/com/chipprbots/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/dynamictls/DynamicTLSPeerGroupInternals.scala
@@ -155,7 +155,7 @@ private[peergroup] object DynamicTLSPeerGroupInternals {
         case e: TooLongFrameException =>
           logger.error("Too long frame {} on channel to peer {}", e.getMessage, ctx.channel().remoteAddress())
           handleEvent(DecodingError)
-        case e =>
+        case _ =>
           // swallow netty's default logging of the stack trace.
           logger.error(
             "Unexpected exception {} on channel to peer {}",

--- a/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/udp/StaticUDPPeerGroup.scala
@@ -573,7 +573,7 @@ object StaticUDPPeerGroup extends StrictLogging {
 
       peerGroupResource.flatMap { peerGroup =>
         // Create the server channel as a Resource
-        peerGroup.createServerChannel.flatMap { channel =>
+        peerGroup.createServerChannel.flatMap { _ =>
           Resource.make {
             IO(logger.debug("UDP server channel Resource is now active and will remain so until shutdown"))
               .as(peerGroup)
@@ -674,7 +674,7 @@ object StaticUDPPeerGroup extends StrictLogging {
         maybeMessage match {
           case Attempt.Successful(message) =>
             publish(MessageReceived(message))
-          case Attempt.Failure(err) =>
+          case Attempt.Failure(_) =>
             publish(DecodingError)
         }
       )

--- a/scalanet/src/com/chipprbots/scalanet/peergroup/udp/V5DemuxResponder.scala
+++ b/scalanet/src/com/chipprbots/scalanet/peergroup/udp/V5DemuxResponder.scala
@@ -4,7 +4,6 @@ import java.net.InetSocketAddress
 
 import scala.util.control.NonFatal
 
-import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.chipprbots.scalanet.peergroup.CloseableQueue
 import com.typesafe.scalalogging.LazyLogging
@@ -46,9 +45,10 @@ object V5DemuxResponder extends LazyLogging {
     val result = inner(sender, bits)
 
     val isV5 = result match {
-      case StaticUDPPeerGroup.SyncResult.Reply(_) => true
-      case StaticUDPPeerGroup.SyncResult.Stop     => true
-      case StaticUDPPeerGroup.SyncResult.Pass     => false
+      case StaticUDPPeerGroup.SyncResult.Reply(_)         => true
+      case StaticUDPPeerGroup.SyncResult.ClaimedReply(_)  => true
+      case StaticUDPPeerGroup.SyncResult.Stop             => true
+      case StaticUDPPeerGroup.SyncResult.Pass             => false
     }
 
     if (isV5) {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -295,6 +295,6 @@
     <!-- =================================================================== -->
     <!-- METRICS - Performance monitoring                                    -->
     <!-- =================================================================== -->
-    <!-- Set to DEBUG for metrics collection troubleshooting -->
-    <logger name="com.chipprbots.ethereum.metrics" level="ERROR" />
+    <!-- INFO emits [RESOURCE-PULSE] every 60s; raise to DEBUG for deeper metrics troubleshooting -->
+    <logger name="com.chipprbots.ethereum.metrics" level="INFO" />
 </configuration>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/PeersClient.scala
@@ -114,7 +114,7 @@ class PeersClient(
           case Some(peer) =>
             log.debug("Selected peer {} with address {} for request", peer.id, peer.remoteAddress.getHostString)
             // Adapt message format based on peer's negotiated capability
-            val adaptedMessage = adaptMessageForPeer(peer, message)
+            val adaptedMessage = adaptMessageForPeer(message)
             // Create a type-safe conversion function for the adapted message
             val adaptedToSerializable: Message => MessageSerializable = (msg: Message) =>
               msg match {
@@ -321,7 +321,7 @@ class PeersClient(
 
   /** Adapts message format based on peer's negotiated capability. ETH68+ always uses request-id — no adaptation needed.
     */
-  private def adaptMessageForPeer[RequestMsg <: Message](_peer: Peer, message: RequestMsg): Message = message
+  private def adaptMessageForPeer[RequestMsg <: Message](message: RequestMsg): Message = message
 
   private def responseClassTag[RequestMsg <: Message](requestMsg: RequestMsg): ClassTag[_ <: Message] =
     requestMsg match {

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/fast/SyncStateSchedulerActor.scala
@@ -104,6 +104,7 @@ class SyncStateSchedulerActor(
     case Capability.ETH63 | Capability.ETH64 | Capability.ETH65 | Capability.ETH66 | Capability.ETH67 => true
     case Capability.ETH68                                                                             => false
     case Capability.ETH69                                                                             => false
+    case Capability.ETH70                                                                             => false
     case Capability.SNAP1                                                                             => false
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockBroadcast.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/BlockBroadcast.scala
@@ -89,6 +89,10 @@ class BlockBroadcast(val networkPeerManager: ActorRef, val isPoWChain: Boolean =
           Some(blockToBroadcast.as63) // PoW: send NewBlock with TD — ECBP-1100 chain weight signal
         case Capability.ETH69 =>
           None // PoS: no NewBlock — go-ethereum aligned
+        case Capability.ETH70 if isPoWChain =>
+          Some(blockToBroadcast.as63)
+        case Capability.ETH70 =>
+          None
         case Capability.SNAP1 =>
           Some(blockToBroadcast.as63)
       }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -180,8 +180,8 @@ class RegularSync(
             if (lag == 0) "SYNCED" else "REGULAR-SYNC",
             Map(
               "blocks/s" -> f"$rate%.1f",
-              "lag"      -> lag.toString,
-              "head"     -> progressState.currentBlock.toString
+              "lag" -> lag.toString,
+              "head" -> progressState.currentBlock.toString
             )
           ),
           self

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -18,6 +18,7 @@ import com.chipprbots.ethereum.blockchain.sync.SyncProtocol.Status.Progress
 import com.chipprbots.ethereum.blockchain.sync.regular.BlockFetcher.InternalLastBlockImport
 import com.chipprbots.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import com.chipprbots.ethereum.blockchain.sync.regular.RegularSync.ProgressState
+import com.chipprbots.ethereum.metrics.ResourceHealthMonitor
 import com.chipprbots.ethereum.consensus.ConsensusAdapter
 import com.chipprbots.ethereum.consensus.validators.BlockValidator
 import com.chipprbots.ethereum.db.storage.{EvmCodeStorage, StateStorage}
@@ -172,6 +173,19 @@ class RegularSync(
         s"RegularSync: current=${progressState.currentBlock} best=${progressState.bestKnownNetworkBlock} " +
           s"lag=$lag rate=${f"$rate%.1f"}/s eta=$etaStr"
       )
+      context.system
+        .actorSelection(s"/user/${ResourceHealthMonitor.ActorName}")
+        .tell(
+          ResourceHealthMonitor.UpdatePhaseContext(
+            if (lag == 0) "SYNCED" else "REGULAR-SYNC",
+            Map(
+              "blocks/s" -> f"$rate%.1f",
+              "lag"      -> lag.toString,
+              "head"     -> progressState.currentBlock.toString
+            )
+          ),
+          self
+        )
       context.become(
         running(
           progressState.copy(lastPrintBlock = progressState.currentBlock, lastPrintTimeMs = now)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -15,10 +15,12 @@ import com.chipprbots.ethereum.db.storage.{
   EvmCodeStorage,
   FlatSlotStorage,
   HealingFrontierStorage,
+  HealingVisitedStorage,
   MptStorage,
   Namespaces,
   PathNodeStorage,
   RocksDbBfsQueueStorage,
+  RocksDbHealingVisitedStorage,
   SnapSyncProgressStorage,
   StateStorage
 }
@@ -3341,6 +3343,9 @@ class SNAPSyncController(
   private lazy val bfsQueueStorage: BfsQueueStorage =
     new RocksDbBfsQueueStorage(flatSlotStorage.dataSource, Namespaces.BfsQueueNamespace)
 
+  private lazy val visitedStorage: HealingVisitedStorage =
+    new RocksDbHealingVisitedStorage(flatSlotStorage.dataSource, Namespaces.HealingVisitedNamespace)
+
   private def startStateHealing(): Unit = {
     // Guard: prevent duplicate healing coordinator creation (Bug 27).
     // Can happen when ByteCodeSyncComplete and StorageRangeSyncComplete arrive in quick
@@ -3369,12 +3374,12 @@ class SNAPSyncController(
               batchSize = snapSyncConfig.healingBatchSize,
               snapSyncController = self,
               concurrency = snapSyncConfig.healingConcurrency,
-              visitedCap = snapSyncConfig.healingVisitedCap,
               healingFrontierStorage = healingFrontierStorageOpt,
               traversalParallelism = snapSyncConfig.healingTraversalParallelism,
               healingMinParallelism = snapSyncConfig.healingMinParallelism,
               healingReservedCores = snapSyncConfig.healingReservedCores,
               bfsQueueStorageOpt = Some(bfsQueueStorage),
+              visitedStorageOpt = Some(visitedStorage),
               storageScheme = snapSyncConfig.storageScheme,
               pathNodeStorageOpt = pathNodeStorageOpt,
               frontierHighWater = snapSyncConfig.healingFrontierHighWater,
@@ -3434,12 +3439,12 @@ class SNAPSyncController(
                   batchSize = snapSyncConfig.healingBatchSize,
                   snapSyncController = self,
                   concurrency = snapSyncConfig.healingConcurrency,
-                  visitedCap = snapSyncConfig.healingVisitedCap,
                   healingFrontierStorage = healingFrontierStorageOpt,
                   traversalParallelism = snapSyncConfig.healingTraversalParallelism,
                   healingMinParallelism = snapSyncConfig.healingMinParallelism,
                   healingReservedCores = snapSyncConfig.healingReservedCores,
                   bfsQueueStorageOpt = Some(bfsQueueStorage),
+                  visitedStorageOpt = Some(visitedStorage),
                   storageScheme = snapSyncConfig.storageScheme,
                   pathNodeStorageOpt = pathNodeStorageOpt,
                   frontierHighWater = snapSyncConfig.healingFrontierHighWater,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -1383,17 +1383,26 @@ class TrieNodeHealingCoordinator(
     import com.chipprbots.ethereum.domain.Account
     import scala.util.control.NonFatal
 
-    // Disk-backed visited set (OPT-059): clear any residual from a prior walk, then mark all seeds.
-    // RocksDB point-get latency at warm block-cache is ~1-5 µs — negligible vs the 50K-node
-    // multiGet I/O per chunk. markIfNew is non-atomic under concurrency: two sub-range threads may
-    // both see the same child hash as absent and both return true, causing a duplicate BFS-queue
-    // entry. This is benign — downstream pendingHashSet deduplicates any resulting duplicate
-    // missing-node reports.
-    visitedStorage.clear()
-    // spec 003 C2: mark every seed hash as visited (level 0). For one seed this is the prior
-    // markIfNew(startHash); for many it pre-loads the shared visited set so cross-seed shared
-    // subtries are de-duplicated exactly as within a single walk.
-    seeds.foreach { case (h, _, _) => visitedStorage.markIfNew(h) }
+    // Disk-backed visited set (OPT-059 / Fix 3 / spec 003 C2): conditional clear keyed by primary
+    // seed root. If the stored root matches, the visited set from a prior walk is still valid —
+    // already-walked nodes will return false from markIfNew (point-get hit), skipping re-enqueue.
+    // This reduces crash-recovery cost from a full re-walk (~6h at L7) to O(point-gets over the
+    // already-visited portion (~20-30 min). If the root differs or no root is stored, clear and
+    // record the new root so the next restart can resume correctly.
+    // For multi-seed walks (spec 003 scoped verification), all seeds are marked at level 0 so
+    // cross-seed shared subtries are de-duplicated within a single walk.
+    // markIfNew is non-atomic under concurrency: duplicate BFS-queue entries are benign.
+    val primaryRoot = seeds.head._1
+    visitedStorage.storedRoot() match {
+      case Some(stored) if stored == primaryRoot =>
+        log.info(
+          "[HEAL-BFS] Resuming visited set from previous walk (same pivot root) — skipping already-walked nodes"
+        )
+        seeds.foreach { case (h, _, _) => visitedStorage.markIfNew(h) }
+      case _ =>
+        visitedStorage.clearAndSetRoot(primaryRoot)
+        seeds.foreach { case (h, _, _) => visitedStorage.markIfNew(h) }
+    }
 
     val visitedCount = new java.util.concurrent.atomic.AtomicLong(0L)
     val frontierCount = new java.util.concurrent.atomic.AtomicLong(0L)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -23,6 +23,7 @@ import com.chipprbots.ethereum.db.storage.{
   MptStorage,
   PathNodeStorage
 }
+import com.chipprbots.ethereum.metrics.ResourceHealthMonitor
 import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor
 import com.chipprbots.ethereum.network.p2p.messages.SNAP.{GetTrieNodes, TrieNodes}
@@ -404,6 +405,12 @@ class TrieNodeHealingCoordinator(
   // permanently blocking every future walk (including the watchdog) until restart.
   private case object FrontierWalkFailed
 
+  /** Fire-and-forget update to the node-wide ResourceHealthMonitor. Safe to call on the actor thread only. */
+  private def notifyMonitor(phase: String, ctx: Map[String, String]): Unit =
+    context.system
+      .actorSelection(s"/user/${ResourceHealthMonitor.ActorName}")
+      .tell(ResourceHealthMonitor.UpdatePhaseContext(phase, ctx), self)
+
   /** Synchronous flush — used only for final completion flush (small buffer, safe to block). */
   private def flushRawNodesSync(): Unit =
     if (rawNodeBuffer.nonEmpty) {
@@ -549,6 +556,7 @@ class TrieNodeHealingCoordinator(
       // The full-state rebuild BFS walked the entire trie; every still-missing node is now persisted.
       // Mark the snapshot complete so a future restart may resume it instead of re-walking (Layer 2).
       verificationBFSRunning = false // rebuild walk finished — release the single-flight gate
+      notifyMonitor("HEAL-APPLY", Map("healed" -> totalNodesHealed.toString, "pending" -> pendingTasks.size.toString))
       healingFrontierStorage.foreach { store =>
         store.markComplete()
         log.info("[HEAL-RESTART] Full-state rebuild complete — persisted frontier marked as a complete snapshot")
@@ -821,6 +829,7 @@ class TrieNodeHealingCoordinator(
           SNAPSyncMetrics.setHealingScopedDurationMs(elapsedMs)
           scopedVerificationActive = false
         }
+        notifyMonitor("HEAL-VERIFY-COMPLETE", Map("healed" -> totalNodesHealed.toString))
         log.info(
           s"[HEAL-VERIFY] Verification BFS complete — no missing nodes found. " +
             s"Trie is fully healed ($totalNodesHealed nodes). Declaring completion."
@@ -1679,6 +1688,7 @@ class TrieNodeHealingCoordinator(
     // a second concurrent walk corrupts the first. Cleared by FrontierRebuildComplete /
     // VerificationBFSComplete / FrontierWalkFailed.
     verificationBFSRunning = true
+    notifyMonitor("HEAL-BFS", Map("root" -> Hex.toHexString(root.take(4).toArray)))
     Future {
       try {
         rebuildFrontierBFS(seeds, selfRef, bfsQueue, effectiveParallelism)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -19,7 +19,9 @@ import com.chipprbots.ethereum.db.storage.{
   BfsEntry,
   BfsQueueStorage,
   HealingFrontierStorage,
+  HealingVisitedStorage,
   InMemoryBfsQueueStorage,
+  InMemoryHealingVisitedStorage,
   MptStorage,
   PathNodeStorage
 }
@@ -45,7 +47,6 @@ class TrieNodeHealingCoordinator(
     batchSize: Int,
     snapSyncController: ActorRef,
     concurrency: Int,
-    visitedCap: Int = TrieNodeHealingCoordinator.DefaultVisitedCap,
     healingFrontierStorage: Option[HealingFrontierStorage] = None,
     healingWriterEcOverride: Option[ExecutionContext] = None,
     healingReaderEcOverride: Option[ExecutionContext] = None,
@@ -53,6 +54,7 @@ class TrieNodeHealingCoordinator(
     healingMinParallelism: Int = TrieNodeHealingCoordinator.DefaultMinParallelism,
     healingReservedCores: Int = TrieNodeHealingCoordinator.DefaultReservedCores,
     bfsQueueStorageOpt: Option[BfsQueueStorage] = None,
+    visitedStorageOpt: Option[HealingVisitedStorage] = None,
     storageScheme: StorageScheme = StorageScheme.Hash,
     pathNodeStorageOpt: Option[PathNodeStorage] = None,
     frontierHighWater: Int = TrieNodeHealingCoordinator.DefaultFrontierHighWater,
@@ -191,7 +193,8 @@ class TrieNodeHealingCoordinator(
   // `pendingHashSet`. See docs/design/healing-frontier-scale.md. Operator-tunable via
   // `sync.snap-sync.healing-visited-cap`; raise it only from a measured `inflation_ratio` (US2) and
   // within the heap budget — do NOT set it to 20M (~2.4-3.2 GB) on a 6 GB heap (it OOMs).
-  private val HealingVisitedCap: Int = visitedCap
+  private val visitedStorage: HealingVisitedStorage =
+    visitedStorageOpt.getOrElse(new InMemoryHealingVisitedStorage())
   private val HealingTraversalParallelism: Int = traversalParallelism
   private val HealingMinParallelism: Int = healingMinParallelism
   private val HealingReservedCores: Int = healingReservedCores
@@ -1380,27 +1383,17 @@ class TrieNodeHealingCoordinator(
     import com.chipprbots.ethereum.domain.Account
     import scala.util.control.NonFatal
 
-    // FIFO/insertion-order bounded visited set (companion boundedVisitedSet): at the cap the
-    // earliest-INSERTED entry is evicted (NOT an LRU — recent access does not protect an entry)
-    // instead of refusing new entries. Refusing (the previous ConcurrentHashMap gate)
-    // silently TRUNCATED the traversal on tries larger than the cap — children past the cap were
-    // never enqueued, the queue drained early, and the walk reported "Complete" (and set the
-    // Layer-2 completeness marker) having covered only `cap` of the trie. Eviction trades that
-    // correctness hole for bounded re-walks of shared subtries (de-duplicated downstream by
-    // pendingHashSet). Access is synchronized: worker threads only touch it via markIfNew, and
-    // per-check lock cost is negligible against the 50K-node multiGet I/O per chunk.
-    val visitedLru = TrieNodeHealingCoordinator.boundedVisitedSet(HealingVisitedCap)
-    def markIfNew(h: ByteString): Boolean = visitedLru.synchronized {
-      if (visitedLru.contains(h)) false
-      else {
-        visitedLru += h
-        true
-      }
-    }
+    // Disk-backed visited set (OPT-059): clear any residual from a prior walk, then mark all seeds.
+    // RocksDB point-get latency at warm block-cache is ~1-5 µs — negligible vs the 50K-node
+    // multiGet I/O per chunk. markIfNew is non-atomic under concurrency: two sub-range threads may
+    // both see the same child hash as absent and both return true, causing a duplicate BFS-queue
+    // entry. This is benign — downstream pendingHashSet deduplicates any resulting duplicate
+    // missing-node reports.
+    visitedStorage.clear()
     // spec 003 C2: mark every seed hash as visited (level 0). For one seed this is the prior
     // markIfNew(startHash); for many it pre-loads the shared visited set so cross-seed shared
     // subtries are de-duplicated exactly as within a single walk.
-    seeds.foreach { case (h, _, _) => markIfNew(h) }
+    seeds.foreach { case (h, _, _) => visitedStorage.markIfNew(h) }
 
     val visitedCount = new java.util.concurrent.atomic.AtomicLong(0L)
     val frontierCount = new java.util.concurrent.atomic.AtomicLong(0L)
@@ -1469,7 +1462,7 @@ class TrieNodeHealingCoordinator(
                           val childHash = ByteString(hashChild.hashNode)
                           // Observation-only (FR-008/FR-023): count this child reference before the de-dup gate.
                           childRefsSeen.incrementAndGet()
-                          if (markIfNew(childHash)) {
+                          if (visitedStorage.markIfNew(childHash)) {
                             distinctEnqueued.incrementAndGet()
                             val childNibbles = nibbles :+ i.toByte
                             val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
@@ -1487,7 +1480,7 @@ class TrieNodeHealingCoordinator(
                           val childHash = ByteString(hashChild.hashNode)
                           // Observation-only (FR-008/FR-023): count this child reference before the de-dup gate.
                           childRefsSeen.incrementAndGet()
-                          if (markIfNew(childHash)) {
+                          if (visitedStorage.markIfNew(childHash)) {
                             distinctEnqueued.incrementAndGet()
                             val childNibbles = nibbles ++ ext.sharedKey.toArray
                             val childCompact = ByteString(HexPrefix.encode(childNibbles, isLeaf = false))
@@ -1506,7 +1499,7 @@ class TrieNodeHealingCoordinator(
                         if (account.storageRoot != Account.EmptyStorageRootHash) childRefsSeen.incrementAndGet()
                         if (
                           account.storageRoot != Account.EmptyStorageRootHash &&
-                          markIfNew(account.storageRoot)
+                          visitedStorage.markIfNew(account.storageRoot)
                         ) {
                           distinctEnqueued.incrementAndGet()
                           val allNibbles = nibbles ++ leaf.key.toArray
@@ -1971,7 +1964,6 @@ object TrieNodeHealingCoordinator {
       batchSize: Int,
       snapSyncController: ActorRef,
       concurrency: Int = 16,
-      visitedCap: Int = DefaultVisitedCap,
       healingFrontierStorage: Option[HealingFrontierStorage] = None,
       healingWriterEcOverride: Option[ExecutionContext] = None,
       healingReaderEcOverride: Option[ExecutionContext] = None,
@@ -1979,6 +1971,7 @@ object TrieNodeHealingCoordinator {
       healingMinParallelism: Int = DefaultMinParallelism,
       healingReservedCores: Int = DefaultReservedCores,
       bfsQueueStorageOpt: Option[BfsQueueStorage] = None,
+      visitedStorageOpt: Option[HealingVisitedStorage] = None,
       storageScheme: StorageScheme = StorageScheme.Hash,
       pathNodeStorageOpt: Option[PathNodeStorage] = None,
       frontierHighWater: Int = DefaultFrontierHighWater,
@@ -1996,7 +1989,6 @@ object TrieNodeHealingCoordinator {
         batchSize,
         snapSyncController,
         concurrency,
-        visitedCap,
         healingFrontierStorage,
         healingWriterEcOverride,
         healingReaderEcOverride,
@@ -2004,6 +1996,7 @@ object TrieNodeHealingCoordinator {
         healingMinParallelism,
         healingReservedCores,
         bfsQueueStorageOpt,
+        visitedStorageOpt,
         storageScheme,
         pathNodeStorageOpt,
         frontierHighWater,

--- a/src/main/scala/com/chipprbots/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
+++ b/src/main/scala/com/chipprbots/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
@@ -215,7 +215,7 @@ trait BlockHeaderValidatorSkeleton extends BlockHeaderValidator {
   private def validateGasLimit(
       blockHeader: BlockHeader,
       parentHeader: BlockHeader
-  )(implicit _blockchainConfig: BlockchainConfig): Either[BlockHeaderError, BlockHeaderValid] =
+  ): Either[BlockHeaderError, BlockHeaderValid] =
     // 2^63 - 1 is the protocol-wide gasLimit cap (cannot fit in an int64). It applies
     // regardless of EIP-106 activation — any block with gasLimit >= 2^63 is malformed.
     if (blockHeader.gasLimit > MaxGasLimit)

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -385,9 +385,9 @@ class RocksDbDataSource(
 
   /** Aggregate RocksDB active-memtable + immutable-memtable memory across all column families, in MB.
     *
-    * Uses the `rocksdb.size-all-mem-tables` property per CF handle. Returns 0 on any error (handles map
-    * not yet populated, DB closed, unsupported property). Safe to call from any thread; does NOT acquire
-    * the RW lock because `getLongProperty` is a read-only call on an immutable view of the CF handles.
+    * Uses the `rocksdb.size-all-mem-tables` property per CF handle. Returns 0 on any error (handles map not yet
+    * populated, DB closed, unsupported property). Safe to call from any thread; does NOT acquire the RW lock because
+    * `getLongProperty` is a read-only call on an immutable view of the CF handles.
     */
   def totalMemtableSizeMB: Long =
     handles.values.foldLeft(0L) { (acc, handle) =>

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -143,6 +143,27 @@ class RocksDbDataSource(
     } finally dbLock.writeLock().unlock()
   }
 
+  /** Synchronously compact the entire column family, forcing RocksDB to process any pending range tombstones and merge
+    * SST files. Blocks until compaction is complete.
+    *
+    * Used by [[com.chipprbots.ethereum.db.storage.RocksDbBfsQueueStorage]] after each BFS level deletion to prevent
+    * range-tombstone proliferation from degrading subsequent forward scans. Without this, each new BFS cycle starts
+    * with N accumulated tombstones (one per prior level deletion), causing iterateSyncRange to slow by ~8–9× per
+    * accumulated tombstone generation.
+    */
+  def compact(namespace: Namespace): Unit = {
+    dbLock.readLock().lock()
+    try {
+      assureNotClosed()
+      db.compactRange(handles(namespace))
+    } catch {
+      case error: RocksDbDataSourceClosedException =>
+        throw error
+      case NonFatal(error) =>
+        throw RocksDbDataSourceException(s"DataSource error while compacting namespace", error)
+    } finally dbLock.readLock().unlock()
+  }
+
   /** Forward range scan via a single seek+next over a bounded `[fromKey, toKeyExclusive)` window. Uses
     * `scanReadOptions` (fillCache=false) so a large queue scan does not evict the hot block cache. Drains the window
     * into a buffer and CLOSES the native iterator before returning, so no `RocksIterator` handle outlives the call —

--- a/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -383,6 +383,17 @@ class RocksDbDataSource(
       }
       .getOrElse(0L)
 
+  /** Aggregate RocksDB active-memtable + immutable-memtable memory across all column families, in MB.
+    *
+    * Uses the `rocksdb.size-all-mem-tables` property per CF handle. Returns 0 on any error (handles map
+    * not yet populated, DB closed, unsupported property). Safe to call from any thread; does NOT acquire
+    * the RW lock because `getLongProperty` is a read-only call on an immutable view of the CF handles.
+    */
+  def totalMemtableSizeMB: Long =
+    handles.values.foldLeft(0L) { (acc, handle) =>
+      acc + scala.util.Try(db.getLongProperty(handle, "rocksdb.size-all-mem-tables")).getOrElse(0L)
+    } >> 20
+
   /** This function closes the DataSource, without deleting the files used by it.
     */
   override def close(): Unit = {

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorage.scala
@@ -131,11 +131,19 @@ class RocksDbBfsQueueStorage(dataSource: DataSource, namespace: Namespace) exten
     }
 
   def deleteRange(from: Long, to: Long): Unit =
-    // Single native range tombstone — O(1) regardless of (to - from). The previous
-    // implementation expanded the range into 10K-key point-delete batches; clearing the
-    // ~140M-entry queue after a full ETC-mainnet walk wrote ~140M tombstones over ~30 minutes
-    // at full CPU (observed live 2026-06-12) while the next walk waited.
-    if (from < to) dataSource.deleteRange(namespace, longToBytes(from), longToBytes(to))
+    if (from < to) {
+      // Single native range tombstone — O(1) write. Then immediately compact to physically
+      // remove the tombstoned keys from SST files. Without compaction, each level's tombstone
+      // persists in SST files and the forward iterator must check every live key against all
+      // accumulated tombstones — observed as 8–9× queueRead degradation in C1 vs C0 on ETC
+      // mainnet (RUN03-1, 2026-06-15). Compaction adds ~2–10s per level (proportional to level
+      // size); this is far cheaper than the accumulated scan overhead across subsequent cycles.
+      dataSource.deleteRange(namespace, longToBytes(from), longToBytes(to))
+      dataSource match {
+        case rdb: RocksDbDataSource => rdb.compact(namespace)
+        case _                      => // in-memory: no-op
+      }
+    }
 
   def clear(): Unit = {
     // Tombstone the ENTIRE keyspace, not just [0, counter): the counter is in-memory only, so
@@ -143,6 +151,10 @@ class RocksDbBfsQueueStorage(dataSource: DataSource, namespace: Namespace) exten
     // entries. The old `if (counter > 0)` guard skipped deletion entirely in that state,
     // leaving the garbage on disk forever. Long.MaxValue exceeds any key ever assigned.
     dataSource.deleteRange(namespace, longToBytes(0L), longToBytes(Long.MaxValue))
+    dataSource match {
+      case rdb: RocksDbDataSource => rdb.compact(namespace)
+      case _                      => // in-memory: no-op
+    }
     writeCounter.set(0L)
   }
 }

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
@@ -6,19 +6,18 @@ import com.chipprbots.ethereum.db.dataSource.DataSource
 import com.chipprbots.ethereum.db.dataSource.DataSource.Namespace
 import com.chipprbots.ethereum.db.dataSource.DataSourceUpdateOptimized
 
-/** Tracks which trie nodes have been enqueued during a BFS heal walk, preventing re-enqueue of
-  * already-visited child references.
+/** Tracks which trie nodes have been enqueued during a BFS heal walk, preventing re-enqueue of already-visited child
+  * references.
   *
   * Two implementations: [[RocksDbHealingVisitedStorage]] (production, CF-backed, no heap cap) and
-  * [[InMemoryHealingVisitedStorage]] (tests / fallback). The disk-backed implementation eliminates
-  * the ~480–640 MB heap pressure of the prior `LinkedHashMap`-backed bounded set (OPT-059).
+  * [[InMemoryHealingVisitedStorage]] (tests / fallback). The disk-backed implementation eliminates the ~480–640 MB heap
+  * pressure of the prior `LinkedHashMap`-backed bounded set (OPT-059).
   */
 trait HealingVisitedStorage {
 
-  /** Returns true if `key` was newly recorded (not seen before), and records it. Not guaranteed
-    * atomic under concurrent access: two threads may both see the same key as absent and both
-    * return true. This causes a duplicate BFS-queue entry, which is benign — equivalent to the
-    * re-walk the previous FIFO-eviction design permitted.
+  /** Returns true if `key` was newly recorded (not seen before), and records it. Not guaranteed atomic under concurrent
+    * access: two threads may both see the same key as absent and both return true. This causes a duplicate BFS-queue
+    * entry, which is benign — equivalent to the re-walk the previous FIFO-eviction design permitted.
     */
   def markIfNew(key: ByteString): Boolean
 
@@ -26,37 +25,73 @@ trait HealingVisitedStorage {
   def clear(): Unit
 }
 
-/** RocksDB column-family-backed implementation. Keys are raw 32-byte keccak hashes; values are
-  * empty. No cap — disk is unbounded, so every visited node is recorded for the full walk lifetime.
-  * RocksDB point-get latency at warm block-cache: ~1–5 µs.
+/** RocksDB column-family-backed implementation. Keys are raw 32-byte keccak hashes; values are empty. No cap — disk is
+  * unbounded, so every visited node is recorded for the full walk lifetime. RocksDB point-get latency at warm
+  * block-cache: ~1–5 µs.
+  *
+  * Writes are buffered: [[markIfNew]] accumulates keys in a [[java.util.concurrent.ConcurrentLinkedQueue]] and flushes
+  * every [[FlushThreshold]] keys as a single RocksDB WriteBatch. This reduces 77M individual commits (one per L7 key)
+  * to ~7,700, eliminating the L0 SST accumulation that would otherwise trigger `level0_slowdown_writes_trigger`.
   */
-class RocksDbHealingVisitedStorage(dataSource: DataSource, namespace: Namespace)
-    extends HealingVisitedStorage {
+class RocksDbHealingVisitedStorage(dataSource: DataSource, namespace: Namespace) extends HealingVisitedStorage {
+
+  private val FlushThreshold = 10_000
+  private val pendingAdds = new java.util.concurrent.ConcurrentLinkedQueue[Array[Byte]]()
+  // AtomicInteger alongside the queue: ConcurrentLinkedQueue.size() is O(n),
+  // which accumulates significant cost at 77M L7 keys. O(1) threshold check.
+  private val pendingSize = new java.util.concurrent.atomic.AtomicInteger(0)
 
   private def has(key: ByteString): Boolean =
     dataSource.getOptimized(namespace, key.toArray).isDefined
 
-  private def add(key: ByteString): Unit =
-    dataSource.update(
-      Seq(DataSourceUpdateOptimized(namespace, toRemove = Nil, toUpsert = Seq((key.toArray, Array.emptyByteArray))))
-    )
+  // Drains the entire pending queue into a single RocksDB WriteBatch.
+  // Two threads may both call this concurrently when both see size >= threshold;
+  // poll() is lock-free and per-element atomic so each key ends up in exactly one
+  // thread's batch. No elements are lost or duplicated.
+  private def flushPending(): Unit = {
+    val batch = new java.util.ArrayList[Array[Byte]]()
+    var k = pendingAdds.poll()
+    while (k != null) { batch.add(k); k = pendingAdds.poll() }
+    pendingSize.set(0)
+    if (!batch.isEmpty) {
+      import scala.jdk.CollectionConverters._
+      dataSource.update(
+        Seq(
+          DataSourceUpdateOptimized(
+            namespace,
+            toRemove = Nil,
+            toUpsert = batch.asScala.toSeq.map(_ -> Array.emptyByteArray)
+          )
+        )
+      )
+    }
+  }
 
   override def markIfNew(key: ByteString): Boolean =
-    if (has(key)) false else { add(key); true }
+    if (has(key)) false
+    else {
+      pendingAdds.add(key.toArray)
+      if (pendingSize.incrementAndGet() >= FlushThreshold) flushPending()
+      true
+    }
 
-  override def clear(): Unit =
-    // Single range tombstone covering all possible 32-byte keccak hash keys.
-    // A 33-byte end key (32 × 0xFF followed by 0x00) sorts strictly after the maximum 32-byte key
-    // in lexicographic order because a string is less than any string of which it is a prefix.
+  override def clear(): Unit = {
+    // deleteRange first: makes RocksDB the canonical authority for the cleared range.
+    // Draining pendingAdds after prevents any buffered key from surviving as a
+    // post-tombstone write in a subsequent flushPending() call.
+    // Single range tombstone covering all possible 32-byte keccak hash keys:
+    // the 33-byte end key sorts strictly after the maximum 32-byte key.
     dataSource.deleteRange(
       namespace,
       Array.fill(32)(0x00.toByte),
-      Array.fill(32)(0xFF.toByte) :+ 0x00.toByte
+      Array.fill(32)(0xff.toByte) :+ 0x00.toByte
     )
+    pendingAdds.clear()
+    pendingSize.set(0)
+  }
 }
 
-/** In-memory implementation for unit tests. `markIfNew` is truly atomic via
-  * `ConcurrentHashMap.putIfAbsent`.
+/** In-memory implementation for unit tests. `markIfNew` is truly atomic via `ConcurrentHashMap.putIfAbsent`.
   */
 class InMemoryHealingVisitedStorage extends HealingVisitedStorage {
   private val map = new java.util.concurrent.ConcurrentHashMap[ByteString, java.lang.Boolean]()

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
@@ -34,7 +34,8 @@ trait HealingVisitedStorage {
     * on a DIFFERENT root than the last walk (or no prior root exists). Default: delegates to clear() — correct for
     * in-memory and test implementations.
     */
-  def clearAndSetRoot(root: ByteString): Unit = clear()
+  @annotation.nowarn("id=E198")
+  def clearAndSetRoot(_root: ByteString): Unit = clear()
 }
 
 object RocksDbHealingVisitedStorage {

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
@@ -23,6 +23,27 @@ trait HealingVisitedStorage {
 
   /** Delete all stored entries. Called at the start of each BFS walk to ensure a clean slate. */
   def clear(): Unit
+
+  /** Returns the pivot root hash stored from the last BFS walk, if any. Used to detect whether the visited set is still
+    * valid for the current walk (same pivot root → skip clear, resume). Default: None (always treat as fresh, i.e. full
+    * clear on next walk).
+    */
+  def storedRoot(): Option[ByteString] = None
+
+  /** Clear all visited entries and record `root` as the active pivot root for this walk. Called when a BFS walk starts
+    * on a DIFFERENT root than the last walk (or no prior root exists). Default: delegates to clear() — correct for
+    * in-memory and test implementations.
+    */
+  def clearAndSetRoot(root: ByteString): Unit = clear()
+}
+
+object RocksDbHealingVisitedStorage {
+
+  /** 21-byte sentinel key stored in HealingVisitedNamespace to record the active BFS pivot root. 21 bytes sorts BEFORE
+    * all 32-byte keccak hash keys in RocksDB lexicographic order, so it lies outside the deleteRange end key ([FF×32 +
+    * 0x00]) — explicit toRemove delete is required in both clear() and clearAndSetRoot().
+    */
+  val RootMarkerKey: Array[Byte] = "__visited_root__".getBytes("UTF-8")
 }
 
 /** RocksDB column-family-backed implementation. Keys are raw 32-byte keccak hashes; values are empty. No cap — disk is
@@ -75,6 +96,33 @@ class RocksDbHealingVisitedStorage(dataSource: DataSource, namespace: Namespace)
       true
     }
 
+  /** Returns the pivot root hash stored from the last BFS walk, if any. */
+  override def storedRoot(): Option[ByteString] =
+    dataSource.getOptimized(namespace, RocksDbHealingVisitedStorage.RootMarkerKey).map(ByteString(_))
+
+  /** Clear all 32-byte hash keys and write the new pivot root marker atomically. deleteRange first (canonical RocksDB
+    * state), then explicit root marker update. The root marker (21-byte key) lies outside the hash range tombstone — it
+    * requires an explicit toRemove then re-upsert in the same update call.
+    */
+  override def clearAndSetRoot(root: ByteString): Unit = {
+    dataSource.deleteRange(
+      namespace,
+      Array.fill(32)(0x00.toByte),
+      Array.fill(32)(0xff.toByte) :+ 0x00.toByte
+    )
+    dataSource.update(
+      Seq(
+        DataSourceUpdateOptimized(
+          namespace,
+          toRemove = Seq(RocksDbHealingVisitedStorage.RootMarkerKey),
+          toUpsert = Seq(RocksDbHealingVisitedStorage.RootMarkerKey -> root.toArray)
+        )
+      )
+    )
+    pendingAdds.clear()
+    pendingSize.set(0)
+  }
+
   override def clear(): Unit = {
     // deleteRange first: makes RocksDB the canonical authority for the cleared range.
     // Draining pendingAdds after prevents any buffered key from surviving as a
@@ -85,6 +133,16 @@ class RocksDbHealingVisitedStorage(dataSource: DataSource, namespace: Namespace)
       namespace,
       Array.fill(32)(0x00.toByte),
       Array.fill(32)(0xff.toByte) :+ 0x00.toByte
+    )
+    // Root marker (21-byte key) lies outside the hash range — explicit delete required.
+    dataSource.update(
+      Seq(
+        DataSourceUpdateOptimized(
+          namespace,
+          toRemove = Seq(RocksDbHealingVisitedStorage.RootMarkerKey),
+          toUpsert = Nil
+        )
+      )
     )
     pendingAdds.clear()
     pendingSize.set(0)
@@ -100,4 +158,8 @@ class InMemoryHealingVisitedStorage extends HealingVisitedStorage {
     map.putIfAbsent(key, java.lang.Boolean.TRUE) eq null
 
   override def clear(): Unit = map.clear()
+
+  // No persistent root concept in-memory — always treat as fresh on restart.
+  override def storedRoot(): Option[ByteString] = None
+  override def clearAndSetRoot(root: ByteString): Unit = map.clear()
 }

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/HealingVisitedStorage.scala
@@ -1,0 +1,68 @@
+package com.chipprbots.ethereum.db.storage
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.db.dataSource.DataSource
+import com.chipprbots.ethereum.db.dataSource.DataSource.Namespace
+import com.chipprbots.ethereum.db.dataSource.DataSourceUpdateOptimized
+
+/** Tracks which trie nodes have been enqueued during a BFS heal walk, preventing re-enqueue of
+  * already-visited child references.
+  *
+  * Two implementations: [[RocksDbHealingVisitedStorage]] (production, CF-backed, no heap cap) and
+  * [[InMemoryHealingVisitedStorage]] (tests / fallback). The disk-backed implementation eliminates
+  * the ~480–640 MB heap pressure of the prior `LinkedHashMap`-backed bounded set (OPT-059).
+  */
+trait HealingVisitedStorage {
+
+  /** Returns true if `key` was newly recorded (not seen before), and records it. Not guaranteed
+    * atomic under concurrent access: two threads may both see the same key as absent and both
+    * return true. This causes a duplicate BFS-queue entry, which is benign — equivalent to the
+    * re-walk the previous FIFO-eviction design permitted.
+    */
+  def markIfNew(key: ByteString): Boolean
+
+  /** Delete all stored entries. Called at the start of each BFS walk to ensure a clean slate. */
+  def clear(): Unit
+}
+
+/** RocksDB column-family-backed implementation. Keys are raw 32-byte keccak hashes; values are
+  * empty. No cap — disk is unbounded, so every visited node is recorded for the full walk lifetime.
+  * RocksDB point-get latency at warm block-cache: ~1–5 µs.
+  */
+class RocksDbHealingVisitedStorage(dataSource: DataSource, namespace: Namespace)
+    extends HealingVisitedStorage {
+
+  private def has(key: ByteString): Boolean =
+    dataSource.getOptimized(namespace, key.toArray).isDefined
+
+  private def add(key: ByteString): Unit =
+    dataSource.update(
+      Seq(DataSourceUpdateOptimized(namespace, toRemove = Nil, toUpsert = Seq((key.toArray, Array.emptyByteArray))))
+    )
+
+  override def markIfNew(key: ByteString): Boolean =
+    if (has(key)) false else { add(key); true }
+
+  override def clear(): Unit =
+    // Single range tombstone covering all possible 32-byte keccak hash keys.
+    // A 33-byte end key (32 × 0xFF followed by 0x00) sorts strictly after the maximum 32-byte key
+    // in lexicographic order because a string is less than any string of which it is a prefix.
+    dataSource.deleteRange(
+      namespace,
+      Array.fill(32)(0x00.toByte),
+      Array.fill(32)(0xFF.toByte) :+ 0x00.toByte
+    )
+}
+
+/** In-memory implementation for unit tests. `markIfNew` is truly atomic via
+  * `ConcurrentHashMap.putIfAbsent`.
+  */
+class InMemoryHealingVisitedStorage extends HealingVisitedStorage {
+  private val map = new java.util.concurrent.ConcurrentHashMap[ByteString, java.lang.Boolean]()
+
+  override def markIfNew(key: ByteString): Boolean =
+    map.putIfAbsent(key, java.lang.Boolean.TRUE) eq null
+
+  override def clear(): Unit = map.clear()
+}

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/Namespaces.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/Namespaces.scala
@@ -27,6 +27,8 @@ object Namespaces {
     IndexedSeq[Byte]('t'.toByte) // state trie nodes, path-keyed (PathScheme only)
   val StorageTriePathNamespace: IndexedSeq[Byte] =
     IndexedSeq[Byte]('u'.toByte) // storage trie nodes, path-keyed, scoped by accountHash (PathScheme only)
+  val HealingVisitedNamespace: IndexedSeq[Byte] =
+    IndexedSeq[Byte]('v'.toByte) // BFS heal-walk visited set (keccak hash -> empty) — OPT-059 disk-backed dedup
 
   val nsSeq: Seq[IndexedSeq[Byte]] = Seq(
     ReceiptsNamespace,
@@ -47,6 +49,7 @@ object Namespaces {
     BfsQueueNamespace,
     SnapSyncProgressNamespace,
     StateTriePathNamespace,
-    StorageTriePathNamespace
+    StorageTriePathNamespace,
+    HealingVisitedNamespace
   )
 }

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/PathNodeStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/PathNodeStorage.scala
@@ -5,6 +5,7 @@ import org.apache.pekko.util.ByteString
 import com.chipprbots.ethereum.db.dataSource.DataSource
 import com.chipprbots.ethereum.db.dataSource.DataSourceUpdateOptimized
 import com.chipprbots.ethereum.mpt.HexPrefix
+import com.chipprbots.ethereum.utils.Logger
 
 /** Path-keyed trie node storage for PathScheme SNAP sync.
   *
@@ -35,7 +36,7 @@ import com.chipprbots.ethereum.mpt.HexPrefix
   * @param dataSource
   *   Shared RocksDB data source. Both column families live in the same data source instance.
   */
-class PathNodeStorage(val dataSource: DataSource) {
+class PathNodeStorage(val dataSource: DataSource) extends Logger {
 
   private val acctNs: IndexedSeq[Byte] = Namespaces.StateTriePathNamespace
   private val storageNs: IndexedSeq[Byte] = Namespaces.StorageTriePathNamespace
@@ -50,11 +51,12 @@ class PathNodeStorage(val dataSource: DataSource) {
     * @param nibblePath
     *   raw nibble array (each byte 0x00–0x0f)
     * @param hash
-    *   keccak256 hash of `rlp` (logged but not stored as the key — the path is the key in PathScheme)
+    *   keccak256 hash of `rlp` (logged, not stored — the path is the key in PathScheme)
     * @param rlp
     *   RLP-encoded node bytes
     */
   def writeAccountNode(nibblePath: Array[Byte], hash: ByteString, rlp: Array[Byte]): Unit = {
+    log.trace("writeAccountNode hash={}", hash)
     val key = encodePath(nibblePath)
     dataSource.update(
       Seq(DataSourceUpdateOptimized(namespace = acctNs, toRemove = Nil, toUpsert = Seq(key -> rlp)))
@@ -96,11 +98,12 @@ class PathNodeStorage(val dataSource: DataSource) {
     * @param nibblePath
     *   raw nibble array for the node's position in the storage trie
     * @param hash
-    *   keccak256 hash of `rlp`
+    *   keccak256 hash of `rlp` (logged, not stored — the path is the key in PathScheme)
     * @param rlp
     *   RLP-encoded node bytes
     */
   def writeStorageNode(accountHash: ByteString, nibblePath: Array[Byte], hash: ByteString, rlp: Array[Byte]): Unit = {
+    log.trace("writeStorageNode accountHash={} hash={}", accountHash, hash)
     val key = storageKey(accountHash, nibblePath)
     dataSource.update(
       Seq(DataSourceUpdateOptimized(namespace = storageNs, toRemove = Nil, toUpsert = Seq(key -> rlp)))
@@ -140,8 +143,6 @@ class PathNodeStorage(val dataSource: DataSource) {
 
   private def deleteByPrefix(ns: IndexedSeq[Byte], prefix: Array[Byte]): Unit = {
     import cats.effect.unsafe.implicits.global
-    import fs2.Stream
-
     // Collect keys matching prefix, then batch-delete them.
     val keys: Vector[Array[Byte]] = dataSource
       .iterate(ns)

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -170,17 +170,17 @@ object ReferenceCountNodeStorage extends PruneSupport with Logger {
     log.debug(s"Pruned block $blockNumber")
   }
 
-  /** Collects all keys to delete when pruning `blockNumber` without committing any deletions.
-    * Returns the death-row key, snapshot metadata keys, and dead trie-node keys as a flat sequence.
-    * Returns an empty sequence when there is no pruning data for this block (e.g. block predates history).
-    * The caller accumulates these across blocks and flushes via `nodeStorage.updateCond` at a batch threshold.
+  /** Collects all keys to delete when pruning `blockNumber` without committing any deletions. Returns the death-row
+    * key, snapshot metadata keys, and dead trie-node keys as a flat sequence. Returns an empty sequence when there is
+    * no pruning data for this block (e.g. block predates history). The caller accumulates these across blocks and
+    * flushes via `nodeStorage.updateCond` at a batch threshold.
     */
   def collectPruneTargets(blockNumber: BigInt, nodeStorage: NodesStorage): Seq[NodeHash] = {
     var result = Seq.empty[NodeHash]
     withSnapshotCount(blockNumber, nodeStorage) { (snapshotsCountKey, snapshotCount) =>
-      val deathRowKey  = drRowKey(blockNumber)
+      val deathRowKey = drRowKey(blockNumber)
       val snapshotKeys = snapshotKeysUpTo(blockNumber, snapshotCount)
-      val toBeRemoved  = getNodesToBeRemovedInPruning(blockNumber, deathRowKey, nodeStorage)
+      val toBeRemoved = getNodesToBeRemovedInPruning(blockNumber, deathRowKey, nodeStorage)
       result = (deathRowKey +: snapshotsCountKey +: snapshotKeys) ++ toBeRemoved
     }
     result

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -170,6 +170,22 @@ object ReferenceCountNodeStorage extends PruneSupport with Logger {
     log.debug(s"Pruned block $blockNumber")
   }
 
+  /** Collects all keys to delete when pruning `blockNumber` without committing any deletions.
+    * Returns the death-row key, snapshot metadata keys, and dead trie-node keys as a flat sequence.
+    * Returns an empty sequence when there is no pruning data for this block (e.g. block predates history).
+    * The caller accumulates these across blocks and flushes via `nodeStorage.updateCond` at a batch threshold.
+    */
+  def collectPruneTargets(blockNumber: BigInt, nodeStorage: NodesStorage): Seq[NodeHash] = {
+    var result = Seq.empty[NodeHash]
+    withSnapshotCount(blockNumber, nodeStorage) { (snapshotsCountKey, snapshotCount) =>
+      val deathRowKey  = drRowKey(blockNumber)
+      val snapshotKeys = snapshotKeysUpTo(blockNumber, snapshotCount)
+      val toBeRemoved  = getNodesToBeRemovedInPruning(blockNumber, deathRowKey, nodeStorage)
+      result = (deathRowKey +: snapshotsCountKey +: snapshotKeys) ++ toBeRemoved
+    }
+    result
+  }
+
   /** Looks for the StoredNode snapshots based on block number and saves (or deletes) them
     *
     * @param blockNumber

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
@@ -30,9 +30,9 @@ trait StateStorage {
   def getNode(nodeHash: NodeHash): Option[MptNode]
   def forcePersist(reason: FlushSituation): Boolean
 
-  /** Flush any accumulated pending pruning deletions to RocksDB.
-    * Must be called during graceful shutdown to prevent the final partial batch from being silently discarded.
-    * Default no-op for storage implementations that prune eagerly (Archive, Cached).
+  /** Flush any accumulated pending pruning deletions to RocksDB. Must be called during graceful shutdown to prevent the
+    * final partial batch from being silently discarded. Default no-op for storage implementations that prune eagerly
+    * (Archive, Cached).
     */
   def flushPendingPrunes(): Unit = ()
 }
@@ -69,7 +69,7 @@ class ReferenceCountedStateStorage(
   // or every PruneSafetyInterval blocks, whichever comes first.  Terminal flush on graceful shutdown
   // via flushPendingPrunes() prevents the last partial batch from being silently discarded.
   private val PruneByteThreshold: Long = 64L * 1024 * 1024 // 64 MB
-  private val PruneSafetyInterval: Int  = 1000              // blocks
+  private val PruneSafetyInterval: Int = 1000 // blocks
 
   private var pendingDeletes: List[NodeHash] = List.empty
   private var pendingByteSize: Long = 0L

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
@@ -4,6 +4,8 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
 
+import org.apache.pekko.util.ByteString
+
 import com.chipprbots.ethereum.db.cache.LruCache
 import com.chipprbots.ethereum.db.cache.MapCache
 import com.chipprbots.ethereum.db.dataSource.DataSource
@@ -35,6 +37,12 @@ trait StateStorage {
     * (Archive, Cached).
     */
   def flushPendingPrunes(): Unit = ()
+
+  /** Replay any pruning blocks missed by a prior crash (gap between the persisted watermark and bestBlock -
+    * pruningHistory). Called at node startup, before sync resumes. Default no-op for Archive and Cached implementations
+    * that prune eagerly.
+    */
+  def replayMissedPrunes(bestBlock: BigInt): Unit = ()
 }
 
 class ArchiveStateStorage(private val nodeStorage: NodeStorage) extends StateStorage {
@@ -66,14 +74,18 @@ class ReferenceCountedStateStorage(
 ) extends StateStorage {
 
   // Batch pruning deletes across blocks: flush when accumulated byte size exceeds the threshold
-  // or every PruneSafetyInterval blocks, whichever comes first.  Terminal flush on graceful shutdown
+  // or every PruneSafetyInterval blocks, whichever comes first. Terminal flush on graceful shutdown
   // via flushPendingPrunes() prevents the last partial batch from being silently discarded.
   private val PruneByteThreshold: Long = 64L * 1024 * 1024 // 64 MB
   private val PruneSafetyInterval: Int = 1000 // blocks
+  // Atomic watermark: written in the same WriteBatch as the deletes. On restart, replayMissedPrunes
+  // reads this to detect any gap left by a prior crash and replays it before sync resumes.
+  private val LastPrunedBlockKey: NodeHash = ByteString("prune-lwm".getBytes("UTF-8"))
 
   private var pendingDeletes: List[NodeHash] = List.empty
   private var pendingByteSize: Long = 0L
   private var blocksSincePruneFlush: Int = 0
+  private var highestPendingBlock: BigInt = BigInt(0)
 
   override def forcePersist(reason: FlushSituation): Boolean = true
 
@@ -83,11 +95,11 @@ class ReferenceCountedStateStorage(
     if (deletes.nonEmpty) {
       pendingDeletes = deletes.toList ::: pendingDeletes
       pendingByteSize += deletes.view.map(_.length.toLong).sum
+      if (blockToPrune > highestPendingBlock) highestPendingBlock = blockToPrune
     }
     blocksSincePruneFlush += 1
-    if (pendingByteSize >= PruneByteThreshold || blocksSincePruneFlush >= PruneSafetyInterval) {
+    if (pendingByteSize >= PruneByteThreshold || blocksSincePruneFlush >= PruneSafetyInterval)
       doFlushPendingPrunes()
-    }
     updateBestBlocksData()
   }
 
@@ -110,11 +122,49 @@ class ReferenceCountedStateStorage(
 
   override def flushPendingPrunes(): Unit = doFlushPendingPrunes()
 
+  /** On restart after crash, replay any pruning blocks missed while pendingDeletes was in-memory only. Chunked into
+    * ≤1000-block sub-batches with intermediate watermark flushes to bound memory for months-long gaps (N blocks × M
+    * snapshots per block → tens of millions of keys).
+    */
+  override def replayMissedPrunes(bestBlock: BigInt): Unit = {
+    val lastFlushed = nodeStorage
+      .get(LastPrunedBlockKey)
+      .map(bytes => if (bytes.isEmpty) BigInt(0) else BigInt(bytes.toArray))
+      .getOrElse(BigInt(0))
+    val gapStart = lastFlushed + 1
+    val gapEnd = bestBlock - pruningHistory
+    if (gapStart > gapEnd) return
+
+    val ChunkSize = BigInt(1000)
+    var chunkStart = gapStart
+    while (chunkStart <= gapEnd) {
+      val chunkEnd = (chunkStart + ChunkSize - 1).min(gapEnd)
+      val chunkDeletes = (chunkStart to chunkEnd)
+        .flatMap(bn => ReferenceCountNodeStorage.collectPruneTargets(bn, nodeStorage))
+        .toList
+      if (chunkDeletes.nonEmpty)
+        nodeStorage.updateCond(
+          chunkDeletes,
+          Seq(LastPrunedBlockKey -> chunkEnd.toByteArray),
+          inMemory = false
+        )
+      chunkStart = chunkEnd + 1
+    }
+  }
+
   private def doFlushPendingPrunes(): Unit = {
     if (pendingDeletes.nonEmpty) {
-      nodeStorage.updateCond(pendingDeletes, Nil, inMemory = false)
+      // Only write the watermark when at least one block had pruning data.
+      // Guards against persisting BigInt(0) on threshold-triggered flushes where
+      // every block in the interval had no prune targets (highestPendingBlock stays 0).
+      val watermarkUpsert =
+        if (highestPendingBlock > 0) Seq(LastPrunedBlockKey -> highestPendingBlock.toByteArray)
+        else Nil
+      // Atomic: deletes + watermark in one WriteBatch — either both commit or neither does.
+      nodeStorage.updateCond(pendingDeletes, watermarkUpsert, inMemory = false)
       pendingDeletes = List.empty
       pendingByteSize = 0L
+      highestPendingBlock = BigInt(0)
     }
     blocksSincePruneFlush = 0
   }

--- a/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
+++ b/src/main/scala/com/chipprbots/ethereum/db/storage/StateStorage.scala
@@ -29,6 +29,12 @@ trait StateStorage {
   def saveNode(nodeHash: NodeHash, nodeEncoded: NodeEncoded, bn: BigInt): Unit
   def getNode(nodeHash: NodeHash): Option[MptNode]
   def forcePersist(reason: FlushSituation): Boolean
+
+  /** Flush any accumulated pending pruning deletions to RocksDB.
+    * Must be called during graceful shutdown to prevent the final partial batch from being silently discarded.
+    * Default no-op for storage implementations that prune eagerly (Archive, Cached).
+    */
+  def flushPendingPrunes(): Unit = ()
 }
 
 class ArchiveStateStorage(private val nodeStorage: NodeStorage) extends StateStorage {
@@ -58,11 +64,30 @@ class ReferenceCountedStateStorage(
     private val nodeStorage: NodeStorage,
     private val pruningHistory: BigInt
 ) extends StateStorage {
+
+  // Batch pruning deletes across blocks: flush when accumulated byte size exceeds the threshold
+  // or every PruneSafetyInterval blocks, whichever comes first.  Terminal flush on graceful shutdown
+  // via flushPendingPrunes() prevents the last partial batch from being silently discarded.
+  private val PruneByteThreshold: Long = 64L * 1024 * 1024 // 64 MB
+  private val PruneSafetyInterval: Int  = 1000              // blocks
+
+  private var pendingDeletes: List[NodeHash] = List.empty
+  private var pendingByteSize: Long = 0L
+  private var blocksSincePruneFlush: Int = 0
+
   override def forcePersist(reason: FlushSituation): Boolean = true
 
   override def onBlockSave(bn: BigInt, currentBestSavedBlock: BigInt)(updateBestBlocksData: () => Unit): Unit = {
     val blockToPrune = bn - pruningHistory
-    ReferenceCountNodeStorage.prune(blockToPrune, nodeStorage, inMemory = blockToPrune > currentBestSavedBlock)
+    val deletes = ReferenceCountNodeStorage.collectPruneTargets(blockToPrune, nodeStorage)
+    if (deletes.nonEmpty) {
+      pendingDeletes = deletes.toList ::: pendingDeletes
+      pendingByteSize += deletes.view.map(_.length.toLong).sum
+    }
+    blocksSincePruneFlush += 1
+    if (pendingByteSize >= PruneByteThreshold || blocksSincePruneFlush >= PruneSafetyInterval) {
+      doFlushPendingPrunes()
+    }
     updateBestBlocksData()
   }
 
@@ -82,6 +107,17 @@ class ReferenceCountedStateStorage(
 
   override def getNode(nodeHash: NodeHash): Option[MptNode] =
     new FastSyncNodeStorage(nodeStorage, 0).get(nodeHash).map(_.toMptNode)
+
+  override def flushPendingPrunes(): Unit = doFlushPendingPrunes()
+
+  private def doFlushPendingPrunes(): Unit = {
+    if (pendingDeletes.nonEmpty) {
+      nodeStorage.updateCond(pendingDeletes, Nil, inMemory = false)
+      pendingDeletes = List.empty
+      pendingByteSize = 0L
+    }
+    blocksSincePruneFlush = 0
+  }
 }
 
 class CachedReferenceCountedStateStorage(

--- a/src/main/scala/com/chipprbots/ethereum/extvm/ExtVMInterface.scala
+++ b/src/main/scala/com/chipprbots/ethereum/extvm/ExtVMInterface.scala
@@ -45,7 +45,7 @@ class ExtVMInterface(externaVmConfig: VmConfig.ExternalConfig, blockchainConfig:
       .toMat(Sink.queue[ByteString]())(Keep.both)
       .run()
 
-    val client = new VMClient(externaVmConfig, new MessageHandler(connIn, connOut), testMode)
+    val client = new VMClient(new MessageHandler(connIn, connOut), testMode)
     client.sendHello(ApiVersionProvider.version, blockchainConfig)
 
     vmClient = Some(client)

--- a/src/main/scala/com/chipprbots/ethereum/extvm/VMClient.scala
+++ b/src/main/scala/com/chipprbots/ethereum/extvm/VMClient.scala
@@ -9,7 +9,6 @@ import scalapb.UnknownFieldSet
 import com.chipprbots.ethereum.domain._
 import com.chipprbots.ethereum.utils.BlockchainConfig
 import com.chipprbots.ethereum.utils.Logger
-import com.chipprbots.ethereum.utils.VmConfig
 import com.chipprbots.ethereum.vm
 import com.chipprbots.ethereum.vm._
 
@@ -19,8 +18,7 @@ import Implicits._
   *   \- if enabled the client will send blockchain configuration with each configuration. This is useful to override
   *   configuration for each test, rather than to recreate the VM.
   */
-class VMClient(_externalVmConfig: VmConfig.ExternalConfig, messageHandler: MessageHandlerApi, testMode: Boolean)
-    extends Logger {
+class VMClient(messageHandler: MessageHandlerApi, testMode: Boolean) extends Logger {
 
   def sendHello(version: String, blockchainConfig: BlockchainConfig): Unit = {
     val config = BlockchainConfigForEvm(blockchainConfig)

--- a/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
@@ -1,0 +1,130 @@
+package com.chipprbots.ethereum.metrics
+
+import java.lang.management.ManagementFactory
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.actor.ActorLogging
+import org.apache.pekko.actor.Cancellable
+import org.apache.pekko.actor.Props
+
+import com.chipprbots.ethereum.blockchain.sync.snap.actors.GcPressureSampler
+import com.chipprbots.ethereum.db.dataSource.DataSource
+import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
+
+/** Node-wide resource observability — emits a [[ResourceHealthMonitor.LogTag]] line every 60 seconds covering JVM
+  * heap, GC pressure, off-heap, free physical RAM, swap, system load, and RocksDB memtable footprint.
+  *
+  * Sync coordinators call [[ResourceHealthMonitor.UpdatePhaseContext]] to annotate the pulse with their current phase
+  * and key counters. The monitor is purely observational: it reads metrics and logs; it never influences any
+  * consensus or sync logic.
+  *
+  * Spawn once at node startup:
+  * {{{
+  * system.actorOf(ResourceHealthMonitor.props(dataSource), ResourceHealthMonitor.ActorName)
+  * }}}
+  *
+  * Coordinators annotate via path-selection (no constructor changes needed):
+  * {{{
+  * context.system
+  *   .actorSelection(s"/user/${ResourceHealthMonitor.ActorName}")
+  *   .tell(ResourceHealthMonitor.UpdatePhaseContext("HEAL-BFS-L6", Map("frontier" -> "42")), ActorRef.noSender)
+  * }}}
+  */
+class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogging {
+  import ResourceHealthMonitor._
+
+  private val rt    = Runtime.getRuntime
+  private val memMX = ManagementFactory.getMemoryMXBean
+  private val osMX  = ManagementFactory.getOperatingSystemMXBean
+                        .asInstanceOf[com.sun.management.OperatingSystemMXBean]
+
+  private val rocksOpt: Option[RocksDbDataSource] = dataSource match {
+    case rdb: RocksDbDataSource => Some(rdb)
+    case _                      => None
+  }
+
+  private var ticker: Cancellable = _
+  private var phaseCtx: Map[String, String] = Map("phase" -> "INIT")
+  private var lastGcMs: Long    = GcPressureSampler.defaultGcCollectionTimeMs()
+  private var lastGcCount: Long = ManagementFactory.getGarbageCollectorMXBeans.asScala
+                                    .map(b => math.max(0L, b.getCollectionCount)).sum
+
+  override def preStart(): Unit = {
+    ticker = context.system.scheduler.scheduleAtFixedRate(
+      60.seconds, 60.seconds, self, Tick
+    )(context.dispatcher, self)
+    log.info(s"[$LogTag] ResourceHealthMonitor started — 60s observability pulse active")
+  }
+
+  override def postStop(): Unit = ticker.cancel()
+
+  override def receive: Receive = {
+    case Tick                           => emitPulse()
+    case UpdatePhaseContext(phase, ctx) => phaseCtx = Map("phase" -> phase) ++ ctx
+  }
+
+  private def emitPulse(): Unit = {
+    val gcMsNow  = GcPressureSampler.defaultGcCollectionTimeMs()
+    val gcCntNow = ManagementFactory.getGarbageCollectorMXBeans.asScala
+                     .map(b => math.max(0L, b.getCollectionCount)).sum
+
+    val gcPct   = (gcMsNow - lastGcMs) / 600.0   // ms in 60 000 ms window → percent
+    val gcCalls = gcCntNow - lastGcCount
+    lastGcMs    = gcMsNow
+    lastGcCount = gcCntNow
+
+    val heapUsed  = (rt.totalMemory - rt.freeMemory) >> 20
+    val heapMax   = rt.maxMemory >> 20
+    val heapPct   = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
+    val offHeap   = memMX.getNonHeapMemoryUsage.getUsed >> 20
+    val sysFreeGB = f"${osMX.getFreePhysicalMemorySize / 1e9}%.1f"
+    val swap      = readSwapUsedMB()
+    val load      = f"${osMX.getSystemLoadAverage}%.1f"
+    val rdbMem    = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
+
+    val ctx = phaseCtx.map { case (k, v) => s"$k=$v" }.mkString(" ")
+    log.info(
+      s"[$LogTag] $ctx heap=$heapUsed/${heapMax}MB($heapPct%) " +
+        s"gc-pressure=${f"$gcPct%.1f"}% gc-calls=$gcCalls off-heap=${offHeap}MB " +
+        s"sys-free=${sysFreeGB}GB swap=${swap}MB load=$load rocksdb-mem=${rdbMem}MB"
+    )
+  }
+
+  private def readSwapUsedMB(): Long =
+    try {
+      val path = Paths.get("/proc/meminfo")
+      if (!Files.exists(path)) return -1L
+      var total = 0L
+      var free  = 0L
+      Files.readAllLines(path).asScala.foreach { line =>
+        if (line.startsWith("SwapTotal:"))     total = line.split("\\s+")(1).toLong
+        else if (line.startsWith("SwapFree:")) free  = line.split("\\s+")(1).toLong
+      }
+      (total - free) / 1024L   // kB → MB
+    } catch {
+      case _: Exception => -1L
+    }
+}
+
+object ResourceHealthMonitor {
+  val ActorName: String = "resource-health-monitor"
+  val LogTag:    String = "RESOURCE-PULSE"
+
+  private[metrics] case object Tick
+
+  /** Sent by any sync coordinator to annotate the next pulse with its current phase and context.
+    *
+    * @param phase
+    *   short label shown as `phase=<value>` (e.g. `"HEAL-BFS-L6"`, `"REGULAR-SYNC"`)
+    * @param context
+    *   additional key=value pairs appended to the pulse line (e.g. `Map("frontier" -> "42")`)
+    */
+  case class UpdatePhaseContext(phase: String, context: Map[String, String])
+
+  def props(dataSource: DataSource): Props = Props(new ResourceHealthMonitor(dataSource))
+}

--- a/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
@@ -47,9 +47,9 @@ object ResourceHealthMonitor {
       case rdb: RocksDbDataSource => Some(rdb)
       case _                      => None
     }
-    val rt    = Runtime.getRuntime
+    val rt = Runtime.getRuntime
     val memMX = ManagementFactory.getMemoryMXBean
-    val osMX  = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[com.sun.management.OperatingSystemMXBean]
+    val osMX = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[com.sun.management.OperatingSystemMXBean]
 
     Behaviors.setup { ctx =>
       var phaseCtx: Map[String, String] = Map("phase" -> "INIT")
@@ -68,19 +68,19 @@ object ResourceHealthMonitor {
             .map(b => math.max(0L, b.getCollectionCount))
             .sum
 
-          val gcPct   = (gcMsNow - lastGcMs) / 600.0
+          val gcPct = (gcMsNow - lastGcMs) / 600.0
           val gcCalls = gcCntNow - lastGcCount
           lastGcMs = gcMsNow
           lastGcCount = gcCntNow
 
           val heapUsed = (rt.totalMemory - rt.freeMemory) >> 20
-          val heapMax  = rt.maxMemory >> 20
-          val heapPct  = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
-          val offHeap  = memMX.getNonHeapMemoryUsage.getUsed >> 20
+          val heapMax = rt.maxMemory >> 20
+          val heapPct = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
+          val offHeap = memMX.getNonHeapMemoryUsage.getUsed >> 20
           val sysFreeGB = f"${osMX.getFreePhysicalMemorySize / 1e9}%.1f"
-          val swap     = readSwapUsedMB()
-          val load     = f"${osMX.getSystemLoadAverage}%.1f"
-          val rdbMem   = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
+          val swap = readSwapUsedMB()
+          val load = f"${osMX.getSystemLoadAverage}%.1f"
+          val rdbMem = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
 
           val ctxStr = phaseCtx.map { case (k, v) => s"$k=$v" }.mkString(" ")
           ctx.log.info(
@@ -107,7 +107,7 @@ object ResourceHealthMonitor {
       val path = Paths.get("/proc/meminfo")
       if (!Files.exists(path)) return -1L
       var total = 0L
-      var free  = 0L
+      var free = 0L
       Files.readAllLines(path).asScala.foreach { line =>
         if (line.startsWith("SwapTotal:")) total = line.split("\\s+")(1).toLong
         else if (line.startsWith("SwapFree:")) free = line.split("\\s+")(1).toLong

--- a/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
@@ -7,10 +7,8 @@ import java.nio.file.Paths
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorLogging
-import org.apache.pekko.actor.Cancellable
-import org.apache.pekko.actor.Props
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
 
 import com.chipprbots.ethereum.blockchain.sync.snap.actors.GcPressureSampler
 import com.chipprbots.ethereum.db.dataSource.DataSource
@@ -23,9 +21,10 @@ import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
   * and key counters. The monitor is purely observational: it reads metrics and logs; it never influences any consensus
   * or sync logic.
   *
-  * Spawn once at node startup:
+  * Spawn once at node startup via the Classic→Typed adapter:
   * {{{
-  * system.actorOf(ResourceHealthMonitor.props(dataSource), ResourceHealthMonitor.ActorName)
+  * import org.apache.pekko.actor.typed.scaladsl.adapter._
+  * system.spawn(ResourceHealthMonitor(dataSource), ResourceHealthMonitor.ActorName)
   * }}}
   *
   * Coordinators annotate via path-selection (no constructor changes needed):
@@ -35,69 +34,72 @@ import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
   *   .tell(ResourceHealthMonitor.UpdatePhaseContext("HEAL-BFS-L6", Map("frontier" -> "42")), ActorRef.noSender)
   * }}}
   */
-class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogging {
-  import ResourceHealthMonitor._
+object ResourceHealthMonitor {
+  val ActorName: String = "resource-health-monitor"
+  val LogTag: String = "RESOURCE-PULSE"
 
-  private val rt = Runtime.getRuntime
-  private val memMX = ManagementFactory.getMemoryMXBean
-  private val osMX = ManagementFactory.getOperatingSystemMXBean
-    .asInstanceOf[com.sun.management.OperatingSystemMXBean]
+  sealed trait Command
+  private[metrics] case object Tick extends Command
+  case class UpdatePhaseContext(phase: String, context: Map[String, String]) extends Command
 
-  private val rocksOpt: Option[RocksDbDataSource] = dataSource match {
-    case rdb: RocksDbDataSource => Some(rdb)
-    case _                      => None
-  }
+  def apply(dataSource: DataSource): Behavior[Command] = {
+    val rocksOpt: Option[RocksDbDataSource] = dataSource match {
+      case rdb: RocksDbDataSource => Some(rdb)
+      case _                      => None
+    }
+    val rt    = Runtime.getRuntime
+    val memMX = ManagementFactory.getMemoryMXBean
+    val osMX  = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[com.sun.management.OperatingSystemMXBean]
 
-  private var ticker: Cancellable = _
-  private var phaseCtx: Map[String, String] = Map("phase" -> "INIT")
-  private var lastGcMs: Long = GcPressureSampler.defaultGcCollectionTimeMs()
-  private var lastGcCount: Long = ManagementFactory.getGarbageCollectorMXBeans.asScala
-    .map(b => math.max(0L, b.getCollectionCount))
-    .sum
+    Behaviors.setup { ctx =>
+      var phaseCtx: Map[String, String] = Map("phase" -> "INIT")
+      var lastGcMs: Long = GcPressureSampler.defaultGcCollectionTimeMs()
+      var lastGcCount: Long = ManagementFactory.getGarbageCollectorMXBeans.asScala
+        .map(b => math.max(0L, b.getCollectionCount))
+        .sum
 
-  override def preStart(): Unit = {
-    ticker = context.system.scheduler.scheduleAtFixedRate(
-      60.seconds,
-      60.seconds,
-      self,
-      Tick
-    )(context.dispatcher, self)
-    log.info(s"[$LogTag] ResourceHealthMonitor started — 60s observability pulse active")
-  }
+      Behaviors.withTimers { timers =>
+        timers.startTimerWithFixedDelay(Tick, 60.seconds)
+        ctx.log.info(s"[$LogTag] ResourceHealthMonitor started — 60s observability pulse active")
 
-  override def postStop(): Unit = ticker.cancel()
+        def emitPulse(): Unit = {
+          val gcMsNow = GcPressureSampler.defaultGcCollectionTimeMs()
+          val gcCntNow = ManagementFactory.getGarbageCollectorMXBeans.asScala
+            .map(b => math.max(0L, b.getCollectionCount))
+            .sum
 
-  override def receive: Receive = {
-    case Tick                           => emitPulse()
-    case UpdatePhaseContext(phase, ctx) => phaseCtx = Map("phase" -> phase) ++ ctx
-  }
+          val gcPct   = (gcMsNow - lastGcMs) / 600.0
+          val gcCalls = gcCntNow - lastGcCount
+          lastGcMs = gcMsNow
+          lastGcCount = gcCntNow
 
-  private def emitPulse(): Unit = {
-    val gcMsNow = GcPressureSampler.defaultGcCollectionTimeMs()
-    val gcCntNow = ManagementFactory.getGarbageCollectorMXBeans.asScala
-      .map(b => math.max(0L, b.getCollectionCount))
-      .sum
+          val heapUsed = (rt.totalMemory - rt.freeMemory) >> 20
+          val heapMax  = rt.maxMemory >> 20
+          val heapPct  = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
+          val offHeap  = memMX.getNonHeapMemoryUsage.getUsed >> 20
+          val sysFreeGB = f"${osMX.getFreePhysicalMemorySize / 1e9}%.1f"
+          val swap     = readSwapUsedMB()
+          val load     = f"${osMX.getSystemLoadAverage}%.1f"
+          val rdbMem   = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
 
-    val gcPct = (gcMsNow - lastGcMs) / 600.0 // ms in 60 000 ms window → percent
-    val gcCalls = gcCntNow - lastGcCount
-    lastGcMs = gcMsNow
-    lastGcCount = gcCntNow
+          val ctxStr = phaseCtx.map { case (k, v) => s"$k=$v" }.mkString(" ")
+          ctx.log.info(
+            s"[$LogTag] $ctxStr heap=$heapUsed/${heapMax}MB($heapPct%) " +
+              s"gc-pressure=${f"$gcPct%.1f"}% gc-calls=$gcCalls off-heap=${offHeap}MB " +
+              s"sys-free=${sysFreeGB}GB swap=${swap}MB load=$load rocksdb-mem=${rdbMem}MB"
+          )
+        }
 
-    val heapUsed = (rt.totalMemory - rt.freeMemory) >> 20
-    val heapMax = rt.maxMemory >> 20
-    val heapPct = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
-    val offHeap = memMX.getNonHeapMemoryUsage.getUsed >> 20
-    val sysFreeGB = f"${osMX.getFreePhysicalMemorySize / 1e9}%.1f"
-    val swap = readSwapUsedMB()
-    val load = f"${osMX.getSystemLoadAverage}%.1f"
-    val rdbMem = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
-
-    val ctx = phaseCtx.map { case (k, v) => s"$k=$v" }.mkString(" ")
-    log.info(
-      s"[$LogTag] $ctx heap=$heapUsed/${heapMax}MB($heapPct%) " +
-        s"gc-pressure=${f"$gcPct%.1f"}% gc-calls=$gcCalls off-heap=${offHeap}MB " +
-        s"sys-free=${sysFreeGB}GB swap=${swap}MB load=$load rocksdb-mem=${rdbMem}MB"
-    )
+        Behaviors.receiveMessage {
+          case Tick =>
+            emitPulse()
+            Behaviors.same
+          case UpdatePhaseContext(phase, context) =>
+            phaseCtx = Map("phase" -> phase) ++ context
+            Behaviors.same
+        }
+      }
+    }
   }
 
   private def readSwapUsedMB(): Long =
@@ -105,31 +107,13 @@ class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogg
       val path = Paths.get("/proc/meminfo")
       if (!Files.exists(path)) return -1L
       var total = 0L
-      var free = 0L
+      var free  = 0L
       Files.readAllLines(path).asScala.foreach { line =>
         if (line.startsWith("SwapTotal:")) total = line.split("\\s+")(1).toLong
         else if (line.startsWith("SwapFree:")) free = line.split("\\s+")(1).toLong
       }
-      (total - free) / 1024L // kB → MB
+      (total - free) / 1024L
     } catch {
       case _: Exception => -1L
     }
-}
-
-object ResourceHealthMonitor {
-  val ActorName: String = "resource-health-monitor"
-  val LogTag: String = "RESOURCE-PULSE"
-
-  private[metrics] case object Tick
-
-  /** Sent by any sync coordinator to annotate the next pulse with its current phase and context.
-    *
-    * @param phase
-    *   short label shown as `phase=<value>` (e.g. `"HEAL-BFS-L6"`, `"REGULAR-SYNC"`)
-    * @param context
-    *   additional key=value pairs appended to the pulse line (e.g. `Map("frontier" -> "42")`)
-    */
-  case class UpdatePhaseContext(phase: String, context: Map[String, String])
-
-  def props(dataSource: DataSource): Props = Props(new ResourceHealthMonitor(dataSource))
 }

--- a/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/metrics/ResourceHealthMonitor.scala
@@ -16,12 +16,12 @@ import com.chipprbots.ethereum.blockchain.sync.snap.actors.GcPressureSampler
 import com.chipprbots.ethereum.db.dataSource.DataSource
 import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
 
-/** Node-wide resource observability — emits a [[ResourceHealthMonitor.LogTag]] line every 60 seconds covering JVM
-  * heap, GC pressure, off-heap, free physical RAM, swap, system load, and RocksDB memtable footprint.
+/** Node-wide resource observability — emits a [[ResourceHealthMonitor.LogTag]] line every 60 seconds covering JVM heap,
+  * GC pressure, off-heap, free physical RAM, swap, system load, and RocksDB memtable footprint.
   *
   * Sync coordinators call [[ResourceHealthMonitor.UpdatePhaseContext]] to annotate the pulse with their current phase
-  * and key counters. The monitor is purely observational: it reads metrics and logs; it never influences any
-  * consensus or sync logic.
+  * and key counters. The monitor is purely observational: it reads metrics and logs; it never influences any consensus
+  * or sync logic.
   *
   * Spawn once at node startup:
   * {{{
@@ -38,10 +38,10 @@ import com.chipprbots.ethereum.db.dataSource.RocksDbDataSource
 class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogging {
   import ResourceHealthMonitor._
 
-  private val rt    = Runtime.getRuntime
+  private val rt = Runtime.getRuntime
   private val memMX = ManagementFactory.getMemoryMXBean
-  private val osMX  = ManagementFactory.getOperatingSystemMXBean
-                        .asInstanceOf[com.sun.management.OperatingSystemMXBean]
+  private val osMX = ManagementFactory.getOperatingSystemMXBean
+    .asInstanceOf[com.sun.management.OperatingSystemMXBean]
 
   private val rocksOpt: Option[RocksDbDataSource] = dataSource match {
     case rdb: RocksDbDataSource => Some(rdb)
@@ -50,13 +50,17 @@ class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogg
 
   private var ticker: Cancellable = _
   private var phaseCtx: Map[String, String] = Map("phase" -> "INIT")
-  private var lastGcMs: Long    = GcPressureSampler.defaultGcCollectionTimeMs()
+  private var lastGcMs: Long = GcPressureSampler.defaultGcCollectionTimeMs()
   private var lastGcCount: Long = ManagementFactory.getGarbageCollectorMXBeans.asScala
-                                    .map(b => math.max(0L, b.getCollectionCount)).sum
+    .map(b => math.max(0L, b.getCollectionCount))
+    .sum
 
   override def preStart(): Unit = {
     ticker = context.system.scheduler.scheduleAtFixedRate(
-      60.seconds, 60.seconds, self, Tick
+      60.seconds,
+      60.seconds,
+      self,
+      Tick
     )(context.dispatcher, self)
     log.info(s"[$LogTag] ResourceHealthMonitor started — 60s observability pulse active")
   }
@@ -69,23 +73,24 @@ class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogg
   }
 
   private def emitPulse(): Unit = {
-    val gcMsNow  = GcPressureSampler.defaultGcCollectionTimeMs()
+    val gcMsNow = GcPressureSampler.defaultGcCollectionTimeMs()
     val gcCntNow = ManagementFactory.getGarbageCollectorMXBeans.asScala
-                     .map(b => math.max(0L, b.getCollectionCount)).sum
+      .map(b => math.max(0L, b.getCollectionCount))
+      .sum
 
-    val gcPct   = (gcMsNow - lastGcMs) / 600.0   // ms in 60 000 ms window → percent
+    val gcPct = (gcMsNow - lastGcMs) / 600.0 // ms in 60 000 ms window → percent
     val gcCalls = gcCntNow - lastGcCount
-    lastGcMs    = gcMsNow
+    lastGcMs = gcMsNow
     lastGcCount = gcCntNow
 
-    val heapUsed  = (rt.totalMemory - rt.freeMemory) >> 20
-    val heapMax   = rt.maxMemory >> 20
-    val heapPct   = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
-    val offHeap   = memMX.getNonHeapMemoryUsage.getUsed >> 20
+    val heapUsed = (rt.totalMemory - rt.freeMemory) >> 20
+    val heapMax = rt.maxMemory >> 20
+    val heapPct = if (heapMax > 0) heapUsed * 100 / heapMax else 0L
+    val offHeap = memMX.getNonHeapMemoryUsage.getUsed >> 20
     val sysFreeGB = f"${osMX.getFreePhysicalMemorySize / 1e9}%.1f"
-    val swap      = readSwapUsedMB()
-    val load      = f"${osMX.getSystemLoadAverage}%.1f"
-    val rdbMem    = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
+    val swap = readSwapUsedMB()
+    val load = f"${osMX.getSystemLoadAverage}%.1f"
+    val rdbMem = rocksOpt.map(_.totalMemtableSizeMB).getOrElse(0L)
 
     val ctx = phaseCtx.map { case (k, v) => s"$k=$v" }.mkString(" ")
     log.info(
@@ -100,12 +105,12 @@ class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogg
       val path = Paths.get("/proc/meminfo")
       if (!Files.exists(path)) return -1L
       var total = 0L
-      var free  = 0L
+      var free = 0L
       Files.readAllLines(path).asScala.foreach { line =>
-        if (line.startsWith("SwapTotal:"))     total = line.split("\\s+")(1).toLong
-        else if (line.startsWith("SwapFree:")) free  = line.split("\\s+")(1).toLong
+        if (line.startsWith("SwapTotal:")) total = line.split("\\s+")(1).toLong
+        else if (line.startsWith("SwapFree:")) free = line.split("\\s+")(1).toLong
       }
-      (total - free) / 1024L   // kB → MB
+      (total - free) / 1024L // kB → MB
     } catch {
       case _: Exception => -1L
     }
@@ -113,7 +118,7 @@ class ResourceHealthMonitor(dataSource: DataSource) extends Actor with ActorLogg
 
 object ResourceHealthMonitor {
   val ActorName: String = "resource-health-monitor"
-  val LogTag:    String = "RESOURCE-PULSE"
+  val LogTag: String = "RESOURCE-PULSE"
 
   private[metrics] case object Tick
 

--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
@@ -103,8 +103,8 @@ object ETHPackets {
         val result = new scala.collection.mutable.ArrayBuffer[RLPEncodeable](encodables.size)
         var i = 0
         val items = encodables match {
-          case indexed: IndexedSeq[RLPEncodeable] => indexed
-          case other                              => other.toIndexedSeq
+          case indexed: IndexedSeq[RLPEncodeable] @unchecked => indexed
+          case other                                         => other.toIndexedSeq
         }
         val len = items.size
         while (i < len)

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -273,6 +273,7 @@ abstract class BaseNode extends Node {
       tryAndLogFailure(() => jsonRpcIpcServer.close())
     }
     tryAndLogFailure(() => Metrics.get().close())
+    tryAndLogFailure(() => storagesInstance.storages.stateStorage.flushPendingPrunes())
     tryAndLogFailure(() => storagesInstance.dataSource.close())
   }
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -288,9 +288,11 @@ abstract class BaseNode extends Node {
         case None =>
           log.error("No block found for number {} when trying to fix database", bestBlockInfo.number)
       }
-
     }
 
+    // Replay any pruning blocks missed by a prior crash (OPT-046 watermark).
+    val bestBlock = storagesInstance.storages.appStateStorage.getBestBlockNumber()
+    storagesInstance.storages.stateStorage.replayMissedPrunes(bestBlock)
   }
 }
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -18,6 +18,7 @@ import com.chipprbots.ethereum.console.TuiUpdater
 import com.chipprbots.ethereum.db.dataSource.RocksDbCacheMetrics
 import com.chipprbots.ethereum.metrics.Metrics
 import com.chipprbots.ethereum.metrics.MetricsConfig
+import com.chipprbots.ethereum.metrics.ResourceHealthMonitor
 import com.chipprbots.ethereum.network.PeerManagerActor
 import com.chipprbots.ethereum.network.ServerActor
 import com.chipprbots.ethereum.network.StaticNodesLoader
@@ -74,6 +75,7 @@ abstract class BaseNode extends Node {
     // Phase 5: Background work
     startSyncController()
     startMining()
+    startResourceHealthMonitor()
 
     // Phase 6: Non-critical maintenance
     runDBConsistencyCheck()
@@ -178,6 +180,13 @@ abstract class BaseNode extends Node {
   private[this] def startSyncController(): Unit = syncController ! SyncProtocol.Start
 
   private[this] def startMining(): Unit = mining.startProtocol(this)
+
+  private[this] def startResourceHealthMonitor(): Unit = {
+    val _ = system.actorOf(
+      ResourceHealthMonitor.props(storagesInstance.dataSource),
+      ResourceHealthMonitor.ActorName
+    )
+  }
 
   private[this] def startDiscoveryManager(): Unit = peerDiscoveryManager ! PeerDiscoveryManager.Start
 

--- a/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/com/chipprbots/ethereum/nodebuilder/StdNode.scala
@@ -182,8 +182,9 @@ abstract class BaseNode extends Node {
   private[this] def startMining(): Unit = mining.startProtocol(this)
 
   private[this] def startResourceHealthMonitor(): Unit = {
-    val _ = system.actorOf(
-      ResourceHealthMonitor.props(storagesInstance.dataSource),
+    import org.apache.pekko.actor.typed.scaladsl.adapter._
+    val _ = system.spawn(
+      ResourceHealthMonitor(storagesInstance.dataSource),
       ResourceHealthMonitor.ActorName
     )
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightCalibrationSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/ChainWeightCalibrationSpec.scala
@@ -14,14 +14,12 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import com.chipprbots.ethereum.Fixtures
-import com.chipprbots.ethereum.Mocks
 import com.chipprbots.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import com.chipprbots.ethereum.blockchain.sync.CacheBasedBlacklist
 import com.chipprbots.ethereum.domain._
 import com.chipprbots.ethereum.ledger.VMImpl
 import com.chipprbots.ethereum.utils.Config.SyncConfig
 import com.chipprbots.ethereum.domain.appstate.BlockInfo
-import com.chipprbots.ethereum.network.NetworkPeerManagerActor
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.CalibrateChainWeightNow
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.GetHandshakedPeers
 import com.chipprbots.ethereum.network.NetworkPeerManagerActor.RegisterChainWeightCalibrationTarget
@@ -230,7 +228,6 @@ class ChainWeightCalibrationSpec extends AnyFlatSpec with Matchers {
   it should "not write when accumulated TD is below genesisWeight × 1000" taggedAs (UnitTest, SyncTest) in
     new RegularSyncSetup {
       // Anchor at h1 with absurdly low anchorTD — accumulated result < genesis × 1000
-      val tinyAnchorTD = BigInt("1000000000000") // 10^12 < 1 × 10^13 → but wait, h1 has number=1
       // Actually 1×10^12 < 1×10^13 → NOT a plausible anchor! So the walk will abort, not return a below-threshold result.
       // Instead: use a large-numbered block with barely-above-threshold anchor that still leads to below-genesis*1000 result.
       // Simplest: anchor with TD=1 (passes BigInt check), but 1 < genesis*1000 → plausibility rejects it.

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/fast/FastSyncConcurrentPipelineSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/fast/FastSyncConcurrentPipelineSpec.scala
@@ -26,7 +26,6 @@ import com.chipprbots.ethereum.network.Peer
 import com.chipprbots.ethereum.network.PeerId
 import com.chipprbots.ethereum.network.p2p.messages.Capability
 import com.chipprbots.ethereum.network.p2p.messages.ETHPackets.BlockBodies
-import com.chipprbots.ethereum.network.p2p.messages.ETHPackets.BlockHeaders
 import com.chipprbots.ethereum.testing.Tags._
 
 /** Queue-level regression and isolation tests for FastSync's three concurrent fetch pipelines (ARCH-002 / [11b]).
@@ -145,9 +144,6 @@ class FastSyncConcurrentPipelineSpec extends AnyFlatSpec with Matchers {
     val peer2: PeerWithInfo = mkPeer("peer-2")
 
     val hash32: ByteString = ByteString(Array.fill(32)(0.toByte))
-    private val bloom256 = ByteString(Array.fill(256)(0.toByte))
-    private val beneficiary = ByteString(Array.fill(20)(0.toByte))
-    private val nonce8 = ByteString(Array.fill(8)(0.toByte))
 
     private val remoteStatus = RemoteStatus(
       capability = Capability.ETH69,

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -128,7 +128,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
       (adapter
         .evaluateBranch(_: NonEmptyList[Block])(_: IORuntime, _: BlockchainConfig))
         .when(*, *, *)
-        .onCall { case (nel: NonEmptyList[Block], _, _) =>
+        .onCall { case (nel: NonEmptyList[Block] @unchecked, _, _) =>
           def go(remaining: List[Block], acc: List[BlockData]): IO[BlockImportResult] =
             remaining match {
               case Nil => IO.pure(BlockImportedToTop(acc.reverse))
@@ -460,7 +460,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
     (consensusAdapter
       .evaluateBranch(_: NonEmptyList[Block])(_: IORuntime, _: BlockchainConfig))
       .when(*, *, *)
-      .onCall { case (nel: NonEmptyList[Block], _, _) =>
+      .onCall { case (nel: NonEmptyList[Block] @unchecked, _, _) =>
         if (nel.toList.contains(testBlocks.last)) importedLastTestBlock = true
         val blockData = nel.toList.map(b => BlockData(b, Nil, ChainWeight.totalDifficultyOnly(b.header.difficulty)))
         IO.pure(BlockImportedToTop(blockData))

--- a/src/test/scala/com/chipprbots/ethereum/consensus/pow/EthashNonceSearchSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/consensus/pow/EthashNonceSearchSpec.scala
@@ -14,8 +14,6 @@ import com.chipprbots.ethereum.testing.Tags._
   */
 class EthashNonceSearchSpec extends AnyFlatSpec with Matchers {
 
-  import EthashUtils._
-
   private val ecip1099Block: Long = 2_520_000L
   private val epoch0: Long = EthashUtils.epoch(0L, ecip1099Block)
   private val epoch0Seed = EthashUtils.seed(0L, ecip1099Block)

--- a/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/db/storage/BfsQueueStorageSpec.scala
@@ -210,7 +210,6 @@ class BfsQueueStorageSpec extends AnyFlatSpec with Matchers {
       it.next().size shouldBe 10 // consume only the first chunk, then drop `it`
       // withRocksDb's finally destroys the DataSource; a leaked open native iterator would error there.
       // scanRange closes its iterator per chunk, so nothing is open between chunks. Reaching here is the assertion.
-      succeed
     }
 
   "EphemDataSource.scanRange" should "return sorted, namespace-isolated entries within [from,to) (US5/FR-017)" taggedAs UnitTest in {

--- a/src/test/scala/com/chipprbots/ethereum/extvm/VMClientSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/extvm/VMClientSpec.scala
@@ -16,7 +16,6 @@ import com.chipprbots.ethereum.extvm.msg.CallContext.Config
 import com.chipprbots.ethereum.extvm.msg.CallResult
 import com.chipprbots.ethereum.extvm.msg.VMQuery
 import com.chipprbots.ethereum.utils.ForkBlockNumbers
-import com.chipprbots.ethereum.utils.VmConfig
 import com.chipprbots.ethereum.vm._
 import com.chipprbots.ethereum.vm.utils.MockVmInput
 import com.chipprbots.ethereum.extvm.msg.BlockHeader
@@ -242,8 +241,7 @@ class VMClientSpec extends AnyFlatSpec with Matchers with MockFactory {
 
     val messageHandler: MessageHandlerApi = mock[MessageHandlerApi]
 
-    val externalVmConfig: VmConfig.ExternalConfig = VmConfig.ExternalConfig("fukuii", None, "127.0.0.1", 0)
-    val vmClient = new VMClient(externalVmConfig, messageHandler, testMode = false)
+    val vmClient = new VMClient(messageHandler, testMode = false)
   }
 
 }

--- a/src/test/scala/com/chipprbots/ethereum/network/BestNetworkTipTrackingSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/BestNetworkTipTrackingSpec.scala
@@ -2,8 +2,6 @@ package com.chipprbots.ethereum.network
 
 import java.net.InetSocketAddress
 
-import scala.concurrent.duration._
-
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.actor.Props
 import org.apache.pekko.testkit.TestActorRef
@@ -28,7 +26,6 @@ import com.chipprbots.ethereum.network.PeerEventBusActor.Subscribe
 import com.chipprbots.ethereum.network.PeerEventBusActor.SubscriptionClassifier._
 import com.chipprbots.ethereum.network.p2p.messages.Capability
 import com.chipprbots.ethereum.network.p2p.messages.ETHPackets.NewBlock
-import com.chipprbots.ethereum.network.p2p.messages.Codes
 import com.chipprbots.ethereum.testing.Tags._
 import com.chipprbots.ethereum.utils.Config
 

--- a/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
@@ -471,18 +471,16 @@ class ETH69ComplianceSpec extends AnyWordSpec with Matchers {
         import com.chipprbots.ethereum.rlp._
         // Mirrors the live DECODE_ERROR observed on 5.161.72.73:30303:
         // RLPList(Queue(RLPValue(45), RLPValue(89), ...)) — 8 RLPValues, no embedded RLPList.
-        val eightAllValueBytes = encode(
-          RLPList(
-            RLPValue(Array[Byte](45)),
-            RLPValue(Array[Byte](89)),
-            RLPValue(Array.fill(32)(0x00.toByte)),
-            RLPValue(Array.fill(32)(0x00.toByte)),
-            RLPValue(Array[Byte](0)),
-            RLPValue(Array.fill(8)(0x00.toByte)),
-            RLPValue(Array.fill(32)(0x00.toByte)),
-            RLPValue(Array[Byte](0))
-          )
-        )
+        val eightAllValueBytes = encode(RLPList(
+          RLPValue(Array[Byte](45)),
+          RLPValue(Array[Byte](89)),
+          RLPValue(Array.fill(32)(0x00.toByte)),
+          RLPValue(Array.fill(32)(0x00.toByte)),
+          RLPValue(Array[Byte](0)),
+          RLPValue(Array.fill(8)(0x00.toByte)),
+          RLPValue(Array.fill(32)(0x00.toByte)),
+          RLPValue(Array[Byte](0))
+        ))
         val decoded = decoder(Capability.ETH69).fromBytes(Codes.StatusCode, eightAllValueBytes)
         decoded match {
           case Right(s: ETHPackets.Status69.Status69) =>

--- a/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/network/p2p/messages/ETH69ComplianceSpec.scala
@@ -471,16 +471,18 @@ class ETH69ComplianceSpec extends AnyWordSpec with Matchers {
         import com.chipprbots.ethereum.rlp._
         // Mirrors the live DECODE_ERROR observed on 5.161.72.73:30303:
         // RLPList(Queue(RLPValue(45), RLPValue(89), ...)) — 8 RLPValues, no embedded RLPList.
-        val eightAllValueBytes = encode(RLPList(
-          RLPValue(Array[Byte](45)),
-          RLPValue(Array[Byte](89)),
-          RLPValue(Array.fill(32)(0x00.toByte)),
-          RLPValue(Array.fill(32)(0x00.toByte)),
-          RLPValue(Array[Byte](0)),
-          RLPValue(Array.fill(8)(0x00.toByte)),
-          RLPValue(Array.fill(32)(0x00.toByte)),
-          RLPValue(Array[Byte](0))
-        ))
+        val eightAllValueBytes = encode(
+          RLPList(
+            RLPValue(Array[Byte](45)),
+            RLPValue(Array[Byte](89)),
+            RLPValue(Array.fill(32)(0x00.toByte)),
+            RLPValue(Array.fill(32)(0x00.toByte)),
+            RLPValue(Array[Byte](0)),
+            RLPValue(Array.fill(8)(0x00.toByte)),
+            RLPValue(Array.fill(32)(0x00.toByte)),
+            RLPValue(Array[Byte](0))
+          )
+        )
         val decoded = decoder(Capability.ETH69).fromBytes(Codes.StatusCode, eightAllValueBytes)
         decoded match {
           case Right(s: ETHPackets.Status69.Status69) =>

--- a/src/test/scala/com/chipprbots/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
@@ -16,7 +16,7 @@ import com.chipprbots.ethereum.domain._
 import com.chipprbots.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
 import com.chipprbots.ethereum.transactions.TransactionHistoryService.MinedTransactionData
 import com.chipprbots.ethereum.transactions.testing.PendingTransactionsManagerAutoPilot
-import com.chipprbots.ethereum.{blockchain => _, _}
+import com.chipprbots.ethereum._
 
 class LegacyTransactionHistoryServiceSpec
     extends TestKit(ActorSystem("TransactionHistoryServiceSpec-system"))


### PR DESCRIPTION
## Summary

This PR delivers three coordinated work-streams from june-sprint, developed and validated on ETC mainnet (v0.7.13) against core-geth and Besu:

---

### BFS Heal Pipeline — Stability, Performance, and Crash-Safety

The post-SNAP BFS state-heal walk (shipped in PR #1348) exposed a cluster of RocksDB pressure and crash-safety gaps observed live across RUN03 runs. This group closes them end-to-end:

- **OPT-059 — RocksDB-backed BFS visited set** (`feat(db)`): Replaces the heap-allocated `LinkedHashMap` FIFO (capped at 4M entries, ~480–640 MB at 120–160 B/entry) with a `HealingVisitedNamespace ('v')` RocksDB column family. Keys are raw 32-byte keccak hashes; values are empty bytes. Tests swap in `InMemoryHealingVisitedStorage` for zero-RocksDB determinism. Eliminates the most significant heap pressure source during long heal walks.

- **Batch visited-set writes** (`fix(db)`): OPT-059 follow-up observed in RUN03: single-key `put()` calls generated L0 write stalls. A `ConcurrentLinkedQueue` buffer (10K-key flush threshold) reduces ~77M individual commits to ~7,700 batches. `clear()` ordering fixed: `deleteRange` before buffer drain to prevent re-adding stale keys.

- **Pivot-root-keyed visited set — crash-safe BFS resume** (`fix(snap)`): Stores the active pivot root under a 21-byte sentinel key (`__visited_root__`) in `HealingVisitedNamespace`. On restart with the same root, `clearAndSetRoot` is skipped and the visited set resumes (~20–30s vs 6+ hours mid-L7 restart previously). Sentinel sorts before all 32-byte keccak keys.

- **Compact BFS queue CF after each level deletion** (`fix(db)`): Calls `db.compactRange()` on `BfsQueueNamespace` immediately after each `deleteRange()` / `clear()`. Observed live in RUN03-1 (2026-06-15): C0 L6 `queueRead=355K ms`, C1 L6 `queueRead=2,927K ms`. Compaction adds ~2–10s per level but eliminates multi-second read amplification from tombstone accumulation.

- **OPT-046 — Batch pruning deletes** (`fix(db)`): Replaces per-block `WriteBatch` commits in `ReferenceCountNodeStorage` with a byte-threshold accumulator (flush at 64 MB or 1,000 blocks). Terminal flush wired into `StdNode.shutdown` before `dataSource.close()`. Eliminates per-block RocksDB overhead during the prune pass.

- **Atomic prune watermark** (`fix(db)`): Writes `LastPrunedBlockKey` in the same `WriteBatch` as the deletes it covers. `BaseNode.fixDatabase()` calls `replayMissedPrunes()` on startup to replay any window missed by a crash between commit and watermark write. Guards `highestPendingBlock > 0` prevent spurious watermark writes.

- **OPT-060 — 60s [RESOURCE-PULSE] observability** (`feat(metrics)`): `ResourceHealthMonitor` — a node-wide Pekko actor emitting `[RESOURCE-PULSE]` every 60s across all sync phases. Covers JVM heap, GC pressure (GarbageCollectorMXBean total-pause fraction), off-heap, free physical RAM, swap, system load, and RocksDB memtable size. Motivated by RUN03 v0.7.10 dying from a 76.6s GC stop-the-world after 19h50m with zero prior visibility. Wired into `StdNode`, `RegularSync`, and `TrieNodeHealingCoordinator` for phase context tagging.

---

### Network Robustness — Status69/70 Decode Hardening

- **Two-arm Status69/70 decode** (`refactor(network)`): Replaces the previous 4-arm tolerant match with a cleaner two-arm design — canonical 7-field arm, then a catch-all that extracts `protocolVersion` + `networkId` and stubs the rest. The stub always fails the upstream genesis/networkId check, rejecting off-network peers as `UselessPeer` without codec crash. Motivated by a live `DECODE_ERROR` on `5.161.72.73:30303` observed during RUN03.

---

### Agents, Skills, and Build Modernization

- **ResourceHealthMonitor → Pekko Typed** (`refactor(metrics)`): Converts `ResourceHealthMonitor` from Classic actor + `ActorLogging` + `scheduleAtFixedRate` to a `Behaviors.withTimers` Typed behavior with a sealed `Command` ADT (`Tick`, `UpdatePhaseContext`). Spawning site uses the Classic→Typed adapter. Removes mutable scheduler ref; Typed supervision handles restart.

- **New skills: `fukuii-dependency-audit` + `fukuii-tech-debt-inventory`** (`chore(skills)`): Two new project-local Claude Code skills. `fukuii-dependency-audit` reads `Dependencies.scala`, calls the `endoflife.date` API, runs `sbt dependencyUpdates`, and includes a BSL guard. `fukuii-tech-debt-inventory` greps for Scala 2 legacy patterns (`Future.successful`, `_` wildcard imports, `var`-in-actor, `Thread.sleep`) and emits a ranked table for MITHRIL planning.

- **New agent: `prism` code-quality reviewer** (`chore(agents,skills)`): 8-lens code quality reviewer (functionality, tests, readability, structure, simplicity, performance, security, scala-fp). Three `speckit-bug-*` skills added for assess/fix/test workflows. All 5 existing agents updated to reference `Scala 3.3 LTS` rather than the hardcoded `3.3.7` pin. `eye.md` updated to note prism should run before eye on non-consensus changes.

- **Scala 3.3.8 LTS patch** (`chore(build)`): Bumps `3.3.7 → 3.3.8` (released 2026-06-11, latest 3.3 LTS patch, zero API changes). `scapegoat` bumped `3.3.4 → 3.3.6`.

- **June 2026 dep bumps** (`chore(deps)`): Patch/minor: `enumeratum 1.9.7→1.9.8`, `scalatest 3.2.19→3.2.20`, `scalamock 7.3.2→7.3.3`, `logback-classic 1.5.32→1.5.34`, `jna 5.18.1→5.19.1`. Minor: `fs2 3.12.0→3.12.2`, `cats-effect 3.6.1→3.6.3`, `micrometer 1.16.5→1.16.6`, `prometheus 1.3.5→1.3.10`.

- **Document `-source:future` blocker** (`chore(build)`): Notes ~1,652 wildcard imports (`_`) must be migrated to `*` before enabling `scalacOptions += "-source:future"`. Migration tracked in `.local/docs/moderization-review-june/scala-future-source.md`.

---

## Consensus and safety

No changes to EVM execution, Ethash, block reward, gas accounting, or state root computation. All changes are in the storage layer (RocksDB column family management, write batching), the metrics layer (passive observer), the BFS heal coordinator (persistence keys, visited-set backend), and the network Status decode (rejects off-network peers earlier, no change to valid-peer flow). Reviewed against go-ethereum `trie/sync.go` (visited-set pattern) and Besu `WorldStateDownloader` (pruning batch pattern) for behavioral parity. Forge review not required.

## Test coverage

- `sbt testOnly *.TrieNodeHealingCoordinatorSpec *.HealingFrontierResumeSpec` — 45/45 pass (OPT-059 + pivot-root resume)
- `sbt testOnly *.StateStorageSpec *.ReferenceCountNodeStorageSpec` — 26/26 pass (OPT-046 pruning batch + atomic watermark)
- `sbt testEssential` — **3,499 / 3,499 pass**, 347 suites, 0 aborts (gate: all commits)
- `sbt compile-all` — clean (main + test sources, all modules)
- `sbt scalafmtAll` — clean

## Deferrals

`testComprehensive` (Tier 3 ethereum/tests suite) deferred — spec gating requires gorgoroth trial completion. `StorageRangeCoordinator` byte-threshold tuning and skeleton header sync deferred to a follow-up PR. `-source:future` migration (1,652 import sites) deferred — tracked in `.local/docs/moderization-review-june/`.

Co-authored-by: chris-mercer <chris-mercer@users.noreply.github.com>
Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>