### PR TITLE
fix(snap): restore the complete fresh-node Mordor SNAP regression set (#1384 stale-base clobber)

### DIFF
--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -1869,7 +1869,6 @@ private class SNAPSyncControllerImpl(
     then
       if SNAPSyncController.shouldSkipHealingAfterDownloads(
           snapSyncConfig,
-          storagePhaseForceCompleted,
           resumedStaleCursors
         )
       then
@@ -3509,7 +3508,11 @@ private class SNAPSyncControllerImpl(
     * the node's existing RocksDB DataSource (via `flatSlotStorage`); the CF auto-creates on open.
     */
   private lazy val healingFrontierStorageOpt: Option[HealingFrontierStorage] =
-    if snapSyncConfig.healingFrontierPersistence then Some(new HealingFrontierStorage(flatSlotStorage.dataSource))
+    // #4 (restored, spec-005): the pruned post-heal verification also needs the frontier store
+    // (prunedHealVerification default true) — without it the first verification reverts to a full
+    // ~90M-node trie walk. Dropped by #1384's stale base.
+    if snapSyncConfig.healingFrontierPersistence || snapSyncConfig.prunedHealVerification then
+      Some(new HealingFrontierStorage(flatSlotStorage.dataSource))
     else None
 
   private lazy val bfsQueueStorage: BfsQueueStorage =
@@ -3545,6 +3548,9 @@ private class SNAPSyncControllerImpl(
                   concurrency = snapSyncConfig.healingConcurrency,
                   visitedCap = snapSyncConfig.healingVisitedCap,
                   healingFrontierStorage = healingFrontierStorageOpt,
+                  // #1319/spec-002 (restored): gate the coordinator's frontier-mirror writes +
+                  // completeness markers ON, matching store presence (dropped by #1384's stale base).
+                  frontierPersistenceEnabled = snapSyncConfig.healingFrontierPersistence,
                   traversalParallelism = snapSyncConfig.healingTraversalParallelism,
                   healingMinParallelism = snapSyncConfig.healingMinParallelism,
                   healingReservedCores = snapSyncConfig.healingReservedCores,
@@ -3620,6 +3626,9 @@ private class SNAPSyncControllerImpl(
                     concurrency = snapSyncConfig.healingConcurrency,
                     visitedCap = snapSyncConfig.healingVisitedCap,
                     healingFrontierStorage = healingFrontierStorageOpt,
+                    // #1319/spec-002 (restored): gate frontier-mirror writes + completeness markers
+                    // ON, matching store presence (dropped by #1384's stale base).
+                    frontierPersistenceEnabled = snapSyncConfig.healingFrontierPersistence,
                     traversalParallelism = snapSyncConfig.healingTraversalParallelism,
                     healingMinParallelism = snapSyncConfig.healingMinParallelism,
                     healingReservedCores = snapSyncConfig.healingReservedCores,
@@ -5044,7 +5053,6 @@ object SNAPSyncController:
 
   private[snap] def shouldSkipHealingAfterDownloads(
       snapSyncConfig: SNAPSyncConfig,
-      storagePhaseForceCompleted: Boolean,
       resumedStaleCursors: Boolean
   ): Boolean =
     // The deferred-merkleization fast path (skip healing, lazy-heal during block execution) is
@@ -5052,7 +5060,11 @@ object SNAPSyncController:
     // resumed from a prior session (against a possibly drifted root), the delta MUST be walked
     // and re-fetched from the current pivot root before completion — otherwise the state is
     // handed off with silent holes. So a resume forces the full healing walk.
-    snapSyncConfig.deferredMerkleization && !storagePhaseForceCompleted && !resumedStaleCursors
+    // #1371 (restored — #1384's stale base re-added the `!storagePhaseForceCompleted` term, which
+    // routed force-completed deferred-merkleization back into the full heal walk → the
+    // "exactly 1 node, healed=0 forever" stall). Force-completion does not invalidate the
+    // freshly-built trie; only a resumed stale cursor does.
+    snapSyncConfig.deferredMerkleization && !resumedStaleCursors
 
   /** Freshness gate for `refreshPivotInPlace`: reject candidate pivots whose source peer is more than `maxStaleness`
     * blocks behind the CL-driven head.
@@ -5120,7 +5132,10 @@ object SNAPSyncController:
           blacklist,
           syncController,
           validatorFactory
-        ).startSnapSync()
+        ).start() // #1378: start() arms the 5s PollHandshakedPeers timer that populates the
+      //          controller's peerListHelper. Calling startSnapSync() directly bypasses it,
+      //          leaving snapPeersForPivot permanently empty → pivot never selected →
+      //          FallbackToFastSync loop. Reverted by #1384's stale-base clobber; restored.
       }
     }
 
@@ -5147,6 +5162,7 @@ case class SNAPSyncConfig(
     // Layer 2: persist the outstanding healing frontier so a restart resumes (O(frontier)) instead of
     // re-walking the full state. Default false (ships dark). See docs/design/healing-frontier-scale.md.
     healingFrontierPersistence: Boolean = false,
+    prunedHealVerification: Boolean = true, // #4 (restored): pruned post-heal verification vs full ~90M-node walk
     // Operator ceiling for BFS level parallelism. Effective =
     // min(this, min(nproc, max(healingMinParallelism, nproc - healingReservedCores))).
     healingTraversalParallelism: Int = actors.TrieNodeHealingCoordinator.DefaultBfsParallelism,
@@ -5287,6 +5303,9 @@ object SNAPSyncConfig:
         else actors.TrieNodeHealingCoordinator.DefaultVisitedCap,
       healingFrontierPersistence = snapConfig.hasPath("healing-frontier-persistence") &&
         snapConfig.getBoolean("healing-frontier-persistence"),
+      prunedHealVerification =
+        if snapConfig.hasPath("pruned-heal-verification") then snapConfig.getBoolean("pruned-heal-verification")
+        else true,
       healingTraversalParallelism =
         if snapConfig.hasPath("healing-traversal-parallelism") then snapConfig.getInt("healing-traversal-parallelism")
         else actors.TrieNodeHealingCoordinator.DefaultBfsParallelism,

--- a/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
+++ b/src/main/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncController.scala
@@ -5133,9 +5133,9 @@ object SNAPSyncController:
           syncController,
           validatorFactory
         ).start() // #1378: start() arms the 5s PollHandshakedPeers timer that populates the
-      //          controller's peerListHelper. Calling startSnapSync() directly bypasses it,
-      //          leaving snapPeersForPivot permanently empty → pivot never selected →
-      //          FallbackToFastSync loop. Reverted by #1384's stale-base clobber; restored.
+        //          controller's peerListHelper. Calling startSnapSync() directly bypasses it,
+        //          leaving snapPeersForPivot permanently empty → pivot never selected →
+        //          FallbackToFastSync loop. Reverted by #1384's stale-base clobber; restored.
       }
     }
 

--- a/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
+++ b/src/main/scala/com/chipprbots/ethereum/network/NetworkPeerManagerActor.scala
@@ -640,7 +640,15 @@ object NetworkPeerManagerActor:
             reader.getChainWeightByHash(ourBest.header.hash).foreach { ourWeight =>
               if peerTD > ourWeight.totalDifficulty.value then
                 val ratio = peerTD / ourWeight.totalDifficulty.value
-                if ratio > BigInt(10_000) then
+                // FRESH-NODE EXEMPTION (#1367, restored 2026-06-30 — dropped during the Scala-3
+                // refactors #1373/#1378/#1384). TD-PROXY-GAP must NOT fire when our best block is at
+                // genesis (number == 0). On a freshly-wiped node the genesis TD is the real chain
+                // difficulty, not a stale proxy, so the ratio vs a real peer's cumulative TD always
+                // exceeds 10K. Firing the eviction disconnects + 5-min-blacklists every legitimate
+                // SNAP peer before the eager best-block probe runs → maxBlockNumber=0 everywhere →
+                // pivot=0 forever. TD-PROXY-GAP is only meaningful past genesis (post-SNAP genesis-
+                // proxy TD on a high best block). `number.value > 0` is the minimal, unambiguous guard.
+                if ratio > BigInt(10_000) && ourBest.header.number.value > 0 then
                   // TD-PROXY-GAP: stored TD is a genesis proxy from SNAP finalization.
                   chainWeightCalibrationTarget.foreach { target =>
                     target ! com.chipprbots.ethereum.blockchain.sync.SyncProtocol

--- a/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
+++ b/src/test/scala/com/chipprbots/ethereum/blockchain/sync/snap/SNAPSyncControllerSpec.scala
@@ -180,7 +180,6 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers:
 
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = config,
-      storagePhaseForceCompleted = false,
       resumedStaleCursors = false
     ) shouldBe true
   }
@@ -196,7 +195,6 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers:
     // force-completed flag is therefore no longer a routing input (the caller keeps it for logging).
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = config,
-      storagePhaseForceCompleted = false,
       resumedStaleCursors = false
     ) shouldBe true
   }
@@ -209,13 +207,11 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers:
     // flag states; assert both.
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = SNAPSyncConfig(deferredMerkleization = false, movingRootDeltaHeal = false),
-      storagePhaseForceCompleted = false,
       resumedStaleCursors = false
     ) shouldBe false
 
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = SNAPSyncConfig(deferredMerkleization = false, movingRootDeltaHeal = true),
-      storagePhaseForceCompleted = false,
       resumedStaleCursors = false
     ) shouldBe false
   }
@@ -228,7 +224,6 @@ class SNAPSyncControllerSpec extends AnyFlatSpec with Matchers:
     // silent state corruption. The healing walk from the new root re-fetches the delta.
     SNAPSyncController.shouldSkipHealingAfterDownloads(
       snapSyncConfig = config,
-      storagePhaseForceCompleted = false,
       resumedStaleCursors = true
     ) shouldBe false
   }

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.7.42"
+(ThisBuild / version) := "0.7.43"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.7.44"
+(ThisBuild / version) := "0.7.45"

--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.7.43"
+(ThisBuild / version) := "0.7.44"


### PR DESCRIPTION
**Complete restore of the fresh-node ETC/Mordor SNAP regression that #1384 introduced.** #1384 (opaque-type PR) not only dropped the #1367 TD-PROXY-GAP guard but **reset `SNAPSyncController.scala` to a months-old base** (pre-#1378/#1319/#1371/spec-005), silently reverting five hardening fixes at once. A fresh ETC/Mordor node on 0.8.0 could not sync (fast sync is non-viable, no checkpoint exists until SNAP works).

**Live-validated:** a fresh wiped-rocksdb Mordor secondary on this build selects pivot **16,470,909** and downloads accounts at **~8,240/s** (235K of 2.7M in the first minute) — vs. the broken build, which retained 0 peers / picked no pivot / fell back to fast sync.

Restored fixes:
1. **#1367** — `&& ourBest.header.number.value > 0` on the TD-PROXY-GAP eviction (fresh genesis node stops evicting its own SNAP peers). *Retains the 10 peers.*
2. **#1378 (THE pivot blocker)** — `apply()` calls `.start()` not `.startSnapSync()`; `.start()` arms the 5s peer-poll timer that populates the controller's `peerListHelper`. Without it, `snapPeersForPivot` was permanently empty (`handshakedPeers=0` while the network held 10) → pivot never selected → `FallbackToFastSync` loop.
3. **#1319/spec-002** — re-wire `frontierPersistenceEnabled = healingFrontierPersistence` at both `TrieNodeHealingCoordinator` sites (frontier-mirror writes + completeness markers were defaulting OFF).
4. **spec-005** — restore `prunedHealVerification` (field default true + parsing + the `|| prunedHealVerification` term) — else first post-heal verification = full ~90M-node walk.
5. **#1371** — drop the stale-base `!storagePhaseForceCompleted` term in `shouldSkipHealingAfterDownloads` (the "1 node healed=0 forever" stall).

forge verified the dropped-fix set against the last-known-good Mordor-SNAP commit (#1381). Restores prior behavior; ships in 0.8.0 (pre-version-bump) as the user requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)