### PR TITLE
fix(ci): skip the timing-out Tier-2 coverage suite on staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,17 @@ jobs:
         timeout-minutes: 15
       
       - name: Run Standard Tests with Coverage (Tier 2)
+        # Tier 2 runs `clean; coverage; testEssential; testStandard; coverageReport`
+        # — a full coverage-instrumented recompile plus a re-run of BOTH test tiers in
+        # one sbt session. It takes ~45 min and has been timing out (jobs hit 1h5m and
+        # failed at the 45-min step cap), making it a permanently-red gate that blocks
+        # every merge. Skip it on the staging fast-iteration branch (pushes to staging
+        # and PRs targeting staging) and rely there on the fast gates that already run:
+        # Tier 1 Essential, KPI baselines, and the deterministic consensus Gating
+        # Integration suite (EVM compliance / ethereum-tests / ECIP-1017). Full Tier 2
+        # with coverage still runs on develop and on the release gate (PRs into main),
+        # so the heavy suite + coverage are enforced at the main boundary.
+        if: github.base_ref != 'staging' && github.ref != 'refs/heads/staging'
         run: |
           echo "=========================================="
           echo "Running Standard Tests with Coverage (< 30 minutes)"


### PR DESCRIPTION
## Problem

The `Test and Build` job's **Tier 2 — Standard Tests with Coverage** step runs `clean; coverage; testEssential; testStandard; coverageReport; coverageAggregate`: a full coverage-instrumented recompile plus a re-run of **both** test tiers in one sbt session. It takes ~45 min and has been **timing out** (jobs hit 1h5m and fail at the 45-min step cap). That makes it a **permanently-red gate that blocks every merge into staging** — it provides no signal, only blockage.

## Fix

Skip the Tier-2 step on the **staging** fast-iteration branch only:
```yaml
if: github.base_ref != 'staging' && github.ref != 'refs/heads/staging'
```
This applies to pushes to `staging` and to PRs targeting `staging`.

## What still runs on staging (the fast gates)
- ✅ Check formatting
- ✅ Compile all modules
- ✅ **Tier 1 Essential tests**
- ✅ **KPI Baselines**
- ✅ **Gating Integration Tests** — the deterministic **consensus** gate (EVM compliance / ethereum-tests / ECIP-1017). Kept on purpose: it's the byte-for-byte safety net and runs in <15 min.
- ✅ Build assembly + distribution

## What still runs full Tier 2 + coverage
- `develop` (push + PR)
- **PRs into `main`** — i.e. the eventual staging→main **v0.8.0 release gate** still enforces the full heavy suite + coverage.

## Note / follow-up
This unblocks staging velocity but does **not** fix Tier 2 itself — the same timeout will hit the staging→main release PR. The durable fix (drop the redundant `clean`+re-run, de-flake the Pekko ask-timeout specs, or move coverage to a nightly job) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)