### PR TITLE
fix(ci): pin sbt meta-build to scala213 in scalafmt — protect project loading

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -15,3 +15,23 @@ runner.dialect = scala3
 rewrite.rules = [AvoidInfix, RedundantBraces, SortModifiers]
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = true
+
+# The sbt meta-build (project/*.scala) and *.sbt files are compiled by sbt's bundled
+# Scala 2.12 — Scala-3 syntax is a hard parse error there. The global scala3 dialect
+# plus the two scala3 rewrites above otherwise rewrite these files into 2.12-invalid
+# syntax (import x.* , `extends X:` fewer-braces, `Setting[?]`) and break `sbt` project
+# loading outright. The autofix `scalafmtSbt` job did exactly this once already, pushing
+# a commit that left the meta-build uncompilable. Pin these files to a 2.x dialect and
+# disable the scala3 rewrites so `scalafmtSbt` stays 2.12-safe and idempotent.
+fileOverride {
+  "glob:**/project/**.scala" {
+    runner.dialect = scala213
+    rewrite.scala3.convertToNewSyntax = false
+    rewrite.scala3.removeOptionalBraces = false
+  }
+  "glob:**.sbt" {
+    runner.dialect = scala213
+    rewrite.scala3.convertToNewSyntax = false
+    rewrite.scala3.removeOptionalBraces = false
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ inThisBuild(
     ),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(),
-    scalaVersion := `scala-3`,                            // must be in inThisBuild for scalafixSemanticdb.revision
-    semanticdbEnabled := true,                            // required for scalafix semantic rules
+    scalaVersion := `scala-3`, // must be in inThisBuild for scalafixSemanticdb.revision
+    semanticdbEnabled := true, // required for scalafix semantic rules
     semanticdbVersion := scalafixSemanticdb.revision,
     // Add reliable resolvers to avoid transient HTTP 503 errors
     resolvers ++= Seq(
@@ -61,7 +61,7 @@ val baseScalacOptions = Seq(
 
 // Scala 3 warning and feature options
 val scala3Options = Seq(
-  "-source:future",  // Enforce Scala 3 future syntax (import x.* required, not import x._)
+  "-source:future", // Enforce Scala 3 future syntax (import x.* required, not import x._)
   "-language:adhocExtensions", // Allow extending non-open classes (TestKit, Pekko test patterns)
   "-Wunused:all", // Enable unused warnings for Scala 3 (required for scalafix)
   "-Wconf:id=E198:error", // Ratchet step 4/4: unused symbols are build errors (Scala 3: id=E198, cat=unused is not valid)


### PR DESCRIPTION
## Summary

`staging` is currently primed to corrupt the sbt meta-build on **every** PR whose autofix runs. This is a one-line-of-config guard against that.

**Root cause:** #1375 fixed the autofix command so it actually runs `sbt "scalafmtAll; scalafmtSbt"` (previously the bare two-task form mis-parsed and no-op'd). But `.scalafmt.conf` applies `runner.dialect = scala3` plus `rewrite.scala3.convertToNewSyntax` / `removeOptionalBraces` **globally** — including `project/*.scala` and `build.sbt`, which are compiled by sbt's bundled **Scala 2.12**. So `scalafmtSbt` now rewrites the meta-build into Scala-3 syntax:

- `object SolidityPlugin extends AutoPlugin {` → `extends AutoPlugin:`
- `import sbt._` → `import sbt.*`
- `Seq[sbt.Def.Setting[_]]` → `Seq[sbt.Def.Setting[?]]`
- block braces → fewer-braces

all hard parse errors in the meta-build → `sbt` can't load → the CI **Check formatting** step and the **Autofix** job both go red with `47 errors found` / `Project loading failed`.

This already happened on #1378: its autofix pushed a "style: apply scalafmt" commit that left the meta-build uncompilable.

## Fix

Add a `.scalafmt.conf` `fileOverride` pinning `project/**.scala` and `*.sbt` to the `scala213` dialect with the two scala3 rewrites disabled there. `scalafmtSbt` then formats the meta-build with 2.12-safe rules — braces and `_` wildcards preserved — and is idempotent. `build.sbt` is reformatted to the resulting canonical form (comment-whitespace only; `Setting[_]` preserved, no semantic change).

## Testing

- `sbt` loads (meta-build compiles).
- `sbt "scalafmtCheckAll; scalafmtSbtCheck"` — both green (exit 0).
- `project/SolidityPlugin.scala` stays braced; no Scala-3-only tokens in the meta-build.
- Same fix verified live on #1378's branch, which is now un-blocked.

## Note

#1378 carries an identical copy of this guard (it had to, to un-break its own CI). Whichever merges first, the other's `.scalafmt.conf` addition becomes a trivial duplicate to resolve/drop on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)