### PR TITLE
fix(ci): docs-link-check.yml lychee arg + fork-guard, stale ci.yml labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test and Build (JDK 25, Scala 3.3.7)
+    name: Test and Build (JDK 25, Scala 3.3.8)
     # Skip pure version-bump pushes (auto-version) — the merge that caused the bump already
     # ran full CI. pull_request events are unaffected (head_commit is empty there).
     if: >-
@@ -196,7 +196,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: coverage-reports-jdk25-scala-3.3.7
+          name: coverage-reports-jdk25-scala-3.3.8
           path: |
             **/target/scala-*/scoverage-report/**
             **/target/scala-*/scoverage-data/**
@@ -217,7 +217,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-results-jdk25-scala-3.3.7
+          name: test-results-jdk25-scala-3.3.8
           path: |
             **/target/test-reports/**
             **/target/scala-*/test-classes/**/*.log
@@ -229,7 +229,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ethereum-tests-results-jdk25-scala-3.3.7
+          name: ethereum-tests-results-jdk25-scala-3.3.8
           path: |
             **/target/scala-*/it-classes/**/*.log
             /tmp/fukuii-it-test/**/*.log
@@ -239,7 +239,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: fukuii-distribution-jdk25-scala-3.3.7
+          name: fukuii-distribution-jdk25-scala-3.3.8
           path: |
             target/universal/*.zip
             **/target/scala-*/*-assembly-*.jar

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -45,7 +45,6 @@ jobs:
             --verbose
             --no-progress
             --accept 200,204
-            --exclude-mail
             --exclude 'localhost'
             --exclude '127.0.0.1'
             --exclude 'github.com/.*/edit/'
@@ -65,7 +64,9 @@ jobs:
             automated
 
       - name: Comment on PR
-        if: steps.lychee.outcome == 'failure' && github.event_name == 'pull_request'
+        # Skip on fork PRs — posting a comment needs a write token forks don't get
+        # (same fork-guard autofix.yml and pr-management.yml already use).
+        if: steps.lychee.outcome == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -67,6 +67,12 @@ jobs:
         run: mkdocs build --strict
 
       - name: Deploy Preview
+        # Skip on fork PRs — pushing the preview to gh-pages needs a write token forks
+        # don't get (default GITHUB_TOKEN is read-only there; no `permissions:` block
+        # can override that platform-level restriction). Same fork-guard autofix.yml/
+        # pr-management.yml/docs-link-check.yml already use. `mkdocs build --strict`
+        # above still runs unconditionally and is the real correctness gate.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./site/


### PR DESCRIPTION
## Summary

`docs-link-check.yml` fails on essentially every fork PR that touches `docs/**`, independent of what the PR actually changes:

- `lycheeverse/lychee-action@v2` (a floating major-version tag) currently resolves to a lychee CLI release that removed the `--exclude-mail` flag this workflow hardcodes in its `args:` block — the Link Checker step errors out before checking a single real link. Dropped the flag; mail addresses are excluded by default in current lychee releases.
- The "Comment on PR" step's `if:` was missing the fork-guard every sibling workflow (`autofix.yml`, `pr-management.yml`) already uses (`github.event.pull_request.head.repo.full_name == github.repository`). On a fork PR this tries to post a comment with a read-only `GITHUB_TOKEN` and 403s, turning what should be a clean skip into a second hard failure.

Also corrected `ci.yml`'s job name and 4 artifact-name labels, stale at "3.3.7" — `build.sbt`'s `scalaVersion` moved to `3.3.8` in commit `e1685545` but these labels were never updated.

**Follow-up commit**: while watching PR #1387's own CI after pushing its fixes, found a third bug in the same family: `docs-preview.yml`'s "Deploy Preview" step (`rossjrw/pr-preview-action@v1`, which pushes the built site to `gh-pages`) 403s on every fork PR — `Permission to chippr-robotics/fukuii.git denied to github-actions[bot]`. The default `GITHUB_TOKEN` is read-only on a fork PR regardless of the workflow's own `permissions:` block (a GitHub platform-level restriction). The earlier `mkdocs build --strict` step (the real correctness gate) already runs unconditionally and is unaffected — added the same fork-guard to skip the doomed-on-forks deploy attempt.

Discovered while root-causing PR #1387's failing `Check Documentation Links` / `Documentation Preview` checks — all three bugs are pre-existing and unrelated to that PR's diff, so they're fixed here separately rather than bundled in.

## Test plan

- [x] All three edited workflow YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] This PR's own `Check Documentation Links` and `Documentation Preview` runs (using the fixed workflow YAML from this PR's own head branch) confirm the Link Checker step no longer errors on the CLI arg, and both fork-guarded steps (Comment on PR, Deploy Preview) skip cleanly instead of 403ing