### PR TITLE
fix(ci): repair #1361 toolchain fallout blocking staging CI

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/p2p/messages/ETHPackets.scala
@@ -104,7 +104,7 @@ object ETHPackets {
         var i = 0
         val items = encodables match {
           case indexed: IndexedSeq[RLPEncodeable @unchecked] => indexed
-          case other                              => other.toIndexedSeq
+          case other                                         => other.toIndexedSeq
         }
         val len = items.size
         while (i < len)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,6 +9,17 @@
     <!-- Silent by default - enable specific loggers when troubleshooting tests -->
     <logger name="com.chipprbots.ethereum.vm.VM" level="OFF" />
 
+    <!-- ScopedVerificationObservabilitySpec asserts the TrieNodeHealingCoordinator's INFO
+         `[HEAL-VERIFY-SCOPED]` logs via Pekko's TestEventListener + EventFilter. The test
+         system runs under the Slf4jLoggingFilter (the test application.conf default that the
+         per-suite parseString override does not reliably displace at the ActorSystem layer),
+         and that filter gates EventStream publication on the SLF4J/logback level for the
+         actor's logger. With the root at ERROR the INFO event is dropped before it reaches
+         the EventStream, so EventFilter.info(...).intercept{} times out. Admitting INFO for
+         this logger lets the filter publish the event so the assertion can capture it. -->
+    <logger name="com.chipprbots.ethereum.blockchain.sync.snap.actors.TrieNodeHealingCoordinator"
+            level="INFO" />
+
     <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
## Why
#1361 (Scala 3.3.8 LTS + June dep bumps, `82e46bca6`) was merged with **red CI** — it left `staging` failing two unrelated gates, which blocks **every** PR to staging:

1. **`scalafmtCheckAll`** — `ETHPackets.scala` had a stale `=>` alignment after the toolchain bump (`scalafmt: 1 files must be formatted`).
2. **`testStandard`** — `ScopedVerificationObservabilitySpec`'s 2 `EventFilter` tests time out.

## Root cause of the EventFilter failures (diagnosed, test-infra only)
The scoped-verification **production path is fine** (the gauges confirm it engages: `scoped_verification.gauge=1`, `scoped_subtrees.gauge=3`). The dep bump changed a config-merge outcome so the running `ActorSystem` ends up with `Slf4jLoggingFilter` (gated by logback's root level = `ERROR`) instead of the per-suite override — so the coordinator's `[HEAL-VERIFY-SCOPED]` INFO logs were dropped **before** the Pekko EventStream, starving `TestEventListener`/`EventFilter`. Verified by subscribing a probe to `system.eventStream` (0 events captured pre-fix, 11 post-fix incl. the target line).

## Fix (2 files, no production code)
- **`ETHPackets.scala`** — reformatted with scalafmt 3.8.3 (whitespace only).
- **`src/test/resources/logback-test.xml`** — route the coordinator logger at `INFO` so its `[HEAL-VERIFY-SCOPED]` logs reach the EventStream regardless of which logging-filter wins the config merge.

No production code changed; no assertion weakened/disabled; the real `ScopedVerificationObservabilitySpec` is byte-for-byte unchanged.

## Verified locally (node stopped)
- `sbt scalafmtCheckAll` → ✅ exit 0
- `sbt "testOnly *ScopedVerificationObservabilitySpec"` → ✅ 2 passed (twice, stable)
- `testEssential` (on the same toolchain) → 3,623 passed / 0 failed

Unblocks staging CI for all PRs (incl. #1362 spec-004, which rebases on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)