### PR TITLE
port(#1374): moving-root delta heal on the typed base (spec 009) — validated live

### DIFF
--- a/src/main/resources/conf/base/sync.conf
+++ b/src/main/resources/conf/base/sync.conf
@@ -182,6 +182,12 @@ sync {
     # with NO serve-root advance in between, the coordinator emits a surfacing WARN log + metric so operators can
     # see the stuck node. A serve-root refresh resets the per-task counter (a legitimate retry trigger).
     decoupled-heal-max-attempts-no-refresh = 12
+    # Moving-root delta heal (spec 009). PLUMBING ONLY so far — NO code reads this flag yet, so it is byte-for-byte
+    # behavior-neutral until the behavior hunks land in later batches. When wired (ETC SNAP default true), the heal
+    # will complete toward AND fetch against ONE current served root (no separate walk/serve split): the GetTrieNodes
+    # fetch root collapses to the completeness root, an absent heal root is seeded+fetched, and top-down discovery is
+    # the sole seed. When false, the heal uses the spec-004 walk/serve split.
+    moving-root-delta-heal = true
     # Pruned (descend-and-stop) heal verification (spec 005). When true (default), the completeness
     # verification walk treats any present node that carries a durable per-subtree-complete record
     # (CF 'g', content-addressed, root-independent) as a verified frontier leaf and does NOT descend

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -852,21 +852,31 @@ private class SNAPSyncControllerImpl(
       // the in-flight latch so a later tick can retry.
       case SNAPSyncController.HealingServeRoot(blockNumber, rootOpt) =>
         healingServeRootRequestInFlight = false
-        rootOpt match
-          case Some(root) if root.value.nonEmpty =>
-            lastHealingServeRootBlock = Some(blockNumber)
-            ctx.log.info(
-              s"[HEAL-SERVE-ROOT] Pushing newest-servable serve root ${root.value.take(4).toHex} (block $blockNumber) " +
-                s"to healing coordinator (walk root unchanged)."
-            )
-            trieNodeHealingCoordinator.foreach(
-              _ ! actors.TrieNodeHealingCoordinator.HealingServeRootRefresh(root.value)
-            )
-          case _ =>
-            ctx.log.info(
-              "[HEAL-SERVE-ROOT] Parent could not fetch a newest-servable root (no peers / bootstrap failed). " +
-                "Keeping the current serve root; will retry on a later healing tick."
-            )
+        // spec 009 T014/FR-010: under moving-root delta heal the stale-move trigger re-pegs the single heal root via
+        // refreshPivotInPlace → HealingPivotRefreshed (H-S6), NOT a serve-root push, so this reply is no longer
+        // solicited on the flag path. A late HealingServeRoot (e.g. an in-flight RequestHealingServeRoot from before the
+        // flag engaged) must NOT push a HealingServeRootRefresh — under single-root heal the serve root IS the walk root
+        // and a serve-root-only move would be meaningless. Flag OFF: byte-identical to the spec-004 push below.
+        if snapSyncConfig.movingRootDeltaHeal then
+          ctx.log.debug(
+            "[HEAL] late HealingServeRoot reply ignored — moving-root delta heal re-pegs via HealingPivotRefreshed"
+          )
+        else
+          rootOpt match
+            case Some(root) if root.value.nonEmpty =>
+              lastHealingServeRootBlock = Some(blockNumber)
+              ctx.log.info(
+                s"[HEAL-SERVE-ROOT] Pushing newest-servable serve root ${root.value.take(4).toHex} (block $blockNumber) " +
+                  s"to healing coordinator (walk root unchanged)."
+              )
+              trieNodeHealingCoordinator.foreach(
+                _ ! actors.TrieNodeHealingCoordinator.HealingServeRootRefresh(root.value)
+              )
+            case _ =>
+              ctx.log.info(
+                "[HEAL-SERVE-ROOT] Parent could not fetch a newest-servable root (no peers / bootstrap failed). " +
+                  "Keeping the current serve root; will retry on a later healing tick."
+              )
         Behaviors.same
 
       case EnsureSnapServerPeersConnected =>
@@ -1422,6 +1432,13 @@ private class SNAPSyncControllerImpl(
       // during block execution (BlockImporter/StateNodeFetcher, with real parent-root context) — the established
       // post-SNAP regular-sync fallback. This converges to a REAL Completed/regular-sync state; it is NOT a silent
       // skip-and-mark-done (finalizeSnapSync still enforces the snapStateRoot == pivotHeader.stateRoot anchor guard).
+      //
+      // spec 009 FR-001/FR-008: under `movingRootDeltaHeal` this handler is the BOUNDED last-resort, NOT the default.
+      // The coordinator's absent-root branch SEEDS the served root and fetches it (batch-2 T006) instead of emitting
+      // HealingRootUnservable, so under the flag this is reached only when the controller's own re-peg budget is
+      // exhausted (refreshPivotInPlace's MaxHealRepegNoRootAttempts, batch-4 H-S7) — that branch calls completeSnapSync()
+      // directly (the same handoff below). This handler stays for the flag-OFF path (where the coordinator still emits
+      // HealingRootUnservable) and as a defensive catch; either way it is fail-SAFE (anchor-guard gated), never fail-open.
       case HealingRootUnservable(root) if currentPhase == StateHealing =>
         ctx.log.warn(
           s"[HEAL-ROOT-UNSERVABLE] Heal walk root ${root.toHex.take(16)} is absent from local storage and cannot be " +

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3571,7 +3571,8 @@ private class SNAPSyncControllerImpl(
                   // Without passing this explicitly the deployed (PR #1319) persisted-frontier resume goes dark.
                   frontierPersistenceEnabled = snapSyncConfig.healingFrontierPersistence,
                   decoupledHealServeRoot = snapSyncConfig.decoupledHealServeRoot,
-                  decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh
+                  decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh,
+                  movingRootDeltaHeal = snapSyncConfig.movingRootDeltaHeal
                 )
               )
               .onFailure[Throwable](
@@ -3650,7 +3651,8 @@ private class SNAPSyncControllerImpl(
                     // passed explicitly or the deployed (PR #1319) persisted-frontier resume goes dark in production.
                     frontierPersistenceEnabled = snapSyncConfig.healingFrontierPersistence,
                     decoupledHealServeRoot = snapSyncConfig.decoupledHealServeRoot,
-                    decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh
+                    decoupledHealMaxAttemptsNoRefresh = snapSyncConfig.decoupledHealMaxAttemptsNoRefresh,
+                    movingRootDeltaHeal = snapSyncConfig.movingRootDeltaHeal
                   )
                 )
                 .onFailure[Throwable](
@@ -5193,6 +5195,10 @@ case class SNAPSyncConfig(
     // FR-006 surfacing threshold: after this many unsatisfied heal attempts with no serve-root advance in
     // between, the coordinator surfaces the stuck task (log + metric). NEVER force-completes.
     decoupledHealMaxAttemptsNoRefresh: Int = 12,
+    // spec 009 (Moving-Root Delta Heal) — PLUMBING ONLY in this batch. No code reads this flag yet, so flag-ON and
+    // flag-OFF are byte-for-byte identical. Default true sets the intended ETC SNAP default once the behavior hunks
+    // land in later batches (single served heal root, seed-absent-root, re-peg, pruned completion).
+    movingRootDeltaHeal: Boolean = true,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,
     timeout: FiniteDuration = 30.seconds,
@@ -5327,6 +5333,9 @@ object SNAPSyncConfig:
         if snapConfig.hasPath("decoupled-heal-max-attempts-no-refresh") then
           snapConfig.getInt("decoupled-heal-max-attempts-no-refresh")
         else 12,
+      movingRootDeltaHeal =
+        if snapConfig.hasPath("moving-root-delta-heal") then snapConfig.getBoolean("moving-root-delta-heal")
+        else true,
       stateValidationEnabled = snapConfig.getBoolean("state-validation-enabled"),
       maxRetries = snapConfig.getInt("max-retries"),
       timeout = snapConfig.getDuration("timeout").toMillis.millis,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -5278,9 +5278,11 @@ case class SNAPSyncConfig(
     // FR-006 surfacing threshold: after this many unsatisfied heal attempts with no serve-root advance in
     // between, the coordinator surfaces the stuck task (log + metric). NEVER force-completes.
     decoupledHealMaxAttemptsNoRefresh: Int = 12,
-    // spec 009 (Moving-Root Delta Heal) — PLUMBING ONLY in this batch. No code reads this flag yet, so flag-ON and
-    // flag-OFF are byte-for-byte identical. Default true sets the intended ETC SNAP default once the behavior hunks
-    // land in later batches (single served heal root, seed-absent-root, re-peg, pruned completion).
+    // spec 009 (Moving-Root Delta Heal). Read by TrieNodeHealingCoordinator (single served heal root in
+    // requestNextBatch; seed-absent-root vs the HealingRootUnservable handoff in StartTrieNodeHealing; the
+    // HealingServeRootRefresh no-op) and by SNAPSyncController (re-peg trigger in maybeRequestHealingServeRoot;
+    // bounded last-resort in refreshPivotInPlace). Default true = the ETC SNAP default; flag-OFF restores the
+    // spec-004 decoupled serve-root path byte-for-byte (rollback path, FR-007).
     movingRootDeltaHeal: Boolean = true,
     stateValidationEnabled: Boolean = true,
     maxRetries: Int = 3,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -370,6 +370,15 @@ private class SNAPSyncControllerImpl(
   // The serve root is considered stale when it is more than this many blocks behind the network head. Matches
   // SyncController.RecentRootMarginBlocks (64) so the refreshed root lands comfortably inside peers' serve window.
   private val HealingServeRootMarginBlocks: BigInt = BigInt(64)
+  // spec 009 T009/T014 (Moving-Root Delta Heal — BOUNDED re-peg last-resort). Under `movingRootDeltaHeal` the heal
+  // re-pegs the single heal root via refreshPivotInPlace (from maybeRequestHealingServeRoot). If a re-peg attempt
+  // during StateHealing finds NO suitable served root (refreshPivotInPlace's newPivotOpt.isEmpty branch), this counter
+  // increments; once it reaches the budget the controller takes the SAME fail-SAFE lazy-heal handoff (completeSnapSync
+  // → on-demand GetTrieNodes during block execution, anchor guard STILL enforced) rather than looping the 30s
+  // RetryPivotRefresh forever (the heal-churn #1371 fought). Fail-SAFE (never force-marks-done / weakens any gate),
+  // never fail-OPEN. Reset on any successful re-peg (completePivotRefreshWithStateRoot) and on entering healing.
+  private var healRepegNoRootAttempts: Int = 0
+  private val MaxHealRepegNoRootAttempts: Int = 10 // 10 × 30s ≈ 5 min of no servable root before the lazy handoff
   // Suppress duplicate ConnectToPeer for snap-server-peers for 60s after a send attempt.
   // Prevents the race where the reconnect timer fires within the 5s peersScanInterval
   // window after STATUS_EXCHANGE completes (peer in ETH handshake but not yet in handshakedPeers).
@@ -3533,6 +3542,7 @@ private class SNAPSyncControllerImpl(
       ctx.log.warn("startStateHealing called but healing coordinator already exists — ignoring duplicate")
     else
       trieWalkInProgress = false // Reset for fresh healing phase
+      healRepegNoRootAttempts = 0 // spec 009 T014: fresh healing phase — reset the bounded re-peg last-resort budget
       ctx.log.info(s"Starting state healing with batch size ${snapSyncConfig.healingBatchSize}")
 
       stateRoot.foreach { root =>
@@ -3986,14 +3996,44 @@ private class SNAPSyncControllerImpl(
           .filter(_ > 0)
 
     if newPivotOpt.isEmpty then
-      ctx.log.warn(
-        "Cannot refresh pivot: no suitable SNAP peers available. Scheduling retry in 30s."
-      )
-      // Don't restart or fallback — SNAP peers are intermittent on ETC mainnet.
-      // The serve window is ~28 min; peers will reappear when new blocks are mined.
-      // Restarting can't help with no peers, and it destroys all downloaded trie data.
-      timers.cancel(PivotBootstrapRetryKey)
-      timers.startSingleTimer(PivotBootstrapRetryKey, RetryPivotRefresh, 30.seconds)
+      // spec 009 T014 (Moving-Root Delta Heal — bounded re-peg last-resort). Under `movingRootDeltaHeal`, a re-peg
+      // during StateHealing that finds NO suitable served root counts against a budget; once exhausted, take the SAME
+      // fail-SAFE lazy-heal handoff the (now-rare) HealingRootUnservable signal uses — completeSnapSync() → on-demand
+      // GetTrieNodes during block execution. CONSTRAINT 1 (never fail-OPEN): completeSnapSync → finalizeSnapSync STILL
+      // enforces the snapStateRoot == pivotHeader.stateRoot anchor guard, so an incomplete state CANNOT finalize (a
+      // mismatch escalates to HealingImpossible/restart) — this is the lazy on-demand-heal handoff (FR-001/FR-008), not
+      // a forced completion. CONSTRAINT 2 (return-Behavior): completeSnapSync() returns a narrowing Behavior[Command]
+      // but refreshPivotInPlace is Unit; exactly as the HealingRootUnservable handler does, we call it for its side
+      // effects (currentPhase=Completed, syncController ! Done, child teardown) and discard the returned Behavior.
+      // Outside healing or flag OFF: the unbounded 30s-retry stays byte-identical (SNAP peers are intermittent on ETC).
+      if snapSyncConfig.movingRootDeltaHeal && currentPhase == StateHealing then
+        healRepegNoRootAttempts += 1
+        if healRepegNoRootAttempts >= MaxHealRepegNoRootAttempts then
+          ctx.log.warn(
+            s"[HEAL-REPEG] No servable root for $healRepegNoRootAttempts consecutive re-peg attempts (budget " +
+              s"$MaxHealRepegNoRootAttempts exhausted, ~${MaxHealRepegNoRootAttempts * 30}s). Taking the fail-safe " +
+              s"lazy-heal handoff (completeSnapSync) — missing nodes fetched on-demand via GetTrieNodes during block " +
+              s"execution; the anchor guard still gates finalization. NOT a false completion."
+          )
+          timers.cancel(PivotBootstrapRetryKey)
+          healRepegNoRootAttempts = 0
+          completeSnapSync()
+        else
+          ctx.log.warn(
+            s"Cannot re-peg heal root: no suitable SNAP peers available (attempt " +
+              s"$healRepegNoRootAttempts/$MaxHealRepegNoRootAttempts). Scheduling retry in 30s."
+          )
+          timers.cancel(PivotBootstrapRetryKey)
+          timers.startSingleTimer(PivotBootstrapRetryKey, RetryPivotRefresh, 30.seconds)
+      else
+        ctx.log.warn(
+          "Cannot refresh pivot: no suitable SNAP peers available. Scheduling retry in 30s."
+        )
+        // Don't restart or fallback — SNAP peers are intermittent on ETC mainnet.
+        // The serve window is ~28 min; peers will reappear when new blocks are mined.
+        // Restarting can't help with no peers, and it destroys all downloaded trie data.
+        timers.cancel(PivotBootstrapRetryKey)
+        timers.startSingleTimer(PivotBootstrapRetryKey, RetryPivotRefresh, 30.seconds)
     else
       val newPivotBlock = newPivotOpt.get
       val newPivotHeaderOpt = blockchainReader.getBlockHeaderByNumber(newPivotBlock)
@@ -4282,6 +4322,10 @@ private class SNAPSyncControllerImpl(
             bytecodeCoordinator.foreach(_ ! actors.ByteCodeCoordinator.ByteCodePivotRefreshed)
             // Healing coordinator: update root, clear pending tasks and stateless peers.
             // Then re-walk the trie with the new root to discover missing nodes.
+            // spec 009 T014: a successful re-peg landed a fresh served root — reset the bounded no-root budget so the
+            // lazy-heal last-resort only fires after a fresh run of consecutive empty re-peg attempts. Harmless flag-OFF
+            // (the budget is never incremented unless movingRootDeltaHeal && StateHealing).
+            healRepegNoRootAttempts = 0
             trieNodeHealingCoordinator.foreach { coordinator =>
               coordinator ! actors.TrieNodeHealingCoordinator.HealingPivotRefreshed(newStateRoot.value)
             }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -3720,7 +3720,14 @@ private class SNAPSyncControllerImpl(
     * an empty one).
     */
   private def maybeRequestHealingServeRoot(): Unit =
-    if snapSyncConfig.decoupledHealServeRoot &&
+    // spec 009 T009/C4 (moving-root re-peg trigger): the staleness MATH below is shared with the spec-004 serve-root
+    // path; only the ACTION differs by flag. Flag OFF (decoupledHealServeRoot): push a HealingServeRootRefresh (moves
+    // the coordinator's SERVE root only; the walk root and the controller's stateRoot/pivot are untouched). Flag ON
+    // (movingRootDeltaHeal): re-peg the SINGLE heal root via refreshPivotInPlace → completePivotRefreshWithStateRoot →
+    // HealingPivotRefreshed, moving the controller's stateRoot/pivotBlock AND the coordinator's heal root IN LOCKSTEP
+    // against a canonical header stateRoot. The pendingPivotRefresh.isEmpty guard below also prevents stacking a second
+    // re-peg header bootstrap while one is in flight.
+    if (snapSyncConfig.decoupledHealServeRoot || snapSyncConfig.movingRootDeltaHeal) &&
       currentPhase == StateHealing &&
       trieNodeHealingCoordinator.isDefined &&
       !healingServeRootRequestInFlight &&
@@ -3742,13 +3749,28 @@ private class SNAPSyncControllerImpl(
             case Some(lastBlock) => (networkBest - lastBlock) > (HealingServeRootMarginBlocks * 2)
             case None            => true
           if stale then
-            healingServeRootRequestInFlight = true
-            ctx.log.info(
-              s"[HEAL-SERVE-ROOT] Requesting newest-servable serve root: networkBest=$networkBest target=$target " +
-                s"(margin=$HealingServeRootMarginBlocks, lastServeBlock=${lastHealingServeRootBlock.getOrElse("none")}). " +
-                s"Routing via parent RecentRoot bootstrap."
-            )
-            syncController ! SNAPSyncController.RequestHealingServeRoot
+            if snapSyncConfig.movingRootDeltaHeal then
+              // spec 009 T009/C4: re-peg the single heal root to a fresh served root. refreshPivotInPlace selects a
+              // canonical header (networkBest − margin), fetches it, and emits HealingPivotRefreshed via
+              // completePivotRefreshWithStateRoot — moving completeness AND fetch (one root) while RETAINING every
+              // persisted verified node and resetting verificationPassComplete so a fresh pruned descent gates
+              // completion against the new root. Record the block so the cadence (≤ once per window) matches the
+              // serve-root path; the actual root lands when the refresh settles.
+              lastHealingServeRootBlock = Some(target)
+              ctx.log.info(
+                s"[HEAL-REPEG] Heal root stale (networkBest=$networkBest, target=$target, " +
+                  s"margin=$HealingServeRootMarginBlocks, lastRepegBlock=${lastHealingServeRootBlock.getOrElse("none")}) " +
+                  s"— re-pegging the single heal root via refreshPivotInPlace (spec 009 moving-root delta heal)."
+              )
+              refreshPivotInPlace("spec009 moving-root re-peg: heal root stale")
+            else
+              healingServeRootRequestInFlight = true
+              ctx.log.info(
+                s"[HEAL-SERVE-ROOT] Requesting newest-servable serve root: networkBest=$networkBest target=$target " +
+                  s"(margin=$HealingServeRootMarginBlocks, lastServeBlock=${lastHealingServeRootBlock.getOrElse("none")}). " +
+                  s"Routing via parent RecentRoot bootstrap."
+              )
+              syncController ! SNAPSyncController.RequestHealingServeRoot
         }
       }
 

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncMetrics.scala
@@ -263,8 +263,8 @@ object SNAPSyncMetrics extends MetricsContainer:
   // Distinguish the fixed completeness WALK root from the advancing SERVE root used to fetch missing nodes,
   // and report cross-root heals and currently-unservable tasks. These NEVER gate any consensus or completion
   // decision — pure instrumentation pushed by `TrieNodeHealingCoordinator`. The root gauges carry the leading
-  // 8 bytes of each root hash as an (unsigned-ish) long "short label" so an operator can eyeball-correlate them
-  // with the `[HEAL]` log lines (which print the first 4 bytes); 0 = not yet set / feature off.
+  // 6 bytes of each root hash as a non-negative long "short label" (always >= 0 and exactly representable as a
+  // Prometheus double) so an operator can eyeball-correlate them with the `[HEAL]` log lines; 0 = not yet set / off.
 
   /** 1 = decoupled serve-root is engaged (feature on); 0 = single-root (coupled) heal. */
   final private val HealingDecoupledEngagedGauge =

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -408,13 +408,16 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
   // T020: number of serve-root refreshes engaged this coordinator lifetime (observability only).
   private var serveRootRefreshCount: Long = 0L
 
-  /** spec 004 T019: encode the leading 8 bytes of a root hash as a numeric "short label" gauge value so an operator can
-    * eyeball-correlate the walk-root / serve-root gauges with the `[HEAL]` log lines (which print 4 bytes). This is
-    * observation-only — never read by any walk / completeness / fetch decision. Empty ⇒ 0.
+  /** spec 004 T019: encode the leading 6 bytes of a root hash as a numeric "short label" gauge value so an operator can
+    * eyeball-correlate the walk-root / serve-root gauges with the `[HEAL]` log lines. This is observation-only — never
+    * read by any walk / completeness / fetch decision. Empty ⇒ 0. Six bytes (48 bits) is deliberate: it is always
+    * non-negative and is exactly representable in a Prometheus gauge's IEEE-754 double (53-bit mantissa). Eight bytes
+    * pushed the leading byte's high bit into the Long sign (rendering a spurious negative ~-3.7e18) AND exceeded the
+    * mantissa (the displayed double no longer matched the actual bytes).
     */
   private def shortRootLabel(root: ByteString): Long =
     var acc = 0L
-    val n = root.length.min(8)
+    val n = root.length.min(6)
     var i = 0
     while i < n do
       acc = (acc << 8) | (root(i) & 0xffL)

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -83,7 +83,14 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
     decoupledHealServeRoot: Boolean = false,
     // FR-006 surfacing threshold: after this many unsatisfied attempts with no serve-root advance, surface (log +
     // metric). Never force-completes.
-    decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh
+    decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh,
+    // spec 009 (Moving-Root Delta Heal) — PLUMBING ONLY in this batch. No code reads this flag yet, so flag-ON and
+    // flag-OFF are byte-for-byte identical. Behavior (single served heal root for completeness AND fetch,
+    // seed-absent-root, re-peg, pruned completion) lands in later batches. Impl default false (bare construction stays
+    // neutral); the production default-on flows from SNAPSyncConfig via the spawn sites.
+    // @annotation.unused: this batch is plumbing-only — nothing in the impl body reads the flag yet, so the strict
+    // Scala-3 unused-param check would (correctly) reject it. Remove the annotation in the batch that wires behavior.
+    @annotation.unused movingRootDeltaHeal: Boolean = false
 ):
 
   import TrieNodeHealingCoordinator.*
@@ -2423,7 +2430,9 @@ object TrieNodeHealingCoordinator:
       // OFF to match the impl default and the spec-005 decoupling (store may be present for pruned-heal records only).
       frontierPersistenceEnabled: Boolean = false,
       decoupledHealServeRoot: Boolean = false,
-      decoupledHealMaxAttemptsNoRefresh: Int = DefaultDecoupledHealMaxAttemptsNoRefresh
+      decoupledHealMaxAttemptsNoRefresh: Int = DefaultDecoupledHealMaxAttemptsNoRefresh,
+      // spec 009 (Moving-Root Delta Heal) — plumbing only; no behavior reads it yet (see impl ctor).
+      movingRootDeltaHeal: Boolean = false
   ): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
@@ -2455,7 +2464,8 @@ object TrieNodeHealingCoordinator:
           prunedHealVerification = prunedHealVerification,
           frontierPersistenceEnabled = frontierPersistenceEnabled,
           decoupledHealServeRoot = decoupledHealServeRoot,
-          decoupledHealMaxAttemptsNoRefresh = decoupledHealMaxAttemptsNoRefresh
+          decoupledHealMaxAttemptsNoRefresh = decoupledHealMaxAttemptsNoRefresh,
+          movingRootDeltaHeal = movingRootDeltaHeal
         ).start()
       }
     }

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -1588,7 +1588,7 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
           // Inline child discovery — Besu/geth aligned scheduler approach.
           // Each healed node is decoded to find missing children; queue them directly
           // without waiting for a full 3h trie walk. Walk becomes validation-only.
-          taskByHash.get(nodeHash).foreach(task => discoverMissingChildren(nodeData, task.pathset))
+          taskByHash.get(nodeHash).foreach(task => discoverMissingChildren(nodeData, task.pathset, nodeHash))
         else
           log.debug(
             s"Healing response node not in request set (unexpected): ${Hex.toHexString(nodeHash.take(4).toArray)}"
@@ -2205,7 +2205,7 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
     * B3 FIX: branch children are checked with a single multiGetNodes call instead of up to 16 serial isNodeInStorage
     * calls on the actor thread. Extension child uses the same pattern for consistency.
     */
-  private def discoverMissingChildren(nodeData: ByteString, pathset: Seq[ByteString]): Unit =
+  private def discoverMissingChildren(nodeData: ByteString, pathset: Seq[ByteString], nodeHash: ByteString): Unit =
     import com.chipprbots.ethereum.mpt.{MptTraversals, BranchNode, ExtensionNode, HashNode, LeafNode}
     import com.chipprbots.ethereum.mpt.HexPrefix
     import com.chipprbots.ethereum.domain.Account
@@ -2286,6 +2286,45 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
             log.info(
               s"[HEAL-DISCOVER] Inline children queued: $childrenDiscoveredTotal total " +
                 s"(+${newEntries.size} from this node, pending: ${pendingTasks.size})"
+            )
+
+        // spec 005 C3b/D2/T009/T012 — heal-side subtree-complete SEED (consensus-load-bearing; the single highest
+        // chain-split risk of this port). Stage this just-healed node's OWN hash as a subtree-complete candidate IFF
+        // its subtree is durably closed by INDUCTION: every hash-referenced child is PRESENT on disk AND itself
+        // recorded subtree-complete (isSubtreeComplete). The isSubtreeComplete clause is load-bearing — mere PRESENCE is
+        // NEVER enough: a download-mosaic node can be present yet its subtree incomplete, so seeding on presence alone
+        // would write a false record → the pruned descent would skip a real hole → false completion → divergent
+        // finalized state. "present AND recorded" SUBSUMES "no missing child" and "no pending child": a still-pending /
+        // in-flight child is either absent (fails isNodeInStorage) or present-but-unrecorded (fails isSubtreeComplete).
+        // For a leaf (no hash children) the closure is VACUOUS — the inductive BASE (PrunedHealCrashSafetySpec T-3).
+        // Inline children carry NO hash references (a 32-byte hash makes a node ≥32 bytes, so it is never inlined), so
+        // direct HashNode children + the account-leaf storage root are the COMPLETE set of subtree roots under this
+        // node. Gated on prunedEnabled (else inert ⇒ OFF-path byte-identical). STAGED only — the durable record is
+        // written by writeDurableSubtreeRecords strictly AFTER mptStorage.persist() (D3 record-after-persist); a crash
+        // before the flush drops the in-memory candidate ⇒ safe descend. The `newEntries.isEmpty` pre-gate is a cheap
+        // necessary short-circuit (a found missing non-pending child means not closed); the forall over actual
+        // storage+record state is the AUTHORITATIVE gate and can never false-record regardless of pending/filter state.
+        if prunedEnabled && newEntries.isEmpty then
+          val subtreeRoots: Seq[ByteString] = decoded match
+            case branch: BranchNode =>
+              branch.children.collect { case hn: HashNode => ByteString(hn.hashNode) }.toSeq
+            case ext: ExtensionNode =>
+              ext.next match
+                case hn: HashNode => Seq(ByteString(hn.hashNode))
+                case _            => Seq.empty
+            case leaf: LeafNode if !isStorageTrie =>
+              Account(leaf.value).toOption match
+                case Some(account) if account.storageRoot != Account.EmptyStorageRootHash =>
+                  Seq(account.storageRoot.value)
+                case _ => Seq.empty
+            case _ => Seq.empty
+          val subtreeClosed =
+            subtreeRoots.forall(c => isNodeInStorage(c) && healingFrontierStorage.exists(_.isSubtreeComplete(c)))
+          if subtreeClosed then
+            pendingSubtreeRecords += nodeHash
+            log.debug(
+              s"[HEAL-VERIFY-PRUNED] Staged subtree-complete candidate ${Hex.toHexString(nodeHash.take(4).toArray)} " +
+                s"(${subtreeRoots.size} child subtree(s) present+recorded) — durable record written post-flush (D3)."
             )
       catch
         case NonFatal(e) =>

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -956,6 +956,14 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
         )
         stateRoot = newStateRoot
         flushRawNodesSync() // Flush any buffered nodes before clearing state
+        // spec 009 T010/C4 — RE-PEG-RETAINS-NODES INVARIANT (consensus-load-bearing): a re-peg MUST NOT delete any
+        // persisted trie node. Content-addressed verified nodes (keccak-keyed) carry over unchanged under the new root
+        // (~99.9% shared), so every node healed against the old root stays valid under `newStateRoot` and the
+        // post-re-peg delta only SHRINKS. The ONLY state cleared on this path is in-memory frontier (pendingTasks /
+        // pendingHashSet / activeRequests, below) plus the OPTIONAL frontier-mirror CF via clearPersistedFrontier(),
+        // which operates solely on `healingFrontierStorage` (CF 'g' — frontier mirror + completeness/subtree records)
+        // and NEVER touches the trie-node store `mptStorage`. If a future edit makes a re-peg drop trie nodes it is a
+        // consensus bug (a referenced node could go missing under the new root → false completion / import fault).
         clearPersistedFrontier() // Layer 2: old-root frontier is stale after refresh — reseed (below) repopulates it
         clearHealedPathsSet() // spec 003 C1/F5: old-root healed paths are stale — clear before next gate
         pendingTasks.clear() // Will be re-populated by root reseed + inline discovery / trie walk from controller
@@ -1019,7 +1027,14 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
       // unchanged walk root (FR-001), so byte-for-byte completion parity with the coupled path is preserved by
       // construction. No-op when the feature is disabled (the fetch would ignore `serveRoot` anyway, but skipping
       // keeps the observability/counter state inert so the OFF path is byte-identical to today, SC-006).
-      if !decoupledHealServeRoot then
+      if movingRootDeltaHeal then
+        // spec 009 T014/FR-010: under moving-root delta heal the serve root IS the walk root (the fetch collapses to
+        // `stateRoot` in requestNextBatch, T005), so the spec-004 serve-root machinery is SUPERSEDED. The controller
+        // re-pegs via HealingPivotRefreshed and stops requesting serve roots (H-S6/H-S2), but a late in-flight
+        // HealingServeRootRefresh could still arrive — treat it as a documented no-op (serveRoot / serveRootRefreshCount
+        // stay inert). Flag OFF: byte-identical to the spec-004 path below (kept one release for A/B, FR-007).
+        log.debug("[HEAL] HealingServeRootRefresh ignored — single moving root (spec 009)")
+      else if !decoupledHealServeRoot then
         log.debug("[HEAL-SERVE-ROOT] HealingServeRootRefresh ignored — decoupled-heal-serve-root disabled")
       else if newServeRoot.isEmpty || newServeRoot == serveRoot then
         // T011 U2: never adopt an empty/zero serve root; a same-root refresh is a no-op (no counter churn).

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinator.scala
@@ -84,13 +84,14 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
     // FR-006 surfacing threshold: after this many unsatisfied attempts with no serve-root advance, surface (log +
     // metric). Never force-completes.
     decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh,
-    // spec 009 (Moving-Root Delta Heal) — PLUMBING ONLY in this batch. No code reads this flag yet, so flag-ON and
-    // flag-OFF are byte-for-byte identical. Behavior (single served heal root for completeness AND fetch,
-    // seed-absent-root, re-peg, pruned completion) lands in later batches. Impl default false (bare construction stays
-    // neutral); the production default-on flows from SNAPSyncConfig via the spawn sites.
-    // @annotation.unused: this batch is plumbing-only — nothing in the impl body reads the flag yet, so the strict
-    // Scala-3 unused-param check would (correctly) reject it. Remove the annotation in the batch that wires behavior.
-    @annotation.unused movingRootDeltaHeal: Boolean = false
+    // spec 009 (Moving-Root Delta Heal). When true, the heal completes toward AND fetches against ONE current served
+    // root: requestNextBatch (T005) collapses the fetch root to the completeness root `stateRoot`, and
+    // StartTrieNodeHealing (T006) seeds an absent heal root as a frontier task and fetches it instead of handing off to
+    // lazy healing. When false, the heal uses the spec-004 walk/serve split (byte-identical to pre-spec-009). Impl
+    // default false (bare construction stays on the spec-004 path); the production default-on flows from SNAPSyncConfig
+    // via the spawn sites. The content-hash store gate and the finalizeSnapSync anchor guard are byte-untouched on BOTH
+    // paths — under the flag the gate matches BY CONSTRUCTION (fetch root == completeness root), never by weakening it.
+    movingRootDeltaHeal: Boolean = false
 ):
 
   import TrieNodeHealingCoordinator.*
@@ -713,6 +714,33 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
               // Mark the persisted frontier authoritative when the full walk is done (all workers complete).
               selfRef ! RestartFullRebuild(root, emptyPath)
         }(ec)
+      else if movingRootDeltaHeal then
+        // spec 009 T006/C2 (Moving-Root Delta Heal): the heal root node's OWN bytes are absent locally, but the root
+        // IS fetchable — GetTrieNodes(rootHash=stateRoot, paths=[[emptyPath]]) returns S's root node, whose keccak ==
+        // stateRoot, so the content-hash gate (byte-untouched) accepts it. The local mosaic is only a content-addressed
+        // CACHE that lets discovery prune already-present subtrees. SEED the root as a frontier task (empty-path) and
+        // fetch it against the single served root `stateRoot` (T005), EXACTLY as the HealingPivotRefreshed re-peg seed
+        // below already does for an absent re-pegged root — do NOT hand off to lazy healing. Persisted nodes are NOT
+        // discarded (this only ADDS the root task). `discoverMissingChildren` then drives the top-down delta from here.
+        // Start-of-heal and re-peg therefore seed an absent root IDENTICALLY (one moving-root mechanism).
+        if !pendingHashSet.contains(root) && !isNodeInStorage(root) then
+          val seedEntry = HealingEntry(Seq(emptyPath), root)
+          pendingTasks += seedEntry
+          pendingHashSet += root
+          persistFrontier(Seq(seedEntry)) // Layer 2: the absent heal root is a new frontier entry (mirror only)
+          log.info(
+            s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} absent locally — seeding it as a frontier task " +
+              s"and fetching against the single served root (spec 009 moving-root delta heal); discovery drives the " +
+              s"top-down delta from the root. NOT handing off to lazy healing."
+          )
+          tryRedispatchPendingTasks()
+        else
+          // Root became present (or already seeded) between the outer check and here — nothing to seed; let normal
+          // discovery / completion proceed (mirrors HealingPivotRefreshed's already-present branch).
+          log.info(
+            s"[HEAL] Root ${Hex.toHexString(root.take(8).toArray)} already seeded or present — no re-seed needed."
+          )
+          tryRedispatchPendingTasks()
       else
         // COMPLEMENTARY GUARD (root-cause w98gfx4wn / PR #1371 seed-guard): the walk-root node's OWN bytes are absent
         // from local storage.
@@ -1453,7 +1481,10 @@ private[actors] class TrieNodeHealingCoordinatorImpl(
       // before it is ever stored — see handleResponse (C4). The walk root used for completeness is unchanged.
       val request = GetTrieNodes(
         requestId = requestId,
-        rootHash = if decoupledHealServeRoot then serveRoot else stateRoot,
+        // spec 009 T005/C1: under `movingRootDeltaHeal` collapse the fetch root to the completeness root `stateRoot`
+        // so the content-hash gate (keccak(node) == requested task hash) matches BY CONSTRUCTION — the spec-004
+        // wrong-axis fix. Flag OFF: byte-identical to spec-004 (serve root when decoupled, else the walk root).
+        rootHash = if movingRootDeltaHeal then stateRoot else if decoupledHealServeRoot then serveRoot else stateRoot,
         paths = paths,
         responseBytes = responseBytes
       )

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -196,12 +196,18 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "run healing when deferred merkleization is OFF" taggedAs UnitTest in {
-    // The non-deferred path is unchanged: the account trie IS built locally (SnapHashTrie writes the
-    // root), so the walk root is servable and healing works. Healing must run.
-    val config = SNAPSyncConfig(deferredMerkleization = false)
+    // spec 009 T013: the non-deferred path ALWAYS runs healing (returns false). The historical rationale was FALSE —
+    // the non-deferred path writes per-task FRAGMENT roots, NOT the pivot/heal root, so that root node is typically
+    // ABSENT locally. Healing still works because under movingRootDeltaHeal the coordinator SEEDS the absent served
+    // root and FETCHES it (it does not need a local coherent root). The routing decision here is unchanged on BOTH
+    // flag states; assert both.
+    SNAPSyncController.shouldSkipHealingAfterDownloads(
+      snapSyncConfig = SNAPSyncConfig(deferredMerkleization = false, movingRootDeltaHeal = false),
+      resumedStaleCursors = false
+    ) shouldBe false
 
     SNAPSyncController.shouldSkipHealingAfterDownloads(
-      snapSyncConfig = config,
+      snapSyncConfig = SNAPSyncConfig(deferredMerkleization = false, movingRootDeltaHeal = true),
       resumedStaleCursors = false
     ) shouldBe false
   }

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealObservabilitySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/DecoupledHealObservabilitySpec.scala
@@ -46,13 +46,14 @@ class DecoupledHealObservabilitySpec
   private def getTrieNodesOf(send: NetworkPeerManagerActor.SendMessageCmd): SNAP.GetTrieNodes =
     send.message.underlyingMsg.asInstanceOf[SNAP.GetTrieNodes]
 
-  /** Mirror of `TrieNodeHealingCoordinator.shortRootLabel`: the leading (up to) 8 bytes of a root packed big-endian
+  /** Mirror of `TrieNodeHealingCoordinator.shortRootLabel`: the leading (up to) 6 bytes of a root packed big-endian
     * into a Long. Replicated here so a gauge observation can be tied to a specific, distinct root value (the gauges are
-    * global singletons; matching the exact short label proves THIS coordinator wrote it).
+    * global singletons; matching the exact short label proves THIS coordinator wrote it). Six bytes (48 bits) keeps the
+    * label non-negative and exactly representable as a Prometheus double — must stay in lockstep with production.
     */
   private def shortRootLabel(root: ByteString): Long =
     var acc = 0L
-    val n = root.length.min(8)
+    val n = root.length.min(6)
     var i = 0
     while i < n do
       acc = (acc << 8) | (root(i) & 0xffL)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/HealingTrieFixtures.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/HealingTrieFixtures.scala
@@ -82,7 +82,10 @@ object HealingTrieFixtures:
       // that exercise the Layer-2 mirror writes / completeness markers (HealingFrontierResumeSpec) set this true.
       frontierPersistenceEnabled: Boolean = false,
       decoupledHealServeRoot: Boolean = false,
-      decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh
+      decoupledHealMaxAttemptsNoRefresh: Int = TrieNodeHealingCoordinator.DefaultDecoupledHealMaxAttemptsNoRefresh,
+      // spec 009 (Moving-Root Delta Heal). Default false so existing spec-004 tests spawn the flag-OFF coordinator
+      // (unchanged); the moving-root tests pass true to exercise seed-from-absent-root / single-root fetch / re-peg.
+      movingRootDeltaHeal: Boolean = false
   )(implicit testKit: ActorTestKit): TypedActorRef[TrieNodeHealingCoordinator.Command] =
     testKit.spawn(
       TrieNodeHealingCoordinator(
@@ -111,7 +114,8 @@ object HealingTrieFixtures:
         prunedHealVerification = prunedHealVerification,
         frontierPersistenceEnabled = frontierPersistenceEnabled,
         decoupledHealServeRoot = decoupledHealServeRoot,
-        decoupledHealMaxAttemptsNoRefresh = decoupledHealMaxAttemptsNoRefresh
+        decoupledHealMaxAttemptsNoRefresh = decoupledHealMaxAttemptsNoRefresh,
+        movingRootDeltaHeal = movingRootDeltaHeal
       )
     )
 

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/MovingRootDeltaHealFixtures.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/MovingRootDeltaHealFixtures.scala
@@ -1,0 +1,183 @@
+package com.chipprbots.ethereum.blockchain.sync.snap.actors
+
+import org.apache.pekko.util.ByteString
+
+import com.chipprbots.ethereum.crypto.kec256
+import com.chipprbots.ethereum.domain.Account
+import com.chipprbots.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode, MptTraversals, NullNode}
+import com.chipprbots.ethereum.testing.TestMptStorage
+
+/** Deterministic synthetic-trie fixtures for the spec 009 Moving-Root Delta Heal tests.
+  *
+  * Unlike [[HealingTrieFixtures]] — which stores nodes object-for-object for the rebuild-WALK tests — these fixtures
+  * exercise the FETCH path: the heal seeds a frontier task, sends a `GetTrieNodes`, and `handleResponse` decodes the
+  * served RAW RLP bytes and content-verifies them (`kec256(bytes) == requested task hash`) before storing. So every
+  * served node here is returned as the exact `MptTraversals.encodeNode(node)` bytes whose `kec256` equals the hash the
+  * coordinator requests — the same shape the production peer serves.
+  *
+  * No randomness: every node derives from a fixed [[kec256]] seed string, so the same `(rootHash, deltaBytes…)` come
+  * out on every run and every host.
+  *
+  *   - [[deltaTrie]]: a small account trie whose ROOT is deliberately ABSENT locally (so the flag-ON
+  *     seed-from-absent-root path fires) with a KNOWN missing-node delta: root extension → one absent leaf child. A
+  *     peer serving the root + the child heals the entire 2-node delta and the frontier drains to empty.
+  *   - [[incompleteSubtree]]: a present interior BranchNode whose child is ABSENT — the "download-present but
+  *     subtree-incomplete" shape. Used by the completion-gate soundness test (C5): delta-discovery alone does NOT
+  *     descend into a present interior node, so the absent grandchild would be missed without the pruned descent.
+  */
+object MovingRootDeltaHealFixtures:
+
+  /** A served node: the (pathset, hash, raw-encoded-bytes) triple `handleResponse` matches on. `kec256(encoded) ==
+    * hash`, and `pathset` is the GetTrieNodes path the coordinator requests for it.
+    */
+  final case class ServedNode(pathset: Seq[ByteString], hash: ByteString, encoded: ByteString)
+
+  /** A known-delta fixture rooted at an ABSENT node.
+    *
+    * @param storage
+    *   the (empty) [[TestMptStorage]] — the root and every delta node start ABSENT, exactly the fresh-heal mosaic where
+    *   the served head-64 root was never built locally.
+    * @param rootHash
+    *   the absent heal root; `GetTrieNodes(rootHash, [[emptyPath]])` returns `rootNode.encoded`.
+    * @param rootNode
+    *   the served root node (empty-path).
+    * @param childNode
+    *   the single missing descendant discovered when the root is healed.
+    * @param deltaNodes
+    *   every node the heal must fetch to fully close the delta, in discovery order: root first, then its child.
+    */
+  final case class DeltaFixture(
+      storage: TestMptStorage,
+      rootHash: ByteString,
+      rootNode: ServedNode,
+      childNode: ServedNode,
+      deltaNodes: Seq[ServedNode]
+  ):
+
+    /** The total node count in this delta (root + descendants). Used to assert the heal requests ≈ delta, not O(total).
+      */
+    def deltaSize: Int = deltaNodes.size
+
+  private def emptyChildren: Array[MptNode] = Array.fill[MptNode](16)(NullNode)
+
+  /** The account-trie empty-path compact key (the GetTrieNodes path for a root / account-trie node seed). */
+  val emptyPath: ByteString =
+    ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array.empty[Byte], isLeaf = false))
+
+  private def served(node: MptNode, pathset: Seq[ByteString]): ServedNode =
+    val encoded = MptTraversals.encodeNode(node)
+    ServedNode(pathset, kec256(ByteString(encoded)), ByteString(encoded))
+
+  /** Build the known-delta fixture.
+    *
+    * Shape (account trie, `isStorage = false`), nothing stored locally:
+    * {{{
+    *   root (ExtensionNode, ABSENT)  sharedKey = [0x4]
+    *     └─ next → child (LeafNode, ABSENT, HashNode-referenced)
+    *   child : an EOA account leaf (storageRoot == EmptyStorageRootHash ⇒ no further children)
+    * }}}
+    *
+    * Healing the root (empty path) → `discoverMissingChildren` decodes the extension, sees its `HashNode` child is not
+    * on disk, enqueues EXACTLY ONE child task; healing that child (an empty-storage account leaf) discovers nothing →
+    * the frontier drains to empty. Total fetched = 2 nodes = the whole delta.
+    */
+  def deltaTrie(): DeltaFixture =
+    val storage = new TestMptStorage()
+
+    // The missing descendant: a normal externally-owned-account leaf with empty storage and empty code, so the
+    // account-trie discovery arm finds no storage root to seed (storageRoot == EmptyStorageRootHash) ⇒ no children.
+    // The leaf value is large enough (a 4-field account RLP, ~70+ bytes) that the leaf is HashNode-referenced (≥ 32B)
+    // by its parent rather than inline-encoded, so the extension references it by 32-byte hash exactly as production.
+    val accountLeafKey = ByteString(Array[Byte](0x0a, 0x0b, 0x0c)) // arbitrary deterministic leaf-key nibbles
+    val accountValue = ByteString(Account.empty().toBytes)
+    val childLeaf = LeafNode(accountLeafKey, accountValue)
+    val childEncoded = MptTraversals.encodeNode(childLeaf)
+    val childHash = kec256(ByteString(childEncoded))
+    // Child path: parentNibbles ([] for the empty-path root) ++ ext.sharedKey ([0x4]) ⇒ compact-encode([0x4]).
+    val childCompact = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array[Byte](0x4), isLeaf = false))
+    val childPathset = Seq(childCompact)
+    val childServed = ServedNode(childPathset, childHash, ByteString(childEncoded))
+
+    // The root is an extension referencing the child by hash. ABSENT locally.
+    val rootExt = ExtensionNode(ByteString(Array[Byte](0x4)), HashNode(childHash.toArray))
+    val rootServed = served(rootExt, Seq(emptyPath))
+
+    DeltaFixture(
+      storage = storage,
+      rootHash = rootServed.hash,
+      rootNode = rootServed,
+      childNode = childServed,
+      deltaNodes = Seq(rootServed, childServed)
+    )
+
+  /** A present-interior-node-with-absent-child fixture for the pruned-descent completion-gate test (C5).
+    *
+    * @param storage
+    *   holds the root and the present interior BranchNode, but NOT `absentGrandchildHash`.
+    * @param rootHash
+    *   the present heal root (a BranchNode → the present interior node).
+    * @param presentInteriorHash
+    *   a BranchNode present on disk whose child `absentGrandchildHash` is NOT present — the download-mosaic gap that
+    *   delta-discovery alone cannot see (it does not descend into a present interior node).
+    * @param absentGrandchildHash
+    *   the referenced-but-absent node the PRUNED DESCENT must catch.
+    * @param grandchildServed
+    *   the (path, hash, bytes) the heal fetches to CLOSE the gap once the descent has re-enqueued it. `hash ==
+    *   absentGrandchildHash` and `kec256(bytes) == hash`, so serving it passes the content gate. The grandchild is a
+    *   storage-trie leaf (no further children) so the post-heal descent is clean and completion is declared.
+    */
+  final case class IncompleteSubtreeFixture(
+      storage: TestMptStorage,
+      rootHash: ByteString,
+      presentInteriorHash: ByteString,
+      absentGrandchildHash: ByteString,
+      grandchildServed: ServedNode
+  )
+
+  /** Build the download-present-but-incomplete-subtree fixture. The root and the interior branch are stored
+    * object-for-object (the heal reads them back as present); the interior branch references a grandchild hash that is
+    * deliberately NOT stored. delta-discovery stops at the present interior node; only a descent into it finds the gap.
+    *
+    * The absent grandchild is a real LeafNode whose RLP `kec256` equals the referenced hash, so the completion-gate
+    * test can also serve it (close the gap) and confirm a later clean descent declares completion. The grandchild's
+    * served path is `[interior-slot-3-nibble]` — the HP-compact path the descent assigns when it re-enqueues slot 3 of
+    * the (empty-path) interior branch reached via root slot 0 — but the heal does not assert on the path here; the test
+    * fishes the actual re-enqueued GetTrieNodes and serves by the requested hash.
+    */
+  def incompleteSubtree(): IncompleteSubtreeFixture =
+    val storage = new TestMptStorage()
+
+    // The absent grandchild is a REAL storage-trie leaf (≥ 32B value ⇒ HashNode-referenced, served by hash). Its
+    // kec256 IS the hash the interior branch references, so the descent's re-enqueued task accepts the served bytes.
+    val grandLeaf =
+      LeafNode(
+        ByteString(Array[Byte](0x07)),
+        ByteString(kec256(ByteString("moving-root/incomplete/grandchild")).toArray)
+      )
+    val grandEncoded = MptTraversals.encodeNode(grandLeaf)
+    val absentGrandchildHash = kec256(ByteString(grandEncoded))
+
+    // A PRESENT interior branch whose slot-3 child is the absent grandchild.
+    val interiorChildren = emptyChildren
+    interiorChildren(3) = HashNode(absentGrandchildHash.toArray)
+    val interior = BranchNode(interiorChildren, None)
+    storage.putNode(interior)
+    val interiorHash = ByteString(interior.hash)
+
+    // A PRESENT root branch referencing the interior node.
+    val rootChildren = emptyChildren
+    rootChildren(0) = HashNode(interior.hash)
+    val root = BranchNode(rootChildren, None)
+    storage.putNode(root)
+
+    // Served-grandchild path: root-slot-0 → interior-slot-3 ⇒ account-trie nibbles [0x0, 0x3]. The heal fetches it by
+    // hash; the path here documents the descent's child-path arithmetic for the reader (not asserted in the test).
+    val grandCompact = ByteString(com.chipprbots.ethereum.mpt.HexPrefix.encode(Array[Byte](0x0, 0x3), isLeaf = false))
+
+    IncompleteSubtreeFixture(
+      storage = storage,
+      rootHash = ByteString(root.hash),
+      presentInteriorHash = interiorHash,
+      absentGrandchildHash = absentGrandchildHash,
+      grandchildServed = ServedNode(Seq(grandCompact), absentGrandchildHash, ByteString(grandEncoded))
+    )

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/PrunedHealCrashSafetySpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/PrunedHealCrashSafetySpec.scala
@@ -154,16 +154,13 @@ class PrunedHealCrashSafetySpec extends ScalaTestWithActorTestKit() with AnyFlat
 
   // ── T-3: record written only after the subtree's bytes are durable ──────────────────────────────
 
-  // DEFERRED to PR #1374 (spec 005 C3b — wire pendingSubtreeRecords seeding so a healed clean subtree is recorded
-  // subtree-complete). The #1373 typed rewrite dropped the C3b seeding, so the heal path currently records only the
-  // root, never an interior healed leaf; this assertion (isSubtreeComplete(leaf) == true) cannot pass until C3b is
-  // re-wired. #1374 rebuilds this coordinator and carries its own spec-005 machinery, so wiring C3b there (not here)
-  // avoids duplicate, re-ported work. Tagged DisabledTest ⇒ excluded from testEssential/testStandard until #1374.
+  // spec 005 C3b — WIRED in the #1374 typed port (batch-5). `discoverMissingChildren` now stages a just-healed node's
+  // own hash into `pendingSubtreeRecords` when its subtree is durably closed by induction (every hash child present AND
+  // itself recorded subtree-complete); the durable record is written post-`persist()` by `writeDurableSubtreeRecords`
+  // (D3 record-after-persist). A clean leaf (no children) is the vacuous inductive BASE — recorded as soon as its bytes
+  // flush — so isSubtreeComplete(leaf) is observable after completion and only ever after the bytes are durable.
   "Crash safety (T-3, FR-006)" should
-    "record a clean subtree complete only AFTER its bytes are durable — never observable before" taggedAs (
-      UnitTest,
-      DisabledTest
-    ) in {
+    "record a clean subtree complete only AFTER its bytes are durable — never observable before" taggedAs UnitTest in {
       val storage = new TestMptStorage()
       val root = storedRoot(storage)
       val (pathset, hash, encoded) = cleanLeaf(0)

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/actors/TrieNodeHealingCoordinatorSpec.scala
@@ -1,6 +1,6 @@
 package com.chipprbots.ethereum.blockchain.sync.snap.actors
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko.actor.testkit.typed.scaladsl.{FishingOutcomes, ScalaTestWithActorTestKit}
 
 import java.nio.ByteBuffer
 
@@ -1216,3 +1216,306 @@ class TrieNodeHealingCoordinatorSpec
     // The unservable handoff must NEVER fire on a present root.
     snapSyncController.expectNoMessage(300.millis)
   }
+
+  // ─── spec 009 (Moving-Root Delta Heal) flag-ON behavioral coverage ───────────────────────────────────────────────
+  //
+  // These tests spawn the coordinator with `movingRootDeltaHeal = true`. The factory/impl default is `false`, so every
+  // test ABOVE keeps exercising the spec-004 flag-OFF path unchanged (flag-OFF is byte-identical to pre-spec-009).
+
+  /** Extract the underlying `GetTrieNodes` from a captured `SendMessageCmd` (the coordinator wraps the request in a
+    * `GetTrieNodesEnc`, a `MessageSerializable`; `underlyingMsg` is the original message).
+    */
+  private def getTrieNodesOf(send: NetworkPeerManagerActor.SendMessageCmd): SNAP.GetTrieNodes =
+    send.message.underlyingMsg.asInstanceOf[SNAP.GetTrieNodes]
+
+  private def healPendingTasks(
+      coordinator: org.apache.pekko.actor.typed.ActorRef[TrieNodeHealingCoordinator.Command]
+  ): Int =
+    val probe = testKit.createTestProbe[HealingStatistics]()
+    coordinator ! TrieNodeHealingCoordinator.HealingGetProgress(probe.ref)
+    probe.expectMessageType[HealingStatistics].pendingTasks
+
+  /** True iff the node's bytes are readable from storage (the same gate the coordinator uses via `isNodeInStorage`). */
+  private def isInStorage(storage: TestMptStorage, hash: ByteString): Boolean =
+    try
+      storage.get(hash.toArray); true
+    catch case _: com.chipprbots.ethereum.mpt.MerklePatriciaTrie.MissingNodeException => false
+
+  "Moving-root delta heal (spec 009 US2, C1)" should
+    "store served root + internal nodes when the fetch root == heal root (content gate matches by construction)" taggedAs UnitTest in {
+      // C1 (the spec-004 wrong-axis fix): under the flag the GetTrieNodes fetch root is collapsed to the completeness
+      // root `stateRoot`, so a peer serving that exact root returns nodes whose keccak == the requested task hash → the
+      // content-hash gate (byte-untouched) ACCEPTS and persists them. No "non-matching hash" drops. We drive the full
+      // 2-node delta to completion and assert both served nodes were accepted by the gate (via ProgressNodesHealed).
+      val fx = MovingRootDeltaHealFixtures.deltaTrie()
+      val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+      val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+      val coordinator = HealingTrieFixtures.spawnCoordinator(
+        stateRoot = fx.rootHash,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+        mptStorage = fx.storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(classicSystem.dispatcher),
+        movingRootDeltaHeal = true
+      )
+
+      // Heal start: absent root ⇒ seed-from-absent-root (C2) enqueues the root and a peer makes it dispatch.
+      coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(fx.rootHash)
+      val peerProbe = testKit.createTestProbe[NetworkPeerManagerActor.SendMessageCmd]()
+      val peer = PeerTestHelpers.createTestPeer("md-c1-peer", peerProbe.ref.toClassic)
+      coordinator ! TrieNodeHealingCoordinator.HealingPeerAvailable(peer)
+
+      // First request fetches the root (empty-path) against the heal root.
+      val send1 = networkPeerManager.expectMessageType[NetworkPeerManagerActor.SendMessageCmd](3.seconds)
+      val req1 = getTrieNodesOf(send1)
+      req1.rootHash shouldBe fx.rootHash // fetch root == heal root (C1)
+      coordinator ! TrieNodeHealingCoordinator.TrieNodesResponseMsg(
+        SNAP.TrieNodes(requestId = req1.requestId, nodes = Seq(fx.rootNode.encoded))
+      )
+
+      // The root passed the content gate — the controller is told ≥ 1 node healed (NOT dropped). Sum healed-progress
+      // across the drain (the gate-acceptance signal, deterministic; the async durable flush is racy under suite load).
+      var healedTotal = 0L
+      snapSyncController.fishForMessage(3.seconds) {
+        case SNAPSyncController.ProgressNodesHealed(c) =>
+          healedTotal += c
+          if healedTotal >= 1L then FishingOutcomes.complete else FishingOutcomes.continue
+        case _ => FishingOutcomes.continueAndIgnore
+      }
+
+      // Second request fetches the discovered child, again against the heal root.
+      val send2 = networkPeerManager.expectMessageType[NetworkPeerManagerActor.SendMessageCmd](3.seconds)
+      val req2 = getTrieNodesOf(send2)
+      req2.rootHash shouldBe fx.rootHash
+      coordinator ! TrieNodeHealingCoordinator.TrieNodesResponseMsg(
+        SNAP.TrieNodes(requestId = req2.requestId, nodes = Seq(fx.childNode.encoded))
+      )
+
+      // The child also passed the content gate — total healed reaches the full 2-node delta with NO drops.
+      snapSyncController.fishForMessage(3.seconds) {
+        case SNAPSyncController.ProgressNodesHealed(c) =>
+          healedTotal += c
+          if healedTotal >= 2L then FishingOutcomes.complete else FishingOutcomes.continue
+        case _ => FishingOutcomes.continueAndIgnore
+      }
+      healedTotal shouldBe 2L // both served nodes accepted by the content-hash gate (fetch root == heal root, C1)
+    }
+
+  "Moving-root delta heal (spec 009 US2, C2)" should
+    "fetch an absent heal root (NOT hand off HealingRootUnservable) and seed the frontier" taggedAs UnitTest in {
+      // C2: under the flag an absent heal root is SEEDED as a frontier task (empty-path) and fetched against the single
+      // served root — NOT handed off to lazy healing. This is the same seed HealingPivotRefreshed performs.
+      val fx = MovingRootDeltaHealFixtures.deltaTrie()
+      val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+      val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+      val coordinator = HealingTrieFixtures.spawnCoordinator(
+        stateRoot = fx.rootHash,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+        mptStorage = fx.storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(classicSystem.dispatcher),
+        movingRootDeltaHeal = true
+      )
+
+      coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(fx.rootHash)
+
+      // The root was SEEDED (frontier == 1), NOT handed off.
+      eventually(timeout(5.seconds), interval(100.millis))(healPendingTasks(coordinator) shouldBe 1)
+      // The default unservable handoff must NOT fire under the flag.
+      snapSyncController.expectNoMessage(300.millis)
+
+      // With a peer, the seeded root is fetched (empty-path GetTrieNodes carrying the heal root).
+      val peerProbe = testKit.createTestProbe[NetworkPeerManagerActor.SendMessageCmd]()
+      val peer = PeerTestHelpers.createTestPeer("md-c2-peer", peerProbe.ref.toClassic)
+      coordinator ! TrieNodeHealingCoordinator.HealingPeerAvailable(peer)
+      val send = networkPeerManager.expectMessageType[NetworkPeerManagerActor.SendMessageCmd](3.seconds)
+      val req = getTrieNodesOf(send)
+      req.rootHash shouldBe fx.rootHash
+      req.paths.head shouldBe Seq(MovingRootDeltaHealFixtures.emptyPath) // empty-path root seed
+    }
+
+  "Moving-root delta heal (spec 009 US3, C4 re-peg retains nodes)" should
+    "preserve persisted verified nodes across HealingPivotRefreshed and not grow the frontier" taggedAs UnitTest in {
+      // C4: heal the root against root A so it is durably persisted, then re-peg to a different root. HealingPivotRefreshed
+      // clears ONLY in-memory frontier — it MUST NOT delete trie nodes. Assert the healed root is STILL readable from
+      // storage after the re-peg, and the post-re-peg pending count ≤ pre + the one new-root seed.
+      val fx = MovingRootDeltaHealFixtures.deltaTrie()
+      val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+      val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+      val coordinator = HealingTrieFixtures.spawnCoordinator(
+        stateRoot = fx.rootHash,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+        mptStorage = fx.storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(classicSystem.dispatcher),
+        movingRootDeltaHeal = true
+      )
+
+      coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(fx.rootHash)
+      val peerProbe = testKit.createTestProbe[NetworkPeerManagerActor.SendMessageCmd]()
+      val peer = PeerTestHelpers.createTestPeer("md-c4-peer", peerProbe.ref.toClassic)
+      coordinator ! TrieNodeHealingCoordinator.HealingPeerAvailable(peer)
+
+      // Serve the root — it passes the content gate (acceptance via ProgressNodesHealed) and the flush makes it durable.
+      val send1 = networkPeerManager.expectMessageType[NetworkPeerManagerActor.SendMessageCmd](3.seconds)
+      val req1 = getTrieNodesOf(send1)
+      coordinator ! TrieNodeHealingCoordinator.TrieNodesResponseMsg(
+        SNAP.TrieNodes(requestId = req1.requestId, nodes = Seq(fx.rootNode.encoded))
+      )
+      snapSyncController.fishForMessage(3.seconds) {
+        case SNAPSyncController.ProgressNodesHealed(c) =>
+          if c >= 1L then FishingOutcomes.complete else FishingOutcomes.continueAndIgnore
+        case _ => FishingOutcomes.continueAndIgnore
+      }
+      // The root is durably in storage before the re-peg (the node whose survival we assert).
+      eventually(timeout(5.seconds), interval(100.millis))(isInStorage(fx.storage, fx.rootHash) shouldBe true)
+
+      // Re-peg to a DIFFERENT root (distinct from fx.rootHash) — the production stale-move signal.
+      val newRoot = kec256(ByteString("md-c4-repeg-new-root"))
+      newRoot should not be fx.rootHash
+      coordinator ! TrieNodeHealingCoordinator.HealingPivotRefreshed(newRoot)
+
+      // INVARIANT (T010/C4): the re-peg cleared in-memory frontier + the optional mirror CF, but DID NOT delete any
+      // persisted trie node. The previously-healed ROOT node remains readable — content-addressed, reusable under newRoot.
+      eventually(timeout(5.seconds), interval(100.millis))(isInStorage(fx.storage, fx.rootHash) shouldBe true)
+      isInStorage(fx.storage, fx.rootHash) shouldBe true // still present after the re-peg settles
+      // Post-re-peg the frontier is at most the (absent) new-root seed (≤ 1) — no re-download of the completed subtree.
+      healPendingTasks(coordinator) should be <= 1
+    }
+
+  "Moving-root delta heal (spec 009 US3, C5 sound completion)" should
+    "NOT complete on delta-discovery alone when a present node has an absent child — only after the gap is healed" taggedAs UnitTest in {
+      // C5 (THE consensus invariant): the download mosaic can leave a PRESENT interior node whose grandchild is ABSENT.
+      // Pure delta-discovery does not descend into a present node, so it would declare pending==0 with a real hole — a
+      // false completion. The PRUNED DESCENT (the rebuild/verification BFS, with NO subtree-complete records so nothing
+      // is pruned) DECODES the present interior node and emits the absent grandchild as a frontier entry, so isComplete
+      // stays false and StateHealingComplete is WITHHELD until the gap is healed and a clean descent passes.
+      val fx = MovingRootDeltaHealFixtures.incompleteSubtree()
+      val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+      val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+      val coordinator = HealingTrieFixtures.spawnCoordinator(
+        stateRoot = fx.rootHash,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+        mptStorage = fx.storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(classicSystem.dispatcher),
+        movingRootDeltaHeal = true
+      )
+
+      // Sanity: the descent target is genuinely a download-mosaic gap — interior present, grandchild absent.
+      isInStorage(fx.storage, fx.presentInteriorHash) shouldBe true
+      isInStorage(fx.storage, fx.absentGrandchildHash) shouldBe false
+
+      // Root is PRESENT ⇒ StartTrieNodeHealing runs the descent (rebuild BFS), which descends into the present interior
+      // node and finds the absent grandchild → enqueues it.
+      coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(fx.rootHash)
+
+      // The descent re-enqueued the absent grandchild: pending becomes ≥ 1 and completion is NOT declared.
+      eventually(timeout(5.seconds), interval(100.millis))(healPendingTasks(coordinator) should be >= 1)
+      // No StateHealingComplete is sent while the gap is open — delta-discovery alone does NOT close it.
+      snapSyncController.expectNoMessage(500.millis)
+      healPendingTasks(coordinator) should be >= 1
+
+      // Now heal the gap: a peer arrives, the seeded grandchild is fetched, and we serve its bytes (kec256 matches).
+      val peerProbe = testKit.createTestProbe[NetworkPeerManagerActor.SendMessageCmd]()
+      val peer = PeerTestHelpers.createTestPeer("md-c5-peer", peerProbe.ref.toClassic)
+      coordinator ! TrieNodeHealingCoordinator.HealingPeerAvailable(peer)
+      val send = networkPeerManager.expectMessageType[NetworkPeerManagerActor.SendMessageCmd](3.seconds)
+      val req = getTrieNodesOf(send)
+      req.rootHash shouldBe fx.rootHash // fetch root == heal root (single root)
+      coordinator ! TrieNodeHealingCoordinator.TrieNodesResponseMsg(
+        SNAP.TrieNodes(requestId = req.requestId, nodes = Seq(fx.grandchildServed.encoded))
+      )
+
+      // The grandchild is now present; a later clean descent finds zero absent and completion IS declared.
+      eventually(timeout(5.seconds), interval(100.millis))(
+        isInStorage(fx.storage, fx.absentGrandchildHash) shouldBe true
+      )
+      snapSyncController.fishForMessage(10.seconds) {
+        case SNAPSyncController.StateHealingComplete   => FishingOutcomes.complete
+        case _: SNAPSyncController.ProgressNodesHealed => FishingOutcomes.continueAndIgnore
+        case _                                         => FishingOutcomes.continueAndIgnore
+      }
+    }
+
+  "Moving-root delta heal (spec 009 US1, T016b flag-OFF byte-unchanged)" should
+    "take the spec-004 HealingRootUnservable handoff for an absent root when the flag is OFF" taggedAs UnitTest in {
+      // T016b: flag OFF ⇒ the legacy spec-004 decoupled path is byte-unchanged. An absent heal root is NOT seeded; the
+      // coordinator signals HealingRootUnservable (the spec-004 lazy-heal handoff) exactly as before spec 009. This is
+      // the direct A/B contrast to the flag-ON C2 test (which SEEDS the same absent root instead) — the single fork.
+      val fx = MovingRootDeltaHealFixtures.deltaTrie() // same absent-root fixture as the flag-ON C2 test
+      val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+      val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+      val coordinator = HealingTrieFixtures.spawnCoordinator(
+        stateRoot = fx.rootHash,
+        networkPeerManager = networkPeerManager.ref,
+        requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+        mptStorage = fx.storage,
+        batchSize = 16,
+        snapSyncController = snapSyncController.ref,
+        healingWriterEcOverride = Some(classicSystem.dispatcher),
+        movingRootDeltaHeal = false // flag OFF — spec-004 path
+      )
+
+      coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(fx.rootHash)
+
+      // Flag OFF: the absent root is NOT seeded — the spec-004 handoff fires (byte-identical to pre-spec-009).
+      snapSyncController.expectMessage(3.seconds, SNAPSyncController.HealingRootUnservable(fx.rootHash))
+      // And no frontier task was seeded (the seed-from-absent-root behavior is gated entirely behind the flag).
+      healPendingTasks(coordinator) shouldBe 0
+    }
+
+  "Moving-root delta heal (spec 009 US1, T016c A/B parity)" should
+    "reach completion against the SAME root under flag OFF and flag ON for an already-complete trie (no divergent root)" taggedAs UnitTest in {
+      // T016c (SC-005 unit proxy): for a controlled fixture whose trie is already fully present locally (root present,
+      // zero missing nodes), BOTH the flag-OFF (spec-004) and the flag-ON (moving-root) paths run the SAME pruned
+      // descent from the SAME present root, find zero absent, and declare StateHealingComplete against that one root —
+      // identical outcome, no divergent finalized root. The present-and-complete trie removes the absent-root fork
+      // (where the two paths legitimately differ — seed vs handoff) and isolates the shared completion gate.
+      def runAlreadyCompleteHeal(flag: Boolean): Unit =
+        // A minimal already-complete trie: a single account leaf IS the root (no children), present on disk.
+        val storage = new TestMptStorage()
+        val leaf =
+          com.chipprbots.ethereum.mpt.LeafNode(
+            ByteString(Array[Byte](0x0a, 0x0b, 0x0c)),
+            ByteString(com.chipprbots.ethereum.domain.Account.empty().toBytes)
+          )
+        storage.putNode(leaf)
+        val rootHash = ByteString(leaf.hash)
+
+        val networkPeerManager = testKit.createTestProbe[NetworkPeerManagerActor.Command]()
+        val snapSyncController = testKit.createTestProbe[SNAPSyncController.Command]()
+        val coordinator = HealingTrieFixtures.spawnCoordinator(
+          stateRoot = rootHash,
+          networkPeerManager = networkPeerManager.ref,
+          requestTracker = new SNAPRequestTracker()(classicSystem.scheduler),
+          mptStorage = storage,
+          batchSize = 16,
+          snapSyncController = snapSyncController.ref,
+          healingWriterEcOverride = Some(classicSystem.dispatcher),
+          movingRootDeltaHeal = flag
+        )
+
+        coordinator ! TrieNodeHealingCoordinator.StartTrieNodeHealing(rootHash)
+        coordinator ! TrieNodeHealingCoordinator.HealingCheckCompletion
+
+        // Both paths: the present root + empty delta ⇒ a clean pruned descent ⇒ completion against THIS root.
+        snapSyncController.fishForMessage(10.seconds) {
+          case SNAPSyncController.StateHealingComplete   => FishingOutcomes.complete
+          case _: SNAPSyncController.ProgressNodesHealed => FishingOutcomes.continueAndIgnore
+          case _                                         => FishingOutcomes.continueAndIgnore
+        }
+        // The root the heal completed against is unchanged — no re-peg, no divergent finalized root.
+        isInStorage(storage, rootHash) shouldBe true
+
+      runAlreadyCompleteHeal(flag = false) // spec-004 path completes against the present root
+      runAlreadyCompleteHeal(flag = true) // moving-root path completes against the SAME present root — parity
+    }


### PR DESCRIPTION
## Moving-root delta heal — typed-base port of #1374 (spec 009)

Typed-base port of the closed **#1374** (moving-root delta heal, spec 009) — the absent-root / wedge fix that lets a **fresh ETC SNAP sync complete against core-geth** instead of stalling at the advancing-pivot absent-root wall. #1374 (classic, untyped) is closed as superseded by this typed implementation.

**#1380 has merged to staging** — this PR now targets `staging` directly (rebased; the diff is the 8 moving-root commits on top of `chore: bump version to 0.7.30`).

### Validated LIVE on the working image ✅

Built `chipprbots/fukuii:moving-root-1374` from this branch and ran it on barad-dûr:

- **Fresh Mordor SNAP completed end-to-end in ~24 min** (wiped rocksdb → at head). Seed-absent-root fired (`[HEAL] Root …absent locally — seeding…fetching against the single served root (spec 009)…NOT handing off to lazy healing`); heal converged (`HEAL-BFS 4,549,604 nodes / 16 levels, 0 missing`); **C3b** `HEAL-VERIFY-PRUNED 161,312 subtrees pruned (descend-and-stop), zero missing → declaring completion`; `finalizeSnapSync` anchored at pivot; `RegularSync [COMPLETE ✓]`, `eth_syncing=false`.
- **ETC mainnet heal running** with the moving-root re-peg engaged (`pivot refreshed … Re-seeded with new root … for inline discovery of pivot delta`).

### Mechanism (FR-gated, flag `moving-root-delta-heal`, default `true`)

- **Single moving heal root** — collapse the walk-root / fetch-root split (supersedes spec-004).
- **Seed-absent-root** (T006) — fetch an absent heal root via empty-path `GetTrieNodes` instead of the `HealingRootUnservable` handoff. The **#1371 seed-guard is combined, not reverted**: flag-ON adds a seed middle-arm; the handoff stays as the flag-OFF / rollback `else` (FR-007).
- **Re-peg** (T009) — re-peg the single root in lockstep via `refreshPivotInPlace` → `HealingPivotRefreshed` when it goes stale.
- **Bounded last-resort** (T014) — `MaxHealRepegNoRootAttempts = 10`; never fail-open (anchor guard still gates).
- **C3b** — heal-side subtree-complete seed (inductive; leaf = vacuous base). Independently adversarially verified **sound**.

### Consensus safety

- Content-hash store gate and `finalizeSnapSync` anchor guard **byte-untouched**. All flag-OFF paths byte-identical (rollback path, FR-007).

### Validation (unit)

- `compile-all` green · 141/141 heal + pruned specs · `scalafmtAll` clean · consensus-determinism gate `testCrypto` 4/4 + `testMPT` 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)