### PR TITLE
fix(ci): repair long-carried sbt multi-command CI failures (scalafmt autofix + docker build)

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -84,7 +84,10 @@ jobs:
           sudo apt-get install sbt
 
       - name: Apply scalafmt
-        run: sbt scalafmtAll scalafmtSbt
+        # Use sbt's quoted multi-command syntax. The bare `sbt scalafmtAll scalafmtSbt`
+        # form is mis-parsed by sbt (it reads the two space-separated tasks as one
+        # selector and fails with "Expected '/'"), which had this job red on every PR.
+        run: sbt "scalafmtAll; scalafmtSbt"
         env:
           FUKUII_DEV: true
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ COPY . /build
 RUN --mount=type=cache,target=/root/.ivy2 \
     --mount=type=cache,target=/root/.sbt \
     --mount=type=cache,target=/root/.cache \
-    sbt assembly dist
+    sbt "assembly; dist"
 
 # Extract the distribution zip and drop the assembly JAR alongside the dist
 # libs so the runtime stage has both layouts available under /fukuii-dist.


### PR DESCRIPTION
## Problem — one root cause, two long-red jobs
sbt's bare space-separated multi-command form (`sbt cmd1 cmd2`) is mis-parsed by the current sbt — it reads the two tasks as one selector and fails instantly with `Expected '/'`. Two CI invocations hit this and have been **red on every PR** (and every staging push):

1. **`Apply scalafmt`** autofix job — `.github/workflows/autofix.yml`: `sbt scalafmtAll scalafmtSbt`.
2. **`Build Main Docker Image`** — `docker/Dockerfile:53`: `sbt assembly dist`. This one **cascades**: `run / consensus` and every `Consume-engine` (Osaka/Prague) sweep fail at "Tag base Docker image" → "No simulator log found — the consume-engine image likely failed to build" because they never get a base image.

## Fix
Use sbt's quoted multi-command syntax in both:
- `sbt "scalafmtAll; scalafmtSbt"`
- `sbt "assembly; dist"`

## Verification
Locally (nodes stopped): `sbt "scalafmtCheckAll; scalafmtSbtCheck"` (same semicolon form) parses + runs clean (`[success]`); the bare space form reproduces the CI `Expected '/'` error. The semicolon separator is task-agnostic, so `assembly; dist` and `scalafmtAll; scalafmtSbt` parse the same way.

CI-only fix (workflow + Dockerfile); no source/consensus impact. This should green `Build Main Docker Image`, `run / consensus`, the `Consume-engine` sweeps, and `Apply scalafmt` across all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)