### PR TITLE
chore: bump version to 0.8.0 (release)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // - Increment by 0.1.0 at each milestone
 // - Version 1.0.0 at project completion
 
-(ThisBuild / version) := "0.7.45"
+(ThisBuild / version) := "0.8.0"


### PR DESCRIPTION
Milestone version bump `0.7.x` → **0.8.0** for the v0.8.0 release.

## What 0.8.0 ships
- Opaque-type chain refactor (#1384) + its 6 regression fixes (toHexString recursion, KZG trusted-setup restore, treasury OLYMPIA-SAFETY guard, frontier flag).
- EIP-1559 base-fee serve fix (`.max(1)` on the increase branch only) + run/sync sync-server fixes.
- Complete fresh-node SNAP regression restore (#1385) — pivot bootstrap, frontier persistence, pruned-heal verification.

## Validation
Fresh wiped-rocksdb **Mordor SNAP synced end-to-end to chain head**: pivot → 100% download (2.71M accounts) → verification walk → heal closed → at head, stable.

## ⚠️ Merge order
**Merge #1385 (SNAP fix, staging→main) FIRST.** #1385 also touches `version.sbt` (auto-bump 0.7.42→0.7.43); this branch will be rebased onto the post-#1385 main (taking 0.8.0) before it goes ready, so the version does not regress. Kept as **draft** until then.

After merge, fire the release via `release.yml` `workflow_dispatch` (version `0.8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)