### PR TITLE
feat(snap): decouple heal walk root from serve-window-bound fetch (spec 004)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory": "specs/003-scoped-heal-verification"}
+{
+  "feature_directory": "specs/004-decoupled-heal-serve-root"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,14 @@ Read it before planning or implementing. Highlights:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/003-scoped-heal-verification/plan.md` (scope the post-SNAP heal completion
-verification to re-walk only the healed subtrees instead of re-seeding the state
-root and re-walking the whole ~90M-node trie — reuse the BFS kernel with multi-seed,
-mandatory full-root fallback when full coverage isn't durably proven, byte-for-byte
-completion parity (FR-007). Consensus-adjacent; forge-reviewed; builds on the
-hold-pivot livelock fix #1357). Prior plan: `specs/002-bfs-heal-performance/plan.md`.
+`specs/004-decoupled-heal-serve-root/plan.md` (decouple the post-SNAP heal's local
+completeness walk from the serve-window-bound node fetch: hold the WALK root fixed for
+the whole walk (a local read needing no peers) while fetching missing nodes from an
+advancing SERVE root that stays inside peers' ~128-block snap serve window. Trie nodes
+are content-addressed and the fetched node is verified keccak256==hash before store
+(the load-bearing guardrail), so a newer servable root safely supplies the deep nodes.
+Cures the serve-window-vs-walk-time deadlock that stalls heal at ~99%. Consensus-adjacent;
+forge-reviewed; byte-for-byte completion parity (FR-007); default-on; composes with the
+hold-pivot fix #1357 as its durable generalization. Needs build + one redeploy.) Prior
+plans: `specs/003-scoped-heal-verification/plan.md`, `specs/002-bfs-heal-performance/plan.md`.
 <!-- SPECKIT END -->

--- a/docs/adr/consensus/CON-010-decoupled-heal-serve-root.md
+++ b/docs/adr/consensus/CON-010-decoupled-heal-serve-root.md
@@ -1,0 +1,63 @@
+# CON-010: Decoupled heal serve-root — fixed walk root, advancing fetch root
+
+**Status**: Accepted
+
+**Date**: 2026-06-17
+
+**Spec**: `specs/004-decoupled-heal-serve-root/`
+
+**Related**: [[CON-009]] (healing completeness marker), PR #1357 (hold-pivot livelock fix), `specs/003-scoped-heal-verification/`
+
+## Context
+
+After SNAP sync, `TrieNodeHealingCoordinator` proves the state trie is complete with a **completeness walk**: a local read-only BFS over the trie that finds referenced-but-missing nodes, **heals** each by fetching it from a peer via SNAP `GetTrieNodes`, and declares `StateHealingComplete` only when a walk finds zero missing.
+
+Today the walk and the fetch are pinned to the **same single state root** (`stateRoot`). That coupling deadlocks a slow or peer-scarce node:
+
+- The completeness walk takes **hours** (~16-20h for the full ETC-mainnet trie on slow storage — see `specs/002`/`specs/003`).
+- ETC peers serve `GetTrieNodes` for a given state root only for roughly the most recent ~128 blocks (~28 minutes at ~13s/block).
+- By the time the slow walk reaches the deep storage gaps, the pinned root has **aged out of every (non-archive) peer's serve window**, so the fetch times out and the deep gaps can never be filled. Live evidence: heal stuck at ~99% (27,346 nodes healed), with all-peers-stateless rolls clustering at 26-27 minute intervals — the serve window.
+
+The hold-pivot fix (PR #1357) holds the root across *stagnation* but cannot help here: holding an aged, unservable root just trades roll-churn for a hold-stall, and a genuine all-peers-stateless roll re-seeds the multi-hour walk. Neither converges.
+
+This is **consensus-adjacent**: it changes how the node *sources* the nodes it must possess before it trusts its post-SNAP state. A wrong node accepted, or completion declared with a gap, leads to a post-state-root mismatch at block execution (a node-local liveness failure on chain 61, requiring re-sync — not a chain split).
+
+## Key insight
+
+Trie nodes are **content-addressed** (identified by their keccak256 hash, independent of which state root references them). A newer, currently-servable root shares the vast majority (~99.9%) of the *deep* trie nodes with the older root, because deep state changes little block-to-block. So a node missing under the old, no-longer-servable root can be fetched **by its path from a currently-servable root** and, once stored content-addressed, it satisfies the old root too.
+
+## Decision
+
+Split the single root into two roles:
+
+> **The WALK root (`stateRoot`) stays fixed for the duration of a walk and is the sole basis of the completeness decision. The SERVE root (`serveRoot`) — used only to fetch missing nodes from peers — advances independently to track the current serve window. Completeness is judged exclusively by the walk finding zero missing against the fixed walk root.**
+
+1. **Fixed walk root.** `stateRoot` keeps its existing semantics; it is read by the walk seeds, `isComplete`, the `verificationPassComplete` chokepoint, `markComplete`, and the scoped-verification `healedPathsRoot` tag. The new code never mutates it. The walk is a pure local read needing no peers, so it runs to completion regardless of serve windows. This is the durable generalization of hold-pivot (PR #1357): the walk root is held even across genuine serve-window aging, because healing no longer depends on it being servable.
+
+2. **Advancing serve root.** A new `serveRoot` var (initialized to `stateRoot`) is read only at the `GetTrieNodes` build site, and only when enabled: `rootHash = if (decoupledHealServeRoot) serveRoot else stateRoot`. It advances only via a new, side-effect-free `HealingServeRootRefresh(newServeRoot)` message — which sets `serveRoot` and clears the FR-006 attempt counters and **nothing else** (it must not touch the walk root, frontier, `verificationPassComplete`, or re-seed). It must NOT be confused with `HealingPivotRefreshed`, which deliberately mutates the walk root and resets completeness state.
+
+3. **Serve-root source (D4 = newest-servable).** `SNAPSyncController` requests a newest-servable root (`networkBest − 64`) from `SyncController` via a dedicated `RequestHealingServeRoot`/`HealingServeRoot` bootstrap slot (distinct from `StorageRecoveryActor`'s recent-root requester and from the walk-root-mutating pivot-refresh path), and pushes it to the coordinator as `HealingServeRootRefresh`. The refresh fires on the existing ~1s healing tick, gated so it only requests when the serve root has drifted > 2×margin behind head (never per-block). On a None/failed reply the controller **keeps the current serve root** (degrades to coupled rather than adopting an invalid root).
+
+4. **The content-hash check is the load-bearing safety guardrail (FR-004).** SNAP `GetTrieNodes` is *path-addressed*, so a serve root may resolve a requested path to a **different-content node** than the walk root expects. The existing check in `handleResponse` — accept a returned node **iff** `keccak256(node)` equals a requested task hash (the walk root's expectation) — makes this safe: a mismatching node fails the check and is **dropped** (never stored, never counted), and the task stays pending. This check is preserved byte-for-byte and **must never be weakened or bypassed on any decoupled path**. It is the single guardrail that converts a path-mismatch into a safe drop-and-retry rather than a corrupting accept.
+
+5. **No false completion, no silent infinite retry (D5 = surface-only, FR-006).** A node no servable root can supply keeps being retried as the serve root advances. A per-task attempt counter (`healAttempts`, bounded by the pending set, cleared on every serve-root advance) surfaces a stuck task via log + metric after a bounded threshold (`decoupled-heal-max-attempts-no-refresh`, default 12) — **observation only**. `HealingForceComplete` is neutralized under decoupling: it may not declare `StateHealingComplete` while any task is unsatisfied. Completion is impossible to declare falsely because it requires the walk to find zero missing against the walk root.
+
+6. **Config + fallback (FR-008).** `sync.snap-sync.decoupled-heal-serve-root` (default `true`). When off, `serveRoot` is unused and the fetch reads `stateRoot` — byte-identical to pre-spec-004. In-memory only; safe to flip without migration; a restart re-initializes `serveRoot` to the walk root (coupled until the first refresh).
+
+## Byte-for-byte completion parity (FR-007)
+
+Parity holds by construction: `coverage(complete) = the walk finds zero missing against stateRoot`. The serve root supplies only node *bytes*, each verified to equal the walk root's expected hash before storage. Therefore the same final set of stored, content-verified nodes is reached regardless of which root sourced them ⇒ the same walk result ⇒ the same `StateHealingComplete` decision, the same persisted CF `g` completeness marker, and the same state root as the coupled single-root path. No new completion site and no new marker set-point are introduced.
+
+## Consequences
+
+- A completeness walk that takes many multiples of the serve window now completes (the deep gaps heal from whatever root is currently servable), unblocking post-SNAP healing on slow / peer-scarce ETC nodes.
+- No EVM / gas / RLP / block-validation / Ethash / ECIP-1017 code is touched; ETC PoW and block-number fork dispatch are unaffected; the mechanism is chain-agnostic sync-layer.
+- A residual *liveness* risk remains for shallow account-trie nodes that change nearly every block (a path that differs in every servable root). The gap set after SNAP is dominated by *deep* storage nodes (high cross-root sharing), so this is rare; FR-006 surfaces it rather than hiding or force-completing it. If shallow-gap liveness is ever observed, the serve-root selection can be switched from newest-servable to oldest-still-servable (maximal sharing) — a documented tuning lever (research D4).
+- Requires a build + one redeploy; the next walk after deploy runs to completion. It does not rescue an already-running stuck walk.
+
+## Alternatives considered
+
+- **Raw-hash `GetTrieNodes`** (root-independent fetch): immune to the path-mismatch entirely, but the ETC SNAP protocol is path-addressed (matching core-geth/Besu) — changing the wire format is out of scope and an interop risk.
+- **Pin an archive snap peer that serves the held root indefinitely**: a valid operational unblock, but depends on having such a peer; this change fixes the client-side deadlock regardless of peer archive depth.
+- **Force-complete after N failed attempts**: rejected — it would declare success with a real gap (consensus-unsafe). Superseded by the surface-only D5 behavior.
+- **Mutate `stateRoot` for the fetch and restore it**: rejected — races the walk and breaks the parity argument.

--- a/specs/004-decoupled-heal-serve-root/checklists/requirements.md
+++ b/specs/004-decoupled-heal-serve-root/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Decoupled Heal Serve-Root
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a deeply technical infrastructure feature; the "stakeholders" are node operators and protocol engineers, and the necessary domain vocabulary (state root, trie node, content-addressing, serve window, completeness walk) is the stakeholder language, not implementation leakage. The requirements deliberately avoid code, file, function, and framework references — those appear only in the Overview as motivating context and are reserved for `/speckit-plan`.
+- The binding correctness invariants are FR-007 (byte-for-byte completion parity with the coupled single-root path) and FR-004 (content-hash integrity on every node sourced from the serve root). FR-005 keeps the completeness decision anchored to the fixed walk root, and FR-006 forbids both false completion and silent infinite retry. This is consensus-adjacent and MUST go through the `forge` protocol in planning/implementation.
+- One open default — the enablement switch's default value (FR-008) — is recorded as an Assumption rather than a [NEEDS CLARIFICATION] marker, because both reasonable choices remain correct under the FR-008 single-root fallback; it will be settled in `/speckit-plan`.
+- Validation result: all items pass on the first iteration. Spec is ready for `/speckit-clarify` (optional) or `/speckit-plan`.

--- a/specs/004-decoupled-heal-serve-root/contracts/internal-interfaces.md
+++ b/specs/004-decoupled-heal-serve-root/contracts/internal-interfaces.md
@@ -1,0 +1,109 @@
+# Phase 1 Contracts: Decoupled Heal Serve-Root (internal interfaces)
+
+This is an internal sync-orchestration change — no external/wire API. The "contracts" are the internal actor messages, the coordinator's root vars, the fetch-site selection, the config, and the (untouched) completion gate. Citations are `staging` HEAD; line numbers are anchors, not guarantees.
+
+## C1 — Serve-root variable (coordinator state)
+
+```
+// TrieNodeHealingCoordinator — NEW field, alongside `private var stateRoot` (:40)
+private var serveRoot: ByteString = stateRoot   // advancing servable root; == walk root until refreshed
+```
+
+Contract: `serveRoot` is read **only** at the fetch build site (C3). It is never read by the walk seeds, `isComplete`, `verificationPassComplete`, `markComplete`, or the scoped-verification `healedPathsRoot` tag. `stateRoot` (walk root) semantics are unchanged.
+
+## C2 — `HealingServeRootRefresh` message (NEW)
+
+```
+// Messages.scala — TrieNodeHealingCoordinator message set (~:250)
+final case class HealingServeRootRefresh(newServeRoot: ByteString)
+```
+
+Handler contract (in `TrieNodeHealingCoordinator`):
+- Sets `serveRoot = newServeRoot`.
+- Resets the FR-006 attempt counters (a serve-root advance is the legitimate retry trigger).
+- Does **NOTHING ELSE**: MUST NOT mutate `stateRoot`, clear `pendingTasks`/frontier, reset `verificationPassComplete`, or re-seed the walk. (Contrast `HealingPivotRefreshed` `:629-701`, which does all of those and MUST NOT be reused for serve-root advance.)
+- No-op when the feature is disabled.
+
+## C3 — Fetch-root selection at the GetTrieNodes build site
+
+```
+// requestNextBatch, TrieNodeHealingCoordinator.scala:1078-1083
+val request = GetTrieNodes(
+  requestId = requestId,
+  rootHash  = if (decoupledHealEnabled) serveRoot else stateRoot,   // <-- only changed line
+  paths     = paths,
+  responseBytes = responseBytes
+)
+```
+
+Contract: the **only** behavioral fetch change. Everything downstream (response handling, content-hash check, store) is unchanged.
+
+## C4 — Content-hash guardrail (UNCHANGED — must be preserved)
+
+```
+// handleResponse, TrieNodeHealingCoordinator.scala:1129-1137 (DO NOT WEAKEN)
+val nodeHash = ByteString(keccak.digest(nodeData.toArray))
+if (taskByHash.contains(nodeHash)) { /* store content-keyed (:1140), satisfy task */ }
+else { /* drop (:1174): not stored, not counted, task stays pending */ }
+```
+
+Contract (the load-bearing safety invariant, FR-004/SC-004): a node returned by *any* serve root is accepted **iff** its keccak256 equals a requested task hash (the walk root's expectation). This is what makes decoupling safe despite path-addressed fetch (a serve root that resolves a path to a different node yields a hash mismatch → drop). No decoupled code path may bypass this.
+
+## C5 — FR-006 attempt counter + surfacing (NEW)
+
+```
+private val healAttempts = mutable.Map.empty[ByteString, Int]   // bounded by pendingTasks
+// on unsatisfied re-queue (:1184-1189): healAttempts(hash) += 1
+// on HealingServeRootRefresh: healAttempts.clear()  (or decay)
+// when healAttempts(hash) > decoupledHealMaxAttemptsNoRefresh: emit surfacing log + metric
+```
+
+Contract: surfacing is **observation only**. It MUST NOT call `HealingForceComplete` (`:614`) or let stagnation-abandon declare `StateHealingComplete` while any task is unsatisfied (SC-002). Completion remains gated solely on the walk finding zero missing against the walk root.
+
+## C6 — Completion gate (UNCHANGED)
+
+```
+// HealingCheckCompletion (:748-806) → verificationPassComplete (set only in VerificationBFSComplete :812
+//   after BFS vs stateRoot finds isComplete :1329) → markComplete (:766) → StateHealingComplete
+```
+
+Contract (FR-005/FR-007): completeness is decided purely by the walk against the fixed walk root. The serve root supplies node *bytes* only (content-verified at C4). Same final stored nodes ⇒ same walk result ⇒ same marker + same state root as the coupled path. **No new completion site, no new marker set-point.**
+
+## C7 — Controller → coordinator serve-root push (SNAPSyncController + SyncController)
+
+Flow (reusing the `RecentRoot` bootstrap template, `SyncController.scala:1482-1565`):
+```
+chain advance / serve-window aging
+  └─ SNAPSyncController requests a servable root (RequestRecentRoot-style, networkBest−64)
+       └─ SyncController PivotHeaderBootstrap → RecentRoot(block, stateRoot)
+            └─ SNAPSyncController ! HealingServeRootRefresh(stateRoot)  → trieNodeHealingCoordinator
+```
+Contract: the healing requester must not contend with `StorageRecoveryActor` on `SyncController`'s single `recentRootRequester` (`:1484`) — use a distinct slot/tag. The push targets the coordinator with `HealingServeRootRefresh` (C2), never `HealingPivotRefreshed`.
+
+## C8 — Config (NEW)
+
+```
+# sync.conf, snap-sync block
+decoupled-heal-serve-root = true            # FR-008; off ⇒ coupled (fetch uses walk root)
+decoupled-heal-max-attempts-no-refresh = N  # FR-006 surfacing threshold (planning to pick N)
+```
+Threaded through `SnapSyncConfig` (alongside `healHoldPivotOnStagnation`, `SNAPSyncController.scala:4923`) → `TrieNodeHealingCoordinator.props` (`:3364`,`:3429`) → constructor (`:39-61`).
+
+## C9 — Metrics (NEW, FR-010)
+
+Additive `app_`-prefixed gauges via `SNAPSyncMetrics`:
+- walk root (label/short hash), current serve root (label/short hash),
+- count of nodes healed via a serve root different from the walk root,
+- count of tasks currently unservable (over the FR-006 threshold).
+
+## Test contracts (deterministic, Pekko TestKit — no `Thread.sleep`)
+
+| # | Asserts | Maps to |
+| --- | --- | --- |
+| T-1 | With feature on + `serveRoot` ≠ `stateRoot`, the `GetTrieNodes` request carries `serveRoot`; the walk seeds carry `stateRoot`. | FR-001/FR-002, C1/C3 |
+| T-2 | `HealingServeRootRefresh` updates `serveRoot` only — `stateRoot`, frontier, `verificationPassComplete`, pendingTasks unchanged. | FR-001/FR-009, C2 |
+| T-3 | A returned node whose keccak ≠ requested hash is dropped, not stored, not counted, task stays pending. | FR-004/SC-004, C4 |
+| T-4 | A task no serve root satisfies: not completed; attempt counter increments; resets on `HealingServeRootRefresh`; surfaces past threshold; no `StateHealingComplete`. | FR-006/SC-002, C5 |
+| T-5 | Same final healed state ⇒ identical completion outcome (StateHealingComplete + CF `g` marker + state root) via decoupled vs coupled (flag flip). | FR-007/SC-003 |
+| T-6 | Feature off ⇒ fetch uses `stateRoot`; behavior byte-identical to today. | FR-008/SC-006, C3 |
+| T-7 | Engagement + observability signals (walk root, serve root, cross-root heal count, unservable count) emitted. | FR-010, C9 |

--- a/specs/004-decoupled-heal-serve-root/data-model.md
+++ b/specs/004-decoupled-heal-serve-root/data-model.md
@@ -1,0 +1,58 @@
+# Phase 1 Data Model: Decoupled Heal Serve-Root
+
+No new persisted schema. All new state is **in-memory** in `TrieNodeHealingCoordinator` (a restart falls back to coupled behavior / full re-walk, which is safe). The durable stores are reused unchanged: the content-addressed node store (RocksDB CF `n`, read via `multiGetNodes`, written content-keyed at `:1140`) and the completeness marker (CF `g`, `markComplete`/`isComplete`).
+
+## Entities
+
+### Walk root (`stateRoot`)
+- **What**: the fixed state root the local completeness BFS is anchored to for a heal round; the sole basis of the completeness decision.
+- **Representation**: the existing `private var stateRoot: ByteString` (`TrieNodeHealingCoordinator.scala:40`). **Semantics unchanged** by this feature — it is read by the walk seeds, `isComplete`, `verificationPassComplete`, `markComplete`, and the scoped-verification `healedPathsRoot` tag.
+- **Lifecycle**: set at heal start; mutated only by `HealingPivotRefreshed` (genuine all-peers-stateless roll) as today. Hold-pivot keeps it stable across stagnation by not sending that message.
+- **Invariant (FR-001)**: not changed by serve-window aging. A `HealingServeRootRefresh` MUST NOT touch it.
+
+### Serve root (`serveRoot`) — NEW
+- **What**: the currently-servable state root used to fetch missing nodes from peers; advances with the chain, decoupled from the walk root.
+- **Representation**: new `private var serveRoot: ByteString = stateRoot` (initialized to the walk root for fallback parity).
+- **Lifecycle**: updated only by the new `HealingServeRootRefresh(newServeRoot)` handler; read only at the fetch build site (`:1080`), and only when the feature is enabled.
+- **Invariants**: (FR-002/FR-003) tracks a root within peers' serve window; (FR-011) O(1) to update, no growth; (SC-006) when the feature is off, `serveRoot` is unused and the fetch reads `stateRoot`.
+
+### Missing node / heal task (content-addressed)
+- **What**: a trie node the walk found absent locally, identified by its content hash; the unit of healing. Existing `HealingEntry(pathset, hash)` and the `pendingTasks`/`activeRequests` sets.
+- **Key field**: `hash` (keccak256 of the node) — the walk-root's expectation. The fetch sends `pathset` under `serveRoot`; acceptance requires `keccak256(returned) == hash` (`:1137`). Identity is root-independent (this is what makes cross-root sourcing sound).
+- **Invariant (FR-004/SC-004)**: a returned node is stored only if its content hash equals the requested task hash; mismatches are dropped, never stored, never counted as healed.
+
+### Heal-attempt counter — NEW (FR-006)
+- **What**: per-task count of fetch attempts that did not satisfy the task (timeout or content-mismatch), used to bound silent retry.
+- **Representation**: a side `mutable.Map[ByteString /*task hash*/, Int]`, bounded by the pending-task set size (FR-011).
+- **Lifecycle**: incremented on each unsatisfied re-queue (`:1184-1189`); **reset on each `HealingServeRootRefresh`** (a serve-root advance is the legitimate retry trigger); when a task exceeds a bounded threshold *with no serve-root advance in between*, emit a surfacing signal (log + metric). It MUST NOT trigger completion or abandonment.
+
+### Serve window (conceptual)
+- **What**: the bounded range of recent blocks/roots peers will serve snap data for (≈ most recent ~128 blocks on ETC). Not stored; informs how stale `serveRoot` may be before a refresh is needed. The refresh target reuses `RecentRootMarginBlocks = 64` (`SyncController.scala:89`).
+
+### Config — NEW (FR-008)
+- **`decoupled-heal-serve-root: Boolean`** (default `true`) in `sync.conf` snap-sync block → `SnapSyncConfig` → `TrieNodeHealingCoordinator.props`/constructor. Off ⇒ coupled behavior (fetch uses `stateRoot`).
+
+## Relationships & state flow
+
+```
+chain advances ─► SNAPSyncController obtains servable root (RecentRoot bootstrap, networkBest−64)
+                     └─► HealingServeRootRefresh(serveRoot) ─► coordinator: serveRoot := r  (walk root untouched)
+walk (stateRoot) ─► finds missing node (pathset, hash) ─► fetch GetTrieNodes(rootHash = serveRoot, pathset)
+   peer returns node under serveRoot ─► keccak256 == hash ?
+        yes ─► store content-keyed ─► task satisfied ─► (later) walk re-reads by hash ─► 0 missing ─► markComplete
+        no  ─► drop, re-queue, attempt++ ; on serveRoot refresh attempt:=0 ; over threshold w/o refresh ─► surface (FR-006)
+completion gate: verificationPassComplete (walk vs stateRoot finds isComplete) ─ unchanged ─► StateHealingComplete
+```
+
+## Validation rules (from requirements)
+
+| Rule | Source | Enforcement |
+| --- | --- | --- |
+| Walk root never changed by serve-window aging | FR-001 | `HealingServeRootRefresh` touches only `serveRoot` |
+| Fetch uses a servable root, not the walk root | FR-002/FR-003 | fetch `rootHash = if (enabled) serveRoot else stateRoot` |
+| Content-hash match before store | FR-004 | existing check at `:1137` (unchanged, must not weaken) |
+| Completeness judged against fixed walk root | FR-005 | completion path reads `stateRoot` only (unchanged) |
+| No false complete, no silent infinite retry | FR-006 | attempt counter + surface; force-complete/abandon neutralized |
+| Byte-for-byte parity with coupled path | FR-007 | same stored nodes ⇒ same walk ⇒ same marker + state root |
+| Config fallback to coupled | FR-008 | flag default-on; off ⇒ `stateRoot` fetch |
+| Bounded memory | FR-011 | `serveRoot` O(1); counter bounded by pending set |

--- a/specs/004-decoupled-heal-serve-root/plan.md
+++ b/specs/004-decoupled-heal-serve-root/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Decoupled Heal Serve-Root
+
+**Branch**: `004-decoupled-heal-serve-root` (work branched from `staging`) | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-decoupled-heal-serve-root/spec.md`
+
+## Summary
+
+Split the single root the post-SNAP heal pins everything to (`TrieNodeHealingCoordinator.stateRoot`) into two roles: a **fixed walk root** that the local completeness BFS uses for the whole walk (a pure local read, needs no peers, so it runs to completion regardless of serve windows), and an **advancing serve root** used only to fetch the missing nodes from peers (refreshed to whatever is currently within the ~128-block snap serve window). Because trie nodes are content-addressed and every fetched node is already verified `keccak256(node) == requested hash` before storage (`TrieNodeHealingCoordinator.scala:1137`), fetching via a newer servable root safely supplies the deep nodes the walk found under the old walk root, while a path that resolves to a *different* node simply fails the hash check and is retried. The completeness decision is untouched — it remains the walk finding zero missing against the fixed walk root through the single existing `verificationPassComplete`/`markComplete` chokepoint — so the outcome is byte-for-byte identical to today (FR-007). Gated by `decoupled-heal-serve-root` (default `true`), composing with hold-pivot (`#1357`) as its durable generalization. Requires a build + one redeploy; the next walk then runs to completion.
+
+## Technical Context
+
+**Language/Version**: Scala 3.3.7 LTS on JDK 25
+
+**Primary Dependencies**: Apache Pekko (actors) — `TrieNodeHealingCoordinator`, `SNAPSyncController`, `SyncController`; RocksDB (content-addressed node store CF `n` via `multiGetNodes`; completeness marker CF `g`); the SNAP wire protocol (`GetTrieNodes`/`TrieNodes`, path-addressed — `SNAP.scala:553`); the existing `RecentRoot`/`PivotHeaderBootstrap` plumbing in `SyncController` (`:1482-1565`) reused to source the advancing serve root.
+
+**Storage**: No new persisted schema. The new `serveRoot` var and FR-006 attempt counters are **in-memory only** (a restart falls back to coupled behavior / a full re-walk — safe). Reuses the content-addressed node store and the CF `g` completeness marker unchanged.
+
+**Testing**: ScalaTest + Pekko TestKit (deterministic, no `Thread.sleep` per Principle III). Unit tests T-1…T-7 (see contracts): decoupled fetch root, side-effect-free serve-root refresh, content-mismatch drop, unservable-node FR-006 behavior, decoupled-vs-coupled completion parity, off-fallback, observability. `forge`-aligned focus on the content-hash guardrail (FR-004) and byte-parity (FR-007).
+
+**Target Platform**: Linux server (barad-dûr ETC-mainnet node, 16 GB host); chain ETC/Mordor (chain-ID 61, PoW, ECIP-1017). Sync-layer only; not applicable to ETH/Sepolia consensus paths.
+
+**Project Type**: Single project — the `node` (main) module; an internal sync-orchestration change, no external API surface.
+
+**Performance Goals**: Walk completion is no longer bounded by the ~28-min serve window (SC-005); serve-root refresh is O(1) (FR-011); no new per-block or per-node hot-path cost (the fetch-root selection is a single conditional; the content-hash check already runs today).
+
+**Constraints**: Byte-for-byte completion parity with the coupled path (FR-007, the binding consensus invariant); content-hash integrity preserved on every fetched node (FR-004 — the load-bearing guardrail, MUST NOT be weakened); the walk root MUST stay fixed across serve-window aging (FR-001); no false completion and no silent infinite retry (FR-006); bounded memory (FR-011); deterministic.
+
+**Scale/Scope**: ETC mainnet state trie ~90M+ nodes; observed gap sets tens-to-tens-of-thousands (deep L8/L9 storage); change confined to `TrieNodeHealingCoordinator`, `SNAPSyncController`, `SyncController` (serve-root push), `Messages`/`SnapSyncConfig`, and `sync.conf` — plus deterministic tests and `app_`-prefixed metrics.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **I. Consensus Determinism Is Sacred (NON-NEGOTIABLE)** — **PASS.** Consensus-*adjacent* (sync orchestration), not consensus-*critical*: `forge` confirmed zero files under `vm/consensus/crypto/domain/ledger` are touched; ETC PoW / block-number fork dispatch / ECIP-1017 are unaffected; the change is chain-agnostic. The one load-bearing safety property is the existing content-hash check (`keccak256(node) == requested hash`, `:1137`) — preserved verbatim, it makes a path-addressed fetch from a *different* serve root **safe** (a wrong-content node fails the check and is dropped, never stored). Completeness is still decided solely by the walk against the fixed walk root through the single existing `verificationPassComplete`/`markComplete` site — **no new completion site, no new marker**. FR-007 byte-parity holds by construction (same final stored, content-verified nodes ⇒ same walk ⇒ same outcome). Designed under `forge` (impact analysis complete); implementation + review continue under `forge` with byte-parity validation. Determinism budget respected (no new per-block cost).
+- **II. Spec-Driven Development** — **PASS.** specify → plan → tasks → implement; artifacts under `specs/004-decoupled-heal-serve-root/`. A consensus-adjacent ADR will be recorded under `docs/adr/consensus/` (sibling to spec 002's CON-009) capturing the walk-root/serve-root split and the content-hash-guardrail rationale.
+- **III. Test Discipline & Tiered Coverage** — **PASS (planned).** Deterministic TestKit tests T-1…T-7; no `Thread.sleep`; statement coverage held ≥ 70%. The content-mismatch (T-3) and parity (T-5) tests are the consensus-aligned core.
+- **IV. Idiomatic, Formatted Scala 3** — **PASS (planned).** `scalafmt` (3.8.3, 120 cols, Scala 3) + `scalafix`. The change is additive: a new `serveRoot` var, a new `HealingServeRootRefresh` message + handler, a one-line conditional at the fetch site, a bounded attempt-counter map, config plumbing, and metrics. No edits to the walk seeds, `isComplete`, `verificationPassComplete`, `markComplete`, or the `HealingPivotRefreshed` body.
+- **V. Quality Gates** — **PASS (planned).** `sbt pp` before PR; CI green (`scalafmtCheckAll`, `compile-all`, Tier-1/Tier-2); `forge` review + ethereum/tests sanity before merge.
+- **VI. Security & Operational Safety** — **PASS.** No key/crypto change; no RPC surface change (the new message is an internal actor message). The content-hash check is the integrity guard and is preserved.
+- **VII. Transparent Versioning & Decision Records** — **PASS (planned).** PATCH version bump; conventional `feat(snap):` commit; consensus-adjacent ADR linked from the plan.
+
+**Result: all gates pass. No violations → Complexity Tracking not required.** Two *design decisions* (not violations) are flagged for user sign-off before `/speckit-tasks`: research **D4** (serve-root selection policy — newest- vs oldest-servable) and **D5** (FR-006 surfacing is observation-only; force-complete/stagnation-abandon neutralized under decoupling).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-decoupled-heal-serve-root/
+├── plan.md              # This file
+├── research.md          # Phase 0 — current-state findings (F-A..F-F) + decisions D1..D6 + flagged decisions
+├── data-model.md        # Phase 1 — Walk root, Serve root, Missing node, attempt counter, serve window, config
+├── quickstart.md        # Phase 1 — validation/run guide (unit T-1..T-7 + live)
+├── contracts/
+│   └── internal-interfaces.md   # Phase 1 — serveRoot var, HealingServeRootRefresh, fetch-site, content guardrail, completion gate, config, metrics, test contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 — created by /speckit-tasks (NOT this command)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/
+├── actors/
+│   ├── TrieNodeHealingCoordinator.scala   # NEW serveRoot var; HealingServeRootRefresh handler (serve-root only);
+│   │                                       # fetch-site rootHash conditional (:1080); FR-006 attempt counter + surface;
+│   │                                       # content-hash check (:1137) PRESERVED; walk seeds / completion gate UNTOUCHED
+│   └── Messages.scala                      # NEW HealingServeRootRefresh(newServeRoot)
+├── SNAPSyncController.scala                # serve-root acquisition (RecentRoot bootstrap reuse) → push HealingServeRootRefresh;
+│                                           # SnapSyncConfig field; props plumbing (:3364,:3429)
+src/main/scala/com/chipprbots/ethereum/blockchain/sync/
+└── SyncController.scala                    # RecentRoot requester slot/tag so healing ≠ storage-recovery contention (:1482-1565)
+
+src/main/resources/conf/base/sync.conf      # decoupled-heal-serve-root, decoupled-heal-max-attempts-no-refresh keys
+
+src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/
+└── ...                                     # T-1..T-7 deterministic TestKit specs
+
+docs/adr/consensus/                          # ADR for the walk-root/serve-root split (consensus-adjacent)
+```
+
+**Structure Decision**: Single-project (the `node` main module). All changes are internal to the SNAP sync orchestration layer — the `TrieNodeHealingCoordinator` actor, its `Messages`, the `SNAPSyncController` serve-root push + `SnapSyncConfig`, the `SyncController` requester slot, and `sync.conf` — plus deterministic tests and `app_`-prefixed metrics. No new module, no external interface, no wire-protocol change.
+
+## Complexity Tracking
+
+> No Constitution Check violations — section intentionally empty. (The two flagged items in the Constitution Check are design-decision sign-offs, not complexity deviations.)

--- a/specs/004-decoupled-heal-serve-root/quickstart.md
+++ b/specs/004-decoupled-heal-serve-root/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart & Validation: Decoupled Heal Serve-Root
+
+How to validate the feature end-to-end against the spec's success criteria. References [data-model.md](./data-model.md) and [contracts/internal-interfaces.md](./contracts/internal-interfaces.md) rather than duplicating them.
+
+## Prerequisites
+
+- Branch based on `staging` (carries hold-pivot `#1357` and scoped verification `004`'s predecessor, spec 003).
+- Deterministic test runner: `sbt testEssential` (Tier-1) / `sbt testStandard` (Tier-1+2). **Do NOT run while the barad-dûr node is active on the same host** (freezes it — see CLAUDE.md); run on CI or an idle host.
+- Config (default-on): `sync.snap-sync.decoupled-heal-serve-root = true`, plus the FR-006 threshold `decoupled-heal-max-attempts-no-refresh`.
+
+## What "done" looks like
+
+| Success criterion | How it's proven |
+| --- | --- |
+| SC-001 / SC-005 — walk completes though it outlives the serve window | Live node: a completeness walk spanning many serve windows reaches `StateHealingComplete` (previously impossible). Metric: serve-root advanced N times during one walk; walk root unchanged throughout. |
+| SC-002 — zero false completions | Unit T-4: a task no serve root satisfies never yields completion; no `MissingRootNode` at block import after a decoupled completion. |
+| SC-003 — byte-for-byte parity | Unit T-5: decoupled vs coupled completion → identical state root + identical CF `g` marker. |
+| SC-004 — content integrity | Unit T-3: a wrong-content node (keccak ≠ requested hash) is dropped, never stored/counted. |
+| SC-006 — safe fallback | Unit T-6: feature off ⇒ fetch uses the walk root; behavior byte-identical to today. |
+
+## Validation scenarios (unit / deterministic — Pekko TestKit, no `Thread.sleep`)
+
+Run the C-section test contracts T-1…T-7 (see [contracts](./contracts/internal-interfaces.md)). The correctness-critical ones:
+
+1. **Decoupled fetch (T-1, FR-001/FR-002)**: set `serveRoot ≠ stateRoot`; drive a fetch; assert the `GetTrieNodes.rootHash == serveRoot` while the BFS seed uses `stateRoot`.
+2. **Serve-root refresh is side-effect-free (T-2, FR-001/FR-009)**: send `HealingServeRootRefresh(r)`; assert `serveRoot==r` and `stateRoot`, frontier, `verificationPassComplete`, pendingTasks all unchanged.
+3. **Content guardrail (T-3, FR-004 — the load-bearing safety test)**: feed a `TrieNodes` response whose node hashes to something other than the requested task hash; assert it is dropped, not stored, not counted, task stays pending.
+4. **Unservable node (T-4, FR-006/SC-002)**: a task no serve root can satisfy → never completes; attempt counter increments, resets on `HealingServeRootRefresh`, surfaces past threshold; assert no `StateHealingComplete` and no `HealingForceComplete`.
+5. **Parity (T-5, FR-007/SC-003)**: for one fixed final healed state, reach completion decoupled vs coupled (flag flip) → identical state root + identical CF `g` marker bytes.
+6. **Fallback (T-6, SC-006)**: feature off ⇒ `GetTrieNodes.rootHash == stateRoot`; byte-identical to today.
+
+## Live validation (on the barad-dûr ETC node, read-only)
+
+After build + deploy, on a node whose walk exceeds the serve window:
+- Log/metric shows the **walk root held constant** for the whole walk while the **serve root advances** (e.g. `serveRoot` updated every ~serve-window as the chain moves), via the engagement signal (FR-010).
+- Heal-serve `GetTrieNodes` timeouts drop versus the pre-change baseline (the held root no longer ages out of the fetch); `healed` climbs past the prior ~99% plateau to completion.
+- The walk reaches 0 frontier against the fixed walk root → a `[HEAL-VERIFY-SCOPED]`/`StateHealingComplete` line → regular sync — **without** a serve-window-aging roll re-seeding the walk.
+- Contrast: with the flag off, the node exhibits the prior stall/roll churn (SC-006 / the differentiator).
+
+Use `docker logs --tail N` (the full-log read truncates on this node) and the metrics endpoint (`:9095`). RPC `net_connectToPeer` works for adding peers but `net_peerCount` and most ask-based RPC time out while the walk pegs CPU — verify via `:9095`, not the JSON-RPC reply.
+
+## Out of scope for validation here
+
+- Persisting `serveRoot`/attempt counters across restart (in-memory by design; restart falls back to coupled / re-walk).
+- The serve-root *selection policy* (newest- vs oldest-servable, research D4) — a flagged decision; validate whichever is chosen, and watch the FR-006 surfacing metric for shallow-gap liveness if newest-servable is kept.

--- a/specs/004-decoupled-heal-serve-root/research.md
+++ b/specs/004-decoupled-heal-serve-root/research.md
@@ -1,0 +1,59 @@
+# Phase 0 Research: Decoupled Heal Serve-Root
+
+Grounded in a `forge` impact analysis of the current `staging` tree (consensus-adjacent protocol). All file:line citations are from `staging` HEAD.
+
+## Current-state findings (the coupling to break)
+
+- **F-A — Walk root and fetch root are one var.** `TrieNodeHealingCoordinator` holds a single `private var stateRoot: ByteString` (`:40`). The BFS walk (`rebuildFrontierBFS`, seeded via `startVerificationBFS`/`startFrontierBFS` at `:803/:885/:698/:524`) and the missing-node fetch (`GetTrieNodes(rootHash = stateRoot, …)` at `:1078-1083`) both read it. `stateRoot` mutates only in `HealingPivotRefreshed` (`:645`). So walk-root == fetch-root today.
+- **F-B — `GetTrieNodes` is path-addressed, not hash-addressed.** `SNAP.scala:553-562`: `(requestId, rootHash, paths: Seq[Seq[ByteString]], responseBytes)`. The node hash (`HealingEntry.hash`) is carried client-side only, for verification; it is never sent. A peer serving root `R` walks `R` down the nibble path and returns whatever node sits there under `R`.
+- **F-C — Content verification already exists.** `handleResponse` (`:1129-1137`) computes `keccak256(returnedNode)` and accepts it only if it matches a requested task hash (`taskByHash.contains(nodeHash)`); otherwise it is dropped (`:1174`), not stored, not counted. The store is content-keyed (`:1140`).
+- **F-D — Completeness is decided by the walk against the walk root only.** `HealingCheckCompletion` (`:748-806`) declares complete only when `verificationPassComplete` is true, which is set only in `VerificationBFSComplete` (`:812`) after a BFS against `stateRoot` finds `isComplete` (`:1329`). `markComplete()` (`:766`) is on that path. The fetch root is never read by the walk, `isComplete`, `verificationPassComplete`, or `markComplete`.
+- **F-E — Hold-pivot has no held-root var.** `#1357` holds the root by *declining to mutate* `stateRoot` (`HealingResumeDispatch` handler `:703-724` touches neither `stateRoot` nor `verificationPassComplete`). Controller side: `SNAPSyncController.scala:1125-1141`.
+- **F-F — Serve-root plumbing exists (for storage recovery).** `RequestRecentRoot` → `SyncController.scala:1482-1565` (`recentRootTarget(snapHeights, RecentRootMarginBlocks=64)`) → `RecentRoot(block, stateRoot)` → `StorageRecoveryActor` → `StoragePivotRefreshed`. Reusable as a *template*, not in place.
+
+## Decisions
+
+### D1 — Split `stateRoot` into a fixed walk root + an advancing serve root
+
+- **Decision**: Keep `stateRoot` as the **walk root** (unchanged semantics, the completeness basis). Add a new `private var serveRoot: ByteString = stateRoot` used **only** at the fetch build site (`:1080`). The walk continues to seed from `stateRoot`.
+- **Rationale**: F-A/F-D show the walk and completeness already key off `stateRoot`; introducing a separate `serveRoot` for the fetch is the minimal split that satisfies FR-001 (fixed walk root) and FR-002 (servable fetch root) with zero change to the completeness path → FR-007 parity by construction.
+- **Alternatives**: (a) mutate `stateRoot` for the fetch and restore it — rejected, races the walk and breaks parity reasoning. (b) raw-hash fetch (root-independent) — rejected, the wire protocol is path-addressed (F-B) and matching core-geth/Besu is required.
+
+### D2 — A new narrow `HealingServeRootRefresh` message; never reuse `HealingPivotRefreshed`
+
+- **Decision**: Add `HealingServeRootRefresh(newServeRoot)` to the coordinator's message set; its handler sets `serveRoot = newServeRoot` and **does nothing else** (no frontier clear, no `verificationPassComplete` reset, no `stateRoot` mutation, no re-seed).
+- **Rationale**: `HealingPivotRefreshed` (`:629-701`) deliberately mutates the walk root and resets the completeness state — exactly what FR-001/FR-009 must avoid. A dedicated message keeps the serve-root advance side-effect-free and makes the FR-009 "generalization of hold-pivot" explicit (hold the walk root even across genuine serve-window aging, because healing no longer depends on it being servable).
+- **Alternatives**: reuse `HealingPivotRefreshed` with a flag — rejected, too easy to regress the walk-root hold.
+
+### D3 — Serve-root source: reuse the `RecentRoot` bootstrap, pushed to the coordinator
+
+- **Decision**: In `SNAPSyncController`, obtain an advancing servable root via the existing `RequestRecentRoot`→`RecentRoot` bootstrap (F-F) and push it to the coordinator as `HealingServeRootRefresh` on chain advance / serve-window aging. Add a distinct requester slot (or tag) so healing and storage-recovery do not contend on `SyncController`'s single `recentRootRequester`.
+- **Rationale**: Reuses proven plumbing (`networkBest−64` header bootstrap), minimal new surface, no new wire protocol.
+- **Alternatives**: a brand-new header-fetch path — rejected, duplicates `RecentRoot`.
+
+### D4 — Serve-root selection policy: newest-servable default, with content-check as the safety net (oldest-servable noted as a liveness lever)
+
+- **Decision**: Default the serve root to the **newest servable root** (`networkBest−64`, reusing `RecentRootMarginBlocks`). Rely on the existing content-hash check (F-C) to keep this **safe**, and on FR-006 retry-on-advance to keep it **live**. Document **oldest-still-servable** (closest to the walk root → maximal node sharing) as a tuning lever if shallow-gap liveness is ever observed.
+- **Rationale**: The actual post-SNAP gap set is **deep** trie nodes (the upper trie walks with 0 frontier; gaps surface at L8/L9). Deep nodes of rarely-touched accounts are **identical across all recent roots**, so any servable root supplies them; newest-servable reuses existing plumbing with no extra selection logic. forge's shallow-node-divergence concern (nodes near the root change nearly every block) is real in principle but **moot for a deep gap set**, and FR-006 catches the rare non-shared node.
+- **Alternatives**: oldest-still-servable as the default — defensible (maximizes sharing) but adds selection logic and is unnecessary for deep gaps; kept as a documented fallback. **This is a flagged decision for user sign-off** (correctness is identical under either due to F-C; only liveness for rare shallow gaps differs).
+
+### D5 — FR-006 unservable-node handling: bounded retry on serve-root advance, surface-only, never force-complete
+
+- **Decision**: Track a per-task attempt counter (side `mutable.Map[hash, Int]`, bounded by the pending-task set). Re-queue unsatisfied tasks as today (`:1184-1189`); **reset the counter on each `HealingServeRootRefresh`** (a serve-root advance is the legitimate retry trigger). After a bounded number of attempts **with no serve-root advance in between**, emit an observable surfacing signal (log + metric) — and **never** route to `HealingForceComplete` (`:614`) or let stagnation-abandon declare `StateHealingComplete` for this case.
+- **Rationale**: FR-006 forbids both false completion and silent infinite retry. The content check (F-C) already guarantees a wrong/missing node can never be accepted (no false completion is even possible), so this is purely about *visibility* and *not abandoning*. Neutralizing the force-complete/abandon paths under decoupling preserves SC-002.
+- **Alternatives**: force-complete after N attempts (today's escape-hatch instinct) — rejected, it would declare success with a real gap (consensus-unsafe).
+
+### D6 — Config switch `decoupled-heal-serve-root`, default on, safe single-root fallback
+
+- **Decision**: Add `sync.snap-sync.decoupled-heal-serve-root` (boolean). When **off**, `serveRoot` tracking is inert and the fetch uses `stateRoot` → byte-identical to today (SC-006). When **on**, the fetch uses `serveRoot`. Thread through `SnapSyncConfig` + both `props` sites (`:3364/:3429`) + constructor. Default **on** (mirrors `heal-hold-pivot-on-stagnation` and `scoped-heal-verification`; it is the fix for a currently-stuck node and composes with hold-pivot).
+- **Rationale**: In-memory only; safe to flip without migration. Default-on is required for it to unblock the production node; the fallback (FR-008) keeps it correct.
+- **Alternatives**: default off (opt-in) — rejected for the immediate use case, but the flag makes it trivially reversible.
+
+## Consensus-safety conclusion (forge)
+
+The single load-bearing guardrail is the **content-hash check at `:1137`**: because the fetch is path-addressed (F-B), a serve root may resolve a path to a different-content node, but that node fails the keccak match and is dropped — it can **never** be accepted under the walk root. Therefore: (1) wrong content is never stored (FR-004/SC-004, already enforced); (2) a still-missing node keeps the walk from finding zero → no false completion (FR-005/SC-002); (3) the completion outcome equals the coupled path for the same final stored nodes (FR-007). **This check MUST NOT be weakened or bypassed on any decoupled code path.** No EVM/gas/RLP/block-validation/Ethash/ECIP-1017 code is touched; PoW/block-number dispatch is unaffected; the change is chain-agnostic.
+
+## Open decisions flagged for user sign-off (pre-/speckit-tasks)
+
+1. **D4 serve-root selection** — newest-servable (default, reuses plumbing; safe; fine for deep gaps) vs oldest-still-servable (max sharing; better liveness for rare shallow gaps; more logic).
+2. **D5 confirmation** — that the unservable-node response is surface-only (log/metric) with the force-complete/stagnation-abandon paths neutralized under decoupling (no `StateHealingComplete` with a known-missing node).

--- a/specs/004-decoupled-heal-serve-root/spec.md
+++ b/specs/004-decoupled-heal-serve-root/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Decoupled Heal Serve-Root (Walk-Root / Serve-Root Separation)
+
+**Feature Branch**: `004-decoupled-heal-serve-root`
+
+**Created**: 2026-06-17
+
+**Status**: Draft
+
+**Input**: User description: "Decouple the local rebuild/verification walk from the serve-window-bound heal so the post-SNAP heal can complete on a slow / peer-scarce node."
+
+## Overview
+
+After SNAP state download, the node must prove the state trie is complete before it can follow the chain. It does this with a **completeness walk** (a local read-only BFS traversal of the trie) that finds any missing nodes, **heals** each missing node by fetching it from a peer, and declares completion only when a walk finds zero missing.
+
+Today the walk and the heal are pinned to the **same single state root**. That coupling is fatal on a slow or peer-scarce node: the walk takes **hours** (a full ETC-mainnet trie traversal is ~16-20h on slow storage, CPU-bound), but peers only serve snap data for a given root for roughly the most recent ~128 blocks (~28 minutes at ~13s/block). By the time the slow walk reaches the deep storage gaps, the pinned root has **aged out of every (non-archive) peer's serve window**, so the heal fetch times out and those gaps can never be filled — the node churns or stalls at ~99% complete and never finishes. This was observed live: heal stuck at ~99% (27,346 nodes healed), with serve-window-aging rolls clustering at 26-27 minute intervals (matching the ~28-minute window).
+
+The key insight that makes the fix sound: **trie nodes are content-addressed** (identified by their content hash, independent of which state root references them), and a newer, currently-servable root **shares the vast majority of the deep trie nodes** with the older root (deep state changes little block-to-block). Therefore a node that is missing under the old, no-longer-servable root can be fetched by its hash/path from a **currently-servable** root and, once stored, it satisfies the old root too.
+
+This feature **separates the two roles of "the root"**: the **walk root** stays fixed for the duration of a walk (a pure local read that needs no peers, so it can run to completion regardless of serve windows), while the **serve root** — the root used to fetch missing nodes from peers — tracks whatever is currently servable and advances with the chain. The walk's wall-clock time no longer has to fit inside a single serve window, so the walk completes, the completeness marker is set, and the node reaches regular sync.
+
+This is **consensus-adjacent** (it changes how the completeness gate sources nodes before the node trusts its state). It MUST follow the `forge` protocol and preserve byte-for-byte completion parity with the existing single-root behavior.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Heal completes on a slow / peer-scarce node (Priority: P1)
+
+A node operator runs an ETC node whose post-SNAP completeness walk takes far longer than peers will serve any single state root. Today the node gets stuck at ~99% forever: the walk outlives the serve window, the deep gaps can't be healed against the aged root, and the node never declares completion. With this feature, the walk stays pinned to one fixed root and runs to completion, while the missing nodes it finds are fetched from whatever root is currently servable — so the gaps fill, the walk reaches zero-missing, and the node declares `StateHealingComplete` and starts following the chain.
+
+**Why this priority**: This is the entire value of the feature — it is the difference between a node that can finish post-SNAP healing on slow/peer-scarce hardware and one that cannot finish at all. It removes the structural serve-window-vs-walk-time deadlock that the prior performance (002) and livelock (hold-pivot) work did not address.
+
+**Independent Test**: On a node whose walk duration exceeds the peer serve window, with a small set of genuinely-missing nodes that are obtainable from a currently-servable root, run the completion gate and confirm the walk root stays fixed for the whole walk, the missing nodes heal from the advancing serve root, and the node reaches `StateHealingComplete` — where the coupled (single-root) behavior would have stalled.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completeness walk that will take longer than peers serve a single root, **and** a set of missing nodes that a currently-servable root can supply, **When** the walk runs, **Then** the walk root does not change due to serve-window aging, the missing nodes are fetched from the (advancing) serve root and stored, and the walk eventually finds zero missing and declares completion.
+2. **Given** the serve root ages out mid-walk as the chain advances, **When** the next heal fetch is issued, **Then** it targets the new currently-servable root (not the aged one), and healing continues without re-seeding or abandoning the walk.
+3. **Given** the same node with the feature disabled, **When** the walk outlives the serve window, **Then** the node exhibits today's coupled behavior (stall/roll churn) — confirming the feature is the differentiator.
+
+### User Story 2 - Never declare complete with a missing or wrong-content node (Priority: P1)
+
+A node operator must be able to trust that "healing complete" means the state trie is genuinely whole and every healed node is the correct content. Sourcing nodes from a *different* root than the walk root must never let a wrong node be accepted, and must never let completion be declared while a required node is still missing.
+
+**Why this priority**: Equal-highest with US1. The optimization is only acceptable if it is provably as safe as the single-root behavior. Accepting a wrong-content node, or declaring completion with an unfilled gap, corrupts the node's view of state and leads to a state-root mismatch at block execution. This is the consensus-critical guardrail.
+
+**Independent Test**: Feed the heal path a peer response whose returned node does not hash to the requested hash and confirm it is rejected and not counted as healed; and run the completion gate with one required node unobtainable from any current root and confirm completion is NOT declared.
+
+**Acceptance Scenarios**:
+
+1. **Given** a peer returns a node whose content hash does not equal the requested hash, **When** the heal path processes it, **Then** the node is rejected, not stored, and not counted as healed.
+2. **Given** a node required by the fixed walk root that no currently-servable root can supply, **When** the completion gate runs, **Then** completion is NOT declared and the node continues to be retried as the serve root advances.
+3. **Given** the same final healed state, **When** completion is reached via the decoupled-heal path vs the coupled single-root path, **Then** the `StateHealingComplete` decision, the persisted completeness marker, and the resulting state root are byte-for-byte identical.
+
+### User Story 3 - Operators can see and control the decoupling (Priority: P2)
+
+A node operator diagnosing a heal wants to see which root the walk is anchored to versus which root heal fetches are currently using, how many nodes were healed from a root different than the walk root, and to be able to fall back to the conservative single-root behavior via configuration.
+
+**Why this priority**: Operability and trust. Useful for validating the feature in production and for incident response, but the core value (US1) and safety (US2) are delivered without it.
+
+**Independent Test**: Run a heal with the feature enabled and confirm an observable signal reports the fixed walk root, the current serve root, and the count of nodes healed via a differing serve root; then disable via config and confirm the node uses the single-root behavior and logs that decoupling is disabled.
+
+**Acceptance Scenarios**:
+
+1. **Given** decoupled healing is engaged, **When** healing runs, **Then** the node emits observable signals for the fixed walk root, the current serve root, the count of nodes healed via a serve root different from the walk root, and any node currently unservable by every root.
+2. **Given** the feature is disabled by configuration, **When** the completion gate runs, **Then** the node uses the existing single-root (walk-root == serve-root) behavior and logs that decoupling is disabled.
+
+### Edge Cases
+
+- **Serve root advances during a walk**: as the chain moves, the serve root is refreshed to the latest servable root; in-flight heal requests issued against a now-stale serve root are retried against the fresh one. The walk root is unaffected.
+- **A node no current root can supply** (pruned everywhere, or genuinely unique to the old root): it MUST keep being retried as the serve root advances, MUST NOT cause a false completion, and MUST NOT loop silently forever — after a bounded number of attempts it is surfaced (logged/escalated) so an operator can act.
+- **Large divergence between walk root and serve root** (the walk root is far behind head): healing still works for every node the servable root shares (content-addressed); only a node that genuinely differs remains missing and is handled by the unservable-node path above.
+- **Wrong-content peer response**: a returned node that does not hash to the requested hash is rejected, not stored, not counted as healed (no silent acceptance).
+- **All peers stateless even for the servable root** (genuine peer outage): the walk root is still held; healing waits and retries when the serve root refreshes or peers return — the walk does not get re-seeded by this.
+- **Restart mid-walk**: the in-memory walk state is lost; the node MUST fall back safely to whatever the persisted state supports (re-walk / today's behavior) and never declare completion on an unproven basis.
+- **Chain not advancing / serve root cannot be refreshed**: if no newer servable root is available, the heal path falls back to using the best root it has (degrades to today's coupled behavior) rather than failing.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: During a heal round, the system MUST anchor the local completeness walk to a **fixed walk root** for the entire duration of that walk; the walk root MUST NOT be changed by peer serve-window aging.
+- **FR-002**: The system MUST fetch the missing nodes the walk discovers from a **serve root** that is currently within peers' serve window, independently of the walk root.
+- **FR-003**: The system MUST refresh the serve root to track the currently-servable window as the chain advances, so heal fetches always target a root peers can serve.
+- **FR-004**: Before storing any node obtained via the serve root, the system MUST verify the node's content hash equals the requested node's hash; a mismatch MUST be rejected, not stored, and not counted as healed.
+- **FR-005**: The completeness decision MUST remain "the local traversal of the fixed walk root finds zero missing nodes." Healing via the serve root supplies node content only; it MUST NOT change the meaning of completeness or the root against which completeness is judged.
+- **FR-006**: A node required by the walk root that no currently-servable root can supply MUST continue to be retried as the serve root advances; the system MUST NOT declare completion while it remains missing, and MUST NOT retry silently forever — after a bounded threshold it MUST be surfaced (observable signal) for operator action.
+- **FR-007**: The completion outcome reached via the decoupled-heal path MUST be byte-for-byte identical to what the coupled single-root path would produce for the same final healed state: the same `StateHealingComplete` decision, the same persisted completeness marker, and the same state root. Decoupling is strictly a node-sourcing optimization with no semantic divergence.
+- **FR-008**: The system MUST provide a configuration switch to enable or disable decoupled healing; when disabled, the node MUST use the existing coupled (walk-root == serve-root) behavior. The switch MUST be safe to flip without data migration.
+- **FR-009**: The feature MUST compose with the existing hold-pivot behavior and scoped verification: holding the walk root through serve-window aging is the intended generalization of hold-pivot, valid precisely because healing no longer depends on the walk root being servable.
+- **FR-010**: The system MUST emit observable signals reporting at minimum: the fixed walk root, the current serve root, the count of nodes healed via a serve root different from the walk root, and any node currently unservable by every root.
+- **FR-011**: The bookkeeping for tracking the serve root and outstanding heal requests MUST be bounded; refreshing the serve root MUST be a constant-time operation with no unbounded memory growth.
+
+### Key Entities *(include if feature involves data)*
+
+- **Walk root**: the fixed state root the local completeness traversal is anchored to for a heal round; the sole basis of the completeness decision.
+- **Serve root**: the currently-servable state root (within peers' serve window) used to fetch missing nodes from peers; advances with the chain, decoupled from the walk root.
+- **Missing node (content-addressed)**: a trie node identified by its content hash; the unit of healing. Its identity is root-independent, which is what makes cross-root sourcing sound.
+- **Serve window**: the bounded range of recent blocks/roots for which peers will serve snap data (≈ the most recent ~128 blocks on ETC).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a node whose completeness walk takes longer than the peer serve window, the post-SNAP heal reaches `StateHealingComplete` and transitions to regular sync — an outcome that was not achievable with the coupled single-root behavior.
+- **SC-002**: Zero false completions: completion is never declared while any node required by the walk root is still missing.
+- **SC-003**: Byte-for-byte parity: for the same final healed state, the state root and persisted completeness marker after a decoupled-heal completion are identical to those after a coupled single-root completion.
+- **SC-004**: Content integrity: 100% of nodes stored via the serve root match their requested content hash; zero wrong-content nodes are stored or counted as healed.
+- **SC-005**: Walk duration no longer bounds completion: a completeness walk that takes several multiples of the serve window still completes, with no serve-window-aging event re-seeding or abandoning the walk.
+- **SC-006**: Safe fallback: with the feature disabled, the node's behavior is identical to today's coupled single-root behavior.
+
+## Assumptions
+
+- A newer, currently-servable state root shares the vast majority (~99.9%) of the deep trie nodes with the held walk root, because deep state changes little block-to-block; therefore most missing nodes are obtainable from a recent servable root. This is the load-bearing assumption that makes decoupling effective; FR-006 guards the residual minority that genuinely differs.
+- Trie nodes are content-addressed, so verifying that a returned node hashes to the requested hash is sufficient to accept it regardless of which root referenced it (FR-004).
+- The completeness walk is a pure local read that needs no peers to run; only the healing of discovered gaps needs peers and the serve window — which is precisely why the two can be decoupled.
+- This feature builds on and composes with the hold-pivot livelock fix (`#1357`, `heal-hold-pivot-on-stagnation`) and scoped verification (`specs/003-scoped-heal-verification`). The walk-root hold here is the durable generalization of hold-pivot; scoped verification continues to govern the post-heal verification scope.
+- The default enablement of the configuration switch (FR-008) is deferred to planning; a safe default (enabled with the conservative single-root fallback intact) will be chosen during `/speckit-plan`, since the FR-008 fallback keeps either choice correct.
+- This is consensus-adjacent and MUST be reviewed and validated under the `forge` protocol; the byte-for-byte completion parity (FR-007) and content integrity (FR-004) are the binding correctness invariants, consistent with the constitution's requirement that the node never declare success on incomplete or incorrect state.
+- The validation target is the ETC/Mordor chain (chain-ID 61, PoW, ECIP-1017); the mechanism is a chain-agnostic sync-layer change and touches no consensus-critical EVM/gas/RLP/block-validation code.
+- This is the next increment in the post-SNAP BFS heal line of work (prior: `specs/002-bfs-heal-performance`, `specs/003-scoped-heal-verification`); it removes the residual serve-window-vs-walk-time deadlock that remained after that work and after the hold-pivot fix. It requires a build and one redeploy; the subsequent walk would then run to completion.

--- a/specs/004-decoupled-heal-serve-root/tasks.md
+++ b/specs/004-decoupled-heal-serve-root/tasks.md
@@ -1,0 +1,156 @@
+---
+description: "Task list for Decoupled Heal Serve-Root (spec 004)"
+---
+
+# Tasks: Decoupled Heal Serve-Root
+
+**Input**: Design documents from `/specs/004-decoupled-heal-serve-root/`
+
+**Prerequisites**: plan.md, spec.md, research.md (D1–D6; **D4 = newest-servable**, **D5 = surface-only** per user sign-off), data-model.md, contracts/internal-interfaces.md
+
+**Tests**: INCLUDED — required by the constitution (Principle III) and the contract test list (T-1…T-7). Write each story's tests first and confirm they FAIL before implementing.
+
+**Decisions locked**: D4 serve-root selection = **newest-servable** (`networkBest−64`, reuse `RecentRoot` plumbing; content-hash check keeps it safe, FR-006 catches the rare non-shared node). D5 = unservable-node handling is **surface-only** (log + metric); `HealingForceComplete`/stagnation-abandon **neutralized** under decoupling so completion is never declared with a known-missing node.
+
+**Format**: `[ID] [P?] [Story] Description` — `[P]` = different file, no dependency on an incomplete task.
+
+**⚠️ Operational guard**: do NOT run `sbt` test/assembly/scalafmt while the barad-dûr node is active (freezes the host). Run T024 on CI or an idle host.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [X] T001 Create feature branch `004-decoupled-heal-serve-root` from `staging` (work branch; do not commit to `staging`/`develop` directly).
+- [X] T002 [P] Create consensus ADR skeleton at `docs/adr/consensus/CON-010-decoupled-heal-serve-root.md` capturing the walk-root/serve-root split, the path-addressed-fetch risk, and the content-hash check as the load-bearing safety guardrail (final content filled in T021).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: these are shared scaffolding all user stories depend on — complete before Phase 3.
+
+- [X] T003 Add config keys to `src/main/resources/conf/base/sync.conf` (snap-sync block): `decoupled-heal-serve-root = true` (FR-008) and `decoupled-heal-max-attempts-no-refresh = 12` (FR-006 surfacing threshold).
+- [X] T004 Add `decoupledHealServeRoot: Boolean` and `decoupledHealMaxAttemptsNoRefresh: Int` to `SnapSyncConfig` and its `fromConfig` parsing in `src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala` (alongside `healHoldPivotOnStagnation`, ~`:4923`).
+- [X] T005 Thread the two config values through `TrieNodeHealingCoordinator.props` at both call sites (~`:3364`, ~`:3429`) and the coordinator constructor (~`:39-61`) in `src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala`.
+- [X] T006 Define `final case class HealingServeRootRefresh(newServeRoot: ByteString)` in the `TrieNodeHealingCoordinator` message set in `src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala` (~`:250`).
+
+**Checkpoint**: config + message scaffolding exists; user-story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Heal completes on a slow / peer-scarce node (Priority: P1) 🎯 MVP
+
+**Goal**: keep the completeness walk pinned to a fixed walk root while fetching missing nodes from an advancing newest-servable serve root, so a walk that outlives the serve window still completes.
+
+**Independent Test**: with the feature on and `serveRoot ≠ stateRoot`, the `GetTrieNodes` fetch carries `serveRoot` while the BFS seeds carry `stateRoot`; a `HealingServeRootRefresh` advances the serve root without disturbing the walk; the walk reaches completion across multiple serve-window advances.
+
+### Tests for User Story 1 (write first; must FAIL before implementation)
+
+- [X] T007 [P] [US1] Create `src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealServeRootSpec.scala` with deterministic Pekko-TestKit tests: **T-1** (feature on + `serveRoot≠stateRoot` ⇒ `GetTrieNodes.rootHash==serveRoot`, walk seeds use `stateRoot`), **T-2** (`HealingServeRootRefresh` updates `serveRoot` only — `stateRoot`/frontier/`verificationPassComplete`/`pendingTasks` unchanged), **T-6** (feature off ⇒ `GetTrieNodes.rootHash==stateRoot`, byte-identical to coupled). No `Thread.sleep`.
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Add `private var serveRoot: ByteString = stateRoot` to `TrieNodeHealingCoordinator` (init to walk root for fallback parity) in `TrieNodeHealingCoordinator.scala` (~`:40`).
+- [X] T009 [US1] Add the `HealingServeRootRefresh` handler in `TrieNodeHealingCoordinator.scala`: set `serveRoot = newServeRoot` and **nothing else** (MUST NOT touch `stateRoot`, frontier, `verificationPassComplete`, `pendingTasks`, or re-seed). No-op when `decoupledHealServeRoot` is false. (Counter reset added in T015.)
+- [X] T010 [US1] Change the fetch-site root in `requestNextBatch` (~`:1080`) to `rootHash = if (decoupledHealServeRoot) serveRoot else stateRoot` in `TrieNodeHealingCoordinator.scala`. (Only behavioral fetch change.)
+- [X] T011 [US1] In `SNAPSyncController.scala`, acquire the **newest-servable** root (`networkBest−64`, reuse the `RecentRoot`/`PivotHeaderBootstrap` bootstrap) on chain advance / serve-window aging and push `HealingServeRootRefresh(serveRoot)` to `trieNodeHealingCoordinator` — **without** routing through `HealingPivotRefreshed` (which mutates the walk root).
+- [X] T012 [US1] In `src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala`, add a distinct `RecentRoot` requester slot/tag (~`:1482-1565`) so the healing serve-root request does not contend with `StorageRecoveryActor`'s single `recentRootRequester`.
+
+**Checkpoint**: the walk root stays fixed while the serve root advances; the fetch targets a servable root. US1 testable via T007.
+
+---
+
+## Phase 4: User Story 2 - Never declare complete with a missing or wrong-content node (Priority: P1)
+
+**Goal**: preserve the content-hash guardrail on the decoupled path and ensure an unservable node never causes false completion or silent infinite retry.
+
+**Independent Test**: a wrong-content peer response is dropped (not stored/counted); a node no serve root can supply never completes, increments the attempt counter, resets on refresh, surfaces past threshold, and never triggers `StateHealingComplete`/`HealingForceComplete`; decoupled vs coupled completion is byte-identical.
+
+> Same-file note: US2 implementation edits `TrieNodeHealingCoordinator.scala` (and is therefore sequenced after US1's edits to that file), but US2 is independently *testable* via T013.
+
+### Tests for User Story 2 (write first; must FAIL before implementation)
+
+- [X] T013 [P] [US2] Create `src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealSafetySpec.scala` with deterministic tests: **T-3** (returned node with `keccak256 ≠ requested hash` ⇒ dropped, not stored, not counted, task stays pending), **T-4** (task no serve root satisfies ⇒ never completes; attempt counter increments; resets on `HealingServeRootRefresh`; surfaces past `decoupled-heal-max-attempts-no-refresh`; no `StateHealingComplete`/`HealingForceComplete`), **T-5** (parity: same final healed state ⇒ identical state root + identical CF `g` completeness-marker bytes via decoupled vs coupled flag flip). No `Thread.sleep`.
+
+### Implementation for User Story 2
+
+- [X] T014 [US2] In `handleResponse` (~`:1129-1137`) of `TrieNodeHealingCoordinator.scala`, confirm the content-hash check (`keccak256(node) == requested task hash`) runs unchanged on the decoupled path and add a guard comment marking it the consensus-safety invariant; ensure no decoupled branch bypasses it (FR-004).
+- [X] T015 [US2] Add the FR-006 attempt counter `private val healAttempts = mutable.Map.empty[ByteString, Int]` in `TrieNodeHealingCoordinator.scala`: increment on each unsatisfied re-queue (~`:1184-1189`); clear in the `HealingServeRootRefresh` handler (T009); when a task exceeds `decoupledHealMaxAttemptsNoRefresh` with no refresh between, emit a surfacing log + metric. Bounded by `pendingTasks` (FR-011). **Never** force-complete.
+- [X] T016 [US2] Neutralize false-completion paths under decoupling in `TrieNodeHealingCoordinator.scala`/`SNAPSyncController.scala`: ensure `HealingForceComplete` (~`:614`) and stagnation-abandon cannot send `StateHealingComplete` while `decoupledHealServeRoot` is on and any task is unsatisfied (SC-002).
+- [X] T017 [US2] Verify/ensure the scoped-verification capture (spec 003) tags `healedPathsRoot` with the **walk root** `stateRoot` (~`:1161`), not `serveRoot`, so the F5 predicate `healedPathsRoot == stateRoot` (~`:787`) is unaffected by decoupling; add a regression assertion in `DecoupledHealSafetySpec.scala`.
+
+**Checkpoint**: decoupling is provably safe — wrong content dropped, no false completion, parity with coupled path.
+
+---
+
+## Phase 5: User Story 3 - Operators can see and control the decoupling (Priority: P2)
+
+**Goal**: observability of walk root vs serve root and cross-root heals, plus the config switch fallback.
+
+**Independent Test**: with the feature on, signals report the fixed walk root, current serve root, count of nodes healed via a differing serve root, and currently-unservable count; with it off, a "decoupling disabled" log and the single-root path.
+
+### Tests for User Story 3 (write first; must FAIL before implementation)
+
+- [X] T018 [P] [US3] Create `src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealObservabilitySpec.scala` with **T-7**: assert engagement + observability signals (walk root, serve root, cross-root heal count, unservable count) are emitted when on, and a "decoupling disabled" signal + single-root fetch when off.
+
+### Implementation for User Story 3
+
+- [X] T019 [P] [US3] Add additive `app_`-prefixed gauges in `src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala` (FR-010): walk root (short hash/label), current serve root, count healed via differing serve root, currently-unservable count; wire the `set*` calls from the coordinator.
+- [X] T020 [US3] Add engagement/fallback logs in `TrieNodeHealingCoordinator.scala`: serve-root refresh (old→new, blocks-behind-head), and "decoupling disabled — using single-root heal" when the flag is off.
+
+**Checkpoint**: operators can confirm engagement and savings; fallback is observable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T021 [P] Complete the consensus ADR `docs/adr/consensus/CON-010-decoupled-heal-serve-root.md` with the final design, the FR-007 byte-parity argument, the FR-004 content-guardrail rationale, and the D4/D5 decisions.
+- [X] T022 `forge` review of the diff: byte-for-byte completion parity (FR-007), the content-hash guardrail (FR-004) is preserved on every decoupled path, walk root never mutated by serve-root refresh (FR-001), and no EVM/consensus-critical file touched.
+- [X] T023 [P] Run `sbt scalafmtAll` + `scalafix` + `sbt compile-all`; resolve all findings (Principle IV). (On CI or an idle host — not while the node is active.)
+- [X] T024 Run `sbt testEssential` then `sbt testStandard` (Tier-1/Tier-2) on CI or an idle host; confirm T-1…T-7 pass and statement coverage ≥ 70%.
+- [X] T025 Validate `specs/004-decoupled-heal-serve-root/quickstart.md` unit scenarios (T-1…T-7 green); record results.
+- [ ] T026 PATCH version bump in `version.sbt`; conventional `feat(snap):` commit referencing spec 004; open PR to `staging`; require CI green + `forge` review before merge. (Deploy = build + one redeploy; fixes the next walk, not the currently-stuck one.)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+- **Setup (P1)**: no deps.
+- **Foundational (P2)**: depends on Setup; **blocks all user stories** (config + `serveRoot` + message must exist first).
+- **US1 (P3)**: depends on Foundational. The MVP core.
+- **US2 (P4)**: depends on Foundational; its implementation edits the same file as US1 (`TrieNodeHealingCoordinator.scala`), so sequence US2 impl after US1 impl. Independently *testable* via T013.
+- **US3 (P5)**: depends on Foundational; light, can follow US1/US2.
+- **Polish (P6)**: depends on US1+US2 (and US3 if shipping it) complete.
+
+### Within-file sequencing (same file ⇒ not parallel)
+- `TrieNodeHealingCoordinator.scala` is touched by T005, T008, T009, T010, T014, T015, T016, T017, T020 — execute these sequentially in that order.
+- `SNAPSyncController.scala`: T004, T011, T016 — sequential.
+- Test spec files (T007, T013, T018) are separate new files ⇒ `[P]` across stories.
+
+### MVP scope
+- **Safe MVP = US1 + US2** (both P1). US1 delivers the decoupling that lets the walk finish; US2 is the consensus-safety guarantee that must land before any deploy. US3 (P2, observability) can follow.
+
+---
+
+## Parallel Opportunities
+
+- T002 (ADR) ∥ T001.
+- The three test-spec files T007 ∥ T013 ∥ T018 (different new files) — but each must be written before its story's implementation.
+- T019 (metrics file) ∥ T020 only if different files (they are: `SNAPSyncMetrics.scala` vs `TrieNodeHealingCoordinator.scala`).
+- T023 (format) ∥ T021 (ADR).
+
+## Parallel Example
+
+```bash
+# Foundational done → write all three story test suites in parallel (different new files):
+Task: "T007 DecoupledHealServeRootSpec.scala (T-1, T-2, T-6)"
+Task: "T013 DecoupledHealSafetySpec.scala (T-3, T-4, T-5)"
+Task: "T018 DecoupledHealObservabilitySpec.scala (T-7)"
+```
+
+## Notes
+- `[P]` = different files, no dependency. Most coordinator edits share one file ⇒ sequential.
+- Locked decisions: **D4 newest-servable**, **D5 surface-only / no force-complete**.
+- The content-hash check (`:1137`) is the single consensus-safety guardrail — never weaken or bypass it on a decoupled path.
+- Build + one redeploy required; this fixes the *next* walk, not the currently-stuck one.

--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -168,6 +168,20 @@ sync {
     # verification (which covers everything), bounding the worst-case heap of the set. The typical
     # healed set is ~100-200 nodes, so 200000 is generous yet bounds the set to tens of MB.
     scoped-heal-max-paths = 200000
+    # Decoupled heal serve-root (spec 004). When true (default), the healing fetch (GetTrieNodes) targets an
+    # advancing "serve root" (newest-servable, networkBest-64) while the completeness WALK stays pinned to the
+    # fixed walk root. This generalizes heal-hold-pivot-on-stagnation: a walk that outlives the snap serve
+    # window still completes, because missing nodes are fetched from a root peers can still serve while
+    # completeness is judged solely against the walk root. Consensus-safe: GetTrieNodes is content-addressed —
+    # a returned node is stored ONLY if keccak256(node) == the walk root's requested task hash, so a serve root
+    # that resolves a path to a different node fails the hash check and is dropped. When false, the fetch uses
+    # the walk root (coupled / pre-spec-004 behaviour), byte-identical to today.
+    decoupled-heal-serve-root = true
+    # FR-006 surfacing threshold (spec 004). A heal task that no serve root can satisfy is RE-QUEUED indefinitely
+    # (never force-completed — that would declare success with a real gap). After this many unsatisfied attempts
+    # with NO serve-root advance in between, the coordinator emits a surfacing WARN log + metric so operators can
+    # see the stuck node. A serve-root refresh resets the per-task counter (a legitimate retry trigger).
+    decoupled-heal-max-attempts-no-refresh = 12
     # Whether to validate state completeness before transitioning to regular sync
     # When enabled, walks the entire state trie to detect missing nodes
     # Recommended: true for production (ensures correctness)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/SyncController.scala
@@ -70,6 +70,9 @@ class SyncController(
   private case object PollRecoveryPeers
   // Self-ping: the recovery recent-root header bootstrap for this generation took too long → decline the roll.
   private case class RecentRootTimeout(generation: Int)
+  // spec 004 (Decoupled Heal Serve-Root) T012: self-ping for the HEALING serve-root header bootstrap. Distinct
+  // from RecentRootTimeout so the healing serve-root request never contends with storage recovery's requester.
+  private case class HealingServeRootTimeout(generation: Int)
 
   // Generation counters for actor names to prevent Pekko name collisions
   // (context.stop is async — new actors can race with still-stopping ones).
@@ -83,6 +86,15 @@ class SyncController(
   private var recentRootRequester: Option[ActorRef] = None
   private var recentRootBootstrap: Option[(ActorRef, ActorRef)] = None // (peersClient, headerBootstrap)
   private var recentRootGeneration: Int = 0
+
+  // spec 004 (Decoupled Heal Serve-Root) T012: a SEPARATE requester slot + bootstrap + generation for the HEALING
+  // serve-root request, so it never contends with `recentRootRequester` (storage recovery's single slot). During
+  // healing, SNAPSyncController (the child) asks for a newest-servable root via RequestHealingServeRoot; we fetch
+  // a recent header with a dedicated PivotHeaderBootstrap (inline in `runningSnapSync` — no transition into the
+  // deadlock-prone bootstrap state) and reply HealingServeRoot to the child. Only one is serviced at a time.
+  private var healingServeRootRequester: Option[ActorRef] = None
+  private var healingServeRootBootstrap: Option[(ActorRef, ActorRef)] = None // (peersClient, headerBootstrap)
+  private var healingServeRootGeneration: Int = 0
   // Roll the download root this many blocks back from the network head — comfortably inside core-geth's
   // ~128-block snapshot serve window so peers can serve the recent root, yet recent enough that ~all
   // cold contracts' storage is unchanged since the original pivot (and thus content-identical).
@@ -197,6 +209,9 @@ class SyncController(
       syncConfig.fastSyncRestartCooloff
     )
 
+    // spec 004 MUST-FIX: this is reachable from runningSnapSync (RestartFastSyncNow). Clear the healing serve-root
+    // latch before we tear down sync children and become(runningFastSync), so no stale requester/bootstrap lingers.
+    abortHealingServeRootRequest("restart fast sync — leaving snap sync")
     stopSyncChildren()
     appStateStorage.clearFastSyncDone().and(appStateStorage.putFastSyncCooldownUntilMillis(cooldownUntil)).commit()
     fastSyncStateStorage.purge()
@@ -287,6 +302,9 @@ class SyncController(
           s"pivot-header-bootstrap-$gen"
         )
 
+      // spec 004 MUST-FIX: clear any in-flight healing serve-root request as part of the transition so no healing
+      // bootstrap survives into runningPivotHeaderBootstrap (where its Completed/Failed/Timeout would dead-letter).
+      abortHealingServeRootRequest("entering pivot header bootstrap")
       context.become(runningPivotHeaderBootstrap(peersClient, headerBootstrap, targetBlock, snapSync))
 
     case StartRegularSyncBootstrapByHash(headHash) =>
@@ -314,6 +332,10 @@ class SyncController(
       // `block == targetBlock` is bypassed in by-hash mode by using a wildcard handler;
       // the resolved Completed.targetBlock is preserved when handed to SNAP via
       // BootstrapComplete.
+      // spec 004 MUST-FIX: abort any in-flight healing serve-root request BEFORE entering the by-hash bootstrap.
+      // With targetBlock == 0 the bootstrap's `Completed` guard accepts ANY block, so a stray healing `Completed`
+      // could otherwise be mis-consumed as the pivot header. Clearing here also prevents the dead-letter wedge.
+      abortHealingServeRootRequest("entering by-hash pivot header bootstrap")
       context.become(
         runningPivotHeaderBootstrap(peersClient, headerBootstrap, targetBlock = BigInt(0), snapSync)
       )
@@ -322,6 +344,8 @@ class SyncController(
       log.info(
         s"SNAP state finalised at pivot=$pivot. Starting regular sync; chain backfill continues in background."
       )
+      // spec 004 MUST-FIX: clear the healing serve-root latch on every exit from runningSnapSync.
+      abortHealingServeRootRequest("SNAP finalised — leaving snap sync")
       resetSnapFastCycleCount()
       // SNAPSyncController already owns the live ChainDownloader child via its
       // `completedWithBackfill` state — don't spawn a duplicate standalone resumer (#1169).
@@ -335,12 +359,16 @@ class SyncController(
       // treat as a legacy "SNAP done" signal.
       snapSync ! PoisonPill
       log.info("SNAP sync completed (legacy Done path), transitioning to regular sync")
+      // spec 004 MUST-FIX: clear the healing serve-root latch on every exit from runningSnapSync.
+      abortHealingServeRootRequest("SNAP done (legacy) — leaving snap sync")
       resetSnapFastCycleCount()
       startRegularSync()
 
     case com.chipprbots.ethereum.blockchain.sync.snap.SNAPSyncController.FallbackToFastSync =>
       snapSync ! PoisonPill
       log.warning("SNAP sync failed repeatedly, falling back to fast sync")
+      // spec 004 MUST-FIX: clear the healing serve-root latch on every exit from runningSnapSync.
+      abortHealingServeRootRequest("SNAP fallback to fast sync — leaving snap sync")
       snapFastCycleCount += 1
       appStateStorage.putSnapFastCycleCount(snapFastCycleCount).commit()
       log.info("SNAP<->Fast cycle count: {}", snapFastCycleCount)
@@ -353,6 +381,9 @@ class SyncController(
       log.warning(
         "SNAP finalization aborted (state root mismatch). Clearing sync state and restarting SNAP with a fresh pivot."
       )
+      // spec 004 MUST-FIX: clear the healing serve-root latch on every exit from runningSnapSync. The new SNAP
+      // actor started below gets a fresh latch, so the stale requester here must not linger.
+      abortHealingServeRootRequest("SNAP healing impossible — restarting snap sync")
       appStateStorage.clearSnapSyncDone().commit()
       appStateStorage.clearFastSyncDone().commit()
       startSnapSync()
@@ -363,9 +394,112 @@ class SyncController(
     case bh: ForkChoiceManager.BeaconHead =>
       handleBeaconHead(bh, snapSyncOpt = Some(snapSync))
 
+    // spec 004 (Decoupled Heal Serve-Root) T012: the healing coordinator (via SNAPSyncController) asks for a
+    // newest-servable root to fetch missing nodes against, while its completeness walk stays pinned to the walk
+    // root. Fetch a recent header via a DEDICATED bootstrap slot (never the storage-recovery `recentRootRequester`)
+    // and reply HealingServeRoot to the child. Run inline — no transition into the deadlock-prone bootstrap state.
+    case SNAPSyncController.RequestHealingServeRoot =>
+      if (healingServeRootRequester.isEmpty && healingServeRootBootstrap.isEmpty) {
+        healingServeRootRequester = Some(sender())
+        log.info("[HEAL-SERVE-ROOT] Healing requested a newest-servable root. Polling peers for the network head.")
+        networkPeerManager ! com.chipprbots.ethereum.network.NetworkPeerManagerActor.GetHandshakedPeers
+      } else {
+        log.debug("[HEAL-SERVE-ROOT] Healing serve-root request already in flight; ignoring duplicate.")
+      }
+
+    // Peer snapshot used both to feed snap peers and (if waiting) to start the healing serve-root bootstrap.
+    case com.chipprbots.ethereum.network.NetworkPeerManagerActor.HandshakedPeers(peers)
+        if healingServeRootRequester.isDefined && healingServeRootBootstrap.isEmpty =>
+      maybeStartHealingServeRootBootstrap(peers)
+
+    case PivotHeaderBootstrap.Completed(block, header) if healingServeRootRequester.isDefined =>
+      val rootHex = header.stateRoot.take(4).toArray.map("%02x".format(_)).mkString
+      log.info(s"[HEAL-SERVE-ROOT] Fetched header for block $block (root $rootHex). Replying to healing.")
+      stopHealingServeRootBootstrap()
+      healingServeRootRequester.foreach(
+        _ ! SNAPSyncController.HealingServeRoot(block, Some(header.stateRoot))
+      )
+      healingServeRootRequester = None
+
+    case PivotHeaderBootstrap.Failed(reason) if healingServeRootRequester.isDefined =>
+      log.warning(s"[HEAL-SERVE-ROOT] Serve-root bootstrap failed ($reason). Replying None (serve root kept).")
+      stopHealingServeRootBootstrap()
+      healingServeRootRequester.foreach(_ ! SNAPSyncController.HealingServeRoot(0, None))
+      healingServeRootRequester = None
+
+    // spec 004 MUST-FIX: the guard (gen == healingServeRootGeneration && requester.isDefined) makes a late timeout a
+    // no-op after abortHealingServeRootRequest — abort clears the requester, and the next request bumps the generation.
+    case HealingServeRootTimeout(gen) if gen == healingServeRootGeneration && healingServeRootRequester.isDefined =>
+      log.warning("[HEAL-SERVE-ROOT] Serve-root bootstrap timed out. Replying None (serve root kept).")
+      stopHealingServeRootBootstrap()
+      healingServeRootRequester.foreach(_ ! SNAPSyncController.HealingServeRoot(0, None))
+      healingServeRootRequester = None
+
     case msg =>
       snapSync.forward(msg)
   }
+
+  /** spec 004 T012: start a one-shot header bootstrap for a newest-servable block (margin back from the network head)
+    * on the dedicated healing serve-root slot, and arm a timeout. On `Completed` we reply
+    * [[snap.SNAPSyncController.HealingServeRoot]] to the waiting child; if no peer height is known yet, reply None so
+    * the child keeps its current serve root (U2). Mirrors `maybeStartRecentRootBootstrap` but on a separate slot.
+    */
+  private def maybeStartHealingServeRootBootstrap(
+      peers: Map[com.chipprbots.ethereum.network.Peer, com.chipprbots.ethereum.network.NetworkPeerManagerActor.PeerInfo]
+  ): Unit = {
+    val snapHeights = peers.values.filter(_.remoteStatus.supportsSnap).map(_.maxBlockNumber)
+    SyncController.recentRootTarget(snapHeights, RecentRootMarginBlocks) match {
+      case Some(recentBlock) =>
+        healingServeRootGeneration += 1
+        val gen = healingServeRootGeneration
+        val peersClient = context.actorOf(
+          PeersClient.props(networkPeerManager, peerEventBus, blacklist, syncConfig, scheduler),
+          s"healing-serve-root-peers-$gen"
+        )
+        val bootstrap = context.actorOf(
+          PivotHeaderBootstrap
+            .props(peersClient, blockchainWriter, recentBlock, syncConfig, scheduler, preferSnapPeers = true),
+          s"healing-serve-root-bootstrap-$gen"
+        )
+        healingServeRootBootstrap = Some((peersClient, bootstrap))
+        log.info(s"[HEAL-SERVE-ROOT] Fetching header for newest-servable block $recentBlock.")
+        scheduler.scheduleOnce(20.seconds, self, HealingServeRootTimeout(gen))(context.dispatcher, self)
+      case None =>
+        log.info("[HEAL-SERVE-ROOT] No usable peer height yet; replying None (serve root kept).")
+        healingServeRootRequester.foreach(_ ! SNAPSyncController.HealingServeRoot(0, None))
+        healingServeRootRequester = None
+    }
+  }
+
+  private def stopHealingServeRootBootstrap(): Unit = {
+    healingServeRootBootstrap.foreach { case (peersClient, bootstrap) =>
+      bootstrap ! PoisonPill
+      peersClient ! PoisonPill
+    }
+    healingServeRootBootstrap = None
+  }
+
+  /** spec 004 (Decoupled Heal Serve-Root) MUST-FIX: abort any in-flight healing serve-root request before the parent
+    * leaves `runningSnapSync` for `runningPivotHeaderBootstrap`. The healing handlers (`HandshakedPeers`,
+    * `PivotHeaderBootstrap.Completed|Failed`, `HealingServeRootTimeout`) live ONLY in `runningSnapSync`; if a
+    * concurrent pivot refresh transitions into `runningPivotHeaderBootstrap` with a healing bootstrap still in flight,
+    * those messages would hit that state's catch-all, be forwarded to the child, and dead-letter — leaving
+    * `healingServeRootRequester = Some(...)` here and the child's `healingServeRootRequestInFlight = true` forever,
+    * silently freezing every future serve-root refresh (the pre-spec-004 deadlock). It also eliminates the ETH by-hash
+    * hazard where a `targetBlock == 0` pivot bootstrap could mis-consume the healing `Completed` as its pivot header.
+    * We reply `HealingServeRoot(0, None)`: the child clears its latch (SNAPSyncController.scala ~637) and keeps its
+    * current serve root (U2), retrying on a later healing tick. Safe no-op when nothing is in flight.
+    */
+  private def abortHealingServeRootRequest(reason: String): Unit =
+    if (healingServeRootRequester.isDefined || healingServeRootBootstrap.isDefined) {
+      log.info(s"[HEAL-SERVE-ROOT] Aborting in-flight serve-root request ($reason) — replying None (serve root kept).")
+      stopHealingServeRootBootstrap()
+      // A HealingServeRootTimeout self-message scheduled by maybeStartHealingServeRootBootstrap may still be in
+      // flight, but it is generation-guarded (gen == healingServeRootGeneration && healingServeRootRequester.isDefined):
+      // clearing the requester below — and the generation bump on the next request — makes any late timeout a no-op.
+      healingServeRootRequester.foreach(_ ! SNAPSyncController.HealingServeRoot(0, None))
+      healingServeRootRequester = None
+    }
 
   def runningRegularSync(regularSync: ActorRef): Receive = { case other =>
     other match {
@@ -647,6 +781,14 @@ class SyncController(
 
     case bh: ForkChoiceManager.BeaconHead =>
       handleBeaconHead(bh, snapSyncOpt = Some(originalSnapSyncRef))
+
+    // spec 004 T012: a healing serve-root request that lands during the brief pivot-header bootstrap window
+    // (a concurrent pivot refresh) is declined immediately so the child's in-flight latch clears and it can
+    // retry on a later healing tick. We never start a second bootstrap here (the pivot bootstrap is already
+    // using the slot). U2: declining keeps the child's current serve root.
+    case SNAPSyncController.RequestHealingServeRoot =>
+      log.debug("[HEAL-SERVE-ROOT] Request arrived during pivot header bootstrap — declining (serve root kept).")
+      sender() ! SNAPSyncController.HealingServeRoot(0, None)
 
     case msg =>
       // Forward coordinator and protocol messages to SNAP sync during the brief bootstrap.

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.collection.mutable
 import scala.util.Try
 
-import com.chipprbots.ethereum.blockchain.sync.{Blacklist, PeerListSupportNg, SyncProtocol}
+import com.chipprbots.ethereum.blockchain.sync.{Blacklist, PeerListSupportNg, SyncController, SyncProtocol}
 import com.chipprbots.ethereum.db.storage.{
   AppStateStorage,
   BfsQueueStorage,
@@ -282,6 +282,16 @@ class SNAPSyncController(
   private var forceCompleteStorageSent: Boolean = false
   private var trieWalkInProgress: Boolean = false
   private var healingRoundCount: Int = 0
+  // spec 004 (Decoupled Heal Serve-Root) T011: serve-root refresh bookkeeping. The healing coordinator fetches
+  // missing nodes against an advancing SERVE root while its completeness walk stays pinned to the walk root. We
+  // ask the parent for a newest-servable root (networkBest − RecentRootMarginBlocks) on the healing tick when the
+  // current serve root has aged > HealingServeRootMarginBlocks behind the network head. A single in-flight latch
+  // (the bootstrap is a ~1s peer round-trip — never per-block) and a block number of the last pushed serve root.
+  private var healingServeRootRequestInFlight: Boolean = false
+  private var lastHealingServeRootBlock: Option[BigInt] = None
+  // The serve root is considered stale when it is more than this many blocks behind the network head. Matches
+  // SyncController.RecentRootMarginBlocks (64) so the refreshed root lands comfortably inside peers' serve window.
+  private val HealingServeRootMarginBlocks: BigInt = BigInt(64)
   // Suppress duplicate ConnectToPeer for snap-server-peers for 60s after a send attempt.
   // Prevents the race where the reconnect timer fires within the 5s peersScanInterval
   // window after STATUS_EXCHANGE completes (peer in ETH handshake but not yet in handshakedPeers).
@@ -610,7 +620,35 @@ class SNAPSyncController(
       // the validation Future and would feed a coordinator that's supposed to
       // be quiescent. The phase gate is defensive; we also cancel the
       // scheduler explicitly in `validateState()` callers.
-      if (currentPhase == StateHealing) requestTrieNodeHealing()
+      if (currentPhase == StateHealing) {
+        requestTrieNodeHealing()
+        // spec 004 T011/U1: piggyback the serve-root staleness check on the existing 1-s healing tick (the only
+        // dispatch hook already present during healing). This does NOT issue a request per block — it only fires
+        // the ~1s parent bootstrap when the serve root is > HealingServeRootMarginBlocks behind the network head
+        // and no request is already in flight.
+        maybeRequestHealingServeRoot()
+      }
+
+    // spec 004 T011/T012: parent's reply to RequestHealingServeRoot. Push the newest-servable root to the healing
+    // coordinator as HealingServeRootRefresh — NOT HealingPivotRefreshed (which would mutate the walk root). U2: a
+    // None/zero reply means no servable root could be fetched; KEEP the current serve root (do not push), and clear
+    // the in-flight latch so a later tick can retry.
+    case SNAPSyncController.HealingServeRoot(blockNumber, rootOpt) =>
+      healingServeRootRequestInFlight = false
+      rootOpt match {
+        case Some(root) if root.nonEmpty =>
+          lastHealingServeRootBlock = Some(blockNumber)
+          log.info(
+            s"[HEAL-SERVE-ROOT] Pushing newest-servable serve root ${root.take(4).toHex} (block $blockNumber) " +
+              s"to healing coordinator (walk root unchanged)."
+          )
+          trieNodeHealingCoordinator.foreach(_ ! actors.Messages.HealingServeRootRefresh(root))
+        case _ =>
+          log.info(
+            "[HEAL-SERVE-ROOT] Parent could not fetch a newest-servable root (no peers / bootstrap failed). " +
+              "Keeping the current serve root; will retry on a later healing tick."
+          )
+      }
 
     case EnsureSnapServerPeersConnected =>
       ensureSnapServerPeersConnected()
@@ -3380,7 +3418,9 @@ class SNAPSyncController(
               frontierHighWater = snapSyncConfig.healingFrontierHighWater,
               frontierLowWater = snapSyncConfig.healingFrontierLowWater,
               scopedHealVerification = snapSyncConfig.scopedHealVerification,
-              scopedHealMaxPaths = snapSyncConfig.scopedHealMaxPaths
+              scopedHealMaxPaths = snapSyncConfig.scopedHealMaxPaths,
+              decoupledHealServeRoot = snapSyncConfig.decoupledHealServeRoot,
+              decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh
             )
             .withDispatcher("sync-dispatcher"),
           s"trie-node-healing-coordinator-$coordinatorGeneration"
@@ -3445,7 +3485,9 @@ class SNAPSyncController(
                   frontierHighWater = snapSyncConfig.healingFrontierHighWater,
                   frontierLowWater = snapSyncConfig.healingFrontierLowWater,
                   scopedHealVerification = snapSyncConfig.scopedHealVerification,
-                  scopedHealMaxPaths = snapSyncConfig.scopedHealMaxPaths
+                  scopedHealMaxPaths = snapSyncConfig.scopedHealMaxPaths,
+                  decoupledHealServeRoot = snapSyncConfig.decoupledHealServeRoot,
+                  decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh
                 )
                 .withDispatcher("sync-dispatcher"),
               s"trie-node-healing-coordinator-$coordinatorGeneration"
@@ -3511,6 +3553,50 @@ class SNAPSyncController(
       } else {
         snapPeers.foreach { peer =>
           coordinator ! actors.Messages.HealingPeerAvailable(peer)
+        }
+      }
+    }
+
+  /** spec 004 T011/U1: ask the parent for a newest-servable serve root when (and only when) the current serve root has
+    * aged > HealingServeRootMarginBlocks behind the network head and no request is already in flight. Reuses the
+    * parent's RecentRoot/PivotHeaderBootstrap plumbing via a dedicated requester slot (T012), so it never contends with
+    * StorageRecoveryActor's recent-root requester or mutates the walk root. No-op when decoupling is disabled, when not
+    * healing, or when no network head / serve target can be computed (U2: keep current serve root rather than pushing
+    * an empty one).
+    */
+  private def maybeRequestHealingServeRoot(): Unit =
+    if (
+      snapSyncConfig.decoupledHealServeRoot &&
+      currentPhase == StateHealing &&
+      trieNodeHealingCoordinator.isDefined &&
+      !healingServeRootRequestInFlight &&
+      // Don't contend with a pivot-refresh header bootstrap: while one is pending the parent is (or is about to be)
+      // in runningPivotHeaderBootstrap, where a concurrent serve-root bootstrap completion could be mis-routed.
+      // The request will fire on a later tick once the refresh settles.
+      pendingPivotRefresh.isEmpty
+    ) {
+      currentNetworkBestFromSnapPeers().foreach { networkBest =>
+        // Target a root inside peers' serve window: networkBest − margin (≥1). recentRootTarget caps at 1.
+        val serveTarget = SyncController.recentRootTarget(Seq(networkBest), HealingServeRootMarginBlocks)
+        serveTarget.foreach { target =>
+          // Refresh cadence (U1): a serve root is fetched at `networkBest − margin`, so it STARTS `margin` blocks
+          // behind the head. We refresh only once it has drifted a FULL window further back — i.e. when it is
+          // > 2×margin behind the current head — giving ~margin blocks of runway between the ~1s peer round-trips
+          // (never per-block). An unset lastHealingServeRootBlock means the coordinator is still fetching against
+          // the walk root (coupled), so engage immediately.
+          val stale = lastHealingServeRootBlock match {
+            case Some(lastBlock) => (networkBest - lastBlock) > (HealingServeRootMarginBlocks * 2)
+            case None            => true
+          }
+          if (stale) {
+            healingServeRootRequestInFlight = true
+            log.info(
+              s"[HEAL-SERVE-ROOT] Requesting newest-servable serve root: networkBest=$networkBest target=$target " +
+                s"(margin=$HealingServeRootMarginBlocks, lastServeBlock=${lastHealingServeRootBlock.getOrElse("none")}). " +
+                s"Routing via parent RecentRoot bootstrap."
+            )
+            context.parent ! SNAPSyncController.RequestHealingServeRoot
+          }
         }
       }
     }
@@ -4060,6 +4146,10 @@ class SNAPSyncController(
     proactiveRollNeedsProbe = false
     probeAttemptCount = 0
     lastProbeAttemptMs = 0L
+    // spec 004 T011: a full restart spawns a fresh healing coordinator (serveRoot re-inits to the walk root);
+    // clear the serve-root bookkeeping so the first healing tick re-engages decoupling against the new round.
+    healingServeRootRequestInFlight = false
+    lastHealingServeRootBlock = None
 
     // NOTE: do NOT reset consecutivePivotRefreshes here. restartSnapSync is often called
     // from refreshPivotInPlace when no new pivot is available, which means the counter would
@@ -4630,6 +4720,20 @@ object SNAPSyncController {
   case object StateValidationComplete
   case object GetProgress
 
+  /** spec 004 (Decoupled Heal Serve-Root) T011/T012: SNAPSyncController → SyncController (parent). During healing, ask
+    * the parent to fetch a newest-servable canonical header (networkBest − RecentRootMarginBlocks) via its own
+    * dedicated PivotHeaderBootstrap slot — distinct from `StartRegularSyncBootstrap` (which is the pivot-refresh path
+    * that mutates the walk root) and from `StorageRecoveryActor`'s recent-root requester. The parent replies with
+    * `HealingServeRoot`.
+    */
+  case object RequestHealingServeRoot
+
+  /** spec 004 T012: SyncController → SNAPSyncController reply with a newest-servable `(blockNumber, stateRoot)`, or
+    * `stateRoot = None` if none could be fetched (no peers / bootstrap failed / timeout). On `None`, the controller
+    * keeps the current serve root (U2) and does NOT push a HealingServeRootRefresh.
+    */
+  final case class HealingServeRoot(blockNumber: BigInt, stateRoot: Option[ByteString])
+
   /** Signal from coordinators that the current pivot/stateRoot is likely not serveable by peers.
     *
     * This is analogous to Nethermind's ExpiredRootHash detection (empty payload + empty proofs).
@@ -4794,6 +4898,14 @@ case class SNAPSyncConfig(
     // Upper bound on the in-memory healed-paths set (spec 003 FR-011). Over-bound rounds fall back to
     // full-root verification rather than growing the set, bounding its worst-case heap.
     scopedHealMaxPaths: Int = 200000,
+    // Decoupled heal serve-root (spec 004 FR-008). When true (default), the healing fetch targets an advancing
+    // newest-servable serve root while the completeness walk stays pinned to the fixed walk root. Off ⇒ coupled
+    // behaviour (fetch uses the walk root), byte-identical to today. Consensus-safety rests on the unchanged
+    // content-hash check at handleResponse (a node is stored only if keccak256 == the walk root's task hash).
+    decoupledHealServeRoot: Boolean = true,
+    // FR-006 surfacing threshold: after this many unsatisfied heal attempts with no serve-root advance in
+    // between, the coordinator surfaces the stuck task (log + metric). NEVER force-completes.
+    decoupledHealMaxAttemptsNoRefresh: Int = 12,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,
     timeout: FiniteDuration = 30.seconds,
@@ -4931,6 +5043,14 @@ object SNAPSyncConfig {
         if (snapConfig.hasPath("scoped-heal-max-paths"))
           snapConfig.getInt("scoped-heal-max-paths")
         else 200000,
+      decoupledHealServeRoot =
+        if (snapConfig.hasPath("decoupled-heal-serve-root"))
+          snapConfig.getBoolean("decoupled-heal-serve-root")
+        else true,
+      decoupledHealMaxAttemptsNoRefresh =
+        if (snapConfig.hasPath("decoupled-heal-max-attempts-no-refresh"))
+          snapConfig.getInt("decoupled-heal-max-attempts-no-refresh")
+        else 12,
       stateValidationEnabled = snapConfig.getBoolean("state-validation-enabled"),
       maxRetries = snapConfig.getInt("max-retries"),
       timeout = snapConfig.getDuration("timeout").toMillis.millis,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
@@ -237,6 +237,34 @@ object SNAPSyncMetrics extends MetricsContainer {
   final private val HealingScopedDurationMsGauge =
     metrics.registry.gauge("snapsync.healing.scoped_duration_ms.gauge", new AtomicLong(0L))
 
+  // ===== Decoupled Heal Serve-Root (spec 004 C9/FR-010 — observation-only) =====
+  //
+  // Distinguish the fixed completeness WALK root from the advancing SERVE root used to fetch missing nodes,
+  // and report cross-root heals and currently-unservable tasks. These NEVER gate any consensus or completion
+  // decision — pure instrumentation pushed by `TrieNodeHealingCoordinator`. The root gauges carry the leading
+  // 8 bytes of each root hash as an (unsigned-ish) long "short label" so an operator can eyeball-correlate them
+  // with the `[HEAL]` log lines (which print the first 4 bytes); 0 = not yet set / feature off.
+
+  /** 1 = decoupled serve-root is engaged (feature on); 0 = single-root (coupled) heal. */
+  final private val HealingDecoupledEngagedGauge =
+    metrics.registry.gauge("snapsync.healing.decoupled.engaged.gauge", new AtomicLong(0L))
+
+  /** Leading 8 bytes of the fixed completeness WALK root (`stateRoot`), as a short numeric label. */
+  final private val HealingWalkRootGauge =
+    metrics.registry.gauge("snapsync.healing.decoupled.walk_root.gauge", new AtomicLong(0L))
+
+  /** Leading 8 bytes of the advancing SERVE root used to fetch missing nodes, as a short numeric label. */
+  final private val HealingServeRootGauge =
+    metrics.registry.gauge("snapsync.healing.decoupled.serve_root.gauge", new AtomicLong(0L))
+
+  /** Count of nodes healed via a serve root that differs from the walk root (cross-root heals). */
+  final private val HealingCrossRootHealsGauge =
+    metrics.registry.gauge("snapsync.healing.decoupled.cross_root_heals.gauge", new AtomicLong(0L))
+
+  /** Count of heal tasks currently unservable (over the FR-006 attempts-without-refresh threshold). */
+  final private val HealingUnservableTasksGauge =
+    metrics.registry.gauge("snapsync.healing.decoupled.unservable_tasks.gauge", new AtomicLong(0L))
+
   // ===== Peer Performance Metrics =====
 
   /** Number of SNAP-capable peers currently connected */
@@ -417,6 +445,13 @@ object SNAPSyncMetrics extends MetricsContainer {
   def setHealingScopedVerification(scoped: Long): Unit = HealingScopedVerificationGauge.set(scoped)
   def setHealingScopedSubtrees(count: Long): Unit = HealingScopedSubtreesGauge.set(count)
   def setHealingScopedDurationMs(ms: Long): Unit = HealingScopedDurationMsGauge.set(ms)
+
+  // spec 004 C9/T019 — decoupled heal serve-root (observation-only)
+  def setHealingDecoupledEngaged(engaged: Boolean): Unit = HealingDecoupledEngagedGauge.set(if (engaged) 1L else 0L)
+  def setHealingWalkRoot(shortLabel: Long): Unit = HealingWalkRootGauge.set(shortLabel)
+  def setHealingServeRoot(shortLabel: Long): Unit = HealingServeRootGauge.set(shortLabel)
+  def setHealingCrossRootHeals(count: Long): Unit = HealingCrossRootHealsGauge.set(count)
+  def setHealingUnservableTasks(count: Long): Unit = HealingUnservableTasksGauge.set(count)
 
   // ===== Peer and Network Metrics =====
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/Messages.scala
@@ -249,6 +249,15 @@ object Messages {
     */
   case class HealingPivotRefreshed(newStateRoot: ByteString) extends TrieNodeHealingCoordinatorMessage
 
+  /** spec 004 (Decoupled Heal Serve-Root): advance the SERVE root used to fetch missing nodes (GetTrieNodes) WITHOUT
+    * touching the completeness WALK root. The handler sets `serveRoot = newServeRoot` and resets the FR-006 per-task
+    * attempt counters; it does NOTHING else — it MUST NOT mutate `stateRoot` (the walk root), clear pendingTasks /
+    * frontier, reset `verificationPassComplete`, or re-seed the walk. No-op when `decoupledHealServeRoot` is disabled.
+    * Contrast `HealingPivotRefreshed`, which deliberately mutates the walk root and resets the completeness state and
+    * MUST NOT be reused for a serve-root advance.
+    */
+  final case class HealingServeRootRefresh(newServeRoot: ByteString) extends TrieNodeHealingCoordinatorMessage
+
   /** Sent by coordinator after MaxConsecutiveStagnations consecutive 2-min HEAL-PULSE cycles with zero healed nodes.
     * Controller should stop coordinator, clear walk checkpoint, refresh pivot.
     */

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -58,7 +58,14 @@ class TrieNodeHealingCoordinator(
     frontierLowWater: Int = TrieNodeHealingCoordinator.DefaultFrontierLowWater,
     frontierBackpressureMaxWaitMs: Long = TrieNodeHealingCoordinator.FrontierBackpressureMaxWaitMs,
     scopedHealVerification: Boolean = true,
-    scopedHealMaxPaths: Int = TrieNodeHealingCoordinator.DefaultScopedHealMaxPaths
+    scopedHealMaxPaths: Int = TrieNodeHealingCoordinator.DefaultScopedHealMaxPaths,
+    // spec 004 (Decoupled Heal Serve-Root). When true, the GetTrieNodes fetch targets `serveRoot` (an advancing
+    // newest-servable root) instead of the walk root `stateRoot`; when false, the fetch uses `stateRoot` (coupled,
+    // byte-identical to pre-spec-004). Completeness is ALWAYS judged against `stateRoot`, regardless of this flag.
+    decoupledHealServeRoot: Boolean = false,
+    // FR-006 surfacing threshold: after this many unsatisfied attempts with no serve-root advance, surface (log +
+    // metric). Never force-completes.
+    decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh
 ) extends Actor
     with ActorLogging {
 
@@ -239,6 +246,13 @@ class TrieNodeHealingCoordinator(
     pendingBackpressure.set(pendingTasks.size)
     SNAPSyncMetrics.setHealingFrontierPending(pendingTasks.size.toLong)
     SNAPSyncMetrics.setHealingActiveRequests(activeRequests.size.toLong)
+    // spec 004 T019/FR-010: refresh the decoupling observability gauges on every pulse (cheap O(1) reads).
+    if (decoupledHealServeRoot) {
+      SNAPSyncMetrics.setHealingCrossRootHeals(crossRootHealCount)
+      SNAPSyncMetrics.setHealingUnservableTasks(
+        healAttempts.count { case (_, n) => n > decoupledHealMaxAttemptsNoRefresh }.toLong
+      )
+    }
   }
 
   /** Frontier-emission backpressure, called from the BFS walk thread (healingWriterEc) before each FrontierRebuilt
@@ -314,6 +328,68 @@ class TrieNodeHealingCoordinator(
     healedPathsRoot = ByteString.empty
     healedPathsOverflowed = false
   }
+
+  // --- spec 004: decoupled heal serve-root (FR-001/FR-002) ---
+  // T008: the SERVE root used to fetch missing nodes (GetTrieNodes). Initialized to the walk root so that when
+  // the feature is OFF (or before any serve-root has been obtained) the fetch is byte-identical to the coupled
+  // path. Advances ONLY via the HealingServeRootRefresh handler; read ONLY at the fetch build site in
+  // requestNextBatch (and only when `decoupledHealServeRoot` is true). The completeness walk and gate never read
+  // it — they key off `stateRoot` (the walk root) exclusively, preserving FR-007 parity by construction.
+  private var serveRoot: ByteString = stateRoot
+  // T015 / FR-006: per-task count of fetch attempts that did not satisfy the task (content-mismatch drop, empty
+  // response, or timeout re-queue). Bounded by the pending-task set (an entry is only ever incremented for a hash
+  // that is being re-queued, and the whole map is cleared on every serve-root advance). A task that exceeds
+  // `decoupledHealMaxAttemptsNoRefresh` with no serve-root advance in between is surfaced (log + metric) — it is
+  // NEVER force-completed: the content-hash check guarantees a wrong/missing node can never be accepted, so a stuck
+  // node simply keeps the walk from finding zero, which is the correct (no-false-completion) behaviour.
+  private val healAttempts = mutable.Map.empty[ByteString, Int]
+  // T019 / FR-010: count of nodes healed via a serve root that differs from the walk root (cross-root heals).
+  private var crossRootHealCount: Long = 0L
+  // T020: number of serve-root refreshes engaged this coordinator lifetime (observability only).
+  private var serveRootRefreshCount: Long = 0L
+
+  /** spec 004 T019: encode the leading 8 bytes of a root hash as a numeric "short label" gauge value so an operator can
+    * eyeball-correlate the walk-root / serve-root gauges with the `[HEAL]` log lines (which print 4 bytes). This is
+    * observation-only — never read by any walk / completeness / fetch decision. Empty ⇒ 0.
+    */
+  private def shortRootLabel(root: ByteString): Long = {
+    var acc = 0L
+    val n = root.length.min(8)
+    var i = 0
+    while (i < n) {
+      acc = (acc << 8) | (root(i) & 0xffL)
+      i += 1
+    }
+    acc
+  }
+
+  /** spec 004 T015/C5/FR-006: record one unsatisfied fetch attempt for a heal task (content-mismatch drop, empty
+    * response, or timeout re-queue). When a task crosses `decoupledHealMaxAttemptsNoRefresh` attempts WITHOUT a
+    * serve-root advance in between (a serve-root refresh clears the whole map), surface it once at the crossing (WARN
+    * log + unservable-count metric). This is OBSERVATION ONLY — it MUST NOT force-complete, abandon, or declare
+    * completion: the content-hash check (C4) guarantees a wrong/missing node can never be accepted, so a stuck node
+    * simply keeps the walk from finding zero, which is the correct no-false-completion behaviour (SC-002). The map is
+    * bounded by the pending-task set (only ever keyed by hashes being re-queued; cleared on every serve-root advance
+    * and decayed when a task is satisfied). No-op when decoupling is disabled — the coupled path's behaviour is
+    * byte-identical to today (SC-006).
+    */
+  private def noteUnservableAttempt(hash: ByteString): Unit =
+    if (decoupledHealServeRoot) {
+      val attempts = healAttempts.getOrElse(hash, 0) + 1
+      healAttempts.update(hash, attempts)
+      if (attempts == decoupledHealMaxAttemptsNoRefresh + 1) {
+        // Crossed the threshold for the first time since the last serve-root advance — surface it once.
+        val unservable = healAttempts.count { case (_, n) => n > decoupledHealMaxAttemptsNoRefresh }
+        log.warning(
+          s"[HEAL-SERVE-ROOT] Heal task ${Hex.toHexString(hash.take(4).toArray)} unservable after $attempts " +
+            s"attempts with no serve-root advance (threshold=$decoupledHealMaxAttemptsNoRefresh). " +
+            s"NOT force-completing (content-hash check keeps completion gated on the walk). " +
+            s"unservable-now=$unservable serve=${Hex.toHexString(serveRoot.take(4).toArray)} " +
+            s"walk=${Hex.toHexString(stateRoot.take(4).toArray)}"
+        )
+        SNAPSyncMetrics.setHealingUnservableTasks(unservable.toLong)
+      }
+    }
 
   // Stateless peer tracking (geth-aligned: peers that return empty TrieNodes for current root)
   private val statelessPeers = mutable.Set[String]()
@@ -439,6 +515,20 @@ class TrieNodeHealingCoordinator(
 
   override def preStart(): Unit = {
     log.info(s"TrieNodeHealingCoordinator starting (concurrency=$concurrency)")
+    // spec 004 T020/T019: surface the decoupling mode once at start, and seed the walk-root / serve-root gauges.
+    // serveRoot == stateRoot here (T008 init), so until the controller pushes a HealingServeRootRefresh the fetch
+    // stays on the walk root (coupled) even when the feature is on.
+    if (decoupledHealServeRoot)
+      log.info(
+        s"[HEAL-SERVE-ROOT] Decoupled heal serve-root ENABLED — completeness walk pinned to walk root " +
+          s"${Hex.toHexString(stateRoot.take(4).toArray)}; missing nodes fetched against an advancing serve root " +
+          s"(content-hash-verified before store). max-attempts-no-refresh=$decoupledHealMaxAttemptsNoRefresh"
+      )
+    else
+      log.info("[HEAL-SERVE-ROOT] Decoupling disabled — using single-root heal (fetch uses the walk root)")
+    SNAPSyncMetrics.setHealingDecoupledEngaged(decoupledHealServeRoot)
+    SNAPSyncMetrics.setHealingWalkRoot(shortRootLabel(stateRoot))
+    SNAPSyncMetrics.setHealingServeRoot(shortRootLabel(serveRoot))
     context.system.scheduler.scheduleWithFixedDelay(2.minutes, 2.minutes, self, HealingStagnationCheck)(
       context.dispatcher,
       ActorRef.noSender
@@ -612,19 +702,33 @@ class TrieNodeHealingCoordinator(
       if (newLimit > 0) tryRedispatchPendingTasks()
 
     case HealingForceComplete =>
-      log.warning(
-        s"[HEAL-FORCE-COMPLETE] Pivot advanced beyond SNAP serve window — " +
-          s"clearing ${pendingTasks.size} pending tasks + ${activeRequests.size} in-flight. " +
-          s"Signaling completion with $totalNodesHealed healed nodes."
-      )
-      clearPersistedFrontier() // Layer 2: healing abandoned — drop the persisted frontier so a restart won't resume it
-      activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
-      activeRequests.clear()
-      pendingTasks.clear()
-      pendingHashSet.clear()
-      clearHealedPathsSet() // spec 003 C1: abandonment — drop the scoped-verification scope (hygiene)
-      snapSyncController ! SNAPSyncController.StateHealingComplete
-      context.stop(self)
+      // spec 004 T016/C5/SC-002: under decoupling, HealingForceComplete must NEVER declare completion while any
+      // task is unsatisfied. Its original purpose — abandon pending tasks because the pivot aged beyond the SNAP
+      // serve window (Besu reloadTrieHeal) — is exactly what decoupling makes obsolete: the serve root advances
+      // independently, so an aged serve window is no longer a reason to abandon the walk root's missing nodes.
+      // Abandoning here would send StateHealingComplete with a real gap (consensus-unsafe). Refuse: keep the
+      // frontier, keep healing; the serve-root refresh path supplies a servable root. (Flag off ⇒ unchanged.)
+      if (decoupledHealServeRoot && !isComplete) {
+        log.warning(
+          s"[HEAL-FORCE-COMPLETE] IGNORED under decoupled-heal-serve-root: ${pendingTasks.size} pending + " +
+            s"${activeRequests.size} in-flight task(s) still unsatisfied. NOT declaring completion (SC-002) — " +
+            s"healing continues against the walk root; serve-root refresh supplies a servable fetch root."
+        )
+      } else {
+        log.warning(
+          s"[HEAL-FORCE-COMPLETE] Pivot advanced beyond SNAP serve window — " +
+            s"clearing ${pendingTasks.size} pending tasks + ${activeRequests.size} in-flight. " +
+            s"Signaling completion with $totalNodesHealed healed nodes."
+        )
+        clearPersistedFrontier() // Layer 2: healing abandoned — drop the persisted frontier so a restart won't resume it
+        activeRequests.keys.foreach(requestTracker.completeRequest(_, 0))
+        activeRequests.clear()
+        pendingTasks.clear()
+        pendingHashSet.clear()
+        clearHealedPathsSet() // spec 003 C1: abandonment — drop the scoped-verification scope (hygiene)
+        snapSyncController ! SNAPSyncController.StateHealingComplete
+        context.stop(self)
+      }
 
     case HealingPivotRefreshed(newStateRoot) =>
       // FR-003: a same-root refresh is a no-op. ByteString `==` is full 32-byte value equality (NOT the
@@ -698,6 +802,43 @@ class TrieNodeHealingCoordinator(
             startVerificationBFS(newStateRoot, pivotReseedPath)
           }
         }
+      }
+
+    case HealingServeRootRefresh(newServeRoot) =>
+      // spec 004 T009/C2: advance the SERVE root ONLY. This is the narrow, side-effect-free counterpart to
+      // HealingPivotRefreshed: it MUST NOT touch the walk root (`stateRoot`), the frontier (`pendingTasks` /
+      // persisted frontier), `verificationPassComplete`, or re-seed the walk. Completeness stays anchored to the
+      // unchanged walk root (FR-001), so byte-for-byte completion parity with the coupled path is preserved by
+      // construction. No-op when the feature is disabled (the fetch would ignore `serveRoot` anyway, but skipping
+      // keeps the observability/counter state inert so the OFF path is byte-identical to today, SC-006).
+      if (!decoupledHealServeRoot) {
+        log.debug("[HEAL-SERVE-ROOT] HealingServeRootRefresh ignored — decoupled-heal-serve-root disabled")
+      } else if (newServeRoot.isEmpty || newServeRoot == serveRoot) {
+        // T011 U2: never adopt an empty/zero serve root; a same-root refresh is a no-op (no counter churn).
+        log.debug(
+          s"[HEAL-SERVE-ROOT] No-op serve-root refresh (empty=${newServeRoot.isEmpty}, " +
+            s"same=${newServeRoot == serveRoot})"
+        )
+      } else {
+        val oldServe = Hex.toHexString(serveRoot.take(4).toArray)
+        val newServe = Hex.toHexString(newServeRoot.take(4).toArray)
+        serveRoot = newServeRoot
+        serveRootRefreshCount += 1
+        // T015 / FR-006: a serve-root advance is the legitimate retry trigger — clear the per-task attempt
+        // counters so a node that was unservable under the old serve root gets a fresh budget under the new one.
+        healAttempts.clear()
+        // T020: engagement log (old -> new serve root). The walk root is logged for contrast so an operator can
+        // see the two roots diverge. blocks-behind-head is not known here (the controller picks the target);
+        // the controller's own T011 log carries it.
+        log.info(
+          s"[HEAL-SERVE-ROOT] Serve root advanced $oldServe -> $newServe " +
+            s"(walk root held at ${Hex.toHexString(stateRoot.take(4).toArray)}, refresh #$serveRootRefreshCount). " +
+            s"Walk/frontier/completeness untouched."
+        )
+        SNAPSyncMetrics.setHealingServeRoot(shortRootLabel(serveRoot))
+        SNAPSyncMetrics.setHealingUnservableTasks(0L) // counters just cleared
+        // Nodes still pending may now be servable by the new serve root — nudge dispatch (does not re-seed).
+        tryRedispatchPendingTasks()
       }
 
     case HealingResumeDispatch =>
@@ -1075,9 +1216,14 @@ class TrieNodeHealingCoordinator(
     // Build the paths list for GetTrieNodes — each entry's pathset is a Seq[ByteString]
     val paths = batch.map(_.pathset)
 
+    // spec 004 T010/C3: the ONLY behavioral fetch change. When decoupling is enabled, fetch missing nodes against
+    // the advancing SERVE root (which peers can still serve); otherwise (or before a serve root is obtained,
+    // `serveRoot == stateRoot` by the T008 init) fetch against the walk root, byte-identical to the coupled path.
+    // GetTrieNodes is path-addressed, so the returned node is content-verified (keccak == task hash) downstream
+    // before it is ever stored — see handleResponse (C4). The walk root used for completeness is unchanged.
     val request = GetTrieNodes(
       requestId = requestId,
-      rootHash = stateRoot,
+      rootHash = if (decoupledHealServeRoot) serveRoot else stateRoot,
       paths = paths,
       responseBytes = responseBytes
     )
@@ -1134,6 +1280,13 @@ class TrieNodeHealingCoordinator(
       if (nodeData.nonEmpty) {
         keccak.reset()
         val nodeHash = ByteString(keccak.digest(nodeData.toArray))
+        // ┌─ CONSENSUS-SAFETY INVARIANT (spec 004 T014/C4/FR-004 — DO NOT WEAKEN OR BYPASS) ─────────────────────┐
+        // │ A node returned by ANY serve root is accepted IFF its keccak256 equals a requested task hash (the     │
+        // │ walk root's expectation). GetTrieNodes is path-addressed, so a serve root may resolve a path to a     │
+        // │ DIFFERENT-content node; that node fails this hash match and is dropped (never stored, never counted   │
+        // │ as healed). This is the single guardrail that makes decoupled (cross-root) fetching safe — it holds   │
+        // │ identically on the coupled and decoupled paths. No decoupled branch may skip it.                      │
+        // └──────────────────────────────────────────────────────────────────────────────────────────────────────┘
         if (taskByHash.contains(nodeHash)) {
           storageScheme match {
             case StorageScheme.Hash =>
@@ -1153,10 +1306,17 @@ class TrieNodeHealingCoordinator(
           }
           healedCount += 1
           totalNodesHealed += 1
+          // spec 004 T019/FR-010: count a heal sourced from a serve root that differs from the walk root.
+          // Observation-only; never affects completion. (Equal roots ⇒ coupled-equivalent, not counted.)
+          if (decoupledHealServeRoot && serveRoot != stateRoot) crossRootHealCount += 1
+          // T015 / FR-006: this task is satisfied — drop its attempt counter (bounded by pendingTasks).
+          healAttempts.remove(nodeHash)
           // spec 003 C1/FR-001: capture this healed node's HealingEntry as a scoped-verification seed.
           // This is the ONLY site that increments totalNodesHealed for network-served nodes, so the
           // accumulator is exactly {nodes whose bytes were written this round}. Tag the round's root on
           // first capture (F5), dedup by hash, and latch overflow at scopedHealMaxPaths (F4/FR-011).
+          // spec 004 T017: healedPathsRoot is tagged with the WALK root `stateRoot` (NOT `serveRoot`), so the
+          // scoped-verification F5 predicate `healedPathsRoot == stateRoot` is unaffected by decoupling.
           taskByHash.get(nodeHash).foreach { task =>
             if (healedPathsThisRound.isEmpty) healedPathsRoot = stateRoot
             if (!healedPathsOverflowed && !healedPathsThisRound.contains(task.hash)) {
@@ -1185,6 +1345,10 @@ class TrieNodeHealingCoordinator(
       if (!healedHashes.contains(task.hash)) {
         pendingHashSet += task.hash
         pendingTasks += task
+        // spec 004 T015/FR-006: an unsatisfied task (server skipped it / content-mismatch drop) bumps its
+        // attempt counter and may surface if it stays unservable across the bounded threshold WITHOUT a
+        // serve-root advance (which clears the map). This NEVER force-completes — see noteUnservableAttempt.
+        noteUnservableAttempt(task.hash)
       }
     }
 
@@ -1272,6 +1436,8 @@ class TrieNodeHealingCoordinator(
       pendingHashSet += task.hash
       pendingTasks += task
       requeued += 1
+      // spec 004 T015/FR-006: a timed-out task is unsatisfied — bump its attempt counter (surfacing only).
+      noteUnservableAttempt(task.hash)
     }
 
     if (requeued > 0) {
@@ -1897,6 +2063,13 @@ object TrieNodeHealingCoordinator {
     */
   val DefaultScopedHealMaxPaths: Int = 200_000
 
+  /** Default FR-006 surfacing threshold (spec 004): after this many unsatisfied heal attempts with no serve-root
+    * advance in between, the coordinator surfaces the stuck task (log + metric). It NEVER force-completes — a task no
+    * serve root can supply keeps the completeness walk from finding zero, so completion can never be falsely declared.
+    * Operator-tunable via `sync.snap-sync.decoupled-heal-max-attempts-no-refresh`.
+    */
+  val DefaultDecoupledHealMaxAttemptsNoRefresh: Int = 12
+
   /** Operator-configurable ceiling for BFS level parallelism. Effective parallelism is `min(DefaultBfsParallelism,
     * max(1, availableProcessors - 2))` so large levels are split across sub-ranges on `healingWriterEc`. See
     * `healing-traversal-parallelism` in `sync.conf`.
@@ -1975,7 +2148,9 @@ object TrieNodeHealingCoordinator {
       frontierLowWater: Int = DefaultFrontierLowWater,
       frontierBackpressureMaxWaitMs: Long = FrontierBackpressureMaxWaitMs,
       scopedHealVerification: Boolean = true,
-      scopedHealMaxPaths: Int = DefaultScopedHealMaxPaths
+      scopedHealMaxPaths: Int = DefaultScopedHealMaxPaths,
+      decoupledHealServeRoot: Boolean = false,
+      decoupledHealMaxAttemptsNoRefresh: Int = DefaultDecoupledHealMaxAttemptsNoRefresh
   ): Props =
     Props(
       new TrieNodeHealingCoordinator(
@@ -2000,7 +2175,9 @@ object TrieNodeHealingCoordinator {
         frontierLowWater,
         frontierBackpressureMaxWaitMs,
         scopedHealVerification,
-        scopedHealMaxPaths
+        scopedHealMaxPaths,
+        decoupledHealServeRoot,
+        decoupledHealMaxAttemptsNoRefresh
       )
     )
 }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealObservabilitySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealObservabilitySpec.scala
@@ -1,0 +1,145 @@
+package com.chipprbots.ethereum.blockchain.sync.snap.actors
+
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.duration._
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.blockchain.sync.snap._
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.metrics.Metrics
+import com.chipprbots.ethereum.network.NetworkPeerManagerActor
+import com.chipprbots.ethereum.network.p2p.messages.SNAP
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.{PeerTestHelpers, TestMptStorage}
+
+/** spec 004 (Decoupled Heal Serve-Root), US3 — engagement + observability (T-7, FR-010, C9).
+  *
+  * With the feature ON the coordinator emits the engagement signal at start (decoupled-engaged gauge = 1, walk-root and
+  * serve-root short-label gauges seeded), advances the serve-root gauge on each HealingServeRootRefresh, and tracks
+  * cross-root heals / unservable tasks. With the feature OFF the "decoupling disabled" path is taken (engaged gauge =
+  * 0) and the fetch uses the walk root.
+  *
+  * The decoupled gauges are global JVM singletons, so this spec ties each observation to its own coordinator by
+  * asserting the walk-root / serve-root gauges equal `shortRootLabel` of distinct roots no other test uses — that value
+  * can only have been written by this coordinator's preStart / refresh handler.
+  */
+class DecoupledHealObservabilitySpec
+    extends TestKit(ActorSystem("DecoupledHealObservabilitySpec"))
+    with ImplicitSender
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  private def gaugeValue(name: String): Double = {
+    val gauge = Metrics.get().registry.find(name).gauge()
+    if (gauge == null) Double.NaN else gauge.value()
+  }
+
+  private def getTrieNodesOf(send: NetworkPeerManagerActor.SendMessage): SNAP.GetTrieNodes =
+    send.message.underlyingMsg.asInstanceOf[SNAP.GetTrieNodes]
+
+  /** Mirror of `TrieNodeHealingCoordinator.shortRootLabel`: the leading (up to) 8 bytes of a root packed big-endian
+    * into a Long. Replicated here so a gauge observation can be tied to a specific, distinct root value (the gauges are
+    * global singletons; matching the exact short label proves THIS coordinator wrote it).
+    */
+  private def shortRootLabel(root: ByteString): Long = {
+    var acc = 0L
+    val n = root.length.min(8)
+    var i = 0
+    while (i < n) {
+      acc = (acc << 8) | (root(i) & 0xffL)
+      i += 1
+    }
+    acc
+  }
+
+  private def buildCoordinator(
+      stateRoot: ByteString,
+      decoupled: Boolean
+  ): (ActorRef, TestProbe) = {
+    val networkPeerManager = TestProbe()
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        batchSize = 16,
+        snapSyncController = TestProbe().ref,
+        healingWriterEcOverride = Some(system.dispatcher),
+        decoupledHealServeRoot = decoupled
+      )
+    )
+    (coordinator, networkPeerManager)
+  }
+
+  // ── T-7 (on): engagement signal + observability gauges emitted ────────────────────────────────
+
+  "Decoupled heal observability (T-7, feature on)" should
+    "emit the engagement signal + walk/serve-root gauges and advance the serve-root gauge on refresh" taggedAs UnitTest in {
+      val stateRoot = kec256(ByteString("observ-t7-on-walk-root"))
+      val (coordinator, _) = buildCoordinator(stateRoot, decoupled = true)
+
+      // preStart engagement signal: decoupled engaged = 1, walk-root gauge seeded to the walk root's short label,
+      // serve-root gauge seeded equal to the walk root (serveRoot == stateRoot at init).
+      awaitAssert(
+        {
+          gaugeValue("snapsync.healing.decoupled.engaged.gauge") shouldBe 1.0 +- 1e-9
+          gaugeValue("snapsync.healing.decoupled.walk_root.gauge") shouldBe shortRootLabel(stateRoot).toDouble +- 1e-9
+          gaugeValue("snapsync.healing.decoupled.serve_root.gauge") shouldBe shortRootLabel(stateRoot).toDouble +- 1e-9
+        },
+        5.seconds,
+        100.millis
+      )
+
+      // A serve-root advance updates the serve-root gauge (to the new root's short label) while the walk-root
+      // gauge stays pinned to the walk root — the two roots are observably distinct after the advance.
+      val newServeRoot = kec256(ByteString("observ-t7-on-serve-root"))
+      coordinator ! Messages.HealingServeRootRefresh(newServeRoot)
+      awaitAssert(
+        {
+          gaugeValue("snapsync.healing.decoupled.serve_root.gauge") shouldBe shortRootLabel(
+            newServeRoot
+          ).toDouble +- 1e-9
+          gaugeValue("snapsync.healing.decoupled.walk_root.gauge") shouldBe shortRootLabel(stateRoot).toDouble +- 1e-9
+        },
+        5.seconds,
+        100.millis
+      )
+    }
+
+  // ── T-7 (off): decoupling-disabled path taken; fetch uses the walk root ───────────────────────
+
+  "Decoupled heal observability (T-7, feature off)" should
+    "take the disabled path (engaged gauge = 0) and fetch against the walk root" taggedAs UnitTest in {
+      val stateRoot = kec256(ByteString("observ-t7-off-walk-root"))
+      val (coordinator, networkPeerManager) = buildCoordinator(stateRoot, decoupled = false)
+
+      // preStart takes the "decoupling disabled" path: engaged gauge = 0. The walk-root gauge is still seeded
+      // (observation-only, always set), and the serve-root gauge equals the walk root (no decoupling).
+      awaitAssert(
+        {
+          gaugeValue("snapsync.healing.decoupled.engaged.gauge") shouldBe 0.0 +- 1e-9
+          gaugeValue("snapsync.healing.decoupled.walk_root.gauge") shouldBe shortRootLabel(stateRoot).toDouble +- 1e-9
+        },
+        5.seconds,
+        100.millis
+      )
+
+      // The fetch uses the walk root (decoupling disabled) — observed on the actual GetTrieNodes.
+      val nodeHash = kec256(ByteString("observ-t7-off-missing-node"))
+      coordinator ! Messages.QueueMissingNodes(Seq((Seq(ByteString(Array[Byte](0x00))), nodeHash)))
+      val peer = PeerTestHelpers.createTestPeer("observ-t7-off-peer", TestProbe().ref)
+      coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+      val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+      getTrieNodesOf(send).rootHash shouldBe stateRoot
+    }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealSafetySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealSafetySpec.scala
@@ -1,0 +1,327 @@
+package com.chipprbots.ethereum.blockchain.sync.snap.actors
+
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.blockchain.sync.snap._
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.db.dataSource.{RocksDbConfig, RocksDbDataSource}
+import com.chipprbots.ethereum.db.storage.{HealingFrontierStorage, Namespaces}
+import com.chipprbots.ethereum.metrics.Metrics
+import com.chipprbots.ethereum.mpt.{LeafNode, MerklePatriciaTrie, MptTraversals}
+import com.chipprbots.ethereum.network.NetworkPeerManagerActor
+import com.chipprbots.ethereum.network.p2p.messages.SNAP
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.{PeerTestHelpers, TestMptStorage}
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.{Executors, TimeUnit}
+
+/** spec 004 (Decoupled Heal Serve-Root), US2 — consensus safety under decoupling.
+  *
+  * Decoupling lets the fetch root differ from the walk root. The single guardrail that keeps this safe is the
+  * content-hash check at the store site (a node is accepted IFF its keccak256 equals a requested task hash). These
+  * tests prove the guardrail holds, that an unservable task never produces a false completion, and that completion
+  * remains byte-for-byte identical to the coupled path.
+  *
+  *   - T-3 (FR-004/SC-004, C4): a returned node whose keccak != the requested task hash is dropped — not stored, not
+  *     counted as healed, the task stays pending.
+  *   - T-4 (FR-006/SC-002, C5): a task no serve root satisfies never completes; its attempt counter increments and
+  *     surfaces past the threshold; a HealingServeRootRefresh resets it; HealingForceComplete does NOT declare
+  *     StateHealingComplete while a task is unsatisfied under decoupling.
+  *   - T-5 (FR-007/SC-003, C6): the same final healed state reaches an identical completion (StateHealingComplete + CF
+  *     `g` marker + unchanged state root) decoupled vs coupled (flag flip).
+  */
+class DecoupledHealSafetySpec
+    extends TestKit(ActorSystem("DecoupledHealSafetySpec"))
+    with ImplicitSender
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  private def gaugeValue(name: String): Double = {
+    val gauge = Metrics.get().registry.find(name).gauge()
+    if (gauge == null) Double.NaN else gauge.value()
+  }
+
+  private def getTrieNodesOf(send: NetworkPeerManagerActor.SendMessage): SNAP.GetTrieNodes =
+    send.message.underlyingMsg.asInstanceOf[SNAP.GetTrieNodes]
+
+  private def stats(coordinator: ActorRef): HealingStatistics = {
+    val probe = TestProbe()
+    coordinator.tell(Messages.HealingGetProgress, probe.ref)
+    probe.expectMsgType[HealingStatistics](2.seconds)
+  }
+
+  private def deleteRecursively(f: File): Unit = {
+    Option(f.listFiles()).foreach(_.foreach(deleteRecursively))
+    f.delete()
+    ()
+  }
+
+  /** Assert the controller is NOT sent StateHealingComplete within `window`. Other controller messages (e.g.
+    * HealingAllPeersStateless from a stateless peer, ProgressNodesHealed) are allowed — the SC-002 guarantee is
+    * specifically that no FALSE COMPLETION is declared while a task is unsatisfied.
+    */
+  private def assertNoStateHealingComplete(controller: TestProbe, window: FiniteDuration): Unit = {
+    val deadline = window.fromNow
+    while (deadline.hasTimeLeft())
+      controller.receiveOne(deadline.timeLeft) match {
+        case SNAPSyncController.StateHealingComplete =>
+          fail("StateHealingComplete was declared while a heal task was still unsatisfied (SC-002)")
+        case _ => () // any other controller message (or nothing) is fine — keep watching
+      }
+  }
+
+  /** A clean storage-trie leaf to heal (no children → a clean round). Returns (pathset, hash, encoded) with
+    * `kec256(encoded) == hash`, exactly what `handleResponse` matches on.
+    */
+  private def cleanLeaf(seed: Int): (Seq[ByteString], ByteString, ByteString) = {
+    val leaf = LeafNode(ByteString(Array[Byte](0x01)), ByteString(kec256(ByteString(s"safety-leaf-$seed")).toArray))
+    val encoded = MptTraversals.encodeNode(leaf)
+    val hash = kec256(ByteString(encoded))
+    val accountHash = kec256(ByteString(s"safety-account-$seed"))
+    (Seq(accountHash, ByteString(Array[Byte](0x20, seed.toByte))), hash, ByteString(encoded))
+  }
+
+  // ── T-3: content-hash guardrail drops a wrong-content node ────────────────────────────────────
+
+  "Content-hash guardrail (T-3)" should
+    "drop a returned node whose keccak != requested hash — not stored, not counted, task stays pending" taggedAs UnitTest in {
+      val stateRoot = kec256(ByteString("safety-t3-walk-root"))
+      val storage = new TestMptStorage()
+      val networkPeerManager = TestProbe()
+      val snapSyncController = TestProbe()
+      val coordinator = system.actorOf(
+        TrieNodeHealingCoordinator.props(
+          stateRoot = stateRoot,
+          networkPeerManager = networkPeerManager.ref,
+          requestTracker = new SNAPRequestTracker()(system.scheduler),
+          mptStorage = storage,
+          batchSize = 16,
+          snapSyncController = snapSyncController.ref,
+          healingWriterEcOverride = Some(system.dispatcher),
+          decoupledHealServeRoot = true
+        )
+      )
+
+      // Queue a task whose hash is a fixed value we control; the response will carry DIFFERENT bytes whose
+      // keccak does not equal that hash — simulating a serve root resolving the path to a different node.
+      val requestedHash = kec256(ByteString("safety-t3-expected-hash"))
+      coordinator ! Messages.QueueMissingNodes(Seq((Seq(ByteString(Array[Byte](0x00))), requestedHash)))
+      val peer = PeerTestHelpers.createTestPeer("safety-t3-peer", TestProbe().ref)
+      coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+      val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+      val reqId = getTrieNodesOf(send).requestId
+
+      val wrongContent = ByteString("safety-t3-wrong-content-bytes")
+      kec256(wrongContent) should not be requestedHash // sanity: the response really mismatches
+      coordinator ! Messages.TrieNodesResponseMsg(SNAP.TrieNodes(requestId = reqId, nodes = Seq(wrongContent)))
+
+      // The wrong-content node is dropped: not stored, not counted as healed, and the task is re-queued.
+      awaitAssert(
+        {
+          val s = stats(coordinator)
+          s.totalNodes shouldBe 0 // not counted as healed
+          s.pendingTasks shouldBe 1 // task stays pending (re-queued, not satisfied)
+        },
+        5.seconds,
+        100.millis
+      )
+      // Never stored under the requested hash — the dropped node left storage untouched, so a lookup of the
+      // requested (unhealed) hash throws MissingNodeException.
+      intercept[MerklePatriciaTrie.MissingNodeException](storage.get(requestedHash.toArray))
+      // No false completion was declared off the back of a dropped node. The controller MAY receive
+      // HealingAllPeersStateless (the single peer returned no usable nodes → stateless → pivot-refresh
+      // request, which is correct), but it must NEVER receive StateHealingComplete while the task is unhealed.
+      assertNoStateHealingComplete(snapSyncController, 500.millis)
+    }
+
+  // ── T-4: an unservable task never completes; counter increments, resets, surfaces; no force-complete ─
+
+  "Unservable heal task (T-4)" should
+    "never complete, increment+surface the attempt counter, reset on refresh, and reject HealingForceComplete" taggedAs UnitTest in {
+      val maxAttempts = 2 // small threshold so 3 unsatisfied attempts cross it deterministically
+      val stateRoot = kec256(ByteString("safety-t4-walk-root"))
+      val storage = new TestMptStorage()
+      val networkPeerManager = TestProbe()
+      val snapSyncController = TestProbe()
+      val coordinator = system.actorOf(
+        TrieNodeHealingCoordinator.props(
+          stateRoot = stateRoot,
+          networkPeerManager = networkPeerManager.ref,
+          requestTracker = new SNAPRequestTracker()(system.scheduler),
+          mptStorage = storage,
+          batchSize = 16,
+          snapSyncController = snapSyncController.ref,
+          healingWriterEcOverride = Some(system.dispatcher),
+          decoupledHealServeRoot = true,
+          decoupledHealMaxAttemptsNoRefresh = maxAttempts
+        )
+      )
+
+      // The single unservable task. We drive repeated unsatisfied attempts via the TIMEOUT path: each timeout
+      // re-queues the task and increments its attempt counter WITHOUT marking the peer stateless (go-ethereum
+      // aligned). A 30s per-peer cooldown is recorded on timeout, so we dispatch each fresh attempt to a NEW
+      // (non-cooling) peer — three rounds cross the threshold=2 surfacing point.
+      val unservableHash = kec256(ByteString("safety-t4-unservable-node"))
+      coordinator ! Messages.QueueMissingNodes(Seq((Seq(ByteString(Array[Byte](0x07))), unservableHash)))
+
+      def dispatchAndTimeout(round: Int): Unit = {
+        val peer = PeerTestHelpers.createTestPeer(s"safety-t4-peer-$round", TestProbe().ref)
+        coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+        val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+        val reqId = getTrieNodesOf(send).requestId
+        coordinator ! Messages.HealingRequestTimeout(reqId)
+        // The task must be back in the pending frontier after the timeout (never abandoned).
+        awaitAssert(stats(coordinator).pendingTasks shouldBe 1, 5.seconds, 100.millis)
+      }
+
+      dispatchAndTimeout(1) // attempts(hash) = 1  (below threshold)
+      dispatchAndTimeout(2) // attempts(hash) = 2  (at threshold, not yet surfaced)
+      dispatchAndTimeout(3) // attempts(hash) = 3  (threshold+1 → surface: WARN log + unservable gauge = 1)
+
+      // NOTE: the FR-006 surfacing is observed via the decoupled "unservable tasks" gauge, which the coordinator
+      // sets to the count of hashes over the threshold at the crossing point (a WARN log is the human signal).
+      // The gauge is the deterministic, machine-checkable observable; we await it because the actor sets it on
+      // its own thread. It is a global singleton, so we assert it reaches the expected count rather than an
+      // exact start value.
+      awaitAssert(
+        gaugeValue("snapsync.healing.decoupled.unservable_tasks.gauge") shouldBe 1.0 +- 1e-9,
+        5.seconds,
+        100.millis
+      )
+
+      // No completion was ever declared while the task stayed unsatisfied (SC-002).
+      assertNoStateHealingComplete(snapSyncController, 300.millis)
+
+      // A serve-root advance is the legitimate retry trigger: it clears the per-task attempt counters and
+      // resets the unservable gauge to 0 (the task gets a fresh budget under the new serve root).
+      coordinator ! Messages.HealingServeRootRefresh(kec256(ByteString("safety-t4-new-serve-root")))
+      awaitAssert(
+        gaugeValue("snapsync.healing.decoupled.unservable_tasks.gauge") shouldBe 0.0 +- 1e-9,
+        5.seconds,
+        100.millis
+      )
+
+      // HealingForceComplete must NOT declare StateHealingComplete while the task is still unsatisfied under
+      // decoupling — abandoning here would signal completion with a real trie gap (consensus-unsafe). The
+      // frontier is preserved and healing continues.
+      coordinator ! Messages.HealingForceComplete
+      assertNoStateHealingComplete(snapSyncController, 500.millis)
+      stats(coordinator).pendingTasks shouldBe 1 // frontier kept, not abandoned
+    }
+
+  // ── T-5: byte-for-byte completion parity, decoupled vs coupled ────────────────────────────────
+
+  /** Drive the same clean healed state to completion with the given decoupling setting; return the CF `g`
+    * completeness-marker bytes observed via `isComplete` after StateHealingComplete (true ⇒ the 0x01 sentinel is
+    * present). Mirrors `ScopedVerificationParitySpec.runToCompletion`: a RocksDB-backed marker pre-set as the shared
+    * full-coverage precondition, a single-thread EC, safe teardown.
+    */
+  private def runToCompletion(decoupled: Boolean): Boolean = {
+    val pool = Executors.newSingleThreadExecutor()
+    val ec = ExecutionContext.fromExecutorService(pool)
+    val dbPath = Files.createTempDirectory("decoupled-parity-rocksdb").toAbsolutePath.toString
+    val dataSource = RocksDbDataSource(
+      new RocksDbConfig {
+        override val createIfMissing: Boolean = true
+        override val paranoidChecks: Boolean = true
+        override val path: String = dbPath
+        override val maxThreads: Int = 1
+        override val maxOpenFiles: Int = 32
+        override val verifyChecksums: Boolean = true
+        override val levelCompaction: Boolean = true
+        override val blockSize: Long = 16384
+        override val blockCacheSize: Long = 33554432
+      },
+      Namespaces.nsSeq
+    )
+    val store = new HealingFrontierStorage(dataSource)
+    store.markComplete() // both modes share the SAME proven full-coverage precondition
+
+    // A present, complete walk root (childless leaf in storage) so the verification walk finds 0 missing.
+    val storage = new TestMptStorage()
+    val rootLeaf = LeafNode(ByteString(Array[Byte](0x01)), ByteString(Array[Byte](0x02)))
+    storage.putNode(rootLeaf)
+    val root = ByteString(rootLeaf.hash)
+
+    val nodes = (0 until 3).map(cleanLeaf)
+    val controller = TestProbe()
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = root,
+        networkPeerManager = TestProbe().ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = storage,
+        batchSize = 64,
+        snapSyncController = controller.ref,
+        healingFrontierStorage = Some(store),
+        healingWriterEcOverride = Some(ec),
+        decoupledHealServeRoot = decoupled
+      )
+    )
+    val death = TestProbe()
+    death.watch(coordinator)
+    try {
+      // Under decoupling, advancing the serve root must not change the completion outcome (it supplies node
+      // bytes only; completion is decided against the unchanged walk root). The served node bytes are the
+      // walk root's expectation either way (content-hash-verified), so the final stored state is identical.
+      if (decoupled) coordinator ! Messages.HealingServeRootRefresh(kec256(ByteString("decoupled-parity-serve-root")))
+      val peer = PeerTestHelpers.createTestPeer(s"parity-peer-$decoupled", TestProbe().ref)
+      coordinator ! Messages.QueueMissingNodes(nodes.map { case (ps, h, _) => (ps, h) })
+      coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+      coordinator ! Messages.TrieNodesResponseMsg(SNAP.TrieNodes(requestId = 1, nodes = nodes.map(_._3)))
+      // Completion is reached via the SAME StateHealingComplete signal on both paths (the load-bearing parity
+      // observable, alongside the marker + state root below). fishForMessage tolerates interleaved progress.
+      controller.fishForMessage(10.seconds) {
+        case SNAPSyncController.StateHealingComplete   => true
+        case _: SNAPSyncController.ProgressNodesHealed => false
+        case _                                         => false
+      }
+      // NOTE: the decoupled-engaged gauge is a global singleton and would race other specs running in
+      // parallel, so it is NOT asserted here — the engaged-vs-disabled path distinction is covered by the
+      // per-coordinator DecoupledHealObservabilitySpec (T-7). T-5's parity claim is the COMPLETION outcome:
+      // the same StateHealingComplete signal (above), the same CF `g` marker (returned below), and the same
+      // unchanged state root. The state root is never recomputed by verification (a pure local read) — assert
+      // the invariant: the same stored leaf yields the same root regardless of the flag.
+      val freshRoot = {
+        val s = new TestMptStorage()
+        val l = LeafNode(ByteString(Array[Byte](0x01)), ByteString(Array[Byte](0x02)))
+        s.putNode(l)
+        ByteString(l.hash)
+      }
+      root shouldBe freshRoot
+      store.isComplete
+    } finally {
+      system.stop(coordinator)
+      death.expectTerminated(coordinator, 5.seconds)
+      pool.shutdown()
+      pool.awaitTermination(5, TimeUnit.SECONDS)
+      dataSource.destroy()
+      deleteRecursively(new File(dbPath))
+    }
+  }
+
+  "Decoupled vs coupled completion (T-5)" should
+    "reach an identical completion (StateHealingComplete + CF `g` marker + state root) under both settings (FR-007)" taggedAs UnitTest in {
+      val decoupledMarker = runToCompletion(decoupled = true)
+      val coupledMarker = runToCompletion(decoupled = false)
+      // Both paths declare completion via the single verificationPassComplete chokepoint and set the SAME
+      // completeness marker. The state root is never recomputed by either path (asserted inside runToCompletion).
+      decoupledMarker shouldBe true
+      coupledMarker shouldBe true
+      decoupledMarker shouldBe coupledMarker
+    }
+}

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealServeRootSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealServeRootSpec.scala
@@ -1,0 +1,164 @@
+package com.chipprbots.ethereum.blockchain.sync.snap.actors
+
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.pekko.util.ByteString
+
+import scala.concurrent.duration._
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import com.chipprbots.ethereum.blockchain.sync.snap._
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.network.NetworkPeerManagerActor
+import com.chipprbots.ethereum.network.p2p.messages.SNAP
+import com.chipprbots.ethereum.testing.Tags._
+import com.chipprbots.ethereum.testing.{PeerTestHelpers, TestMptStorage}
+
+/** spec 004 (Decoupled Heal Serve-Root), US1 — fetch-root decoupling.
+  *
+  * The coordinator keeps two roots: the fixed completeness WALK root (`stateRoot`) that the BFS seeds and the
+  * completion gate key off, and an advancing SERVE root (`serveRoot`) used only to build the `GetTrieNodes` fetch.
+  * These tests drive a real coordinator and assert on the actual `GetTrieNodes` message it sends to its
+  * `networkPeerManager` (captured via a `TestProbe` standing in for `NetworkPeerManagerActor`).
+  *
+  *   - T-1 (FR-001/FR-002, C1/C3): with the feature on and `serveRoot != stateRoot`, the emitted `GetTrieNodes` carries
+  *     `rootHash == serveRoot`, while the walk continues to seed against `stateRoot`.
+  *   - T-2 (FR-001/FR-009, C2): `HealingServeRootRefresh` advances `serveRoot` ONLY — the walk root, the pending
+  *     frontier, and the completion behavior are untouched.
+  *   - T-6 (FR-008/SC-006, C3): with the feature off, the `GetTrieNodes` always carries `rootHash == stateRoot` and a
+  *     `HealingServeRootRefresh` is ignored — byte-identical to the coupled path.
+  */
+class DecoupledHealServeRootSpec
+    extends TestKit(ActorSystem("DecoupledHealServeRootSpec"))
+    with ImplicitSender
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  /** Extract the underlying `GetTrieNodes` from the captured `NetworkPeerManagerActor.SendMessage`. The coordinator
+    * wraps the request in a `GetTrieNodesEnc` (a `MessageSerializable`); `underlyingMsg` is the original message.
+    */
+  private def getTrieNodesOf(send: NetworkPeerManagerActor.SendMessage): SNAP.GetTrieNodes =
+    send.message.underlyingMsg.asInstanceOf[SNAP.GetTrieNodes]
+
+  private def pendingTasks(coordinator: ActorRef): Int = {
+    val probe = TestProbe()
+    coordinator.tell(Messages.HealingGetProgress, probe.ref)
+    probe.expectMsgType[HealingStatistics](2.seconds).pendingTasks
+  }
+
+  /** Build a coordinator with the given decoupling flag, returning (coordinator, networkPeerManager probe,
+    * snapSyncController probe). The walk root is the supplied `stateRoot`.
+    */
+  private def buildCoordinator(
+      stateRoot: ByteString,
+      decoupled: Boolean
+  ): (ActorRef, TestProbe, TestProbe) = {
+    val networkPeerManager = TestProbe()
+    val snapSyncController = TestProbe()
+    val coordinator = system.actorOf(
+      TrieNodeHealingCoordinator.props(
+        stateRoot = stateRoot,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(system.scheduler),
+        mptStorage = new TestMptStorage(),
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(system.dispatcher),
+        decoupledHealServeRoot = decoupled
+      )
+    )
+    (coordinator, networkPeerManager, snapSyncController)
+  }
+
+  // ── T-1: decoupled fetch targets the serve root, walk seeds the walk root ─────────────────────
+
+  "Decoupled heal serve-root (T-1)" should
+    "emit a GetTrieNodes carrying serveRoot once advanced, while the walk seeds stateRoot" taggedAs UnitTest in {
+      val stateRoot = kec256(ByteString("decoupled-t1-walk-root"))
+      val serveRoot = kec256(ByteString("decoupled-t1-serve-root"))
+      serveRoot should not be stateRoot // distinct 32-byte roots
+
+      val (coordinator, networkPeerManager, _) = buildCoordinator(stateRoot, decoupled = true)
+      val peer = PeerTestHelpers.createTestPeer("decoupled-t1-peer", TestProbe().ref)
+
+      // Advance the serve root, then queue a missing node and make a peer available so a fetch dispatches.
+      coordinator ! Messages.HealingServeRootRefresh(serveRoot)
+      val nodeHash = kec256(ByteString("decoupled-t1-missing-node"))
+      coordinator ! Messages.QueueMissingNodes(Seq((Seq(ByteString(Array[Byte](0x00))), nodeHash)))
+      coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+
+      val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+      val request = getTrieNodesOf(send)
+      // C3: the fetch root is the advancing serve root, NOT the walk root.
+      request.rootHash shouldBe serveRoot
+      request.rootHash should not be stateRoot
+    }
+
+  // ── T-2: HealingServeRootRefresh advances the serve root ONLY ─────────────────────────────────
+
+  it should "advance serveRoot only — walk root, frontier and completion behavior unchanged (T-2)" taggedAs UnitTest in {
+    val stateRoot = kec256(ByteString("decoupled-t2-walk-root"))
+    val serveRoot = kec256(ByteString("decoupled-t2-serve-root"))
+
+    val (coordinator, networkPeerManager, snapSyncController) = buildCoordinator(stateRoot, decoupled = true)
+
+    // Queue two missing nodes BEFORE the refresh — the persisted/in-memory frontier under test.
+    val h1 = kec256(ByteString("decoupled-t2-node-1"))
+    val h2 = kec256(ByteString("decoupled-t2-node-2"))
+    coordinator ! Messages.QueueMissingNodes(
+      Seq(
+        (Seq(ByteString(Array[Byte](0x00))), h1),
+        (Seq(ByteString(Array[Byte](0x01))), h2)
+      )
+    )
+    val pendingBefore = pendingTasks(coordinator)
+    pendingBefore shouldBe 2
+
+    // The refresh advances the serve root. It MUST NOT clear the frontier or re-seed the walk.
+    coordinator ! Messages.HealingServeRootRefresh(serveRoot)
+
+    // The pending frontier is unchanged (NOT cleared the way HealingPivotRefreshed would).
+    pendingTasks(coordinator) shouldBe pendingBefore
+
+    // Completion still keys off the WALK root: an idle (no pending) coordinator completes, but here the
+    // frontier is non-empty so HealingCheckCompletion must NOT declare completion — the refresh did not
+    // perturb the completion gate (which reads stateRoot, never serveRoot).
+    coordinator ! Messages.HealingCheckCompletion
+    snapSyncController.expectNoMessage(300.millis)
+
+    // And the fetch now uses the advanced serve root, proving the refresh took effect on serveRoot alone.
+    val peer = PeerTestHelpers.createTestPeer("decoupled-t2-peer", TestProbe().ref)
+    coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+    val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+    getTrieNodesOf(send).rootHash shouldBe serveRoot
+  }
+
+  // ── T-6: feature off ⇒ fetch uses the walk root; refresh is ignored (coupled parity) ──────────
+
+  "Decoupled heal serve-root disabled (T-6)" should
+    "emit a GetTrieNodes carrying stateRoot even after a HealingServeRootRefresh (coupled, byte-identical)" taggedAs UnitTest in {
+      val stateRoot = kec256(ByteString("coupled-t6-walk-root"))
+      val serveRoot = kec256(ByteString("coupled-t6-serve-root"))
+
+      val (coordinator, networkPeerManager, _) = buildCoordinator(stateRoot, decoupled = false)
+      val peer = PeerTestHelpers.createTestPeer("coupled-t6-peer", TestProbe().ref)
+
+      // A serve-root refresh must be a no-op when the feature is disabled.
+      coordinator ! Messages.HealingServeRootRefresh(serveRoot)
+      val nodeHash = kec256(ByteString("coupled-t6-missing-node"))
+      coordinator ! Messages.QueueMissingNodes(Seq((Seq(ByteString(Array[Byte](0x00))), nodeHash)))
+      coordinator.tell(Messages.HealingPeerAvailable(peer), TestProbe().ref)
+
+      val send = networkPeerManager.expectMsgType[NetworkPeerManagerActor.SendMessage](3.seconds)
+      val request = getTrieNodesOf(send)
+      // C3 (off): the fetch root is the walk root, NOT the ignored serve root — coupled behavior.
+      request.rootHash shouldBe stateRoot
+      request.rootHash should not be serveRoot
+    }
+}


### PR DESCRIPTION
## What & why (spec 004 — `specs/004-decoupled-heal-serve-root/`)

Fixes the post-SNAP heal **serve-window deadlock**: the completeness walk takes hours but ETC peers serve a given state root only ~128 blocks (~28 min), so the pinned root ages out mid-walk and deep gaps can never heal — the node stalls at ~99% (observed live: 27,346 healed, all-peers-stateless rolls clustering at the 26-27 min serve window).

**The fix:** decouple the two roles of "the root":
- **Walk root** (`stateRoot`) stays **fixed** for a walk — a pure local read needing no peers, so it runs to completion regardless of serve windows. Sole basis of the completeness decision.
- **Serve root** (`serveRoot`, new) — used **only** at the `GetTrieNodes` fetch site — advances to the newest-servable root (`networkBest−64`, reusing the `RecentRoot`/`PivotHeaderBootstrap` plumbing via a dedicated requester slot), pushed via a new side-effect-free `HealingServeRootRefresh` message (never `HealingPivotRefreshed`).

Trie nodes are content-addressed, and the existing `keccak256(node)==task-hash` check at `handleResponse` (the **load-bearing guardrail**) drops any wrong-content node a path-addressed serve root might return — so completeness stays judged solely by the walk against the fixed walk root → **byte-for-byte parity** with the coupled path (FR-007). `D4=newest-servable`, `D5=surface-only` (unservable node logged/metered, **never force-completed**; `HealingForceComplete` neutralized under decoupling). Config `decoupled-heal-serve-root` (default **on**). Consensus-adjacent; **ADR CON-010**.

## Consensus-adjacent — forge protocol
- `forge` impact analysis → implementation → **independent adversarial review**. Safety claims CONFIRMED: walk root never mutated, content-hash guardrail intact, no false completion possible, OFF-path byte-identical.
- The adversarial review caught a **liveness wedge** (an in-flight serve-root request surviving into `runningPivotHeaderBootstrap` could dead-letter and freeze the serve root) — **fixed**: `abortHealingServeRootRequest` at all 7 exits from `runningSnapSync` (also closes a latent ETH by-hash mis-route).

## Files
6 production (`TrieNodeHealingCoordinator`, `SNAPSyncController`, `SyncController`, `Messages`, `SNAPSyncMetrics`, `sync.conf`) + 3 deterministic TestKit specs + ADR CON-010 + full spec-004 artifacts.

## Testing (local, node stopped)
- ✅ `compile-all` clean (all modules + tests, Scala 3.3.8)
- ✅ scalafmt clean (3.8.3 native = CI version)
- ✅ **`testEssential` (Tier-1): 3,623 passed, 0 failed**
- ✅ 3 new spec-004 specs pass; snap-actor regression 187 passed
- ⚠️ **2 pre-existing failures** in `ScopedVerificationObservabilitySpec` (spec-003 EventFilter INFO-log tests) — **proven pre-existing on clean `origin/staging` (0/2 there too)**, introduced by the #1361 toolchain bump (Scala 3.3.8 + dep bumps), **NOT by this PR**. Flagged separately.

## Deploy note
Build + one redeploy required; this fixes the **next** heal walk, not an already-running stuck one. Branch rebased on latest `staging` (0.7.15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)